### PR TITLE
Add a boolean to enable the use of dac_override

### DIFF
--- a/tor.te
+++ b/tor.te
@@ -20,6 +20,13 @@ gen_tunable(tor_bind_all_unreserved_ports, false)
 ## </desc>
 gen_tunable(tor_can_network_relay, false)
 
+## <desc>
+## <p>
+## Allow tor to run onion services
+## </p>
+## </desc>
+gen_tunable(tor_can_onion_services, false)
+
 type tor_t;
 type tor_exec_t;
 init_daemon_domain(tor_t, tor_exec_t)
@@ -127,6 +134,10 @@ tunable_policy(`tor_can_network_relay',`
     # allow httpd to work as a relay
 	corenet_tcp_connect_all_ephemeral_ports(tor_t)
 	corenet_tcp_bind_http_port(tor_t)
+')
+
+tunable_policy(`tor_can_onion_services',`
+    allow tor_t self:capability { dac_read_search dac_override };
 ')
 
 optional_policy(`


### PR DESCRIPTION
This is needed for tor onion services, as seen on
https://bugzilla.redhat.com/show_bug.cgi?id=1392187