### PR TITLE
Allow local_login_t reads of udev_var_run_t context

### DIFF
--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -135,6 +135,7 @@ auth_use_nsswitch(local_login_t)
 init_dontaudit_use_fds(local_login_t)
 init_stream_connect(local_login_t)
 
+udev_read_db(local_login_t)
 
 userdom_spec_domtrans_all_users(local_login_t)
 userdom_signal_all_users(local_login_t)


### PR DESCRIPTION
When using YubiKey, the `login` process would deny user access as it was
unable to read information from udev_var_run_t files.

===============

This can be easily verified by adding the line
```
auth        sufficient      pam_u2f.so nouserok cue id=1 authfile=/etc/path_to_u2f_authfile
```
to `/etc/pam.d/system-auth` file on F27. Note that `/etc/path_to_u2f_authfile` is a path to the file with user-pubkeys mapping.

After this setting, you can go to a non-graphical tty and try to login.

Expected: you get prompted to touch your YubiKey
Actual (without this fix): you only get prompted for your password