### PR TITLE
Allow unconfined_service_t to transition to container_runtime_t

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -30,3 +30,7 @@ optional_policy(`
 optional_policy(`
 	virt_transition_svirt(unconfined_service_t, system_r)
 ')
+
+optional_policy(`
+	container_runtime_domtrans(unconfined_service_t)
+')


### PR DESCRIPTION
I am seeing bugzillas where people are using lxc toold and having
problems with them transitioning properly.