### PR TITLE
Dontaudit attempts of antivirus_t to bind to reserved ports. 

### DIFF
--- a/antivirus.te
+++ b/antivirus.te
@@ -112,6 +112,7 @@ corecmd_exec_shell(antivirus_domain)
 
 corenet_all_recvfrom_netlabel(antivirus_t)
 corenet_tcp_bind_all_unreserved_ports(antivirus_t)
+corenet_dontaudit_tcp_bind_all_reserved_ports(antivirus_t)
 corenet_tcp_sendrecv_generic_if(antivirus_t)
 corenet_udp_sendrecv_generic_if(antivirus_t)
 corenet_tcp_sendrecv_generic_node(antivirus_domain)


### PR DESCRIPTION
It randomly chooses port in range 1024-2048 (by default), some of which are assigned.
BZ #1248785