### PR TITLE
Additional access required for unconfined domains

### DIFF
--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -374,3 +374,5 @@ allow devices_unconfined_type self:capability sys_rawio;
 allow devices_unconfined_type device_node:{ blk_file lnk_file } *;
 allow devices_unconfined_type device_node:{ file chr_file } ~{ execmod entrypoint };
 allow devices_unconfined_type mtrr_device_t:file ~{ execmod entrypoint };
+dev_getattr_all(devices_unconfined_type)
+

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -495,7 +495,7 @@ allow kern_unconfined proc_type:{ file } ~entrypoint;
 allow kern_unconfined proc_type:{ dir lnk_file } *;
 
 allow kern_unconfined sysctl_type:{ file } ~entrypoint;
-allow kern_unconfined sysctl_type:{ dir } *;
+allow kern_unconfined sysctl_type:{ dir lnk_file } *;
 
 allow kern_unconfined kernel_t:system *;
 


### PR DESCRIPTION
Allow unconfined domains to getattr on all device-node objects
Allow unconfined domains full access to systclt_type lnk_files.

type-bounds checks are giving errors on this since docker_t is allowed
this access.