### PR TITLE
Two fixes to AVC denials found while using staff_u in a graphical environment

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -29,6 +29,7 @@ kernel_read_software_raid_state(staff_t)
 kernel_read_fs_sysctls(staff_t)
 kernel_read_numa_state(staff_t)
 kernel_write_numa_state(staff_t)
+kernel_sigchld(staff_t)
 
 fs_read_hugetlbfs_files(staff_t)
 files_dontaudit_read_all_symlinks(staff_t)

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -36,6 +36,7 @@ files_dontaudit_read_all_symlinks(staff_t)
 
 dev_read_cpuid(staff_t)
 dev_read_kmsg(staff_t)
+dev_rw_inherited_input_dev(staff_t)
 
 domain_read_all_domains_state(staff_t)
 domain_getcap_all_domains(staff_t)


### PR DESCRIPTION
Two fixes to AVC denials found while using `staff_u` in a graphical environment