### PR TITLE
Starting with MySQL 5.7, mysqld option --secure-file-priv is set

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -28,14 +28,14 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/libexec/mysqld_safe-scl-helper --  gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 
 
-/usr/sbin/mysqld(-max)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/sbin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/sbin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
 /usr/sbin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 #
 # /var
 #
-/var/lib/mysql(/.*)?		gen_context(system_u:object_r:mysqld_db_t,s0)
+/var/lib/mysql(-files)?(/.*)?		gen_context(system_u:object_r:mysqld_db_t,s0)
 /var/lib/mysql/mysql\.sock -s	gen_context(system_u:object_r:mysqld_var_run_t,s0)
 
 /var/log/mariadb(/.*)?	gen_context(system_u:object_r:mysqld_log_t,s0)


### PR DESCRIPTION
to /var/lib/mysql-files by default[1].

This affects the LOAD DATA and SELECT ... INTO OUTFILE statements
and the LOAD_FILE() function. For these to work mysqld needs write
and read access to files in /var/lib/mysql-files.

Modify policy to allow this.

MySQL supports special debug variant[2], this is shipped in some
packages of MySQL server.

Add mysqld-debug as mysqld server executable variant in policy.

[1]: http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_secure_file_priv
[2]: http://dev.mysql.com/doc/refman/5.7/en/debugging-server.html