### PR TITLE
virt: add strict policy for virtlogd daemon

### DIFF
--- a/virt.fc
+++ b/virt.fc
@@ -14,10 +14,12 @@ HOME_DIR/\.local/share/libvirt/images(/.*)? gen_context(system_u:object_r:svirt_
 HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_home_t,s0)
 
 /etc/libvirt		-d	gen_context(system_u:object_r:virt_etc_t,s0)
+/etc/libvirt/virtlogd.conf --   gen_context(system_u:object_r:virtlogd_etc_t,s0)
 /etc/libvirt/[^/]*	--	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/libvirt/[^/]*	-d	gen_context(system_u:object_r:virt_etc_rw_t,s0)
 /etc/libvirt/.*/.*		gen_context(system_u:object_r:virt_etc_rw_t,s0)
 /etc/rc\.d/init\.d/libvirtd --	gen_context(system_u:object_r:virtd_initrc_exec_t,s0)
+/etc/rc\.d/init\.d/virtlogd --  gen_context(system_u:object_r:virtlogd_initrc_exec_t,s0)
 /etc/xen		-d	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/xen/[^/]*		--	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/xen/[^/]*		-d	gen_context(system_u:object_r:virt_etc_rw_t,s0)
@@ -29,7 +31,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/sbin/libvirt-qmf	--	gen_context(system_u:object_r:virt_qmf_exec_t,s0)
 /usr/sbin/libvirtd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtlockd --  gen_context(system_u:object_r:virtd_exec_t,s0)
-/usr/sbin/virtlogd --  gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtlogd --  gen_context(system_u:object_r:virtlogd_exec_t,s0)
 /usr/bin/virt-who   --  gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/bin/virsh		--	gen_context(system_u:object_r:virsh_exec_t,s0)
 /usr/sbin/condor_vm-gahp	--	gen_context(system_u:object_r:virtd_exec_t,s0)
@@ -49,9 +51,11 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /var/log/libvirt(/.*)?		gen_context(system_u:object_r:virt_log_t,s0)
 /var/log/vdsm(/.*)?		gen_context(system_u:object_r:virt_log_t,s0)
 /var/run/libvirtd\.pid	--	gen_context(system_u:object_r:virt_var_run_t,s0)
+/var/run/virtlogd\.pid	--	gen_context(system_u:object_r:virtlogd_var_run_t,s0)
 /var/run/libvirt(/.*)?		gen_context(system_u:object_r:virt_var_run_t,s0)
 /var/run/libvirt/qemu(/.*)? 	gen_context(system_u:object_r:qemu_var_run_t,s0-mls_systemhigh)
 /var/run/libvirt/lxc(/.*)?	gen_context(system_u:object_r:virt_lxc_var_run_t,s0)
+/var/run/libvirt/virtlogd-sock	gen_context(system_u:object_r:virtlogd_var_run_t,s0)
 /var/run/libvirt-sandbox(/.*)?	gen_context(system_u:object_r:virt_lxc_var_run_t,s0)
 /var/run/vdsm(/.*)?		gen_context(system_u:object_r:virt_var_run_t,s0)
 
@@ -88,6 +92,9 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /var/run/qemu-ga/fsfreeze-hook.d(/.*)?      gen_context(system_u:object_r:virt_qemu_ga_unconfined_exec_t,s0)
 
 /usr/libexec/qemu-ga(/.*)?	gen_context(system_u:object_r:virt_qemu_ga_exec_t,s0)
+
+/usr/lib/systemd/system/virtlogd\.service --	gen_context(system_u:object_r:virtlogd_unit_file_t,s0)
+/usr/lib/systemd/system/virtlogd\.socket --	gen_context(system_u:object_r:virtlogd_unit_file_t,s0)
 
 /usr/lib/systemd/system/virt.*\.service -- gen_context(system_u:object_r:virtd_unit_file_t,s0)
 /usr/lib/systemd/system/libvirt.*\.service -- gen_context(system_u:object_r:virtd_unit_file_t,s0)

--- a/virt.if
+++ b/virt.if
@@ -85,6 +85,8 @@ template(`virt_domain_template',`
 
 	allow $1_t $1_devpts_t:chr_file { rw_chr_file_perms setattr_chr_file_perms };
 	term_create_pty($1_t, $1_devpts_t)
+
+	virtlogd_log_write($1_t)
 ')
 
 ########################################
@@ -1554,4 +1556,51 @@ interface(`virt_dbus_chat',`
         allow $1 virtd_t:dbus send_msg;
         allow virtd_t $1:dbus send_msg;
         ps_process_pattern(virtd_t, $1)
+')
+
+
+########################################
+## <summary>
+##      Connect to the virtlogd daemon RPC socket
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`virtlogd_connect', `
+        gen_require(`
+	        type virtlogd_t, virtlogd_var_run_t;
+	')
+
+        # Allow domain to look in /var/run
+        files_search_pids($1)
+	# and connect to /var/run/libvirt/virtlogd-sock
+	stream_connect_pattern($1, virtlogd_var_run_t, virtlogd_var_run_t, virtlogd_t)
+
+        # Allow virtlogd to look at /proc/$PID/status
+	# to authenticate the connecting client
+	allow virtlogd_t $1:dir search;
+	allow virtlogd_t $1:file { open read };
+')
+
+
+########################################
+## <summary>
+##      Write to log pipes created by virtlogd
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed to log.
+##      </summary>
+## </param>
+#
+interface(`virtlogd_log_write', `
+        gen_require(`
+	        type virtlogd_t;
+	')
+
+	# Allow domain to write to pipes connected to virtlogd
+        allow $1 virtlogd_t:fifo_file write;
 ')

--- a/virt.te
+++ b/virt.te
@@ -20,6 +20,7 @@ attribute svirt_file_type;
 attribute virt_file_type;
 attribute sandbox_net_domain;
 attribute sandbox_caps_domain;
+attribute virtlog_file_type;
 
 type svirt_tmp_t, svirt_file_type;
 files_tmp_file(svirt_tmp_t)
@@ -238,6 +239,19 @@ init_script_file(virtd_initrc_exec_t)
 type virtd_keytab_t;
 files_type(virtd_keytab_t)
 
+type virtlogd_t, virtlog_file_type;
+type virtlogd_exec_t, virtlog_file_type;
+init_daemon_domain(virtlogd_t, virtlogd_exec_t)
+type virtlogd_var_run_t, virtlog_file_type;
+type virtlogd_etc_t, virtlog_file_type;
+
+type virtlogd_unit_file_t, virtlog_file_type;
+systemd_unit_file(virtlogd_unit_file_t)
+
+type virtlogd_initrc_exec_t, virtlog_file_type;
+init_script_file(virtlogd_initrc_exec_t)
+
+
 type qemu_var_run_t, virt_file_type;
 typealias qemu_var_run_t alias svirt_var_run_t;
 files_pid_file(qemu_var_run_t)
@@ -245,10 +259,12 @@ mls_trusted_object(qemu_var_run_t)
 
 ifdef(`enable_mcs',`
 	init_ranged_daemon_domain(virtd_t, virtd_exec_t, s0 - mcs_systemhigh)
+	init_ranged_daemon_domain(virtlogd_t, virtlogd_exec_t, s0 - mcs_systemhigh)
 ')
 
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(virtd_t, virtd_exec_t, s0 - mls_systemhigh)
+	init_ranged_daemon_domain(virtlogd_t, virtlogd_exec_t, s0 - mls_systemhigh)
 ')
 
 type virt_qmf_t, virt_system_domain;
@@ -431,6 +447,9 @@ manage_files_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t)
 filetrans_pattern(virtd_t, virt_var_run_t, virt_lxc_var_run_t, dir, "lxc")
 allow virtd_t virt_lxc_var_run_t:file { relabelfrom relabelto };
 stream_connect_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t, virtd_lxc_t)
+
+# libvirtd is permitted to talk to virtlogd
+virtlogd_connect(virtd_t)
 
 kernel_read_system_state(virtd_t)
 kernel_read_network_state(virtd_t)
@@ -691,6 +710,47 @@ optional_policy(`
 optional_policy(`
 	unconfined_domain(virtd_t)
 ')
+
+########################################
+#
+# virtd local policy
+#
+
+# virtlogd is allowed to manage files it creates in /var/run
+manage_files_pattern(virtlogd_t, virtlogd_var_run_t, virtlogd_var_run_t)
+
+# virtlogd needs to read /etc/libvirt/virtlogd.conf only
+files_config_file(virtlogd_etc_t)
+allow virtlogd_t virtlogd_etc_t:file read_file_perms;
+files_search_etc(virtlogd_t)
+allow virtlogd_t virt_etc_t:dir search;
+
+# virtlogd creates /var/run/libvirt/virtlogd-sock with isolated
+# context from other stuff in /var/run/libvirt
+filetrans_pattern(virtlogd_t, virt_var_run_t, virtlogd_var_run_t, { dir file sock_file })
+
+# virtlogd creates a /var/run/virtlogd.pid file
+files_pid_file(virtlogd_var_run_t)
+manage_dirs_pattern(virtlogd_t, virtlogd_var_run_t, virtlogd_var_run_t)
+manage_files_pattern(virtlogd_t, virtlogd_var_run_t, virtlogd_var_run_t)
+manage_sock_files_pattern(virtlogd_t, virtlogd_var_run_t, virtlogd_var_run_t)
+files_pid_filetrans(virtlogd_t, virtlogd_var_run_t, { dir file sock_file })
+
+kernel_read_network_state(virtlogd_t)
+
+allow virtlogd_t self:unix_stream_socket { connectto create_stream_socket_perms relabelfrom relabelto };
+
+dev_read_sysfs(virtlogd_t)
+
+logging_send_syslog_msg(virtlogd_t)
+logging_stream_connect_syslog(virtlogd_t)
+
+auth_use_nsswitch(virtlogd_t)
+
+manage_files_pattern(virtlogd_t, virt_log_t, virt_log_t)
+
+allow svirt_t virtlogd_t:fifo_file write;
+
 
 ########################################
 #


### PR DESCRIPTION
The virtlogd daemon is currently given the same context as
libvirtd. This is essentially unrestricted host access which
is not at all desirable. The virtlogd daemon is a small single
purpose daemon whose only job is logging. It should have a
dedicated context which strictly controls what it is permitted
todo.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>