### PR TITLE
These allow rules are requiered to allow chrome to setup user namespace

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -4606,6 +4606,24 @@ interface(`fs_associate_ramfs',`
 
 ########################################
 ## <summary>
+##	Allow the type to associate to proc filesystems.
+## </summary>
+## <param name="type">
+##	<summary>
+##	The type of the object to be associated.
+##	</summary>
+## </param>
+#
+interface(`fs_associate_proc',`
+	gen_require(`
+		type procs_t;
+	')
+
+	allow $1 proc_t:filesystem associate;
+')
+
+########################################
+## <summary>
 ##	Mount a RAM filesystem.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1195,7 +1195,11 @@ template(`userdom_restricted_xwindows_user_template',`
 	#
 	# Local policy
 	#
+	allow $1_usertype self:cap_userns { sys_admin sys_chroot };
+	allow $1_usertype self:dir { add_name write };
+
 	kernel_stream_connect($1_usertype)
+	fs_associate_proc($1_usertype)
 
 	dev_read_sound($1_usertype)
 	dev_write_sound($1_usertype)
@@ -1211,6 +1215,7 @@ template(`userdom_restricted_xwindows_user_template',`
 	libs_dontaudit_setattr_lib_files($1_usertype)
 
 	init_read_state($1_usertype)
+	init_signal($1_usertype)
 
 	tunable_policy(`selinuxuser_rw_noexattrfile',`
 		dev_rw_usbfs($1_t)


### PR DESCRIPTION
Otherwise chrome crashes when run from staff_t.