### PR TITLE
Container processes need to be able to listen on rawip sockets

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -1868,7 +1868,7 @@ allow sandbox_net_domain self:tcp_socket create_stream_socket_perms;
 allow sandbox_net_domain self:netlink_route_socket create_netlink_socket_perms;
 allow sandbox_net_domain self:packet_socket create_socket_perms;
 allow sandbox_net_domain self:socket create_socket_perms;
-allow sandbox_net_domain self:rawip_socket create_socket_perms;
+allow sandbox_net_domain self:rawip_socket create_stream_socket_perms;
 allow sandbox_net_domain self:netlink_kobject_uevent_socket create_socket_perms;
 
 corenet_tcp_bind_generic_node(sandbox_net_domain)


### PR DESCRIPTION
"Customer is reporting that any SCTP connections inside a container are failing,
due to an error in recvmsg(). "

https://bugzilla.redhat.com/show_bug.cgi?id=1349956