### PR TITLE
Allow systemd-journald to receive messages including a memfd

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -457,6 +457,8 @@ allow syslogd_t self:netlink_audit_socket { r_netlink_socket_perms nlmsg_write }
 allow syslogd_t self:netlink_generic_socket create_socket_perms;
 allow syslogd_t syslog_conf_t:file read_file_perms;
 allow syslogd_t syslog_conf_t:dir list_dir_perms;
+# receive messages including a memfd
+allow syslogd_t user_tmp_t:file map;
 
 # Create and bind to /dev/log or /var/run/log.
 allow syslogd_t devlog_t:sock_file manage_sock_file_perms;


### PR DESCRIPTION
I believe these are related to dbus-broker from the bus1 project, which is now able to pass memfd's together with its DBus brokered messages, at least I think this is what changed in my environment around the time I started getting these. (It's possible they're related to systemd-journald code changes, but although I haven't checked, I think that's less likely.)

Without the rule for memfd from this commit, journald logs the following to the console:

```
systemd-journald[621]: Failed to map memfd, ignoring: Permission denied
```

And an AVC such as the following is generated:

```
avc: denied { map } for pid=621 comm="systemd-journal" path="/memfd:sd-test-journal-se (deleted)" dev="tmpfs" ino=51156 \
     scontext=system_u:system_r:syslogd_t:s0 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=file permissive=0
```

This commit adds a specific rule to allow this access to memfd.

**NOTE**: audit2allow suggests setting a boolean would be possible here:

```
#!!!! This avc can be allowed using the boolean 'domain_can_mmap_files'
allow syslogd_t user_tmp_t:file map;
```

But I think adding the specific rule for journald makes sense here. I'm not sure whether `user_tmp_t` is too broad or not, I'll leave that for you to decide.

/cc @wrabcak 