### PR TITLE
Backport coredumpctl fix into f24

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1692,3 +1692,22 @@ interface(`domain_dontaudit_access_check',`
 
 	dontaudit $1 domain:dir_file_class_set audit_access;
 ')
+
+########################################
+## <summary>
+##	Allow set resource limits to all domains.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`domain_setrlimit_all_domains',`
+	gen_require(`
+		attribute domain;
+	')
+
+	allow $1 domain:process setrlimit;
+')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -233,6 +233,7 @@ domain_sigstop_all_domains(init_t)
 domain_sigchld_all_domains(init_t)
 domain_read_all_domains_state(init_t)
 domain_getattr_all_domains(init_t)
+domain_setrlimit_all_domains(init_t)
 
 files_read_config_files(init_t)
 files_read_all_pids(init_t)


### PR DESCRIPTION
This was fixed by allowing init_t to setrlimit on all `domain`s, but the issue has been reported against F24 and was never fixed.  Lukas' f25 patches apply cleanly to the f24 tree.

https://bugzilla.redhat.com/show_bug.cgi?id=1341829#c36