### PR TITLE
Allow systemd-hostnamed to communicate with dhcp via dbus. 

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -259,6 +259,11 @@ optional_policy(`
 	seutil_sigchld_newrole(dhcpc_t)
 	seutil_domtrans_setfiles(dhcpc_t)
 ')
+
+optional_policy(`
+	systemd_dbus_chat_hostnamed(dhcpc_t)
+')
+
 optional_policy(`
 	systemd_passwd_agent_domtrans(dhcpc_t)
 	systemd_signal_passwd_agent(dhcpc_t)


### PR DESCRIPTION
BZ #1242583