### PR TITLE
Allow users to transition from unconfined_t to container types

### DIFF
--- a/sandbox.te
+++ b/sandbox.te
@@ -63,3 +63,7 @@ fs_dontaudit_getattr_all_fs(sandbox_domain)
 userdom_use_inherited_user_terminals(sandbox_domain)
 
 mta_dontaudit_read_spool_symlinks(sandbox_domain)
+
+optional_policy(`
+	unconfined_typebounds(sandbox_domain)
+')

--- a/sandboxX.te
+++ b/sandboxX.te
@@ -506,3 +506,6 @@ optional_policy(`
 ')
 userdom_dontaudit_open_user_ptys(sandbox_x_domain)
 
+optional_policy(`
+	unconfined_typebounds(sandbox_x_domain)
+')

--- a/virt.te
+++ b/virt.te
@@ -1460,6 +1460,7 @@ tunable_policy(`virt_sandbox_use_fusefs',`
 ')
 
 optional_policy(`
+    container_typebounds(svirt_sandbox_domain)
     container_read_share_files(svirt_sandbox_domain)
     container_exec_share_files(svirt_sandbox_domain)
     container_lib_filetrans(svirt_sandbox_domain,container_image_t, sock_file)


### PR DESCRIPTION
If we do this using docker or bubblewrap using the NO_NEW_PRIVS
the transition will fail, this change allows the containers to transition.