### PR TITLE
Allow xdm_t to map xserver_tmpfs_t files

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -166,7 +166,7 @@ interface(`xserver_rw_session',`
 
 	xserver_ro_session($1, $2)
 	allow $1 xserver_t:shm rw_shm_perms;
-	allow $1 xserver_tmpfs_t:file rw_file_perms;
+	allow $1 xserver_tmpfs_t:file { map rw_file_perms };
 ')
 
 #######################################


### PR DESCRIPTION
Allow xdm_t, XDM is the default display manager for the X Window System, to map xserver files stored on a tmpfs file system.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1785876