### PR TITLE
lircd: Fix new drop-root-permissions denials.

### DIFF
--- a/lircd.te
+++ b/lircd.te
@@ -28,6 +28,8 @@ allow lircd_t self:process signal;
 allow lircd_t self:fifo_file rw_fifo_file_perms;
 allow lircd_t self:tcp_socket { accept listen };
 allow lircd_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow lircd_t passwd_file_t:file { read getattr open };
+allow lircd_t self:capability { setuid setgid dac_override };
 
 read_files_pattern(lircd_t, lircd_etc_t, lircd_etc_t)
 


### PR DESCRIPTION
Two new denials  due to  lircd dropping root privileges code.