### PR TITLE
Allow apcupsd to get attributes of filesystems with xattrs

### DIFF
--- a/apcupsd.te
+++ b/apcupsd.te
@@ -80,6 +80,8 @@ corenet_udp_bind_snmp_port(apcupsd_t)
 corenet_sendrecv_snmp_server_packets(apcupsd_t)
 corenet_udp_sendrecv_snmp_port(apcupsd_t)
 
+fs_getattr_xattr_fs(apcupsd_t)
+
 dev_rw_generic_usb_dev(apcupsd_t)
 
 domain_signull_all_domains(apcupsd_t)


### PR DESCRIPTION
```
BZ #1149369
```
