### PR TITLE
virt: add strict policy for virtlogd daemon

### DIFF
--- a/virt.fc
+++ b/virt.fc
@@ -14,10 +14,12 @@ HOME_DIR/\.local/share/libvirt/images(/.*)? gen_context(system_u:object_r:svirt_
 HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_home_t,s0)
 
 /etc/libvirt		-d	gen_context(system_u:object_r:virt_etc_t,s0)
+/etc/libvirt/virtlogd.conf --   gen_context(system_u:object_r:virtlogd_etc_t,s0)
 /etc/libvirt/[^/]*	--	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/libvirt/[^/]*	-d	gen_context(system_u:object_r:virt_etc_rw_t,s0)
 /etc/libvirt/.*/.*		gen_context(system_u:object_r:virt_etc_rw_t,s0)
 /etc/rc\.d/init\.d/libvirtd --	gen_context(system_u:object_r:virtd_initrc_exec_t,s0)
+/etc/rc\.d/init\.d/virtlogd --  gen_context(system_u:object_r:virtlogd_initrc_exec_t,s0)
 /etc/xen		-d	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/xen/[^/]*		--	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/xen/[^/]*		-d	gen_context(system_u:object_r:virt_etc_rw_t,s0)
@@ -29,7 +31,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/sbin/libvirt-qmf	--	gen_context(system_u:object_r:virt_qmf_exec_t,s0)
 /usr/sbin/libvirtd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtlockd --  gen_context(system_u:object_r:virtd_exec_t,s0)
-/usr/sbin/virtlogd --  gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtlogd --  gen_context(system_u:object_r:virtlogd_exec_t,s0)
 /usr/bin/virt-who   --  gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/bin/virsh		--	gen_context(system_u:object_r:virsh_exec_t,s0)
 /usr/sbin/condor_vm-gahp	--	gen_context(system_u:object_r:virtd_exec_t,s0)
@@ -49,9 +51,11 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /var/log/libvirt(/.*)?		gen_context(system_u:object_r:virt_log_t,s0)
 /var/log/vdsm(/.*)?		gen_context(system_u:object_r:virt_log_t,s0)
 /var/run/libvirtd\.pid	--	gen_context(system_u:object_r:virt_var_run_t,s0)
+/var/run/virtlogd\.pid	--	gen_context(system_u:object_r:virtlogd_var_run_t,s0)
 /var/run/libvirt(/.*)?		gen_context(system_u:object_r:virt_var_run_t,s0)
 /var/run/libvirt/qemu(/.*)? 	gen_context(system_u:object_r:qemu_var_run_t,s0-mls_systemhigh)
 /var/run/libvirt/lxc(/.*)?	gen_context(system_u:object_r:virt_lxc_var_run_t,s0)
+/var/run/libvirt/virtlogd-sock	gen_context(system_u:object_r:virtlogd_var_run_t,s0)
 /var/run/libvirt-sandbox(/.*)?	gen_context(system_u:object_r:virt_lxc_var_run_t,s0)
 /var/run/vdsm(/.*)?		gen_context(system_u:object_r:virt_var_run_t,s0)
 
@@ -88,6 +92,8 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /var/run/qemu-ga/fsfreeze-hook.d(/.*)?      gen_context(system_u:object_r:virt_qemu_ga_unconfined_exec_t,s0)
 
 /usr/libexec/qemu-ga(/.*)?	gen_context(system_u:object_r:virt_qemu_ga_exec_t,s0)
+
+/usr/lib/systemd/system/*virtlogd.*	gen_context(system_u:object_r:virtlogd_unit_file_t,s0)
 
 /usr/lib/systemd/system/virt.*\.service -- gen_context(system_u:object_r:virtd_unit_file_t,s0)
 /usr/lib/systemd/system/libvirt.*\.service -- gen_context(system_u:object_r:virtd_unit_file_t,s0)

--- a/virt.if
+++ b/virt.if
@@ -65,6 +65,7 @@ template(`virt_domain_template',`
 		attribute virt_tmpfs_type;
 		attribute virt_ptynode;
 		type qemu_exec_t;
+		type virtlogd_t;
 	')
 
 	type $1_t, virt_domain;
@@ -85,6 +86,10 @@ template(`virt_domain_template',`
 
 	allow $1_t $1_devpts_t:chr_file { rw_chr_file_perms setattr_chr_file_perms };
 	term_create_pty($1_t, $1_devpts_t)
+
+	# Allow domain to write to pipes connected to virtlogd
+	allow $1_t virtlogd_t:fd use;
+	allow $1_t virtlogd_t:fifo_file rw_inherited_fifo_file_perms;
 ')
 
 ########################################

--- a/virt.te
+++ b/virt.te
@@ -238,6 +238,19 @@ init_script_file(virtd_initrc_exec_t)
 type virtd_keytab_t;
 files_type(virtd_keytab_t)
 
+type virtlogd_t;
+type virtlogd_exec_t;
+init_daemon_domain(virtlogd_t, virtlogd_exec_t)
+type virtlogd_var_run_t;
+type virtlogd_etc_t;
+
+type virtlogd_unit_file_t;
+systemd_unit_file(virtlogd_unit_file_t)
+
+type virtlogd_initrc_exec_t;
+init_script_file(virtlogd_initrc_exec_t)
+
+
 type qemu_var_run_t, virt_file_type;
 typealias qemu_var_run_t alias svirt_var_run_t;
 files_pid_file(qemu_var_run_t)
@@ -245,10 +258,12 @@ mls_trusted_object(qemu_var_run_t)
 
 ifdef(`enable_mcs',`
 	init_ranged_daemon_domain(virtd_t, virtd_exec_t, s0 - mcs_systemhigh)
+	init_ranged_daemon_domain(virtlogd_t, virtlogd_exec_t, s0 - mcs_systemhigh)
 ')
 
 ifdef(`enable_mls',`
 	init_ranged_daemon_domain(virtd_t, virtd_exec_t, s0 - mls_systemhigh)
+	init_ranged_daemon_domain(virtlogd_t, virtlogd_exec_t, s0 - mls_systemhigh)
 ')
 
 type virt_qmf_t, virt_system_domain;
@@ -431,6 +446,10 @@ manage_files_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t)
 filetrans_pattern(virtd_t, virt_var_run_t, virt_lxc_var_run_t, dir, "lxc")
 allow virtd_t virt_lxc_var_run_t:file { relabelfrom relabelto };
 stream_connect_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t, virtd_lxc_t)
+
+# libvirtd is permitted to talk to virtlogd
+stream_connect_pattern(virtd_t, virt_var_run_t, virtlogd_var_run_t, virtlogd_t)
+
 
 kernel_read_system_state(virtd_t)
 kernel_read_network_state(virtd_t)
@@ -691,6 +710,51 @@ optional_policy(`
 optional_policy(`
 	unconfined_domain(virtd_t)
 ')
+
+########################################
+#
+# virtlogd local policy
+#
+
+# virtlogd is allowed to manage files it creates in /var/run/libvirt
+manage_files_pattern(virtlogd_t, virt_var_run_t, virtlogd_var_run_t)
+
+# virtlogd needs to read /etc/libvirt/virtlogd.conf only
+files_config_file(virtlogd_etc_t)
+allow virtlogd_t virtlogd_etc_t:file read_file_perms;
+files_search_etc(virtlogd_t)
+allow virtlogd_t virt_etc_t:dir search;
+
+# virtlogd creates /var/run/libvirt/virtlogd-sock with isolated
+# context from other stuff in /var/run/libvirt
+filetrans_pattern(virtlogd_t, virt_var_run_t, virtlogd_var_run_t, { sock_file })
+# This lets systemd create the socket itself too
+files_pid_file(virtlogd_var_run_t)
+
+# virtlogd creates a /var/run/virtlogd.pid file
+allow virtlogd_t virtlogd_var_run_t:file manage_file_perms;
+manage_sock_files_pattern(virtlogd_t, virt_var_run_t, virtlogd_var_run_t)
+files_pid_filetrans(virtlogd_t, virtlogd_var_run_t, file)
+
+kernel_read_network_state(virtlogd_t)
+
+allow virtlogd_t self:unix_stream_socket create_stream_socket_perms;
+
+dev_read_sysfs(virtlogd_t)
+
+logging_send_syslog_msg(virtlogd_t)
+
+auth_use_nsswitch(virtlogd_t)
+
+manage_files_pattern(virtlogd_t, virt_log_t, virt_log_t)
+
+
+# Allow virtlogd to look at /proc/$PID/status
+# to authenticate the connecting libvirtd
+allow virtlogd_t virtd_t:dir list_dir_perms;
+allow virtlogd_t virtd_t:file read_file_perms;
+allow virtlogd_t virtd_t:lnk_file read_lnk_file_perms;
+
 
 ########################################
 #


### PR DESCRIPTION
The virtlogd daemon is currently given the same context as
libvirtd. This is essentially unrestricted host access which
is not at all desirable. The virtlogd daemon is a small single
purpose daemon whose only job is logging. It should have a
dedicated context which strictly controls what it is permitted
todo.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>