### PR TITLE
Allow acpid to attempt to connect to the Linux kernel via generic netlink socket.

### DIFF
--- a/apm.te
+++ b/apm.te
@@ -67,6 +67,7 @@ dontaudit apmd_t self:capability { setuid dac_override dac_read_search sys_tty_c
 allow apmd_t self:process { signal_perms getsession };
 allow apmd_t self:fifo_file rw_fifo_file_perms;
 allow apmd_t self:netlink_socket create_socket_perms;
+allow apmd_t self:netlink_generic_socket create_socket_perms;
 allow apmd_t self:unix_stream_socket { accept listen };
 
 allow apmd_t apmd_lock_t:file manage_file_perms;


### PR DESCRIPTION
Backport. 