### PR TITLE
Make file context more variable for /usr/bin/fusermount and /bin/fuse…

### DIFF
--- a/policy/modules/system/mount.fc
+++ b/policy/modules/system/mount.fc
@@ -1,4 +1,4 @@
-/bin/fusermount    		--      gen_context(system_u:object_r:fusermount_exec_t,s0)
+/bin/fusermount[0-9]?    	--      gen_context(system_u:object_r:fusermount_exec_t,s0)
 /bin/mount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 /bin/umount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 
@@ -8,7 +8,7 @@
 /sbin/mount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 /sbin/umount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 
-/usr/bin/fusermount		--	gen_context(system_u:object_r:fusermount_exec_t,s0)
+/usr/bin/fusermount[0-9]?	--	gen_context(system_u:object_r:fusermount_exec_t,s0)
 /usr/bin/mount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 /usr/bin/umount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 


### PR DESCRIPTION
…rmount

Fusermount is utility for mount and umount FUSE filesystems
Make filecontext variable for /usr/bin/fusermount and /bin/fusermount which have fcontext fusermount_exec_t
by adding "*" after path of binary file
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1792909
Fedora Copr build: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1207519/