### PR TITLE
sysadmin should be allowed to use docker.

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -84,6 +84,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	docker_stream_connect(sysadm_t)
+')
+
+optional_policy(`
 	ssh_filetrans_admin_home_content(sysadm_t)
 	ssh_filetrans_keys(sysadm_t)
 ')


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1253582