### PR TITLE
Allow screen/tmux to read `user_home_type` directories

### DIFF
--- a/screen.te
+++ b/screen.te
@@ -80,6 +80,7 @@ domain_read_all_domains_state(screen_domain)
 files_search_tmp(screen_domain)
 files_search_home(screen_domain)
 files_list_home(screen_domain)
+userdom_list_user_home_content(screen_domain)
 
 fs_search_auto_mountpoints(screen_domain)
 fs_getattr_xattr_fs(screen_domain)


### PR DESCRIPTION
When starting tmux from inside a particular directory (eg,
`/home/user/projects`), the working directory should remain the same. If
tmux is unable to read the working directory, the working directory is
changed to `/` instead. Fix this by allowing `screen_domain` to read
`user_home_type` directories.
