### PR TITLE
Add interface to allow reading files in efivarfs - contains Linux Kernel configuration options for UEFI systems (UEFI Runtime Variables)

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6258,3 +6258,23 @@ interface(`fs_tmpfs_filetrans_named_content',`
 	fs_tmpfs_filetrans($1, cgroup_t, lnk_file, "cpu")
 	fs_tmpfs_filetrans($1, cgroup_t, lnk_file, "cpuacct")
 ')
+
+#######################################
+## <summary>
+##      Read files in efivarfs
+##      - contains Linux Kernel configuration options for UEFI systems
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_read_efivarfs_files',`
+        gen_require(`
+                type efivarfs_t;
+        ')
+
+        read_files_pattern($1, efivarfs_t, efivarfs_t)
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -106,6 +106,9 @@ files_delete_tmpfs_files(systemd_logind_t)
 fs_mount_tmpfs(systemd_logind_t)
 fs_unmount_tmpfs(systemd_logind_t)
 fs_list_tmpfs(systemd_logind_t)
+
+fs_read_efivarfs_files(systemd_logind_t)
+
 fs_manage_fusefs_dirs(systemd_logind_t)
 fs_manage_fusefs_files(systemd_logind_t)
 


### PR DESCRIPTION
BZ #1244973
Already merged to rawhide.