### PR TITLE
Allow firewalld to getattr open search read modules_object_t:dir

### DIFF
--- a/firewalld.te
+++ b/firewalld.te
@@ -69,6 +69,8 @@ kernel_read_network_state(firewalld_t)
 kernel_read_system_state(firewalld_t)
 kernel_rw_net_sysctls(firewalld_t)
 
+files_list_kernel_modules(firewalld_t)
+
 corecmd_exec_bin(firewalld_t)
 corecmd_exec_shell(firewalld_t)
 


### PR DESCRIPTION
This is needed for secure use of netfilter connection tracking helpers.

There is no interface in netfilter to get the list of supported netfilter
connection tracking modules and the helpers they provide. To be able to know
which are usable with the active kernel, firewalld needs to be able to list
the directory "/lib/modules/$(uname -r)/kernel/net/netfilter/" and use
modinfo on the modules that start with "nf_conntrack_" to get the helpers.