### PR TITLE
Allow dbus communications with resolved for DNS lookups

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -238,10 +238,6 @@ optional_policy(`
 	dbus_system_bus_client(ipsec_t)
 	dbus_connect_system_bus(ipsec_t)
 
-    optional_policy(`
-        systemd_dbus_chat_resolved(ipsec_t)
-    ')
-
 	optional_policy(`
 		networkmanager_dbus_chat(ipsec_t)
 	')

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1003,9 +1003,10 @@ interface(`sysnet_dns_name_resolve',`
 		avahi_stream_connect($1)
 	')
 
-    optional_policy(`
-        dbus_stream_connect_system_dbusd($1)
-    ')
+	optional_policy(`
+		dbus_stream_connect_system_dbusd($1)
+		systemd_dbus_chat_resolved($1)
+	')
 
 	optional_policy(`
 		nscd_use($1)


### PR DESCRIPTION
When one adds `resolve` to nsswitch.conf as recommended by
`man nss-resolve`, SELinux blocks DBus communications with
systemd-resolved.

Anyone who wants to do DNS lookups needs to be able to communicate
with systemd-resolved.