### PR TITLE
Allow domains that can use the cups socket to read it also.

### DIFF
--- a/cups.if
+++ b/cups.if
@@ -70,6 +70,7 @@ interface(`cups_stream_connect',`
 
 	files_search_pids($1)
 	stream_connect_pattern($1, cupsd_var_run_t, cupsd_var_run_t, cupsd_t)
+	allow $1 cupsd_var_run_t:sock_file read_sock_file_perms;
 ')
 
 ########################################

--- a/cups.te
+++ b/cups.te
@@ -175,6 +175,7 @@ manage_lnk_files_pattern(cupsd_t, cupsd_var_lib_t, cupsd_var_lib_t)
 
 manage_dirs_pattern(cupsd_t, cupsd_tmp_t, cupsd_tmp_t)
 manage_files_pattern(cupsd_t, cupsd_tmp_t, cupsd_tmp_t)
+manage_lnk_files_pattern(cupsd_t, cupsd_tmp_t, cupsd_tmp_t)
 manage_fifo_files_pattern(cupsd_t, cupsd_tmp_t, cupsd_tmp_t)
 files_tmp_filetrans(cupsd_t, cupsd_tmp_t, { dir fifo_file file })
 


### PR DESCRIPTION
Seems that you need to read cups socket now to get list of printers.