### PR TITLE
dnsmasq: allow NetworkManager to control dnsmasq via D-Bus

### DIFF
--- a/dnsmasq.if
+++ b/dnsmasq.if
@@ -405,3 +405,26 @@ interface(`dnsmasq_admin',`
 	admin_pattern($1, dnsmasq_unit_file_t)
 	allow $1 dnsmasq_unit_file_t:service all_service_perms;
 ')
+
+########################################
+## <summary>
+##	Send and receive messages from
+##	dnsmasq over dbus.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dnsmasq_dbus_chat',`
+	gen_require(`
+		type dnsmasq_t;
+		class dbus send_msg;
+	')
+
+	allow $1 dnsmasq_t:dbus send_msg;
+	allow dnsmasq_t $1:dbus send_msg;
+')
+
+

--- a/dnsmasq.te
+++ b/dnsmasq.te
@@ -111,6 +111,10 @@ optional_policy(`
 optional_policy(`
 	dbus_connect_system_bus(dnsmasq_t)
 	dbus_system_bus_client(dnsmasq_t)
+
+	optional_policy(`
+		networkmanager_dbus_chat(dnsmasq_t)
+	')
 ')
 
 optional_policy(`

--- a/networkmanager.te
+++ b/networkmanager.te
@@ -270,6 +270,7 @@ optional_policy(`
 
 optional_policy(`
 	dnsmasq_read_pid_files(NetworkManager_t)
+	dnsmasq_dbus_chat(NetworkManager_t)
 	dnsmasq_delete_pid_files(NetworkManager_t)
 	dnsmasq_domtrans(NetworkManager_t)
 	dnsmasq_initrc_domtrans(NetworkManager_t)


### PR DESCRIPTION
Since bug https://bugzilla.gnome.org/show_bug.cgi?id=765043,
NetworkManager will control dnsmasq via its D-Bus interface
instead of re-starting the process with static configuration.

  type=USER_AVC msg=audit(1461325861.280:1477): pid=1099 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=signal interface=org.freedesktop.NetworkManager.dnsmasq member=Up dest=org.freedesktop.DBus spid=11580 tpid=11540 scontext=system_u:system_r:dnsmasq_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'
  type=USER_AVC msg=audit(1461325861.463:1478): pid=1099 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_call interface=org.freedesktop.DBus.Properties member=GetAll dest=:1.389 spid=11540 tpid=11580 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:dnsmasq_t:s0 tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'
  type=USER_AVC msg=audit(1461325861.500:1479): pid=1099 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_call interface=org.freedesktop.NetworkManager.dnsmasq member=SetServersEx dest=:1.389 spid=11540 tpid=11580 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:dnsmasq_t:s0 tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'
  type=USER_AVC msg=audit(1461326190.521:1499): pid=1099 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=signal interface=org.freedesktop.NetworkManager.dnsmasq member=Up dest=org.freedesktop.DBus spid=12250 tpid=12211 scontext=system_u:system_r:dnsmasq_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'
  type=USER_AVC msg=audit(1461326190.700:1500): pid=1099 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_call interface=org.freedesktop.DBus.Properties member=GetAll dest=:1.400 spid=12211 tpid=12250 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:dnsmasq_t:s0 tclass=dbus  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'