### PR TITLE
Document userdom_change_password_template() behaviour

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1035,6 +1035,7 @@ template(`userdom_login_user_template', `
 		')
 	')
 
+	# NOTE! This template also allows user to change shell.
 	userdom_change_password_template($1)
 
 	##############################

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -640,6 +640,9 @@ template(`userdom_xwindows_client_template',`
 #######################################
 ## <summary>
 ##	The template for allowing the user to change passwords.
+##	NOTE! This template also allows the user to change shell.
+##	If you want to only allow changing passwords, you should
+##	use usermanage_run_passwd() instead.
 ## </summary>
 ## <param name="userdomain_prefix">
 ##	<summary>


### PR DESCRIPTION
userdom_change_password_template() behaviour can cause unwanted
surprises for the caller. This template also allows the user to
change shell, because /usr/bin/chsh has file context:

  system_u:object_r:chfn_exec_t:s0

i.e. it is the same context that /usr/bin/chfn has.

We cannot change userdom_change_password_template() because
we do not want to break existing policies that may rely on current
behaviour. But we can improve the interface's documentation so that
everyone knows what to expect from this template.