### PR TITLE
Allow systemd-sleep access swapfiles BZ(1797543)

### DIFF
--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -157,6 +157,24 @@ interface(`fstools_getattr_swap_files',`
 
 ########################################
 ## <summary>
+##	Read swapfile
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fstools_read_swap_files',`
+	gen_require(`
+		type swapfile_t;
+	')
+
+	allow $1 swapfile_t:file { read_file_perms };
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete the FSADM pid files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -309,7 +309,7 @@ fs_write_ramfs_sockets(init_t)
 fs_read_efivarfs_files(init_t)
 fs_read_nfsd_files(init_t)
 
-fstools_getattr_swap_files(init_t)
+fstools_read_swap_files(init_t)
 
 mcs_process_set_categories(init_t)
 


### PR DESCRIPTION
Add fstools_read_swap_files() interface.
Allow init_t read swapfile_t files.