### PR TITLE
Add rules to allow systemd to mounton systemd_timedated_var_lib_t

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -627,6 +627,7 @@ systemd_map_resolved_exec_files(init_t)
 systemd_rfkill_setattr_lib(init_t)
 systemd_rfkill_mounton_var_lib(init_t)
 systemd_rfkill_manage_lib_dirs(init_t)
+systemd_timedated_mounton_var_lib(init_t)
 systemd_timedated_manage_lib_dirs(init_t)
 
 create_sock_files_pattern(init_t, init_sock_file_type, init_sock_file_type)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -692,6 +692,24 @@ interface(`systemd_rfkill_manage_lib_dirs',`
 
 ########################################
 ## <summary>
+##	Mounton systemd timesync directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_timedated_mounton_var_lib',`
+	gen_require(`
+		type systemd_timedated_var_lib_t;
+	')
+
+	allow $1 systemd_timedated_var_lib_t:dir mounton;
+')
+
+########################################
+## <summary>
 ##	manage systemd timesync dir
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This is needed to run systemd-timesyncd on a namespace. Without these rules, systemd-timesyncd.service startup fails with status=226/NAMESPACE and the following AVC is reported:

```
avc:  denied  { mounton } for  pid=789 comm="(imesyncd)" path="/run/systemd/unit-root/var/lib/systemd/timesync" dev="dm-0" ino=123456 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_timedated_var_lib_t:s0 tclass=dir permissive=0
```

Tested: built+installed a custom selinux policy package including this commit and confirmed that systemd-timesyncd.service starts correctly when including this rules. Also tested rebooting the system to confirm it works as expected.

This is a follow up for 4f84ae087cd3d3d226db8b53ae02c48a0bdd1f5e, I'm not really sure why I didn't catch this while testing that one, I imagine it might be related to [`d644e80` in systemd rpm repo](https://src.fedoraproject.org/rpms/systemd/c/d644e8032c6e67ba695a4cc222b77f93cd309b82?branch=master) but I haven't really invested the time to confirm that...

In any case, it seems this rule is needed, so assuming it's not controversial, sending the PR. Let me know if you think this deserves more discussion.

Cheers!
Filipe

cc @wrabcak @keszybz @yuwata @poettering
