### PR TITLE
Allow unconfined_service_t filetrans to machineid_t BZ(1772211)

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -33,6 +33,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	init_filetrans_named_content(unconfined_service_t)
+')
+
+optional_policy(`
 	virt_transition_svirt(unconfined_service_t, system_r)
 ')
 


### PR DESCRIPTION
Allow systemd-machine-id-commit.service file transition
/etc/machine-id to machineid_t.

Scratchbuild shows:
```
# rpm -q selinux-policy; sesearch -T -s unconfined_service_t -t etc_t -c file |grep machine-id
selinux-policy-3.14.5-13.200.bz1772211.fc32.noarch
type_transition unconfined_service_t etc_t:file machineid_t machine-id;
```