### PR TITLE
Allow NetworkManager to write audit log messages

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -187,6 +187,7 @@ auth_use_nsswitch(NetworkManager_t)
 libs_exec_ldconfig(NetworkManager_t)
 
 logging_send_syslog_msg(NetworkManager_t)
+logging_send_audit_msgs(NetworkManager_t)
 
 miscfiles_read_generic_certs(NetworkManager_t)
 


### PR DESCRIPTION
Recently NetworkManager gained support for writing messages to the
audit subsystem; add a rule to allow that.

Reproducer:
- set "audit=yes" in [logging] section of /etc/NetworkManager/NetworkManager.conf
- restart NetworkManager
- perform an action that triggers an audit message, for example "nmcli connection add con-name test type ethernet ifname eth0"

AVC denial messages:

type=AVC msg=audit(1440071103.359:1390): avc:  denied  { create } for  pid=22136 comm="NetworkManager" scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=netlink_audit_socket permissive=1
type=AVC msg=audit(1440071103.361:1391): avc:  denied  { nlmsg_relay } for  pid=22136 comm="NetworkManager" scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=netlink_audit_socket permiss\
ive=1
type=AVC msg=audit(1440071103.361:1392): avc:  denied  { audit_write } for  pid=22136 comm="NetworkManager" capability=29  scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=capability pe\
rmissive=1
