### PR TITLE
Consistently label usr_t for kernel/initrd in /usr

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -219,6 +219,14 @@ ifdef(`distro_redhat',`
 /export(/.*)?			gen_context(system_u:object_r:usr_t,s0)
 /ostree(/.*)?           gen_context(system_u:object_r:usr_t,s0)
 
+# Note the Fedora kernel moved to /usr/lib/modules.  This also relates
+# to(rpm-)ostree related stuff:
+# https://github.com/ostreedev/ostree/pull/1079
+# https://github.com/projectatomic/rpm-ostree/pull/959#issuecomment-325780234
+/usr/lib/ostree-boot(/.*)?                gen_context(system_u:object_r:usr_t,s0)
+/usr/lib/modules(/.*)/vmlinuz         -- 	gen_context(system_u:object_r:usr_t,s0)
+/usr/lib/modules(/.*)/initramfs.img   --	gen_context(system_u:object_r:usr_t,s0)
+
 /usr/doc(/.*)?/lib(/.*)?	gen_context(system_u:object_r:usr_t,s0)
 
 /usr/etc(/.*)?			gen_context(system_u:object_r:etc_t,s0)


### PR DESCRIPTION
A while ago the Fedora kernel packaging changed to add a copy in
`/usr/lib/modules`. Relatedly, on ostree-managed systems for historical reasons
we have the kernel in multiple locations. Unfortunately these locations have
different labels and hence can't be hardlinked. But there's no real reason to
have separate labels, so consolidate them.

For more information, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1526191

Note this will change the label of the kernel in `/usr` even
for "traditional" yum-managed systems, but IMO it's better
anyways as `vmlinuz` isn't really a module.