### PR TITLE
rename several contrib modules according to their filenames

### DIFF
--- a/glusterd.te
+++ b/glusterd.te
@@ -1,4 +1,4 @@
-policy_module(glusterfs, 1.1.2)
+policy_module(glusterd, 1.1.3)
 
 ## <desc>
 ## <p>

--- a/passenger.te
+++ b/passenger.te
@@ -1,4 +1,4 @@
-policy_module(passanger, 1.1.1)
+policy_module(passenger, 1.1.2)
 
 ########################################
 #

--- a/rkhunter.te
+++ b/rkhunter.te
@@ -1,4 +1,4 @@
-policy_module(rhhunter, 1.0)
+policy_module(rkhunter, 1.1)
 
 type rkhunter_var_lib_t;
 files_type(rkhunter_var_lib_t)

--- a/stapserver.te
+++ b/stapserver.te
@@ -1,4 +1,4 @@
-policy_module(systemtap, 1.1.0)
+policy_module(stapserver, 1.1.1)
 
 ########################################
 #


### PR DESCRIPTION
These are cosmetic changes needed for fluent transition to
libsemanage-2.4. Since the CIL is used, a module name is not stored in
module but a filename is used instead. With these changes, modules names before update to libsemanage-2.4 will be same as after update.