### PR TITLE
Allow init_t to grab lock on /etc/.pwd.lock

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -607,6 +607,9 @@ create_sock_files_pattern(init_t, init_sock_file_type, init_sock_file_type)
 auth_use_nsswitch(init_t)
 auth_rw_login_records(init_t)
 auth_domtrans_chk_passwd(init_t)
+# Support for DynamicUser= requires grabbing a lock on /etc/.pwd.lock,
+# which is labeled with passwd_file_t, so we need this:
+auth_manage_passwd(init_t)
 
 ifdef(`distro_redhat',`
     # it comes from setupr scripts used in systemd unit files


### PR DESCRIPTION
This is required by the `DynamicUser=` feature of systemd 239, which grabs that lock to verify uniqueness of the users it's about to register through its NSS module.

This is maybe too coarse... But it's a bit hard to find a more fine grained solution that still works well with SELinux. See discussion in systemd/systemd#9583 for more details.

Tested: by installing this policy and starting a test service that has `DynamicUser=yes`, confirmed the user was properly created.

/cc @wrabcak @poettering
