### PR TITLE
Allow two telepathy types read/write access to inherited user ttys

### DIFF
--- a/telepathy.te
+++ b/telepathy.te
@@ -172,6 +172,7 @@ files_search_pids(telepathy_logger_t)
 fs_getattr_all_fs(telepathy_logger_t)
 
 userdom_home_manager(telepathy_logger_t)
+userdom_use_inherited_user_ttys(telepathy_logger_t)
 
 optional_policy(`
 	# ~/.config/dconf/user
@@ -187,6 +188,7 @@ allow telepathy_mission_control_t self:process setsched;
 manage_dirs_pattern(telepathy_mission_control_t, telepathy_mission_control_home_t, telepathy_mission_control_home_t)
 manage_files_pattern(telepathy_mission_control_t, telepathy_mission_control_home_t, telepathy_mission_control_home_t)
 userdom_search_user_home_dirs(telepathy_mission_control_t)
+userdom_use_inherited_user_ttys(telepathy_mission_control_t)
 
 manage_files_pattern(telepathy_mission_control_t, telepathy_gabble_cache_home_t, telepathy_gabble_cache_home_t)
 manage_dirs_pattern(telepathy_mission_control_t, telepathy_gabble_cache_home_t, telepathy_gabble_cache_home_t)


### PR DESCRIPTION
When using staff_u in a graphical enviroment, the following AVC denials can be
captured:

```
type=AVC msg=audit(1438712345.842:1095): avc:  denied  { read write } for
pid=12299 comm="telepathy-logge" path="/dev/tty7" dev="devtmpfs" ino=1048
scontext=staff_u:staff_r:telepathy_logger_t:s0-s0:c0.c1023
tcontext=staff_u:object_r:user_tty_device_t:s0 tclass=chr_file permissive=0

type=AVC msg=audit(1438798796.068:613): avc:  denied  {
read write } for  pid=2347 comm="mission-control" path="/dev/tty2"
dev="devtmpfs" ino=1043
scontext=staff_u:staff_r:telepathy_mission_control_t:s0-s0:c0.c1023
tcontext=staff_u:object_r:user_tty_device_t:s0 tclass=chr_file permissive=0
```
