### PR TITLE
Allow machinectl to run pull-tar BZ(1724247)

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -23,6 +23,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 
 /usr/lib/systemd/systemd-initctl	--	gen_context(system_u:object_r:systemd_initctl_exec_t,s0)
 
+/usr/lib/systemd/systemd-pull		--	gen_context(system_u:object_r:systemd_importd_exec_t,s0)
+
 /etc/systemd/system\.control(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/dracut/modules.d/.*\.service	gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/systemd/system(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1938,6 +1938,7 @@ interface(`systemd_machined_manage_lib_files',`
         ')
 
         files_search_var_lib($1)
+        manage_dirs_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
         manage_files_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
 ')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1143,6 +1143,7 @@ allow systemd_importd_t self:unix_dgram_socket create_socket_perms;
 allow systemd_importd_t self:tcp_socket create_socket_perms;
 allow systemd_importd_t self:udp_socket create_socket_perms;
 allow systemd_importd_t self:unix_dgram_socket sendto;
+allow systemd_importd_t systemd_importd_exec_t:file execute_no_trans;
 
 manage_dirs_pattern(systemd_importd_t, systemd_importd_var_run_t, systemd_importd_var_run_t)
 manage_files_pattern(systemd_importd_t, systemd_importd_var_run_t, systemd_importd_var_run_t)
@@ -1179,6 +1180,7 @@ optional_policy(`
 optional_policy(`
     dbus_system_bus_client(systemd_importd_t)
     dbus_acquire_svc_system_dbusd(systemd_importd_t)
+    unconfined_dbus_send(systemd_importd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow systemd_importd_t dbus chat with unconfined.
Allow systemd_importd_t execute_no_trans systemd_importd_exec_t.
Label /usr/lib/systemd/systemd-pull as systemd_importd_exec_t.
Update systemd_machined_manage_lib_files interface with manage_dirs_pattern.