### PR TITLE
Fixes: xenconsole does not start

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -220,6 +220,7 @@ ifdef(`distro_suse', `
 /dev/xen/gntdev		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/gntalloc	-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/privcmd	-c	gen_context(system_u:object_r:xen_device_t,s0)
+/dev/xen/xenbus		-c	gen_context(system_u:object_r:xen_device_t,s0)
 
 ifdef(`distro_debian',`
 # this is a static /dev dir "backup mount"

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5848,6 +5848,7 @@ interface(`dev_rw_xen',`
 	')
 
 	rw_chr_files_pattern($1, device_t, xen_device_t)
+	allow $1 xen_device_t:chr_file map;
 ')
 
 ########################################
@@ -7020,6 +7021,7 @@ gen_require(`
 	filetrans_pattern($1, device_t, xen_device_t, chr_file, "gntdev")
 	filetrans_pattern($1, device_t, xen_device_t, chr_file, "gntalloc")
 	filetrans_pattern($1, device_t, xen_device_t, chr_file, "privcmd")
+	filetrans_pattern($1, device_t, xen_device_t, chr_file, "xenbus")
 	filetrans_pattern($1, device_t, sound_device_t, chr_file, "controlC0")
 	filetrans_pattern($1, device_t, sound_device_t, chr_file, "controlC1")
 	filetrans_pattern($1, device_t, sound_device_t, chr_file, "controlC2")


### PR DESCRIPTION
Two things were missing:
 - The map functionality, and
 - Accessing /dev/xen/xenbus by xenconsoled

This fixes RHBZ#1484908.

Signed-off-by: Konrad Rzeszutek Wilk <konrad@kernel.org>

P.S.
Also patches had been posted upstream:
http://oss.tresys.com/pipermail/refpolicy/2017-October/010133.html
http://oss.tresys.com/pipermail/refpolicy/2017-October/010134.html