### PR TITLE
Allow rkt to run out of systemd unit files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1409,6 +1409,7 @@ optional_policy(`
 	virt_stream_connect(init_t)
 	virt_noatsecure(init_t)
 	virt_rlimitinh(init_t)
+	virt_transition_svirt_sandbox(init_t, system_r)
 ')
 
 optional_policy(`
@@ -1416,6 +1417,7 @@ optional_policy(`
 	virt_manage_cache(initrc_t)
 	virt_manage_lib_files(initrc_t)
 	virt_stream_connect(initrc_t)
+	virt_transition_svirt_sandbox(initrc_t, system_r)
 ')
 
 # Cron jobs used to start and stop services


### PR DESCRIPTION
When running rkt it will transition to svirt_lxc_net_t
for confined containers, these transitions will allow
you to run rkt as a system service.