### PR TITLE
Allow puppetagent_t to access timedated dbus

### DIFF
--- a/puppet.te
+++ b/puppet.te
@@ -350,6 +350,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_dbus_chat_timedated(puppetagent_t)
 	systemd_dbus_chat_timedated(puppetmaster_t)
 ')
 


### PR DESCRIPTION
Running a puppet exec resource with timedatectl as
command, auditd logs this error:

```
type=USER_AVC
  msg=audit(11/21/2016 15:04:49.306:59375) :
  pid=741
  uid=dbus auid=unset ses=unset
  subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
  msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.1421 spid=31613 tpid=31615
  scontext=system_u:system_r:systemd_timedated_t:s0
  tcontext=system_u:system_r:puppetagent_t:s0
  tclass=dbus
  exe=/usr/bin/dbus-daemon sauid=dbus
  hostname=? addr=? terminal=?'
```

Use the systemd_dbus_chat_timedated interface to allow
puppetagent_t the access.