### PR TITLE
Allow systemd-logind read and write user domain terminals BZ(1696852)

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -305,7 +305,7 @@ udev_manage_rules_files(systemd_logind_t)
 
 userdom_destroy_unpriv_user_shared_mem(systemd_logind_t)
 userdom_read_all_users_state(systemd_logind_t)
-userdom_use_user_ttys(systemd_logind_t)
+userdom_use_user_terminals(systemd_logind_t)
 userdom_manage_tmp_role(system_r, systemd_logind_t)
 userdom_manage_tmpfs_role(system_r, systemd_logind_t)
 


### PR DESCRIPTION
Allow systemd-logind read and write all user domain terminals
instead of just user ttys

Signed-off-by: Zdenek Pytela <zpytela@redhat.com>