### PR TITLE
Allow systemd-logind read access to efivarfs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -106,6 +106,9 @@ files_delete_tmpfs_files(systemd_logind_t)
 fs_mount_tmpfs(systemd_logind_t)
 fs_unmount_tmpfs(systemd_logind_t)
 fs_list_tmpfs(systemd_logind_t)
+
+fs_read_efivarfs_files(systemd_logind_t)
+
 fs_manage_fusefs_dirs(systemd_logind_t)
 fs_manage_fusefs_files(systemd_logind_t)
 


### PR DESCRIPTION
BZ #1244973, #1267207 (partial solution)