### PR TITLE
Allow systemd-journald to be started with NoNewPrivileges=yes

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -91,6 +91,7 @@ files_config_file(syslog_conf_t)
 type syslogd_t;
 type syslogd_exec_t;
 init_daemon_domain(syslogd_t, syslogd_exec_t)
+init_nnp_daemon_domain(syslogd_t)
 mls_trusted_object(syslogd_t)
 
 type syslogd_initrc_exec_t;


### PR DESCRIPTION
Starting with systemd commit https://github.com/systemd/systemd/pull/10743/commits/cd10ab613b219852e1b322952bad6f4931a41aab (from PR https://github.com/systemd/systemd/pull/10743), many services including systemd-journald are started with `NoNewPrivileges=yes`, but that breaks unless the SELinux policy allows for it.

It turns out this wasn't yet allowed for systemd-journald, which runs under the `syslogd_t` SELinux type.

Fix that by calling `init_nnp_daemon_domain(syslogd_t)`.

Tested by rebuilding selinux-policy on Rawhide and booting the system with systemd from master and SELinux enabled.

cc @wrabcak 