### PR TITLE
User Namespace is requires create on process domains

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -236,7 +236,7 @@ allow unconfined_domain_type domain:msg { send receive };
 
 # For /proc/pid
 allow unconfined_domain_type domain:dir list_dir_perms;
-allow unconfined_domain_type domain:file rw_file_perms;
+allow unconfined_domain_type domain:file manage_file_perms;
 allow unconfined_domain_type domain:lnk_file { read_lnk_file_perms ioctl lock };
 
 # act on all domains keys

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -27,7 +27,7 @@ interface(`unconfined_domain_noaudit',`
 	allow $1 self:process { dyntransition transition };
 
 	# Write access is for setting attributes under /proc/self/attr.
-	allow $1 self:file rw_file_perms;
+	allow $1 self:file manage_file_perms;
 	allow $1 self:dir rw_dir_perms;
 
 	# Userland object managers

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -141,6 +141,7 @@ dontaudit unpriv_userdomain self:rawip_socket create_socket_perms;
 # Nautilus causes this avc
 domain_dontaudit_access_check(unpriv_userdomain)
 dontaudit unpriv_userdomain self:dir setattr;
+allow unpriv_userdomain self:file manage_file_perms;
 allow unpriv_userdomain self:key manage_key_perms;
 
 mount_dontaudit_write_mount_pid(unpriv_userdomain)


### PR DESCRIPTION
Need to allow user domains to have create so that tools like crome will
work correctly.  Probably future use cases as well.