### PR TITLE
Rawhide fails to boot, systemd-logind needs to config transient confi…

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1450,6 +1450,25 @@ interface(`init_config_all_script_files',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain to modify the systemd configuration of 
+##	transient scripts.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_config_transient_files',`
+	gen_require(`
+		attribute init_var_run_t;
+	')
+
+	allow $1 init_var_run_t:service all_service_perms;
+')
+
+########################################
+## <summary>
 ##	Read all init script files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -227,6 +227,7 @@ init_undefined(systemd_logind_t)
 init_signal_script(systemd_logind_t)
 init_getattr_script_status_files(systemd_logind_t)
 init_read_utmp(systemd_logind_t)
+init_config_transient_files(systemd_logind_t)
 
 getty_systemctl(systemd_logind_t)
 


### PR DESCRIPTION
…g files

New AVC's caused by systemd-login changes attempting to configure transient
unit files.  Without this change rawhide does not boot in enforcing mode.