### PR TITLE
Add boolean to allow sandbox domains to mount nfs

### DIFF
--- a/virt.te
+++ b/virt.te
@@ -1447,6 +1447,9 @@ tunable_policy(`virt_use_nfs',`
 	fs_manage_nfs_files(svirt_sandbox_domain)
 	fs_manage_nfs_named_sockets(svirt_sandbox_domain)
 	fs_manage_nfs_symlinks(svirt_sandbox_domain)
+	fs_mount_nfs(svirt_sandbox_domain)
+	fs_unmount_nfs(svirt_sandbox_domain)
+	kernel_rw_fs_sysctls(svirt_sandbox_domain)
 ')
 
 tunable_policy(`virt_use_samba',`
@@ -1484,7 +1487,6 @@ dontaudit container_t self:capability fsetid;
 dontaudit container_t self:capability2  block_suspend ;
 allow container_t self:process { execstack execmem };
 manage_chr_files_pattern(container_t, container_file_t, container_file_t)
-kernel_load_module(container_t)
 
 tunable_policy(`virt_sandbox_use_sys_admin',`
 	allow container_t self:capability sys_admin;

--- a/virt.te
+++ b/virt.te
@@ -1463,6 +1463,8 @@ tunable_policy(`virt_sandbox_use_fusefs',`
     fs_manage_fusefs_dirs(svirt_sandbox_domain)
     fs_manage_fusefs_files(svirt_sandbox_domain)
     fs_manage_fusefs_symlinks(svirt_sandbox_domain)
+    fs_mount_fusefs(svirt_sandbox_domain)
+    fs_unmount_fusefs(svirt_sandbox_domain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Customers have requested management of NFS Shares from
a confined domain.

Also we should not allow a confined domain to load kernel modules.
