### PR TITLE
Introduce xdm_manage_bootloader booelan

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -41,11 +41,18 @@ gen_tunable(xserver_clients_write_xshm, false)
 gen_tunable(xserver_execmem, false)
 
 ## <desc>
-## <p>
-## Allow the graphical login program to execute bootloader
-## </p>
+## 	<p>
+## 	Allow the graphical login program to execute bootloader
+##	</p>
 ## </desc>
 gen_tunable(xdm_exec_bootloader, false)
+
+## <desc>
+##	<p>
+##	Allow the graphical login program to create, read, write, and delete files in the /boot director and DOS filesystem.
+## 	</p>
+## </desc>
+gen_tunable(xdm_manage_bootloader,true)
 
 ## <desc>
 ##	<p>
@@ -649,7 +656,6 @@ fs_dontaudit_list_noxattr_fs(xdm_t)
 fs_dontaudit_read_noxattr_fs_files(xdm_t)
 fs_manage_cgroup_dirs(xdm_t)
 fs_manage_cgroup_files(xdm_t)
-fs_manage_dos_files(xdm_t)
 mount_read_pid_files(xdm_t)
 
 mls_socket_write_to_clearance(xdm_t)
@@ -875,12 +881,15 @@ tunable_policy(`use_samba_home_dirs',`
 	fs_exec_cifs_files(xdm_t)
 ')
 
-optional_policy(`
-	tunable_policy(`xdm_exec_bootloader',`
-    	bootloader_exec(xdm_t)
-    	files_read_boot_files(xdm_t)
-    	files_read_boot_symlinks(xdm_t)
-	')
+tunable_policy(`xdm_exec_bootloader',`
+	bootloader_exec(xdm_t)
+	files_read_boot_files(xdm_t)
+	files_read_boot_symlinks(xdm_t)
+')
+
+tunable_policy(`xdm_manage_bootloader',`
+        fs_manage_dos_files(xdm_t)
+	files_manage_boot_files(xdm_t)       
 ')
 
 tunable_policy(`xdm_sysadm_login',`


### PR DESCRIPTION
Created xdm_manage_bootloader boolean to create, read, write, and delete files in the /boot director & DOS filesystem.

Fixed Red Hat Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1750112#

$ rpm -q selinux-policy
selinux-policy-3.14.3-45.fc30.200.noarch

$ sesearch -A -s xdm_t -t boot_t -c file -p write
$

$sudo semanage boolean --list | grep xdm | grep boot      
xdm_exec_bootloader            (off  ,  off)  Allow the graphical login program to execute bootloader

Scratch build installed

$ rpm -q selinux-policy
selinux-policy-3.14.3-45.fc30.300.noarch

$ sesearch -A -s xdm_t -t boot_t -c file -p write
allow xdm_t boot_t:file { append create getattr ioctl link lock open read rename setattr unlink write }; [ xdm_manage_bootloader ]:True

$ sudo semanage boolean --list | grep xdm | grep boot 
xdm_exec_bootloader            (off   ,   off)  Allow the graphical login program to execute bootloader
xdm_manage_bootloader          (on   ,   on)  Allow the graphical login program to create, read, write, and delete files in the /boot director and DOS filesystem