### PR TITLE
Allow NetworkManager_t and policykit_t read access to systemd-machined pid files. 

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -209,6 +209,8 @@ sysnet_search_dhcp_state(NetworkManager_t)
 sysnet_manage_config(NetworkManager_t)
 sysnet_filetrans_named_content(NetworkManager_t)
 
+systemd_machined_read_pid_files(NetworkManager_t)
+
 term_use_unallocated_ttys(NetworkManager_t)
 
 userdom_stream_connect(NetworkManager_t)

--- a/policykit.te
+++ b/policykit.te
@@ -90,6 +90,8 @@ init_list_pid_dirs(policykit_t)
 
 logging_send_syslog_msg(policykit_t)
 
+systemd_machined_read_pid_files(policykit_t)
+
 userdom_getattr_all_users(policykit_t)
 userdom_read_all_users_state(policykit_t)
 userdom_dontaudit_search_admin_dir(policykit_t)


### PR DESCRIPTION
BZ #1255305
