### PR TITLE
Allow init_t to create UNIX sockets for unconfined services (BZ1543049)

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -687,6 +687,7 @@ optional_policy(`
     unconfined_server_noatsecure(init_t)
     unconfined_server_create_tcp_sockets(init_t)
     unconfined_server_create_udp_sockets(init_t)
+    unconfined_server_create_unix_sockets(init_t)
 ')
 
 ########################################

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -317,3 +317,22 @@ interface(`unconfined_server_create_udp_sockets',`
 
 	allow $1 unconfined_service_t:udp_socket create_socket_perms;
 ')
+
+########################################
+## <summary>
+##	Create unconfined_service_t UNIX sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_server_create_unix_sockets',`
+	gen_require(`
+		type unconfined_service_t;
+	')
+
+	allow $1 unconfined_service_t:unix_stream_socket create_stream_socket_perms;
+	allow $1 unconfined_service_t:unix_dgram_socket create_socket_perms;
+')


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1543049

Please also backport to F27.