### PR TITLE
get the correct cert_t context on certbot certificates bz#1289778

### DIFF
--- a/policy/modules/system/miscfiles.fc
+++ b/policy/modules/system/miscfiles.fc
@@ -15,6 +15,7 @@ ifdef(`distro_gentoo',`
 /etc/locale.conf	--	gen_context(system_u:object_r:locale_t,s0)
 /etc/pki(/.*)?			gen_context(system_u:object_r:cert_t,s0)
 /etc/ssl(/.*)?			gen_context(system_u:object_r:cert_t,s0)
+/etc/(letsencrypt|certbot)/(live|archive)(/.*)?			gen_context(system_u:object_r:cert_t,s0)
 /etc/ipa/nssdb(/.*)?			gen_context(system_u:object_r:cert_t,s0)
 /etc/timezone		--	gen_context(system_u:object_r:locale_t,s0)
 /etc/vconsole.conf	--	gen_context(system_u:object_r:locale_t,s0)


### PR DESCRIPTION
The certbot (formally letsencrypt which is why it still has that as a default config directory which I hope to change some day soon) stores the certificates it generates in /etc/letsencrypt/(live|archive/).* 

There's no policy in place to get these the correct type at present so users/admins are having to manually label, or to copy to /etc/pki/tls/{certs,private}/ or to add their own local policies.

This is a blocker for many with simple automated renewal of certificates.

This PR adds labelling for these directories (and their contents) as cert_t so that httpd_t and similar can read them out the box and renewals work as expected.
