### PR TITLE
Add new type systemd_timedated_var_lib_t for /var/lib/systemd/timesync/

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -627,6 +627,7 @@ systemd_map_resolved_exec_files(init_t)
 systemd_rfkill_setattr_lib(init_t)
 systemd_rfkill_mounton_var_lib(init_t)
 systemd_rfkill_manage_lib_dirs(init_t)
+systemd_timedated_manage_lib_dirs(init_t)
 
 create_sock_files_pattern(init_t, init_sock_file_type, init_sock_file_type)
 

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -66,6 +66,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/lib/machines(/.*)?			gen_context(system_u:object_r:systemd_machined_var_lib_t,s0)
 /var/lib/systemd/rfkill(/.*)?         gen_context(system_u:object_r:systemd_rfkill_var_lib_t,s0)
 /var/lib/systemd/linger(/.*)?  		gen_context(system_u:object_r:systemd_logind_var_lib_t,mls_systemhigh)
+/var/lib/systemd/timesync(/.*)? 		gen_context(system_u:object_r:systemd_timedated_var_lib_t,s0)
+/var/lib/private/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_lib_t,s0)
 /var/lib/random-seed 		gen_context(system_u:object_r:random_seed_t,mls_systemhigh)
 /usr/lib/systemd/resolv.*   --   gen_context(system_u:object_r:lib_t,s0)
 /usr/var/lib/random-seed 	gen_context(system_u:object_r:random_seed_t,mls_systemhigh)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -692,6 +692,25 @@ interface(`systemd_rfkill_manage_lib_dirs',`
 
 ########################################
 ## <summary>
+##	manage systemd timesync dir
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_timedated_manage_lib_dirs',`
+	gen_require(`
+		type systemd_timedated_var_lib_t;
+	')
+
+	manage_dirs_pattern($1, systemd_timedated_var_lib_t, systemd_timedated_var_lib_t)
+	read_lnk_files_pattern($1, systemd_timedated_var_lib_t, systemd_timedated_var_lib_t)
+')
+
+########################################
+## <summary>
 ##	Execute a domain transition to run systemd_notify.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -138,6 +138,9 @@ systemd_unit_file(systemd_timedated_unit_file_t)
 type systemd_timedated_var_run_t;
 files_pid_file(systemd_timedated_var_run_t)
 
+type systemd_timedated_var_lib_t;
+files_type(systemd_timedated_var_lib_t)
+
 systemd_domain_template(systemd_sysctl)
 
 #domain for gpt-auto-generator
@@ -826,6 +829,12 @@ manage_files_pattern(systemd_timedated_t, systemd_timedated_var_run_t, systemd_t
 manage_sock_files_pattern(systemd_timedated_t, systemd_timedated_var_run_t, systemd_timedated_var_run_t)
 init_pid_filetrans(systemd_timedated_t, systemd_timedated_var_run_t, { dir file sock_file })
 
+manage_dirs_pattern(systemd_timedated_t, systemd_timedated_var_lib_t, systemd_timedated_var_lib_t)
+manage_files_pattern(systemd_timedated_t, systemd_timedated_var_lib_t, systemd_timedated_var_lib_t)
+read_lnk_files_pattern(systemd_timedated_t, systemd_timedated_var_lib_t, systemd_timedated_var_lib_t)
+init_var_lib_filetrans(systemd_timedated_t, systemd_timedated_var_lib_t, dir, "timesync")
+
+list_dirs_pattern(systemd_timedated_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 read_files_pattern(systemd_timedated_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 
 corecmd_exec_bin(systemd_timedated_t)


### PR DESCRIPTION
Add new type `systemd_timedated_var_lib_t` for `/var/lib/systemd/timesync/`.

Set up rules so that systemd-timesyncd can manage the files in that directory.

Before this commit, I was having trouble with `systemd-timesyncd` on Fedora Rawhide, raising AVCs trying to access/modify files tagged with `init_var_lib_t`.

The `lnk` rules are needed because in many cases `/var/lib/systemd/timesync` is a symlink to `../private/systemd/timesync` (left over from the `DynamicUser=yes` days...) In any case, I think they're still sane enough.

cc @wrabcak @keszybz 