### PR TITLE
Allow reading resolvconf when it is a symlink.

### DIFF
--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -442,6 +442,7 @@ interface(`sysnet_read_config',`
 
 	files_search_etc($1)
 	allow $1 net_conf_t:file read_file_perms;
+	allow $1 net_conf_t:lnk_file read_lnk_file_perms;
 
 	ifdef(`distro_debian',`
 		files_search_pids($1)


### PR DESCRIPTION
/etc/resolv.conf is a symlink on current Fedora Rawhide. This
commit will allow the sysnet_dns_name_resolve() policy to continue
to read the file as a symlink.

https://bugzilla.redhat.com/show_bug.cgi?id=1166071#c7