### PR TITLE
lircd: Fix new drop-root-permissions denials (v2)

### DIFF
--- a/lircd.te
+++ b/lircd.te
@@ -40,7 +40,6 @@ dev_filetrans(lircd_t, lircd_var_run_t, sock_file)
 
 kernel_request_load_module(lircd_t)
 
-auth_read_passwd(lircd_t)
 
 corenet_all_recvfrom_unlabeled(lircd_t)
 corenet_all_recvfrom_netlabel(lircd_t)
@@ -69,6 +68,8 @@ files_read_all_locks(lircd_t)
 term_use_ptmx(lircd_t)
 term_use_usb_ttys(lircd_t)
 term_use_unallocated_ttys(lircd_t)
+
+auth_read_passwd(lircd_t)
 
 logging_send_syslog_msg(lircd_t)
 

--- a/lircd.te
+++ b/lircd.te
@@ -23,7 +23,7 @@ files_pid_file(lircd_var_run_t)
 # Local policy
 #
 
-allow lircd_t self:capability { chown kill sys_admin };
+allow lircd_t self:capability { setuid setgid dac_override chown kill sys_admin };
 allow lircd_t self:process signal;
 allow lircd_t self:fifo_file rw_fifo_file_perms;
 allow lircd_t self:tcp_socket { accept listen };
@@ -39,6 +39,8 @@ files_pid_filetrans(lircd_t, lircd_var_run_t, { dir file })
 dev_filetrans(lircd_t, lircd_var_run_t, sock_file)
 
 kernel_request_load_module(lircd_t)
+
+auth_read_passwd(lircd_t)
 
 corenet_all_recvfrom_unlabeled(lircd_t)
 corenet_all_recvfrom_netlabel(lircd_t)


### PR DESCRIPTION
New try: Add some new permission needed for new code dropping root privileges using setuid()