### PR TITLE
Fix policy for pkcsslotd from opencryptoki

### DIFF
--- a/pkcs.fc
+++ b/pkcs.fc
@@ -4,4 +4,6 @@
 
 /var/lib/opencryptoki(/.*)?	gen_context(system_u:object_r:pkcs_slotd_var_lib_t,s0)
 
+/var/lock/opencryptoki(/.*)?	gen_context(system_u:object_r:pkcs_slotd_lock_t,s0)
+
 /var/run/pkcsslotd.*	gen_context(system_u:object_r:pkcs_slotd_var_run_t,s0)

--- a/pkcs.if
+++ b/pkcs.if
@@ -19,7 +19,7 @@
 #
 interface(`pkcs_admin_slotd',`
 	gen_require(`
-		type pkcs_slotd_t, pkcs_slotd_initrc_exec_t, pkcs_slotd_var_lib_t;
+		type pkcs_slotd_t, pkcs_slotd_initrc_exec_t, pkcs_slotd_var_lib_t, pkcs_slotd_lock;
 		type pkcs_slotd_var_run_t, pkcs_slotd_tmp_t, pkcs_slotd_tmpfs_t;
 	')
 
@@ -33,6 +33,9 @@ interface(`pkcs_admin_slotd',`
 
 	files_search_var_lib($1)
 	admin_pattern($1, pkcs_slotd_var_lib_t)
+
+	files_search_locks($1)
+	admin_pattern($1, pkcs_slotd_lock_t)
 
 	files_search_pids($1)
 	admin_pattern($1, pkcs_slotd_var_run_t)

--- a/pkcs.te
+++ b/pkcs.te
@@ -18,6 +18,9 @@ type pkcs_slotd_var_lib_t;
 typealias pkcs_slotd_var_lib_t alias pkcsslotd_var_lib_t;
 files_type(pkcs_slotd_var_lib_t)
 
+type pkcs_slotd_lock_t;
+files_lock_file(pkcs_slotd_lock_t)
+
 type pkcs_slotd_var_run_t;
 typealias pkcs_slotd_var_run_t alias pkcsslotd_var_run_t;
 files_pid_file(pkcs_slotd_var_run_t)
@@ -46,6 +49,9 @@ manage_files_pattern(pkcs_slotd_t, pkcs_slotd_var_lib_t, pkcs_slotd_var_lib_t)
 manage_lnk_files_pattern(pkcs_slotd_t, pkcs_slotd_var_lib_t, pkcs_slotd_var_lib_t)
 files_var_lib_filetrans(pkcs_slotd_t, pkcs_slotd_var_lib_t, dir)
 
+manage_files_pattern(pkcs_slotd_t, pkcs_slotd_lock_t, pkcs_slotd_lock_t)
+files_lock_filetrans(pkcs_slotd_t, pkcs_slotd_lock_t, file)
+
 manage_dirs_pattern(pkcs_slotd_t, pkcs_slotd_var_run_t, pkcs_slotd_var_run_t)
 manage_files_pattern(pkcs_slotd_t, pkcs_slotd_var_run_t, pkcs_slotd_var_run_t)
 manage_sock_files_pattern(pkcs_slotd_t, pkcs_slotd_var_run_t, pkcs_slotd_var_run_t)
@@ -57,7 +63,9 @@ files_tmp_filetrans(pkcs_slotd_t, pkcs_slotd_tmp_t, dir)
 
 manage_dirs_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
 manage_files_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
-fs_tmpfs_filetrans(pkcs_slotd_t, pkcs_slotd_tmpfs_t, dir)
+fs_tmpfs_filetrans(pkcs_slotd_t, pkcs_slotd_tmpfs_t, { file dir })
+
+auth_read_passwd(pkcs_slotd_t)
 
 logging_send_syslog_msg(pkcs_slotd_t)
 


### PR DESCRIPTION
opencryptoki's daemon cannot be run in Rawhide due to several AVCs. These changes fix it for me.

audit2allow output:

> allow pkcs_slotd_t passwd_file_t:file { read getattr open };
> allow pkcs_slotd_t tmpfs_t:file { read write };
> allow pkcs_slotd_t var_lock_t:dir { write add_name };
> allow pkcs_slotd_t var_lock_t:file { read lock create open setattr };
> allow pkcs_slotd_t var_lock_t:lnk_file read;
