### PR TITLE
Allow x_userdomain to dbus_chat with timedatex.

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -1763,6 +1763,10 @@ optional_policy(`
 	thumb_nnp_domtrans(x_userdomain)
 ')
 
+optional_policy(`
+        timedatex_dbus_chat(x_userdomain)
+')
+
 tunable_policy(`selinuxuser_direct_dri_enabled',`
 	dev_rw_dri(dridomain)
 ',`


### PR DESCRIPTION
Allow users in x_userdomain to send and receive messages from timedatex over dbus.

Attribute x_userdomain: staff_t, sysadm_t, user_t

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1766148

PR for timedatex macro: https://github.com/fedora-selinux/selinux-policy-contrib/pull/160
