### PR TITLE
Allow init_t to execute_no_trans geoclue

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -446,6 +446,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+        geoclue_exec(init_t)
+')
+
+optional_policy(`
 	journalctl_exec(init_t)
 ')
 


### PR DESCRIPTION
Execute geoclue in the init domain

Applied new geoclue_exec macro: https://github.com/fedora-selinux/selinux-policy-contrib/pull/205

Fixed bug: https://bugzilla.redhat.com/show_bug.cgi?id=1714685