### PR TITLE
Remove duplicate entries for initrc_t in init.te

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -903,7 +903,7 @@ dev_write_rand(initrc_t)
 dev_write_urand(initrc_t)
 dev_write_watchdog(initrc_t)
 dev_rw_sysfs(initrc_t)
-dev_list_usbfs(initrc_t)
+dev_read_usbfs(initrc_t)
 dev_read_framebuffer(initrc_t)
 dev_write_framebuffer(initrc_t)
 dev_read_realtime_clock(initrc_t)
@@ -1036,8 +1036,6 @@ userdom_read_user_home_content_files(initrc_t)
 userdom_use_inherited_user_terminals(initrc_t)
 
 ifdef(`distro_debian',`
-	dev_setattr_generic_dirs(initrc_t)
-
 	fs_tmpfs_filetrans(initrc_t, initrc_var_run_t, dir)
 
 	# for storing state under /dev/shm
@@ -1062,7 +1060,6 @@ ifdef(`distro_gentoo',`
 	# early init
 	dev_create_generic_dirs(initrc_t)
 	dev_delete_generic_dirs(initrc_t)
-	dev_setattr_generic_dirs(initrc_t)
 
 	files_manage_all_pids(initrc_t)
 	# allow bootmisc to create /var/lock/.keep.
@@ -1076,8 +1073,6 @@ ifdef(`distro_gentoo',`
 
 	# init scripts touch this
 	clock_dontaudit_write_adjtime(initrc_t)
-
-	logging_send_audit_msgs(initrc_t)
 
 	# for integrated run_init to read run_init_type.
 	# happens during boot (/sbin/rc execs init scripts)
@@ -1301,7 +1296,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	dev_read_usbfs(initrc_t)
 	bluetooth_read_config(initrc_t)
 ')
 
@@ -1386,8 +1380,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	dev_read_usbfs(initrc_t)
-
 	# init scripts run /etc/hotplug/usb.rc
 	hotplug_read_config(initrc_t)
 
@@ -1586,10 +1578,6 @@ optional_policy(`
 
 optional_policy(`
 	stunnel_read_config(initrc_t)
-')
-
-optional_policy(`
-	sysnet_read_dhcpc_state(initrc_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Remove duplicate dev_setattr_generic_dirs(initrc_t) entry
from a conditional block as it also is in an unconditional one.
Remove duplicate logging_send_audit_msgs(initrc_t) entry
from a conditional block as it also is in an unconditional one.
Remove sysnet_read_dhcpc_state(initrc_t)
which is a subset of sysnet_manage_dhcpc_state(initrc_t).
Remove duplicate dev_read_usbfs(initrc_t) entry and
move one to an unconditional block to replace dev_list_usbfs(initrc_t)
which is its subset.