### PR TITLE
Allow to remove duplicates related to defaul nsswitch modules

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -529,7 +529,6 @@ optional_policy(`
 	init_sigchld(domain)
 	init_signull(domain)
 	init_read_machineid(domain)
-    init_dbus_chat(domain)
 ')
 
 ifdef(`distro_redhat',`

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2205,6 +2205,7 @@ interface(`auth_dontaudit_getattr_passwd',`
 ########################################
 ## <summary>
 ##	Read the passwd passwords file (/etc/passwd)
+##	Allow to use sss nsswitch module for passwd and group.
 ##	Allow to use systemd nsswitch module for passwd and group
 ##	which is used for dynamic users.
 ## </summary>
@@ -2220,6 +2221,10 @@ interface(`auth_read_passwd',`
 	')
 
 	allow $1 passwd_file_t:file read_file_perms;
+	optional_policy(`
+		sssd_read_public_files($1)
+		sssd_stream_connect($1)
+	')
 	init_dbus_chat($1)
 ')
 

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2205,6 +2205,8 @@ interface(`auth_dontaudit_getattr_passwd',`
 ########################################
 ## <summary>
 ##	Read the passwd passwords file (/etc/passwd)
+##	Allow to use systemd nsswitch module for passwd and group
+##	which is used for dynamic users.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2218,6 +2220,7 @@ interface(`auth_read_passwd',`
 	')
 
 	allow $1 passwd_file_t:file read_file_perms;
+	init_dbus_chat($1)
 ')
 
 ########################################

--- a/policy/modules/system/netlabel.te
+++ b/policy/modules/system/netlabel.te
@@ -34,16 +34,10 @@ corecmd_exec_shell(netlabel_mgmt_t)
 
 files_read_etc_files(netlabel_mgmt_t)
 
-term_use_all_inherited_terms(netlabel_mgmt_t) 
+term_use_all_inherited_terms(netlabel_mgmt_t)
 
 seutil_use_newrole_fds(netlabel_mgmt_t)
 
 auth_read_passwd(netlabel_mgmt_t)
 
 userdom_use_inherited_user_terminals(netlabel_mgmt_t)
-
-optional_policy(`
-    sssd_stream_connect(netlabel_mgmt_t)
-    sssd_read_public_files(netlabel_mgmt_t)
-')
-


### PR DESCRIPTION
Most of explanation is in commit message itself.

And small simplification is also done in netlabel module. But later I tried to refactoring in selinux-policy-contrib and I realized that the macro `auth_use_nsswitch` needn't be the best place maybe `auth_read_passwd` is a better one for allowing *sss* and *systemd* nsswitch modules which are by default in `/etc/nsswitch` on fedora for some time.

@wrabcak please let me know which of these `auth*` related macros make more sense.

BTW `libnss_systemd.so` can be used just for `passwd/group` but `libnss_sss.so` can be also used for `services/netgroup/sudo/autofs`

But systemd-libs also contains `libnss_myhostname.so.2` and  `libnss_resolve.so.2` which can be used for `hosts` and it seems that they also communicate ower dbus

```
sh$ strings /usr/lib64/libnss_systemd.so.2  | grep system_bus_socket
unix:path=/run/dbus/system_bus_socket
,argv5=--machine/var/run/dbus/system_bus_socket

sh$ strings /usr/lib64/libnss_mymachines.so.2  | grep system_bus_socket
unix:path=/run/dbus/system_bus_socket
,argv5=--machine/var/run/dbus/system_bus_socket

sh$ strings /usr/lib64/libnss_resolve.so.2  | grep system_bus_socket
unix:path=/run/dbus/system_bus_socket
,argv5=--machine/var/run/dbus/system_bus_socket
```