### PR TITLE
Allow setroubleshoot_fixit_t to use temporary files

### DIFF
--- a/setroubleshoot.te
+++ b/setroubleshoot.te
@@ -31,6 +31,12 @@ files_tmp_file(setroubleshoot_tmp_t)
 type setroubleshoot_tmpfs_t;
 files_tmpfs_file(setroubleshoot_tmpfs_t)
 
+type setroubleshoot_fixit_tmp_t;
+files_tmp_file(setroubleshoot_fixit_tmp_t)
+
+type setroubleshoot_fixit_tmpfs_t;
+files_tmpfs_file(setroubleshoot_fixit_tmpfs_t)
+
 ########################################
 #
 # setroubleshootd local policy
@@ -57,6 +63,16 @@ manage_files_pattern(setroubleshootd_t, setroubleshoot_tmpfs_t, setroubleshoot_t
 manage_dirs_pattern(setroubleshootd_t, setroubleshoot_tmpfs_t, setroubleshoot_tmpfs_t)
 fs_tmpfs_filetrans(setroubleshootd_t, setroubleshoot_tmpfs_t, { file dir })
 allow setroubleshootd_t setroubleshoot_tmpfs_t:file mmap_file_perms;
+
+manage_files_pattern(setroubleshoot_fixit_t, setroubleshoot_fixit_tmp_t, setroubleshoot_fixit_tmp_t)
+manage_dirs_pattern(setroubleshoot_fixit_t, setroubleshoot_fixit_tmp_t, setroubleshoot_fixit_tmp_t)
+files_tmp_filetrans(setroubleshoot_fixit_t, setroubleshoot_fixit_tmp_t, { file dir })
+allow setroubleshoot_fixit_t setroubleshoot_fixit_tmp_t:file mmap_file_perms;
+
+manage_files_pattern(setroubleshoot_fixit_t, setroubleshoot_fixit_tmpfs_t, setroubleshoot_fixit_tmpfs_t)
+manage_dirs_pattern(setroubleshoot_fixit_t, setroubleshoot_fixit_tmpfs_t, setroubleshoot_fixit_tmpfs_t)
+fs_tmpfs_filetrans(setroubleshoot_fixit_t, setroubleshoot_fixit_tmpfs_t, { file dir })
+allow setroubleshoot_fixit_t setroubleshoot_fixit_tmpfs_t:file mmap_file_perms;
 
 # database files
 allow setroubleshootd_t setroubleshoot_var_lib_t:dir setattr;


### PR DESCRIPTION
sealert, which is run via org.fedoraproject.SetroubleshootFixit DBUS
service, is labaled as setroubleshoot_fixit_t and as it indirectly uses
libffi for signal handlers, it needs to be able to create and mmap
temporary files

Fixes: rhbz#1278983