### PR TITLE
files: Label OSTree .origin file as etc_t

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -68,6 +68,7 @@ ifdef(`distro_suse',`
 /etc/ostree/remotes.d(/.*)?                      gen_context(system_u:object_r:system_conf_t,s0)
 
 /ostree/repo(/.*)?                      gen_context(system_u:object_r:system_conf_t,s0)
+/ostree(/.*).origin			gen_context(system_u:object_r:etc_t,s0)
 
 /etc/cups/client\.conf	--	gen_context(system_u:object_r:etc_t,s0)
 


### PR DESCRIPTION
This will allow domains like rhsmcertd_t to write to it.  It is also
intended to be potentially editable configuration.