### PR TITLE
Targetd policy upgrade.

### DIFF
--- a/targetd.te
+++ b/targetd.te
@@ -44,6 +44,8 @@ dev_read_urand(targetd_t)
 
 libs_exec_ldconfig(targetd_t)
 
+storage_raw_read_fixed_disk(targetd_t)
+
 storage_getattr_fixed_disk_dev(targetd_t)
 storage_getattr_removable_dev(targetd_t)
 

--- a/targetd.te
+++ b/targetd.te
@@ -45,9 +45,7 @@ dev_read_urand(targetd_t)
 libs_exec_ldconfig(targetd_t)
 
 storage_raw_read_fixed_disk(targetd_t)
-
-storage_getattr_fixed_disk_dev(targetd_t)
-storage_getattr_removable_dev(targetd_t)
+storage_raw_read_removable_device(targetd_t)
 
 sysnet_read_config(targetd_t)
 


### PR DESCRIPTION
 - Allow raw fixed disk device read (required for normal daemon operation on server machines).