### PR TITLE
unconfined_exec_t typebound all exec_type

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -108,6 +108,10 @@ interface(`domain_entry_file',`
 	typeattribute $2 entry_type;
 
 	corecmd_executable_file($2)
+
+	optional_policy(`
+		unconfined_exec_typebounds($2)
+	')
 ')
 
 ########################################

--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -725,3 +725,21 @@ interface(`unconfined_typebounds',`
 	typebounds unconfined_t $1;
 ')
 
+########################################
+## <summary>
+##	unconfined_exec_t domain typebounds file_type.
+## </summary>
+## <param name="domain">
+## <summary>
+##	File type to be typebound.
+## </summary>
+## </param>
+#
+interface(`unconfined_exec_typebounds',`
+	gen_require(`
+		type unconfined_exec_t;
+	')
+
+	typebounds unconfined_exec_t $1;
+')
+


### PR DESCRIPTION
Need these rules to allow unconfined domains to transiton to sandbox
domains over all entrypoints
