### PR TITLE
Move open, audit_access, and execmod to common file perms

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -28,6 +28,9 @@ common file
 	swapon
 	quotaon
 	mounton
+	audit_access
+	open
+	execmod
 }
 
 
@@ -208,9 +211,6 @@ inherits file
 	reparent
 	search
 	rmdir
-	open
-	audit_access
-	execmod
 }
 
 class file
@@ -218,52 +218,26 @@ inherits file
 {
 	execute_no_trans
 	entrypoint
-	execmod
-	open
-	audit_access
 }
 
 class lnk_file
 inherits file
-{
-	open
-	audit_access
-	execmod
-}
 
 class chr_file
 inherits file
 {
 	execute_no_trans
 	entrypoint
-	execmod
-	open
-	audit_access
 }
 
 class blk_file
 inherits file
-{
-	open
-	audit_access
-	execmod
-}
 
 class sock_file
 inherits file
-{
-	open
-	audit_access
-	execmod
-}
 
 class fifo_file
 inherits file
-{
-	open
-	audit_access
-	execmod
-}
 
 class fd
 {


### PR DESCRIPTION
Note that this had kind of been already attempted before, but it broke
libselinux back then (see 056e503ca21a ("Fix access vectors so they do
not break libselinux")). However, since the userspace headers that used
to be generated from the policy source have since been deprecated [1],
it should be safe to do it now.

[1] https://github.com/SELinuxProject/selinux/commit/76913d8adb61b5afe28fd3b4ce91feab29e284dd

Cc: @stephensmalley, @bachradsusi