### PR TITLE
Make init able to mount on tor_var_log_t and tor_var_lib_t

### DIFF
--- a/tor.te
+++ b/tor.te
@@ -40,6 +40,8 @@ type tor_var_run_t;
 files_pid_file(tor_var_run_t)
 init_daemon_run_dir(tor_var_run_t, "tor")
 files_mountpoint(tor_var_run_t)
+files_mountpoint(tor_var_lib_t)
+files_mountpoint(tor_var_log_t)
 
 type tor_unit_file_t;
 systemd_unit_file(tor_unit_file_t)


### PR DESCRIPTION
Should fix #1357395, modeled on fix for #1368621
