### PR TITLE
Allow avahi_t to send msg to xdm_t

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -944,6 +944,11 @@ optional_policy(`
         accountsd_dbus_chat(xdm_t)
     ')
 
+      optional_policy(`
+	        avahi_dbus_chat(xdm_t)
+      ')
+
+
 	optional_policy(`
 		bluetooth_dbus_chat(xdm_t)
 	')


### PR DESCRIPTION
Allow X display manager to send and receive messages from avahi over dbus

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1755401