### PR TITLE
kernel/files.fc: Label /usr/lib/sysimage as usr_t

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -231,6 +231,9 @@ ifdef(`distro_redhat',`
 
 /usr/share/doc(/.*)?/README.*	gen_context(system_u:object_r:usr_t,s0)
 
+# http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html
+/usr/lib/sysimage(/.*)?			gen_context(system_u:object_r:usr_t,s0)
+
 /usr/tmp		-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /usr/tmp/.*			<<none>>
 


### PR DESCRIPTION
Moved from: https://github.com/fedora-selinux/selinux-policy-contrib/pull/43

This ensures that hardlinking works with `/usr/share/rpm` (once the
contrib patch to make it `usr_t` is merged too).

See https://bugzilla.redhat.com/show_bug.cgi?id=1526191
https://github.com/projectatomic/rpm-ostree/pull/959#issuecomment-325780234
https://github.com/projectatomic/rpm-ostree/pull/1142