### PR TITLE
Allow userdomain to chat with stratisd over dbus.

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -198,6 +198,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+        stratisd_dbus_chat(userdomain)
+')
+
+optional_policy(`
 	systemd_dbus_chat_resolved(userdomain)
 ')
 


### PR DESCRIPTION
Allow userdomain attribute to send and receive messages from stratisd,a daemon that manages a pool of block devices to create flexible filesystems, over dbus.

PR for stratisd macro: https://github.com/fedora-selinux/selinux-policy-contrib/pull/184