### PR TITLE
Allow system_dbusd to list sandbox dirs

### DIFF
--- a/dbus.te
+++ b/dbus.te
@@ -213,6 +213,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	virt_list_sandbox_dirs(system_dbusd_t)
+')
+
+optional_policy(`
 	# /var/lib/gdm/.local/share/icc/edid-0a027915105823af34f99b1704e80336.icc
 	xserver_read_inherited_xdm_lib_files(system_dbusd_t)
 ')

--- a/virt.if
+++ b/virt.if
@@ -907,6 +907,24 @@ interface(`virt_sandbox_entrypoint',`
 
 #######################################
 ## <summary>
+##	List Sandbox Dirs
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_list_sandbox_dirs',`
+	gen_require(`
+		type svirt_sandbox_file_t;
+	')
+
+	list_dirs_pattern($1, svirt_sandbox_file_t, svirt_sandbox_file_t)
+')
+
+#######################################
+## <summary>
 ##	Read Sandbox Files
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
When running a systemd container, we want to list the contents of the journal.
This is done using a command like

journalctl -M CONTAINERUUID

Which causes and avc when system dbus examines the content of the /var/log/journal inside of the container.