### PR TITLE
Allow samba to manage lnk_files with samba_share_fusefs boolean

### DIFF
--- a/samba.te
+++ b/samba.te
@@ -475,6 +475,7 @@ tunable_policy(`samba_share_nfs',`
 tunable_policy(`samba_share_fusefs',`
 	fs_manage_fusefs_dirs(smbd_t)
 	fs_manage_fusefs_files(smbd_t)
+	fs_manage_fusefs_symlinks(smbd_t)
 ',`
 	fs_search_fusefs(smbd_t)
 ')


### PR DESCRIPTION
Right now samba only can manage files and directory but no
symlinks.

This allows smbd_t to also manage lnk_files aka symlinks.