### PR TITLE
Dontaudit systemd_tmpfiles_t getattr of all file types BZ(1772976)

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -840,6 +840,63 @@ interface(`files_dontaudit_getattr_non_security_files',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to get the attributes
+##	of proc_type files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`files_dontaudit_getattr_proc_type_files',`
+	gen_require(`
+		attribute proc_type;
+	')
+
+	dontaudit $1 proc_type:file getattr;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to get the attributes
+##	of sysctl_type files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`files_dontaudit_getattr_sysctl_type_files',`
+	gen_require(`
+		attribute sysctl_type;
+	')
+
+	dontaudit $1 sysctl_type:file getattr;
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to get the attributes
+##	of filesystem_type files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`files_dontaudit_getattr_filesystem_type_files',`
+	gen_require(`
+		attribute filesystem_type;
+	')
+
+	dontaudit $1 filesystem_type:file getattr;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to search
 ##	non security dirs.
 ## </summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -576,6 +576,11 @@ fs_manage_tmpfs_dirs(systemd_tmpfiles_t)
 fs_relabel_tmpfs_dirs(systemd_tmpfiles_t)
 fs_list_all(systemd_tmpfiles_t)
 
+files_dontaudit_getattr_all_files(systemd_tmpfiles_t)
+files_dontaudit_getattr_proc_type_files(systemd_tmpfiles_t)
+files_dontaudit_getattr_sysctl_type_files(systemd_tmpfiles_t)
+files_dontaudit_getattr_filesystem_type_files(systemd_tmpfiles_t)
+
 files_manage_non_auth_files(systemd_tmpfiles_t)
 files_relabel_non_auth_files(systemd_tmpfiles_t)
 files_list_lost_found(systemd_tmpfiles_t)


### PR DESCRIPTION
Scratchbuild seems to work:
Before:
```
# sesearch --dontaudit -s systemd_tmpfiles_t -c file -ds
dontaudit systemd_tmpfiles_t systemd_tmpfiles_t:file create;
```
After:
```
# sesearch --dontaudit -s systemd_tmpfiles_t -c file -ds
dontaudit systemd_tmpfiles_t file_type:file getattr;
dontaudit systemd_tmpfiles_t systemd_tmpfiles_t:file create;
```