### PR TITLE
Allow tmpreaper_t to read/setattr all non_security_file_type dirs

### DIFF
--- a/tmpreaper.te
+++ b/tmpreaper.te
@@ -59,10 +59,7 @@ fs_delete_tmpfs_files(tmpreaper_t)
 files_read_var_lib_files(tmpreaper_t)
 files_purge_tmp(tmpreaper_t)
 files_delete_all_non_security_files(tmpreaper_t)
-# why does it need setattr?
-files_setattr_all_tmp_dirs(tmpreaper_t)
-files_setattr_isid_type_dirs(tmpreaper_t)
-files_setattr_usr_dirs(tmpreaper_t)
+files_setattr_non_security_dirs(tmpreaper_t)
 files_getattr_all_dirs(tmpreaper_t)
 files_getattr_all_files(tmpreaper_t)
 


### PR DESCRIPTION
problem
----------
tmpwatch fails to delete files in directories without read and setattr rights wenn started from cron.

findings
----------
* It already allows setattr on some but not on all.
* tmpreaper_t already has the ability to delete all non_security_file_type files.
*  Having the ability to delete files of this type but not reading directories of the same type seems wrong.

solution
----------
allow `tmpreaper_t` permissions `read` and `setattr` on all `non_security_file_type directories`.

reproduced on
-------------------
RHEL7, Fedora 23

fix (basic) tested on
-------------------------
RHEL7, Fedora 23

reproduction steps
------------------------
```
mkdir /var/log/test; touch --date "2015-01-01" /var/log/test/test.log; ls -lZ /var/log/test/test.log
# Test cronjob:
echo '* * * * * root /usr/sbin/tmpwatch "-m" 10d /var/log/test' >/etc/cron.d/tmpwatch_read_setattr_dir_test
aureport --avc --start recent
```