### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/base.conf
+/base.fc
+/policy/modules/kernel/corenetwork.te
+/policy/modules/kernel/corenetwork.if
+/*.pp
+/tmp/


### PR DESCRIPTION
When following the Compiling instructions on the wiki, there are untracked files present in the working directory after compiling. This is simply an attempt to ignore them.