### PR TITLE
Add SELinux policy for LTTng 2.x central tracing registry daemon.

### DIFF
--- a/lttng-tools.fc
+++ b/lttng-tools.fc
@@ -1,0 +1,5 @@
+/usr/bin/lttng-sessiond		--	gen_context(system_u:object_r:lttng_sessiond_exec_t,s0)
+
+/usr/lib/systemd/system/lttng-sessiond.service		--	gen_context(system_u:object_r:lttng_sessiond_unit_file_t,s0)
+
+/var/run/lttng(/.*)?        gen_context(system_u:object_r:lttng_sessiond_var_run_t,s0)

--- a/lttng-tools.if
+++ b/lttng-tools.if
@@ -73,12 +73,6 @@ interface(`lttng_sessiond_systemctl',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
-## <rolecap/>
 #
 interface(`lttng_sessiond_admin',`
 	gen_require(`

--- a/lttng-tools.if
+++ b/lttng-tools.if
@@ -1,0 +1,104 @@
+
+## <summary>LTTng 2.x central tracing registry session daemon.</summary>
+
+########################################
+## <summary>
+##	Execute lttng_sessiond_exec_t in the lttng_sessiond domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`lttng_sessiond_domtrans',`
+	gen_require(`
+		type lttng_sessiond_t, lttng_sessiond_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, lttng_sessiond_exec_t, lttng_sessiond_t)
+')
+
+######################################
+## <summary>
+##	Execute lttng_sessiond in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`lttng_sessiond_exec',`
+	gen_require(`
+		type lttng_sessiond_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, lttng_sessiond_exec_t)
+')
+
+########################################
+## <summary>
+##	Execute lttng_sessiond server in the lttng_sessiond domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`lttng_sessiond_systemctl',`
+	gen_require(`
+		type lttng_sessiond_t;
+		type lttng_sessiond_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+    systemd_read_fifo_file_passwd_run($1)
+	allow $1 lttng_sessiond_unit_file_t:file read_file_perms;
+	allow $1 lttng_sessiond_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, lttng_sessiond_t)
+')
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an lttng_sessiond environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`lttng_sessiond_admin',`
+	gen_require(`
+		type lttng_sessiond_t;
+    	type lttng_sessiond_unit_file_t;
+	')
+
+	allow $1 lttng_sessiond_t:process { signal_perms };
+	ps_process_pattern($1, lttng_sessiond_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 lttng_sessiond_t:process ptrace;
+    ')
+
+	lttng_sessiond_systemctl($1)
+	admin_pattern($1, lttng_sessiond_unit_file_t)
+	allow $1 lttng_sessiond_unit_file_t:service all_service_perms;
+
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/lttng-tools.te
+++ b/lttng-tools.te
@@ -1,0 +1,64 @@
+policy_module(lttng-tools, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type lttng_sessiond_t;
+type lttng_sessiond_exec_t;
+init_daemon_domain(lttng_sessiond_t, lttng_sessiond_exec_t)
+
+type lttng_sessiond_tmpfs_t;
+files_tmpfs_file(lttng_sessiond_tmpfs_t)
+
+type lttng_sessiond_var_run_t;
+files_pid_file(lttng_sessiond_var_run_t)
+
+type lttng_sessiond_unit_file_t;
+systemd_unit_file(lttng_sessiond_unit_file_t)
+
+########################################
+#
+# lttng_sessiond local policy
+#
+
+allow lttng_sessiond_t self:capability { chown setgid setuid fsetid net_admin sys_resource };
+
+allow lttng_sessiond_t self:process { setrlimit signal_perms };
+allow lttng_sessiond_t self:fifo_file rw_fifo_file_perms;
+allow lttng_sessiond_t self:tcp_socket listen;
+allow lttng_sessiond_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_dirs_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
+manage_files_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
+manage_lnk_files_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
+manage_sock_files_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
+files_pid_filetrans(lttng_sessiond_t, lttng_sessiond_var_run_t, { dir })
+
+manage_dirs_pattern(lttng_sessiond_t, lttng_sessiond_tmpfs_t, lttng_sessiond_tmpfs_t)
+manage_files_pattern(lttng_sessiond_t, lttng_sessiond_tmpfs_t, lttng_sessiond_tmpfs_t)
+fs_tmpfs_filetrans(lttng_sessiond_t, lttng_sessiond_tmpfs_t, { dir file })
+
+kernel_read_system_state(lttng_sessiond_t)
+kernel_read_net_sysctls(lttng_sessiond_t)
+kernel_read_fs_sysctls(lttng_sessiond_t)
+
+corecmd_exec_shell(lttng_sessiond_t)
+
+corenet_tcp_bind_generic_node(lttng_sessiond_t)
+corenet_tcp_bind_lltng_port(lttng_sessiond_t)
+
+dev_read_sysfs(lttng_sessiond_t)
+
+fs_getattr_tmpfs(lttng_sessiond_t)
+
+auth_use_nsswitch(lttng_sessiond_t)
+
+modutils_exec_insmod(lttng_sessiond_t)
+modutils_read_module_config(lttng_sessiond_t)
+files_read_kernel_modules(lttng_sessiond_t)
+
+miscfiles_read_localization(lttng_sessiond_t)
+
+sysnet_dns_name_resolve(lttng_sessiond_t)

--- a/lttng-tools.te
+++ b/lttng-tools.te
@@ -58,7 +58,3 @@ auth_use_nsswitch(lttng_sessiond_t)
 modutils_exec_insmod(lttng_sessiond_t)
 modutils_read_module_config(lttng_sessiond_t)
 files_read_kernel_modules(lttng_sessiond_t)
-
-miscfiles_read_localization(lttng_sessiond_t)
-
-sysnet_dns_name_resolve(lttng_sessiond_t)


### PR DESCRIPTION
A new policy for lttng-sessiond daemon. It creates /dev/shm/lttng-ust-wait-5 which is accessed by random services using lttng for kernel tracing.

This is an initial policy to have labeling for dev/shm/lttng-ust-wait-5  and to identify consumers (like Ceph for example).