### PR TITLE
Allow resolvconf links into NetworkManager.

### DIFF
--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -454,6 +454,7 @@ interface(`sysnet_read_config',`
         init_search_pid_dirs($1)
 		allow $1 net_conf_t:dir list_dir_perms;
 		allow $1 net_conf_t:lnk_file read_lnk_file_perms;
+		allow $1 NetworkManager_var_run_t:dir list_dir_perms;
 		read_files_pattern($1, net_conf_t, net_conf_t)
 	')
 ')


### PR DESCRIPTION
/etc/resolv.conf is a symlink into NetworkManager-labeled paths
on current Fedora Rawhide. This commit will allow the
sysnet_dns_name_resolve() policy to continue to read the file.

Here is an example AVC denial that I experienced when a confined
Celery process from the Pulp project tried to read the
/etc/resolv.conf symlink:

```
type=AVC msg=audit(1458145202.837:220): avc:  denied  { search } for  pid=796 comm="celery" name="NetworkManager" dev="tmpfs" ino=20694 scontext=system_u:system_r:celery_t:s0 tcontext=system_u:object_r:NetworkManager_var_run_t:s0 tclass=dir permissive=1
```