### PR TITLE
Fix CI for use on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - docker pull fedora:rawhide
 
 script:
-    - docker run  -v /home/travis/build/fedora-selinux/:/root/build/ fedora:rawhide /bin/sh -c "dnf install -y checkpolicy policycoreutils-devel make m4 git findutils gcc ; cd /root/build/selinux-policy; make policy"
+    - docker run  -v $PWD:/root/build/ fedora:rawhide /bin/sh -c "dnf install -y checkpolicy policycoreutils-devel make m4 git findutils gcc ; cd /root/build/selinux-policy; make policy"
 
 notifications:
     emails:


### PR DESCRIPTION
Generally, I like to enable Travis CI on my forks so I know if I break
the build even before I open a PR. Howver, this repo's .travis.yml
uses a hard-coded path to the home directory, which depends on the name
of the repository owner.

Fix this to use $PWD instead, so that CI works also on forks.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>