### PR TITLE
Allow init_t to create apache log files.

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -437,6 +437,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+    apache_create_log_dirs(init_t)
     apache_delete_tmp(init_t)
     apache_noatsecure(init_t)
 ')


### PR DESCRIPTION
PR for new apache create log dirs macro: fedora-selinux/selinux-policy-contrib#194

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1789868
