### PR TITLE
Allow dhcpc_t creating own socket files inside /var/run/

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -71,7 +71,10 @@ allow dhcpc_t self:fifo_file rw_fifo_file_perms;
 allow dhcpc_t self:tcp_socket create_stream_socket_perms;
 allow dhcpc_t self:udp_socket create_socket_perms;
 allow dhcpc_t self:packet_socket create_socket_perms;
+allow dhcpc_t self:rawip_socket create_socket_perms;
+allow dhcpc_t self:netlink_generic_socket create_socket_perms;
 allow dhcpc_t self:netlink_route_socket { create_socket_perms nlmsg_read nlmsg_write };
+allow dhcpc_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 allow dhcpc_t dhcp_etc_t:dir list_dir_perms;
 read_lnk_files_pattern(dhcpc_t, dhcp_etc_t, dhcp_etc_t)
@@ -86,8 +89,9 @@ allow dhcpc_t dhcpc_state_t:file { map relabel_file_perms };
 
 # create pid file
 manage_files_pattern(dhcpc_t, dhcpc_var_run_t, dhcpc_var_run_t)
+manage_sock_files_pattern(dhcpc_t, dhcpc_var_run_t, dhcpc_var_run_t)
 create_dirs_pattern(dhcpc_t, dhcpc_var_run_t, dhcpc_var_run_t)
-files_pid_filetrans(dhcpc_t, dhcpc_var_run_t, { file dir })
+files_pid_filetrans(dhcpc_t, dhcpc_var_run_t, { file dir sock_file })
 
 # Allow read/write to /etc/resolv.conf and /etc/ntp.conf. Note that any files
 # in /etc created by dhcpcd will be labelled net_conf_t.


### PR DESCRIPTION
Allow dhcpc_t creating netlink_kobject_uevent_socket,
netlink_generic_socket, rawip_socket
BZ(1585971)