### PR TITLE
Allow systemd to send user information back to pid1. BZ(1412750)

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -3356,7 +3356,7 @@ interface(`kernel_stream_write',`
 #######################################
 ## <summary>
 ##  Allow the specified domain to read/write on 
-##  the kernel with a unix socket.
+##  the kernel with a unix stream socket.
 ## </summary>
 ## <param name="domain">
 ##  <summary>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -212,7 +212,8 @@ allow init_t initrc_var_run_t:file { rw_file_perms setattr };
 
 kernel_read_system_state(init_t)
 kernel_share_state(init_t)
-kernel_stream_connect(init_t)
+kernel_rw_stream_socket_perms(init_t)
+kernel_rw_unix_dgram_sockets(init_t)
 kernel_mounton_systemd_ProtectKernelTunables(init_t)
 
 corecmd_exec_chroot(init_t)


### PR DESCRIPTION
Added to systemd in https://github.com/systemd/systemd/commit/00d9ef8560.