### PR TITLE
Restore connecto permssions for init_t

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -212,6 +212,7 @@ allow init_t initrc_var_run_t:file { rw_file_perms setattr };
 
 kernel_read_system_state(init_t)
 kernel_share_state(init_t)
+kernel_stream_connect(init_t)
 kernel_rw_stream_socket_perms(init_t)
 kernel_rw_unix_dgram_sockets(init_t)
 kernel_mounton_systemd_ProtectKernelTunables(init_t)


### PR DESCRIPTION
Fixup for 8279b91986. I thought that kernel_rw_stream_socket_perms
is a superset of kernel_stream_connect, but apparently not:

type=AVC msg=audit(1486044204.161:366): avc:  denied  { connectto } for  pid=2846 comm="(spatcher)" path="/run/systemd/journal/stdout" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0

https://bugzilla.redhat.com/show_bug.cgi?id=1418682