### PR TITLE
Add systemd_mount_dir to deal with service using ReadOnlyDirectory

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -403,6 +403,10 @@ optional_policy(`
 	mta_manage_aliases(init_t)
 ')
 
+optional_policy(`
+    systemd_allow_mount_dir(init_t)
+')
+
 allow init_t self:system all_system_perms;
 allow init_t self:unix_dgram_socket { create_socket_perms sendto };
 allow init_t self:process { setkeycreate setsockcreate setfscreate setrlimit setexec };

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1761,3 +1761,43 @@ interface(`systemd_hwdb_manage_config',`
 	allow $1 systemd_hwdb_etc_t:file {relabelfrom relabelto};
 	files_etc_filetrans($1, systemd_hwdb_etc_t, file)
 ')
+
+########################################
+## <summary>
+##	Allow process to mount directory configured in a
+##  systemd unit as ReadWriteDirectory or ReadOnlyDirectory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`systemd_allow_mount_dir',`
+    gen_require(`
+        attribute systemd_mount_directory;
+    ')
+
+    allow $1 systemd_mount_directory:dir mounton;
+')
+
+########################################
+## <summary>
+##	Mark the following type as mountable by systemd.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type to be authorized to be mounted
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`systemd_mount_dir',`
+    gen_require(`
+        attribute systemd_mount_directory;
+    ')
+
+    files_type($1)
+    typeattribute $1 systemd_mount_directory;
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -8,6 +8,7 @@ policy_module(systemd, 1.0.0)
 attribute systemd_unit_file_type;
 attribute systemd_domain;
 attribute systemctl_domain;
+attribute systemd_mount_directory;
 
 systemd_domain_template(systemd_logger)
 systemd_domain_template(systemd_logind)


### PR DESCRIPTION
Based on feedback from https://github.com/fedora-selinux/selinux-policy/pull/156
by Dominic Grift.