### PR TITLE
Add systemd_private_tmp_type attribute

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -652,6 +652,7 @@ systemd_mounton_inhibit_dir(init_t)
 systemd_timedated_manage_lib_dirs(init_t)
 systemd_login_mounton_pid_dirs(init_t)
 systemd_mounton_inherited_logind_sessions_dirs(init_t)
+systemd_delete_private_tmp(init_t)
 
 create_sock_files_pattern(init_t, init_sock_file_type, init_sock_file_type)
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2176,3 +2176,43 @@ interface(`systemd_dbus_chat_resolved',`
 	allow systemd_resolved_t $1:dbus send_msg;
 	ps_process_pattern(systemd_resolved_t, $1)
 ')
+
+######################################
+## <summary>
+##	Make the specified type usable as a systemd private tmp type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Type to be used as a private tmp type.
+##	</summary>
+## </param>
+#
+interface(`systemd_private_tmp',`
+	gen_require(`
+		attribute systemd_private_tmp_type;
+	')
+
+	typeattribute $1 systemd_private_tmp_type;
+')
+
+#######################################
+## <summary>
+##	Delete filesystem objects with systemd_delete_private_tmp attribute
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`systemd_delete_private_tmp',`
+	gen_require(`
+		attribute systemd_private_tmp_type;
+	')
+
+	allow $1 systemd_private_tmp_type:dir delete_dir_perms;
+	allow $1 systemd_private_tmp_type:fifo_file delete_fifo_file_perms;
+	allow $1 systemd_private_tmp_type:file delete_file_perms;
+	allow $1 systemd_private_tmp_type:lnk_file delete_lnk_file_perms;
+	allow $1 systemd_private_tmp_type:sock_file delete_sock_file_perms;
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -9,6 +9,7 @@ attribute systemd_unit_file_type;
 attribute systemd_domain;
 attribute systemctl_domain;
 attribute systemd_mount_directory;
+attribute systemd_private_tmp_type;
 
 systemd_domain_template(systemd_logger)
 systemd_domain_template(systemd_logind)


### PR DESCRIPTION
Add systemd_private_tmp_type attribute to back the systemd PrivateTmp feature.
Add systemd_private_tmp interface to assign the attribute and
systemd_delete_private_tmp interface to allow a type to delete objects
on the filesystem.
Allow systemd_delete_private_tmp(init_t).

Based on an idea of Dominic Grift.