### PR TITLE
Allow init_t setattr on /var/lib/fprintd

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -741,6 +741,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fprintd_read_var_lib_dir(init_t)
+	fprintd_setattr_var_lib_dir(init_t)
+')
+
+optional_policy(`
     ibacm_create_netlink_rdma_socket(init_t)
     ibacm_read_pid_files(init_t)
 ')


### PR DESCRIPTION
Allow init_t setattr on /var/lib/fprintd
using the fprintd_setattr_var_lib() interface