### PR TITLE
Backport Create init_create_dirs boolean

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -37,6 +37,13 @@ gen_tunable(daemons_dump_core, false)
 ## </desc>
 gen_tunable(daemons_enable_cluster_mode, false)
 
+## <desc>
+## <p>
+## Enable init create, setattr, mounton on non_security_file_type
+## </p>
+## </desc>
+gen_tunable(init_create_dirs, true)
+
 # used for direct running of init scripts
 # by admin domains
 attribute direct_run_init;
@@ -518,6 +525,12 @@ optional_policy(`
 
 tunable_policy(`use_virtualbox',`
     logging_create_generic_logs(init_t)
+')
+
+tunable_policy(`init_create_dirs',`
+    files_create_non_security_dirs(init_t)
+    files_mounton_non_security(init_t)
+    files_setattr_non_security_dirs(init_t)
 ')
 
 allow init_t self:system all_system_perms;


### PR DESCRIPTION
Create init_create_dirs boolean to allow init to create, mounton,
setattr on non_security_file_type directories