### PR TITLE
Allow modemmanager to talk to logind

### DIFF
--- a/modemmanager.te
+++ b/modemmanager.te
@@ -63,3 +63,7 @@ optional_policy(`
 	udev_read_db(modemmanager_t)
 	udev_manage_pid_files(modemmanager_t)
 ')
+
+optional_policy(`
+	systemd_dbus_chat_logind(modemmanager_t)
+')


### PR DESCRIPTION
ModemManager uses logind's sleep inhibitor capability.

avc:  denied { send_msg } for msgtype=method_call
      in exe="/usr/bin/dbus-daemon" sauid=81
      hostname=? addr=? terminal=?