### PR TITLE
Add new macro to systemd.if to get timedated service status

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -784,6 +784,24 @@ interface(`systemd_timedated_mounton_var_lib',`
 	allow $1 systemd_timedated_var_lib_t:dir mounton;
 ')
 
+#######################################
+## <summary>
+##  Get timedated service status
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed to transition.
+##  </summary>
+## </param>
+#
+interface(`systemd_timedated_status',`
+    gen_require(`
+        type systemd_timedated_unit_file_t;
+    ')
+
+    allow $1 systemd_timedated_unit_file_t:service status;
+')
+
 ########################################
 ## <summary>
 ##	manage systemd timesync dir


### PR DESCRIPTION
Add new macro systemd_timedated_status to systemd.if to get timedated service status

add because need create macro for https://github.com/fedora-selinux/selinux-policy-contrib/pull/138