### PR TITLE
Fixed to make SELinux work with docker and prctl(NO_NEW_PRIVS)

### DIFF
--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -687,3 +687,22 @@ interface(`unconfined_transition',`
 	allow unconfined_t $2:file entrypoint;
 	allow $1 unconfined_t:process signal_perms;
 ')
+
+########################################
+## <summary>
+##	unconfined_t domain typebounds calling domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain to be typebound.
+## </summary>
+## </param>
+#
+interface(`unconfined_typebounds',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	typebounds unconfined_t $1;
+')
+

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -193,6 +193,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	docker_entrypoint(unconfined_t)
+')
+
+optional_policy(`
 	dbus_role_template(unconfined, unconfined_r, unconfined_t)
 	role system_r types unconfined_dbusd_t;
 
@@ -328,6 +332,7 @@ optional_policy(`
 optional_policy(`
 	virt_transition_svirt(unconfined_t, unconfined_r)
 	virt_transition_svirt_sandbox(unconfined_t, unconfined_r)
+	virt_sandbox_entrypoint(unconfined_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
We need the following policy

optional_policy(`
        require {
                type svirt_lxc_net_t;
                type unconfined_t;
        }
        virt_stub_svirt_sandbox_file()
        allow unconfined_t svirt_sandbox_file_t:file entrypoint;
        allow docker_t svirt_sandbox_file_t:file entrypoint;
        typebounds unconfined_t docker_t;
        typebounds docker_t svirt_lxc_net_t;
')