### PR TITLE
unlabeled_t can not be an entrypoint.

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -8565,8 +8565,9 @@ interface(`files_rw_all_inherited_files',`
 interface(`files_entrypoint_all_files',`
 	gen_require(`
 		attribute file_type;
+		type unlabeled_t;
 	')
-	allow $1 file_type:file entrypoint;
+	allow $1 {file_type -unlabeled_t} :file entrypoint;
 ')
 
 ########################################


### PR DESCRIPTION
Since it is a file_type we need to remove from this line.