### PR TITLE
Fix attribute in corenetwork.if.in BZ(#1272426)

### DIFF
--- a/policy/modules/kernel/corenetwork.if.in
+++ b/policy/modules/kernel/corenetwork.if.in
@@ -2301,10 +2301,10 @@ interface(`corenet_tcp_bind_all_unreserved_ports',`
 #
 interface(`corenet_tcp_bind_unreserved_ports',`
 	gen_require(`
-		attribute unreserved_port_t;
+		attribute unreserved_port_type;
 	')
 
-	allow $1 unreserved_port_t:tcp_socket name_bind;
+	allow $1 unreserved_port_type:tcp_socket name_bind;
 ')
 
 ########################################


### PR DESCRIPTION
I am Fedora Zh User Group member. I call the "corenet_tcp_bind_unreserved_ports (ircd_hybrid_t)" in the module, but returned the following error when installing the module.

```
$ sudo semodule -i ircd-hybrid.pp
libsepol.type_copy_callback: ircd-hybrid: Expected unreserved_port_t to be an attribute, but it was already declared as a type. (No such file or directory).
libsemanage.semanage_link_sandbox: Link packages failed (No such file or directory).
semodule:  Failed!
```

I find "unreserved_port_type" attributes name is incorrectly written as "unreserved_port_t".
```
grep -n "attribute unreserved_port_t" policy/modules/kernel/corenetwork.if.in
2268:		attribute unreserved_port_type;
2286:		attribute unreserved_port_type;
2304:		attribute unreserved_port_t;          < ----------
2322:		attribute unreserved_port_type;
2412:		attribute unreserved_port_type;
2448:		attribute unreserved_port_type;
```