### PR TITLE
Allow logind to manage /run/user of pulseaudio and session dbus

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -330,6 +330,7 @@ optional_policy(`
 	dbus_connect_system_bus(systemd_logind_t)
 	dbus_system_bus_client(systemd_logind_t)
     dbus_manage_session_tmp_dirs(systemd_logind_t)
+    dbus_manage_session_tmp_files(systemd_logind_t)
 ')
 
 optional_policy(`
@@ -348,6 +349,11 @@ optional_policy(`
 
 optional_policy(`
 	nis_use_ypbind(systemd_logind_t)
+')
+
+optional_policy(`
+       pulseaudio_manage_session_tmp_dirs(systemd_logind_t)
+       pulseaudio_manage_session_tmp_files(systemd_logind_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This is the final commit enabling the patch series of contrib that:
* label /run/user/.../pulse as pulseaudio_home_t
* label /run/user/.../bus as session_dbusd_tmp_t
* label /run/user/.../systemd as session_dbusd_tmp_t

This will need to be merged last. CI will fail until the dependencies are merged, and those are:

- [ ] https://github.com/fedora-selinux/selinux-policy-contrib/pull/196
- [ ] https://github.com/fedora-selinux/selinux-policy-contrib/pull/197