### PR TITLE
Fixes for containers

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1640,6 +1640,7 @@ interface(`domain_unconfined',`
 	mcs_process_set_categories($1)
 
 	userdom_filetrans_home_content($1)
+	domain_named_filetrans($1)
 ')
 
 ########################################

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -37,6 +37,7 @@ systemd_unit_file(iptables_unit_file_t)
 #
 
 allow iptables_t self:capability { dac_read_search  net_admin net_raw };
+allow iptables_t self:cap_userns { dac_read_search  net_admin net_raw };
 dontaudit iptables_t self:capability sys_tty_config;
 allow iptables_t self:fifo_file rw_fifo_file_perms;
 allow iptables_t self:process { sigchld sigkill sigstop signull signal };


### PR DESCRIPTION
We now need iptables to work in a user namespace.
We need content labeled correctly when run by unconfined domains.