### PR TITLE
Fixed to make SELinux work with docker and prctl(NO_NEW_PRIVS)

### DIFF
--- a/virt.if
+++ b/virt.if
@@ -882,6 +882,24 @@ interface(`virt_exec_sandbox_files',`
 	can_exec($1, svirt_sandbox_file_t)
 ')
 
+########################################
+## <summary>
+##	Allow any svirt_sandbox_file_t to be an entrypoint of this domain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`virt_sandbox_entrypoint',`
+	gen_require(`
+		type svirt_sandbox_file_t;
+	')
+	allow $1 svirt_sandbox_file_t:file entrypoint;
+')
+
 #######################################
 ## <summary>
 ##	Read Sandbox Files


### PR DESCRIPTION
We need the following policy

optional_policy(`
	require {
		type svirt_lxc_net_t;
		type unconfined_t;
	}
	virt_stub_svirt_sandbox_file()
	allow unconfined_t svirt_sandbox_file_t:file entrypoint;
	allow docker_t svirt_sandbox_file_t:file entrypoint;
	typebounds unconfined_t docker_t;
	typebounds docker_t svirt_lxc_net_t;
')