### PR TITLE
Label all nvidia binaries as xserver_exec_t

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -104,6 +104,7 @@ HOME_DIR/\.dmrc.*	--	gen_context(system_u:object_r:xdm_home_t,s0)
 /usr/bin/Xorg		--	gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/bin/Xvnc		--	gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/bin/x11vnc		--	gen_context(system_u:object_r:xserver_exec_t,s0)
+/usr/bin/nvidia.*	--	gen_context(system_u:object_r:xserver_exec_t,s0)
 
 /usr/libexec/Xorg\.bin  --  gen_context(system_u:object_r:xserver_exec_t,s0)   
 /usr/libexec/Xorg\.wrap  --  gen_context(system_u:object_r:xserver_exec_t,s0)


### PR DESCRIPTION
Changing this will cause all /dev/nvidia* devices get created with the i
correct label.