### PR TITLE
Add support for user namespace

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -215,6 +215,7 @@ optional_policy(`
 # be used on an attribute.
 
 # Use/sendto/connectto sockets created by any domain.
+allow unconfined_domain_type self:cap_userns all_cap_userns_perms;
 allow unconfined_domain_type domain:{ socket_class_set socket key_socket } *;
 
 allow unconfined_domain_type domain:system all_system_perms;

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -148,6 +148,7 @@ ifdef(`enable_mls',`
 # Use capabilities. old rule:
 allow init_t self:capability ~{ audit_control audit_write sys_module };
 allow init_t self:capability2 ~{ mac_admin mac_override };
+allow init_t self:cap_userns all_cap_userns_perms;
 allow init_t self:tcp_socket { listen accept };
 allow init_t self:packet_socket create_socket_perms;
 allow init_t self:key manage_key_perms;

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -832,6 +832,7 @@ logging_send_syslog_msg(systemd_sysctl_t)
 #
 # systemd_coredump domains
 #
+allow systemd_coredump_t self:cap_userns sys_ptrace;
 
 manage_files_pattern(systemd_coredump_t, systemd_coredump_tmpfs_t, systemd_coredump_tmpfs_t)
 fs_tmpfs_filetrans(systemd_coredump_t, systemd_coredump_tmpfs_t, file )


### PR DESCRIPTION
Unconfined domains should have the same access to userns capabilties as
they do to real capabilities.

Userdomains that can execute chrome need sys_admin sys_chroot
sys_ptrace capabilities, they probbaly will need more,
but I don't know for sure.