### PR TITLE
Always label /home symlinks as home_root_t

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -108,6 +108,12 @@ HOME_ROOT/\.journal		<<none>>
 HOME_ROOT/lost\+found	-d	gen_context(system_u:object_r:lost_found_t,mls_systemhigh)
 HOME_ROOT/lost\+found/.*	<<none>>
 
+# HOME_ROOT is where user HOME dirs reside as per /etc/default/useradd, but
+# there may be a compat symlink from /home to HOME_ROOT. We want to make sure
+# that symlink itself is always labeled home_root_t so that e.g. systemd can
+# getattr as it follows it.
+/home		-l	gen_context(system_u:object_r:home_root_t,s0)
+
 #
 # /initrd
 #


### PR DESCRIPTION
On OSTree systems, `/home` is a symlink to `/var/home`. With the latest
release of RPM-OSTree, `HOME_ROOT` is now `/var/home`. This leaves the
`/home` symlink unmapped and defaulting to `default_t`. This in turn is
preventing systemd from mounting filesystems pointing at `/home` in
`/etc/fstab`.

Let's just unconditionally make sure the link is labeled correctly. On
systems with `HOME_ROOT == /home`, this is just a duplicate rule, which
is harmless.

For more context, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1669982
https://src.fedoraproject.org/rpms/selinux-policy/pull-request/14