### PR TITLE
Allow upsdrvctl to read udevd device table

### DIFF
--- a/nut.te
+++ b/nut.te
@@ -127,6 +127,8 @@ dev_rw_generic_usb_dev(nut_upsdrvctl_t)
 term_use_unallocated_ttys(nut_upsdrvctl_t)
 term_use_usb_ttys(nut_upsdrvctl_t)
 
+udev_read_db(nut_upsdrvctl_t)
+
 init_sigchld(nut_upsdrvctl_t)
 
 #######################################

--- a/nut.te
+++ b/nut.te
@@ -127,9 +127,11 @@ dev_rw_generic_usb_dev(nut_upsdrvctl_t)
 term_use_unallocated_ttys(nut_upsdrvctl_t)
 term_use_usb_ttys(nut_upsdrvctl_t)
 
-udev_read_db(nut_upsdrvctl_t)
-
 init_sigchld(nut_upsdrvctl_t)
+
+optional_policy(`
+	udev_read_db(nut_upsdrvctl_t)
+')
 
 #######################################
 #


### PR DESCRIPTION
Fixes the following (still present on f24, rawhide) https://bugzilla.redhat.com/show_bug.cgi?id=1297163

AVCs:

```
Jun 27 14:12:45 catarina systemd[1]: Starting Network UPS Tools - power device driver controller...
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:129" dev="tmpfs" ino=17628 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:257" dev="tmpfs" ino=16662 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:258" dev="tmpfs" ino=14895 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:0" dev="tmpfs" ino=14725 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:128" dev="tmpfs" ino=17502 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:256" dev="tmpfs" ino=16547 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:384" dev="tmpfs" ino=15635 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="c189:512" dev="tmpfs" ino=15633 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:3-0:1.0" dev="tmpfs" ino=16548 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:3-1:1.0" dev="tmpfs" ino=16663 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:3-2:1.0" dev="tmpfs" ino=14896 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:4-0:1.0" dev="tmpfs" ino=14727 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:5-0:1.0" dev="tmpfs" ino=16549 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:1-0:1.0" dev="tmpfs" ino=15636 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:2-0:1.0" dev="tmpfs" ino=14726 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
Jun 27 14:12:45 catarina audit[5281]: AVC avc:  denied  { read } for  pid=5281 comm="blazer_usb" name="+usb:2-1:1.0" dev="tmpfs" ino=17629 scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0
```