### PR TITLE
Allow getattr as part of files_mounton_kernel_symbol_table.

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -162,7 +162,7 @@ files_search_base_file_types(domain)
 files_read_inherited_tmp_files(domain)
 files_append_inherited_tmp_files(domain)
 files_read_all_base_ro_files(domain)
-files_dontaduit_getattr_kernel_symbol_table(domain)
+files_dontaudit_getattr_kernel_symbol_table(domain)
 
 # All executables should be able to search the directory they are in
 corecmd_search_bin(domain)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6656,8 +6656,8 @@ interface(`files_mounton_kernel_symbol_table',`
 		type system_map_t;
 	')
 
-	allow $1 system_map_t:dir mounton;
-	allow $1 system_map_t:file mounton;
+	allow $1 system_map_t:dir { mounton getattr };
+	allow $1 system_map_t:file { mounton getattr };
 ')
 
 ########################################

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6594,7 +6594,7 @@ interface(`files_create_kernel_symbol_table',`
 ##	</summary>
 ## </param>
 #
-interface(`files_dontaduit_getattr_kernel_symbol_table',`
+interface(`files_dontaudit_getattr_kernel_symbol_table',`
 	gen_require(`
 		type system_map_t;
 	')


### PR DESCRIPTION
Allow `getattr` as part of `files_mounton_kernel_symbol_table`.

This makes it possible to resolve symbolic links on the target `/proc/kallsyms` before mounting over it.

systemd tries to follow symbolic links before mounting over proc files, when `ProtectKernelTunables=yes` is set.

This resolves issue systemd/systemd#10032.

Tested on Rawhide with systemd from trunk, by building new selinux-policy RPMs including this change and reproducing the issue with restart of systemd-hostnamed, which fails without this change.

cc @wrabcak -> Please take a look!

Thanks @sourcejedi for helping narrow this down to an SELinux `dontaudit` rule!
