### PR TITLE
Fix kernel rw kernel sysctl f30

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -2241,7 +2241,7 @@ interface(`kernel_dontaudit_write_kernel_ns_lastpid_sysctl',`
 ## </param>
 ## <rolecap/>
 #
-interface(`kernel_rw_kernel_sysctl',`
+interface(`kernel_rw_kernel_ns_lastpid_sysctl',`
 	gen_require(`
 		type proc_t, sysctl_t, sysctl_kernel_ns_last_pid_t;
 	')

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -2172,6 +2172,27 @@ interface(`kernel_dontaudit_write_kernel_sysctl',`
 
 ########################################
 ## <summary>
+##	Read and write generic kernel sysctls.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kernel_rw_kernel_sysctl',`
+	gen_require(`
+		type proc_t, sysctl_t, sysctl_kernel_t;
+	')
+
+	rw_files_pattern($1, { proc_t sysctl_t sysctl_kernel_t }, sysctl_kernel_t)
+
+	list_dirs_pattern($1, { proc_t sysctl_t }, sysctl_kernel_t)
+')
+
+########################################
+## <summary>
 ##	Read kernel ns lastpid sysctls.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This fixes the mistake that led to https://bugzilla.redhat.com/show_bug.cgi?id=1698575 : on rawhide branch this interface was added with the same name as an existing interface and then renamed, but on f30 branch, the interface was added with the same name as an existing interface and then the original interface was removed.

We revert the erroneous removal commit, and cherry-pick the rename from rawhide branch instead.