### PR TITLE
Allow cephfs to use xattrs for storing contexts

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -18,6 +18,7 @@ type fs_t;
 fs_type(fs_t)
 sid fs gen_context(system_u:object_r:fs_t,s0)
 typealias fs_t alias vxfs_t;
+typealias fs_t alias cephfs_t;
 
 # Use xattrs for the following filesystem types.
 # Requires that a security xattr handler exist for the filesystem.
@@ -44,6 +45,7 @@ fs_use_xattr shiftfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr vxfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr odms gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr vxclonefs gen_context(system_u:object_r:fs_t,s0);
+fs_use_xattr ceph gen_context(system_u:object_r:fs_t,s0);
 
 # Use the allocating task SID to label inodes in the following filesystem
 # types, and label the filesystem itself with the specified context.
@@ -90,11 +92,6 @@ type capifs_t;
 fs_type(capifs_t)
 files_mountpoint(capifs_t)
 genfscon capifs / gen_context(system_u:object_r:capifs_t,s0)
-
-type cephfs_t;
-fs_type(cephfs_t)
-files_mountpoint(cephfs_t)
-genfscon ceph / gen_context(system_u:object_r:cephfs_t,s0)
 
 type cgroup_t alias cgroupfs_t;
 fs_type(cgroup_t)


### PR DESCRIPTION
cephfs recently gained the ability to store SELinux contexts in an xattr
(like most local filesystems). Change the policy to allow for this.

Signed-off-by: Jeff Layton <jlayton@kernel.org>