### PR TITLE
Allow syslog_t to read efivarfs_t files

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -600,9 +600,10 @@ files_read_kernel_symbol_table(syslogd_t)
 files_var_lib_filetrans(syslogd_t, syslogd_var_lib_t, { file dir })
 
 fs_getattr_all_fs(syslogd_t)
+fs_read_efivarfs_files(syslogd_t)
 fs_search_auto_mountpoints(syslogd_t)
 fs_search_cgroup_dirs(syslogd_t)
-
+ 
 miscfiles_manage_generic_cert_files(syslogd_t)
 
 mls_file_write_all_levels(syslogd_t) # Need to be able to write to /var/run/ and /var/log directories


### PR DESCRIPTION
Allow syslog_t to read efivarfs, a (U)EFI variable filesystem, files.

The efivarfs filesystem was created to address the shortcomings of using entries in sysfs to maintain EFI variables.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1787191