### PR TITLE
Allow systemd-module-load.service to read /run/modules-load.d/

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1102,6 +1102,8 @@ files_read_kernel_modules(systemd_modules_load_t)
 modutils_read_module_config(systemd_modules_load_t)
 modutils_read_module_deps_files(systemd_modules_load_t)
 
+allow systemd_modules_load_t init_var_run_t:dir read;
+allow systemd_modules_load_t init_var_run_t:file { getattr ioctl open read };
 
 #######################################
 #


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753885.