### PR TITLE
kernel/files.fc: Label /run/motd as etc_t

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -299,6 +299,7 @@ ifndef(`distro_redhat',`
 /var/run/lock/.*		<<none>>
 
 /run/cockpit/motd	--	gen_context(system_u:object_r:etc_t,s0)
+/run/motd		--	gen_context(system_u:object_r:etc_t,s0)
 /run/motd.d(/.*)?		gen_context(system_u:object_r:etc_t,s0)
 
 /var/spool(/.*)?		gen_context(system_u:object_r:var_spool_t,s0)


### PR DESCRIPTION
This allows sshd to read /run/motd, with
upstream edits to PAM (https://github.com/linux-pam/linux-pam/pull/69).

---

Following up to https://github.com/fedora-selinux/selinux-policy/pull/230, this allows `/run/motd` to be read by `sshd` as well as `/run/motd.d`. This is so that changes in upstream PAM https://github.com/linux-pam/linux-pam/pull/69 (specifically the default behaviour of trying to display `/etc/motd`, `/run/motd`, then `/usr/lib/motd`) can take effect.

Related: Once the RPM patch at https://src.fedoraproject.org/rpms/pam/pull-request/5 lands, this can be used in Rawhide.

cc @dustymabe, @lucab, @LorbusChris feel free to review :)