### PR TITLE
ipsec: fix strongSwan charon-nm

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -92,6 +92,7 @@ allow ipsec_t self:netlink_xfrm_socket { create_netlink_socket_perms nlmsg_write
 allow ipsec_t self:netlink_selinux_socket create_socket_perms;
 allow ipsec_t self:unix_stream_socket { create_stream_socket_perms connectto };
 allow ipsec_t self:netlink_route_socket { create_netlink_socket_perms write };
+allow ipsec_t self:tun_socket create_socket_perms;
 
 allow ipsec_t ipsec_initrc_exec_t:file read_file_perms;
 
@@ -161,6 +162,8 @@ corenet_sendrecv_isakmp_server_packets(ipsec_t)
 corenet_tcp_connect_http_port(ipsec_t)
 corenet_tcp_connect_ldap_port(ipsec_t)
 
+corenet_rw_tun_tap_dev(ipsec_t)
+
 dev_read_sysfs(ipsec_t)
 dev_read_rand(ipsec_t)
 dev_read_urand(ipsec_t)
@@ -206,6 +209,15 @@ optional_policy(`
 
 optional_policy(`
 	udev_read_db(ipsec_t)
+')
+
+optional_policy(`
+	dbus_system_bus_client(ipsec_t)
+	dbus_connect_system_bus(ipsec_t)
+
+	optional_policy(`
+		networkmanager_dbus_chat(ipsec_t)
+	')
 ')
 
 ########################################


### PR DESCRIPTION
StrongSwan has an IPSec IKE daemon and the NetworkManager plugin in the same
binary. They don't split it into a mgmt daemon and actual IPSec daemon.

Also, it uses tun/tap:

<pre>
  avc:  denied  { read write } for
    pid=9755 comm="charon-nm" name="tun" dev="devtmpfs" ino=7165
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:object_r:tun_tap_device_t:s0
    tclass=chr_file
  avc:  denied  { open } for
    pid=9755 comm="charon-nm" path="/dev/net/tun" dev="devtmpfs" ino=7165
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:object_r:tun_tap_device_t:s0
    tclass=chr_file
  avc:  denied  { ioctl } for
    pid=9755 comm="charon-nm" path="/dev/net/tun" dev="devtmpfs" ino=7165
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:object_r:tun_tap_device_t:s0
    tclass=chr_file
  avc:  denied  { create } for
    pid=9755 comm="charon-nm"
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:system_r:ipsec_t:s0
    tclass=tun_socket
  avc:  denied  { write } for
    pid=9755 comm="charon-nm" name="system_bus_socket" dev="tmpfs" ino=15692
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:object_r:system_dbusd_var_run_t:s0
    tclass=sock_file
  avc:  denied  { connectto } for
    pid=9755 comm="charon-nm" path="/run/dbus/system_bus_socket"
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
    tclass=unix_stream_socket
  avc:  denied  { send_msg } for
    msgtype=method_call interface=org.freedesktop.DBus member=Hello dest=org.freedesktop.DBus spid=9755
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
    tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=?  addr=?  terminal=?
  avc:  denied  { acquire_svc } for
    service=org.freedesktop.NetworkManager.strongswan spid=9755
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
    tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=?  addr=?  terminal=?
  avc:  denied  { send_msg } for
    msgtype=method_call interface=org.freedesktop.NetworkManager.VPN.Plugin member=NeedSecrets dest=org.freedesktop.NetworkManager.strongswan spid=643 tpid=9755
    scontext=system_u:system_r:NetworkManager_t:s0
    tcontext=system_u:system_r:ipsec_t:s0
    tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=?  addr=?  terminal=?
  avc:  denied  { send_msg } for
    msgtype=method_return dest=:1.8 spid=9755 tpid=643
    scontext=system_u:system_r:ipsec_t:s0
    tcontext=system_u:system_r:NetworkManager_t:s0
    tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=?  addr=?  terminal=?
</pre>