### PR TITLE
Allow reading of symlinks in the read_config

### DIFF
--- a/puppet.if
+++ b/puppet.if
@@ -246,8 +246,9 @@ interface(`puppet_read_config',`
     ')
 
     files_search_etc($1)
-	list_dirs_pattern($1, puppet_etc_t, puppet_etc_t)
+    list_dirs_pattern($1, puppet_etc_t, puppet_etc_t)
     read_files_pattern($1, puppet_etc_t, puppet_etc_t)
+    read_lnk_files_pattern($1, puppet_etc_t, puppet_etc_t)
 ')
 
 #####################################


### PR DESCRIPTION
Looks like in refpolicy this is correct.