### PR TITLE
Add interface "storage_read_fixed_disk" for reading fixed disk device nodes

### DIFF
--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -253,6 +253,25 @@ interface(`storage_delete_fixed_disk_dev',`
 
 ########################################
 ## <summary>
+##	Allow the caller to read fixed disk device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`storage_read_fixed_disk',`
+	gen_require(`
+		type fixed_disk_device_t;
+
+	')
+
+	read_blk_files_pattern($1, device_t, fixed_disk_device_t)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete fixed disk device nodes.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Required for "targetd" daemon.