### PR TITLE
Allow applications that execute file system types to have map accessx

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -103,6 +103,7 @@ interface(`fs_exec_noxattr',`
 		attribute noxattrfs;
 	')
 
+	allow $1 noxattrfs:file map;
 	can_exec($1, noxattrfs)
 ')
 
@@ -1555,6 +1556,7 @@ interface(`fs_exec_cifs_files',`
 		type cifs_t;
 	')
 
+	allow $1 cifs_t:file map;
 	allow $1 cifs_t:dir list_dir_perms;
 	exec_files_pattern($1, cifs_t, cifs_t)
 ')
@@ -2490,6 +2492,7 @@ interface(`fs_exec_fusefs_files',`
 		type fusefs_t;
 	')
 
+	allow $1 fusefs_t:file map;
 	exec_files_pattern($1, fusefs_t, fusefs_t)
 ')
 
@@ -2796,7 +2799,8 @@ interface(`fs_exec_hugetlbfs_files',`
 		type hugetlbfs_t;
 	')
 
-    allow $1 hugetlbfs_t:dir list_dir_perms;
+	allow $1 hugetlbfs_t:file map;
+	allow $1 hugetlbfs_t:dir list_dir_perms;
 	exec_files_pattern($1, hugetlbfs_t, hugetlbfs_t)
 ')
 
@@ -3699,6 +3703,7 @@ interface(`fs_exec_nfs_files',`
 		type nfs_t;
 	')
 
+	allow $1 nfs_t:file map;
 	allow $1 nfs_t:dir list_dir_perms;
 	exec_files_pattern($1, nfs_t, nfs_t)
 ')
@@ -6004,6 +6009,7 @@ interface(`fs_exec_tmpfs_files',`
 		type tmpfs_t;
 	')
 
+	allow $1 tmpfs_t:file map;
 	exec_files_pattern($1, tmpfs_t, tmpfs_t)
 ')
 


### PR DESCRIPTION
Bash is triggering map errors on fileystems when programs trying to
exec scripts.