### PR TITLE
Allow init_t domain access to USB ttys BZ(1663620)

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -322,6 +322,7 @@ term_use_unallocated_ttys(init_t)
 term_use_console(init_t)
 term_use_all_inherited_terms(init_t)
 term_use_generic_ptys(init_t)
+term_use_usb_ttys(init_t)
 term_use_virtio_console(init_t)
 
 # Run init scripts.


### PR DESCRIPTION
Character device files for USB terminals have a particular usbtty_device_t type.
When a USB device is used as a serial console, systemd-getty-generator
running in init_t domain needs to have access to it, similar to terminals
with a different type.

Fedoras 29 and 28 are affected.

Signed-off-by: Zdenek Pytela <zpytela@redhat.com>