### PR TITLE
Allow puppet_t transtition to shorewall_t

### DIFF
--- a/puppet.te
+++ b/puppet.te
@@ -205,6 +205,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+        shorewall_domtrans(puppetagent_t)
+')
+
+optional_policy(`
     unconfined_domain_noaudit(puppetagent_t)
 ')
 


### PR DESCRIPTION
If puppet executes /sbin/shorewall it won't transition to
shorewall_t and create log files with puppet_log_t context
instead of shorewall_log_t. If service is then managed by
init (sysv/systemd) it will fail to start.

If puppet_t is allowed to transtition to shorewall_t the
logfile will get the correct shorewall_log_t type.

Adapted from TresysTechnology/refpolicy-contrib commit
ea5a6aa58e0d545e812c234ee28dc4d259fa2e77 and
11576979ca3306042abe008aa4b5df6a95c111dd