### PR TITLE
Add interface to allow reading files in efivarfs

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6258,3 +6258,23 @@ interface(`fs_tmpfs_filetrans_named_content',`
 	fs_tmpfs_filetrans($1, cgroup_t, lnk_file, "cpu")
 	fs_tmpfs_filetrans($1, cgroup_t, lnk_file, "cpuacct")
 ')
+
+#######################################
+## <summary>
+##      Read files in efivarfs
+##      - contains Linux Kernel configuration options for UEFI systems
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_read_efivarfs_files',`
+        gen_require(`
+                type efivarfs_t;
+        ')
+
+        read_files_pattern($1, efivarfs_t, efivarfs_t)
+')


### PR DESCRIPTION
 Efivarfs contains Linux Kernel configuration options for UEFI systems (UEFI Runtime Variables)