### PR TITLE
init_domain should identify types as a daemon

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -136,6 +136,24 @@ interface(`init_domain',`
 
 ########################################
 ## <summary>
+##	Define the specify domain as a daemin
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Type to be used as a domain.
+##	</summary>
+## </param>
+#
+interface(`init_daemon',`
+	gen_require(`
+		attribute daemon;
+	')
+
+	typeattribute $1 daemon;
+')
+
+########################################
+## <summary>
 ##	Create a domain which can be started by init,
 ##	with a range transition.
 ## </summary>

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -19,6 +19,8 @@ role unconfined_r types unconfined_service_t;
 corecmd_bin_entry_type(unconfined_service_t)
 corecmd_shell_entry_type(unconfined_service_t)
 
+init_daemon(unconfined_service_t)
+
 optional_policy(`
 	rpm_transition_script(unconfined_service_t, system_r)
 ')


### PR DESCRIPTION
We need rules that allow init_t to impersonate types createing sockets

We also want to allow init_t to impersonate unconfined_service_t socket.
