### PR TITLE
[RFC] Revert "Unconfined domains, need to create content with the correct labels"

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1676,7 +1676,6 @@ interface(`domain_unconfined',`
 	mcs_process_set_categories($1)
 
 	userdom_filetrans_home_content($1)
-	domain_named_filetrans($1)
 ')
 
 ########################################


### PR DESCRIPTION
This reverts commit fcd5a7f97ed4bbbb711ea0f8bc52e54dd5fda3ad.

As discussed in BZ#1660142 [1], let's try taking the device file
transitions away from the general unconfined domain and leaving them
only for a few specific domains. These are currently:
```
$ sesearch -T -t device_t | grep bcache9 | cut -f 2 -d ' '
authconfig_t
init_t
initrc_t
kernel_t
neutron_t
pegasus_t
puppetagent_t
rolekit_t
rpm_script_t
sysadm_t
unconfined_t
```
Before this commit there was much much more of them:
```
$ sesearch -T -t device_t | grep bcache9 | wc -l
91
```
After applying this commit, the size of the binary policy drops from
~8.2 MiB to ~4.0 MiB.

Cc: @stephensmalley @rhatdan

Booting Fedora Rawhide with the modified policy and running a basic set of selinux-policy (Red Hat internal) tests didn't trigger any new failures/AVCs.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1660142#c15