### PR TITLE
Update authlogin policy to allow using google F2A for polydomain

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -1,4 +1,5 @@
 HOME_DIR/\.yubico(/.*)?				    gen_context(system_u:object_r:auth_home_t,s0)
+HOME_DIR/\.google(/.*)?				gen_context(system_u:object_r:auth_home_t,s0)
 HOME_DIR/\.google_authenticator			gen_context(system_u:object_r:auth_home_t,s0)
 HOME_DIR/\.google_authenticator~		gen_context(system_u:object_r:auth_home_t,s0)
 /root/\.yubico(/.*)?                    gen_context(system_u:object_r:auth_home_t,s0)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2368,13 +2368,13 @@ interface(`auth_manage_home_content',`
 ## </param>
 #
 interface(`auth_filetrans_home_content',`
-	
 	gen_require(`
 		type auth_home_t;
 	')
-
+	
 	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator")
 	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~")
+	userdom_user_home_dir_filetrans($1, auth_home_t, dir, ".google")
 	userdom_user_home_dir_filetrans($1, auth_home_t, dir, ".yubico")
 ')
 

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -14,6 +14,14 @@ gen_tunable(authlogin_radius, false)
 
 ## <desc>
 ## <p>
+## Enable manage google 2FA  
+## file for attributes in polydomain.
+## </p>
+## </desc>
+gen_tunable(authlogin_use_2FA,false)
+
+## <desc>
+## <p>
 ## Allow users to login using a yubikey OTP server or challenge response mode
 ## </p>
 ## </desc>
@@ -444,6 +452,14 @@ optional_policy(`
 	tunable_policy(`polyinstantiation_enabled',`
 		namespace_init_domtrans(polydomain)
 	')
+')
+
+optional_policy(`
+        auth_filetrans_home_content(polydomain)
+')
+
+tunable_policy(`authlogin_use_2FA',`
+        auth_manage_home_content(polydomain)
 ')
 
 ######################################


### PR DESCRIPTION
Polydomain is attribute which contain also sshd_t domain
and cockpit_session_t domain which use google F2A
Add for auth_filetrans_home interface  filetrans rule to auth_home_t for generic file
Allow polydomain to create auth dir in user home dir with correct label auth_home_t
which is used for google F2A file
Create boolean which allow polydomain to manage google F2A
file with label auth_home_t in user home directory

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1767606