### PR TITLE
kernel/files.fc: Label /run/motd.d(/.*)? as etc_t

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -299,6 +299,7 @@ ifndef(`distro_redhat',`
 /var/run/lock/.*		<<none>>
 
 /run/cockpit/motd	--	gen_context(system_u:object_r:etc_t,s0)
+/run/motd.d(/.*)?		gen_context(system_u:object_r:etc_t,s0)
 
 /var/spool(/.*)?		gen_context(system_u:object_r:var_spool_t,s0)
 /var/spool/postfix/etc(/.*)?	gen_context(system_u:object_r:etc_t,s0)


### PR DESCRIPTION
This is to allow sshd to read a motd file placed in this
directory.

**Reason**

The reason for this is to let packages that generate a motd
at runtime (e.g. cockpit-ws, greenboot) place the file
in `/run/motd.d/`, rather than in a package-specific
directory in `/run/` containing the motd. The files in
`/run/motd.d/` may then be symlinked from `/etc/motd.d/`
to have the message display on SSH login.

Will also help for
https://github.com/rfairley/fedora-coreos-login-messages
(see https://github.com/coreos/fedora-coreos-tracker/issues/36).

Also, if https://github.com/linux-pam/linux-pam/pull/69
lands, this will allow files to be placed directly into
`/run/motd.d/` (not symlinked) and be displayed on SSH
login. Then, `/run/motd` can be labelled.

**Testing/verification done**

On Fedora 28 Atomic, I have confirmed
```
semanage fcontext -a -t etc_t "/var/run/motd.d(/.*)?"
restorecon -Rv /var/run/motd.d
```
gives the desired behaviour.

**Alternatives**

An alternative label other than `etc_t` that would work
is `pam_var_run_t` - if this would be preferable to `etc_t`.

The other option is to give sshd permission to read
`var_run_t`, but I am not sure how acceptable this is:

```
#============= sshd_t ==============
allow sshd_t var_run_t:file read;
```
