### PR TITLE
Fix systemd_resolved_t domain policy

### DIFF
--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -996,6 +996,7 @@ interface(`sysnet_dns_name_resolve',`
 	files_search_all_pids($1)
 
 	miscfiles_read_generic_certs($1)
+	miscfiles_map_generic_certs($1)
 
 	sysnet_read_config($1)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1064,6 +1064,7 @@ fs_getattr_all_fs(systemd_domain)
 files_read_etc_files(systemd_domain)
 files_read_etc_runtime_files(systemd_domain)
 files_read_usr_files(systemd_domain)
+files_mmap_usr_files(systemd_domain)
 
 init_search_pid_dirs(systemd_domain)
 init_start_transient_unit(systemd_domain)


### PR DESCRIPTION
It's about a map. 
For usr_t:
```
# sesearch -A -s systemd_resolved_t -t usr_t -c file
allow domain base_ro_file_type:file { getattr ioctl lock open read };
allow domain file_type:file map; [ domain_can_mmap_files ]:True
allow systemd_domain usr_t:file { getattr ioctl lock open read };
#
```
After install scrach build:
```
# sesearch -A -s systemd_resolved_t -t usr_t -c file
allow domain base_ro_file_type:file { getattr ioctl lock open read };
allow domain file_type:file map; [ domain_can_mmap_files ]:True
allow systemd_domain usr_t:file { getattr ioctl lock map open read };
#
```

And for cert_t:
```
# sesearch -A -s systemd_resolved_t -t cert_t -c file
allow domain file_type:file map; [ domain_can_mmap_files ]:True
allow nsswitch_domain cert_t:file { getattr ioctl lock open read };
allow nsswitch_domain cert_t:file { getattr ioctl lock open read }; [ authlogin_nsswitch_use_ldap ]:True
#
```
After install scrach build:
```
# sesearch -A -s systemd_resolved_t -t cert_t -c file
allow domain file_type:file map; [ domain_can_mmap_files ]:True
allow nsswitch_domain cert_t:file { getattr ioctl lock map open read };
allow nsswitch_domain cert_t:file { getattr ioctl lock open read }; [ authlogin_nsswitch_use_ldap ]:True
#
```