### PR TITLE
Allow antivirus_t to bind to all unreserved ports.

### DIFF
--- a/antivirus.te
+++ b/antivirus.te
@@ -111,6 +111,7 @@ corecmd_exec_bin(antivirus_domain)
 corecmd_exec_shell(antivirus_domain)
 
 corenet_all_recvfrom_netlabel(antivirus_t)
+corenet_tcp_bind_all_unreserved_ports(antivirus_t)
 corenet_tcp_sendrecv_generic_if(antivirus_t)
 corenet_udp_sendrecv_generic_if(antivirus_t)
 corenet_tcp_sendrecv_generic_node(antivirus_domain)


### PR DESCRIPTION
Clamd binds to random unassigned port (by default in range 1024-2048). 
BZ #1248785