### PR TITLE
Allow x_userdomain to mmap generic SSL certificates

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -71,7 +71,6 @@ init_dbus_chat_script(staff_t)
 init_status(staff_t)
 
 miscfiles_read_hwdata(staff_t)
-miscfiles_map_generic_certs(staff_t)
 
 mount_sigkill(staff_t)
 

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -79,7 +79,6 @@ logging_mmap_journal(sysadm_t)
 
 miscfiles_filetrans_named_content(sysadm_t)
 miscfiles_read_hwdata(sysadm_t)
-miscfiles_map_generic_certs(sysadm_t)
 
 sysnet_filetrans_named_content(sysadm_t)
 

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -1720,6 +1720,9 @@ dev_getattr_agp_dev(x_userdomain)
 # GNOME checks for usb and other devices:
 dev_rw_usbfs(x_userdomain)
 
+# mmap generic SSL certificates
+miscfiles_map_generic_certs(x_userdomain)
+
 miscfiles_read_fonts(x_userdomain)
 miscfiles_setattr_fonts_cache_dirs(x_userdomain)
 miscfiles_read_hwdata(x_userdomain)


### PR DESCRIPTION
Allow users in attribute x_userdomain {staff_t, staff_wine_t, sysadm_t, user_t, user_wine_t, xguest_t } to mmap SSL ceriticates.

After running Firefox as confined user, Firefox stopped the connection to the website and showed a "Warning: Potential Security Risk Ahead" error page instead. The problem was that Firefox couldn't validate certificates of secure website, because process firefox was running in the user_t domain
SELinux policy applied in user_t domain wasn't allowing to mmap SSL certificates. 
Nor in staff_wine_t, sysadm_t, user_wine_t and xguest_t domains.