### PR TITLE
Fix NetworkManager denials

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -42,6 +42,10 @@ init_system_domain(wpa_cli_t, wpa_cli_exec_t)
 # Local policy
 #
 
+# NetworkManager opens rfcomm device to keep the Bluetooth connection open,
+# it doesn't read or write to it.
+allow NetworkManager_t tty_device_t:chr_file open;
+
 # networkmanager will ptrace itself if gdb is installed
 # and it receives a unexpected signal (rh bug #204161)
 allow NetworkManager_t self:capability { fowner chown fsetid kill setgid setuid sys_admin sys_nice dac_override net_admin net_raw net_bind_service ipc_lock sys_chroot };

--- a/networkmanager.te
+++ b/networkmanager.te
@@ -148,6 +148,7 @@ corenet_rw_tun_tap_dev(NetworkManager_t)
 corenet_getattr_ppp_dev(NetworkManager_t)
 
 dev_rw_sysfs(NetworkManager_t)
+dev_write_sysfs_dirs(NetworkManager_t)
 dev_read_rand(NetworkManager_t)
 dev_read_urand(NetworkManager_t)
 dev_dontaudit_getattr_generic_blk_files(NetworkManager_t)

--- a/networkmanager.te
+++ b/networkmanager.te
@@ -84,6 +84,7 @@ can_exec(NetworkManager_t, wpa_cli_exec_t)
 
 list_dirs_pattern(NetworkManager_t, NetworkManager_initrc_exec_t, NetworkManager_initrc_exec_t)
 read_files_pattern(NetworkManager_t, NetworkManager_initrc_exec_t, NetworkManager_initrc_exec_t)
+read_lnk_files_pattern(NetworkManager_t, NetworkManager_initrc_exec_t, NetworkManager_initrc_exec_t)
 
 list_dirs_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_etc_t)
 read_files_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_etc_t)


### PR DESCRIPTION
This one for NetworkManager 1.2 (master) only for now, maybe it will be backported to 1.0 though.

acc4916 Allow NetworkManager to check if sysfs is writable

These affect 1.0 NetworkManager too (Fedora 21, RHEL 7.1):

cd1a611 Allow NetworkManager to keep RFCOMM connection for Bluetooth DUN open
b5b529d Allow NetworkManager nm-dispacher to read links