### PR TITLE
Allow mmap of public_content_{,rw_}t in miscfiles_read_public_files() BZ(1572369)

### DIFF
--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -771,6 +771,7 @@ interface(`miscfiles_read_public_files',`
 	')
 
 	allow $1 { public_content_t public_content_rw_t }:dir list_dir_perms;
+	allow $1 { public_content_t public_content_rw_t }:file map;
 	read_files_pattern($1, { public_content_t public_content_rw_t }, { public_content_t public_content_rw_t })
 	read_lnk_files_pattern($1, { public_content_t public_content_rw_t }, { public_content_t public_content_rw_t })
 ')


### PR DESCRIPTION
As I mentioned in [BZ 1572369](https://bugzilla.redhat.com/show_bug.cgi?id=1572369), I'm not sure whether a more limited map interface for public_content_t is needed or if adding this to the existing miscfiles_read_public_files interface is reasonable.  Opinions from those more familiar with the mmap policies are most welcome.