### PR TITLE
Add transition for ".linphone-web" to mozilla_plugin_t.

### DIFF
--- a/mozilla.te
+++ b/mozilla.te
@@ -521,6 +521,8 @@ userdom_exec_user_tmp_files(mozilla_plugin_t)
 
 userdom_home_manager(mozilla_plugin_t)
 
+userdom_user_home_dir_filetrans(mozilla_plugin_t, mozilla_home_t, dir, ".linphone-web")
+
 tunable_policy(`mozilla_plugin_can_network_connect',`
 	corenet_tcp_connect_all_ports(mozilla_plugin_t)
 ')


### PR DESCRIPTION
The folder is created and used by linphone web plugin. 
BZ#1279752