### PR TITLE
Allow systemd system services read efivarfs files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -204,8 +204,6 @@ fs_list_tmpfs(systemd_logind_t)
 fs_list_dos(systemd_logind_t)
 fs_read_dos_files(systemd_logind_t)
 
-fs_read_efivarfs_files(systemd_logind_t)
-
 fs_manage_fusefs_dirs(systemd_logind_t)
 fs_manage_fusefs_files(systemd_logind_t)
 
@@ -264,6 +262,7 @@ fs_getattr_tmpfs(systemd_logind_t)
 fs_read_tmpfs_symlinks(systemd_logind_t)
 fs_mount_tmpfs(systemd_logind_t)
 fs_delete_tmpfs_files(systemd_logind_t)
+fs_read_efivarfs_files(systemd_logind_t)
 userdom_mounton_tmp_dirs(systemd_logind_t)
 
 storage_setattr_removable_dev(systemd_logind_t)
@@ -379,6 +378,7 @@ manage_files_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_mac
 manage_lnk_files_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
 init_var_lib_filetrans(systemd_machined_t, systemd_machined_var_lib_t, dir, "machines")
 
+fs_read_efivarfs_files(systemd_machined_t)
 fs_read_nsfs_files(systemd_machined_t)
 
 kernel_dgram_send(systemd_machined_t)
@@ -745,6 +745,8 @@ dev_write_kmsg(systemd_localed_t)
 
 files_mmap_usr_files(systemd_localed_t)
 
+fs_read_efivarfs_files(systemd_localed_t)
+
 init_dbus_chat(systemd_localed_t)
 init_reload_services(systemd_localed_t)
 
@@ -787,6 +789,7 @@ kernel_read_sysctl(systemd_hostnamed_t)
 dev_write_kmsg(systemd_hostnamed_t)
 dev_read_sysfs(systemd_hostnamed_t)
 
+fs_read_efivarfs_files(systemd_hostnamed_t)
 fs_read_xenfs_files(systemd_hostnamed_t)
 
 init_status(systemd_hostnamed_t)
@@ -823,6 +826,8 @@ kernel_dontaudit_request_load_module(systemd_rfkill_t)
 dev_read_sysfs(systemd_rfkill_t)
 dev_rw_wireless(systemd_rfkill_t)
 dev_write_kmsg(systemd_rfkill_t)
+
+fs_read_efivarfs_files(systemd_rfkill_t)
 
 init_search_var_lib_dirs(systemd_rfkill_t)
 
@@ -869,6 +874,7 @@ dev_write_kmsg(systemd_timedated_t)
 dev_read_sysfs(systemd_timedated_t)
 
 fs_getattr_xattr_fs(systemd_timedated_t)
+fs_read_efivarfs_files(systemd_timedated_t)
 
 init_dbus_chat(systemd_timedated_t)
 init_status(systemd_timedated_t)
@@ -948,6 +954,8 @@ dev_write_kmsg(systemd_sysctl_t)
 
 domain_use_interactive_fds(systemd_sysctl_t)
 
+fs_read_efivarfs_files(systemd_sysctl_t)
+
 init_stream_connect(systemd_sysctl_t)
 
 logging_send_syslog_msg(systemd_sysctl_t)
@@ -973,6 +981,7 @@ manage_files_pattern(systemd_hwdb_t, systemd_hwdb_etc_t, systemd_hwdb_etc_t)
 allow systemd_hwdb_t systemd_hwdb_etc_t:file {relabelfrom relabelto};
 files_etc_filetrans(systemd_hwdb_t, systemd_hwdb_etc_t, file)
 
+fs_read_efivarfs_files(systemd_hwdb_t)
 
 #######################################
 #


### PR DESCRIPTION
Allow systemd_hostnamed_t, systemd_hwdb_t, systemd_localed_t, systemd_machined_t,
systemd_rfkill_t, systemd_sysctl_t, systemd_timedated_t read efivarfs files.
 
Systemd since v244 can read configuration options from the EFI variable
SystemdOptions to configure systemd behaviour when modifying the kernel
command line is inconvenient, but configuration on disk is read too
late, e. g. for the options related to cgroup hierarchy setup.

Resolves: rhbz#1800935