### PR TITLE
Support for InnoDB Tablespace Encryption.

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -35,7 +35,7 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 #
 # /var
 #
-/var/lib/mysql(-files)?(/.*)?		gen_context(system_u:object_r:mysqld_db_t,s0)
+/var/lib/mysql(-files|-keyring)?(/.*)?		gen_context(system_u:object_r:mysqld_db_t,s0)
 /var/lib/mysql/mysql\.sock -s	gen_context(system_u:object_r:mysqld_var_run_t,s0)
 
 /var/log/mariadb(/.*)?	gen_context(system_u:object_r:mysqld_log_t,s0)


### PR DESCRIPTION
As of MySQL 5.7.11, InnoDB supports data encryption for InnoDB tables
stored in file-per-table tablespaces[1].

To manage the master key, a keyring_file plugin is used. This plugin
needs read and write to directory /var/lib/mysql-keyring, add
directory to policy.

[1]: https://dev.mysql.com/doc/refman/5.7/en/innodb-tablespace-encryption.html