### PR TITLE
systemd is doing a gettattr on blk and chr devices in /run

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -193,6 +193,8 @@ manage_fifo_files_pattern(init_t, init_var_run_t, init_var_run_t)
 files_pid_filetrans(init_t, init_var_run_t, { dir file })
 allow init_t init_var_run_t:dir mounton;
 allow init_t init_var_run_t:sock_file relabelto;
+allow init_t init_var_run_t:blk_file getattr;
+allow init_t init_var_run_t:chr_file getattr;
 
 allow init_t machineid_t:file manage_file_perms;
 files_pid_filetrans(init_t, machineid_t, file, "machine-id")


### PR DESCRIPTION
Looks like devices created during boot are in /run/systemd/inaccessible/blk
/run/systemd/inaccessible/chr

ls -l /run/systemd/inaccessible/
total 0
b---------. 1 root root 0, 0 Aug  7 06:07 blk
c---------. 1 root root 0, 0 Aug  7 06:07 chr
d---------. 2 root root   40 Aug  7 06:07 dir
p---------. 1 root root    0 Aug  7 06:07 fifo
----------. 1 root root    0 Aug  7 06:07 reg
s---------. 1 root root    0 Aug  7 06:07 sock

Maybe could dontaudit these, but getattr access is probably ok.