### PR TITLE
Run lvmdbusd service as lvm_t

### DIFF
--- a/policy/modules/system/lvm.fc
+++ b/policy/modules/system/lvm.fc
@@ -114,6 +114,7 @@ ifdef(`distro_gentoo',`
 /usr/sbin/lvm			--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvm\.static		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmchange		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+/usr/sbin/lvmdbusd              --	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmdiskscan		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmetad		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmiopversion		--	gen_context(system_u:object_r:lvm_exec_t,s0)


### PR DESCRIPTION
Label binary /usr/sbin/lvmdbusd as lvm_exec_t to run lvmdbusd service as lvm_t.
Lvmdbusd -  a service which provides a D-Bus API to the logical volume manager (LVM).