### PR TITLE
Allow init_t domain to settatribute to domain event_device_t

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -251,6 +251,7 @@ dev_read_raw_memory(init_t)
 dev_rw_generic_chr_files(init_t)
 dev_filetrans_all_named_dev(init_t)
 dev_write_watchdog(init_t)
+dev_setattr_input_dev(init_t)
 dev_rw_inherited_input_dev(init_t)
 dev_rw_dri(init_t)
 


### PR DESCRIPTION
Added macro dev_setattr_input_dev(init_t)
systemd_udevd which have domain init_t can settatr of evdev chr_file
Bugzilla1785804

Build COPR: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1142807/