### PR TITLE
Allow systemd_logind to read dosfs files & dirs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -199,6 +199,9 @@ fs_mount_tmpfs(systemd_logind_t)
 fs_unmount_tmpfs(systemd_logind_t)
 fs_list_tmpfs(systemd_logind_t)
 
+fs_list_dos(systemd_logind_t)
+fs_read_dos_files(systemd_logind_t)
+
 fs_read_efivarfs_files(systemd_logind_t)
 
 fs_manage_fusefs_dirs(systemd_logind_t)


### PR DESCRIPTION
Allow systemd-logind - a system service that manages user logins, to read files and list dirs on a DOS filesystem

Fixed Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1751766
https://bugzilla.redhat.com/show_bug.cgi?id=1752826

$ rpm -q selinux-policy 
selinux-policy-3.14.5-3.fc32.10.noarch

$ sesearch -A -s systemd_logind_t -t dosfs_t -p read
$

Scratch build installed

$ rpm -q selinux-policy 
selinux-policy-3.14.5-3.fc32.14.noarch

$ sesearch -A -s systemd_logind_t -t dosfs_t -p read
allow systemd_logind_t dosfs_t:dir { getattr ioctl lock open read search };
allow systemd_logind_t dosfs_t:file { getattr ioctl lock open read };
