### PR TITLE
kernel/files.fc: Label /var/run/motd\.d(./*)? and /var/run/motd as pam_var_run_t

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -299,8 +299,6 @@ ifndef(`distro_redhat',`
 /var/run/lock/.*		<<none>>
 
 /run/cockpit/motd	--	gen_context(system_u:object_r:etc_t,s0)
-/run/motd		--	gen_context(system_u:object_r:etc_t,s0)
-/run/motd.d(/.*)?		gen_context(system_u:object_r:etc_t,s0)
 
 /var/spool(/.*)?		gen_context(system_u:object_r:var_spool_t,s0)
 /var/spool/postfix/etc(/.*)?	gen_context(system_u:object_r:etc_t,s0)

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -72,6 +72,8 @@ ifdef(`distro_gentoo', `
 
 /var/run/console(/.*)?	 	gen_context(system_u:object_r:pam_var_console_t,s0)
 /var/run/faillock(/.*)?		gen_context(system_u:object_r:faillog_t,s0)
+/var/run/motd		--	gen_context(system_u:object_r:pam_var_run_t,s0)
+/var/run/motd\.d(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_mount(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
 /var/run/sepermit(/.*)? 	gen_context(system_u:object_r:pam_var_run_t,s0)


### PR DESCRIPTION
This fixes changes in #230 and #232 which conflicted due to the
/var/run and /run equivalency, causing the etc_t label not to be
applied.

Fixes: #242