### PR TITLE
Add support for systemd-userdbd

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -415,6 +415,7 @@ optional_policy(`
 
 optional_policy(`
 	systemd_exec_systemctl(sshd_t)
+	systemd_userdbd_stream_connect(sshd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -556,6 +556,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_userdbd_stream_connect(nsswitch_domain)
+')
+
+optional_policy(`
     virt_read_lib_files(nsswitch_domain)
 ')
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -682,6 +682,8 @@ systemd_timedated_manage_lib_dirs(init_t)
 systemd_login_mounton_pid_dirs(init_t)
 systemd_mounton_inherited_logind_sessions_dirs(init_t)
 systemd_delete_private_tmp(init_t)
+systemd_userdbd_stream_connect(init_t)
+systemd_userdbd_runtime_filetrans(init_t)
 
 create_sock_files_pattern(init_t, init_sock_file_type, init_sock_file_type)
 

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -24,6 +24,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/systemd-initctl	--	gen_context(system_u:object_r:systemd_initctl_exec_t,s0)
 
 /usr/lib/systemd/systemd-pull		--	gen_context(system_u:object_r:systemd_importd_exec_t,s0)
+/usr/lib/systemd/systemd-userdbd	--	gen_context(system_u:object_r:systemd_userdbd_exec_t,s0)
+/usr/lib/systemd/systemd-userwork	--	gen_context(system_u:object_r:systemd_userdbd_exec_t,s0)
 
 /etc/systemd/system\.control(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/dracut/modules.d/.*\.service	gen_context(system_u:object_r:systemd_unit_file_t,s0)
@@ -48,6 +50,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/system/.*sleep.*\.(service|target)		--	gen_context(system_u:object_r:power_unit_file_t,s0)
 /usr/lib/systemd/system/.*shutdown.*\.(service|target)		--	gen_context(system_u:object_r:power_unit_file_t,s0)
 /usr/lib/systemd/system/.*suspend.*\.(service|target)		--	gen_context(system_u:object_r:power_unit_file_t,s0)
+/usr/lib/systemd/system/systemd-userdbd\.(service|socket)		--	gen_context(system_u:object_r:systemd_userdbd_unit_file_t,s0)
 /usr/lib/systemd/systemd-hostnamed	--	gen_context(system_u:object_r:systemd_hostnamed_exec_t,s0)
 /usr/lib/systemd/systemd-machined	--	gen_context(system_u:object_r:systemd_machined_exec_t,s0)
 /usr/lib/systemd/systemd-rfkill     --  gen_context(system_u:object_r:systemd_rfkill_exec_t,s0)
@@ -79,6 +82,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /var/run/systemd/sessions(/.*)?	gen_context(system_u:object_r:systemd_logind_sessions_t,s0)
 /var/run/systemd/shutdown(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
+/var/run/systemd/userdb(/.*)?	gen_context(system_u:object_r:systemd_userdbd_runtime_t,s0)
 /var/run/systemd/users(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /var/run/systemd/inhibit(/.*)?	gen_context(system_u:object_r:systemd_logind_inhibit_var_run_t,s0)
 /var/run/systemd/ask-password-block(/.*)?	gen_context(system_u:object_r:systemd_passwd_var_run_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2256,3 +2256,65 @@ interface(`systemd_delete_private_tmp',`
 	allow $1 systemd_private_tmp_type:lnk_file delete_lnk_file_perms;
 	allow $1 systemd_private_tmp_type:sock_file delete_sock_file_perms;
 ')
+
+#######################################
+## <summary>
+##	Create objects in the pid directory
+##	with a private type with a type transition.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_userdbd_runtime_filetrans',`
+	gen_require(`
+		type init_var_run_t;
+		type systemd_userdbd_runtime_t;
+	')
+
+	filetrans_pattern($1, init_var_run_t, systemd_userdbd_runtime_t, dir, "userdb")
+')
+
+#######################################
+## <summary>
+##	Manage systemd-userdbd data sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_userdbd_runtime_manage_sockets',`
+	gen_require(`
+		type systemd_userdbd_runtime_t;
+	')
+
+	manage_sock_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t);
+')
+
+#######################################
+## <summary>
+##	Connect to systemd-userdbd with a unix socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_userdbd_stream_connect',`
+	gen_require(`
+		type systemd_userdbd_t;
+        type systemd_userdbd_runtime_t;
+	')
+
+	files_search_pids($1)
+	list_dirs_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+	read_lnk_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+	write_sock_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+
+	allow $1 systemd_userdbd_t:unix_stream_socket connectto;
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -178,6 +178,14 @@ files_tmp_file(systemd_importd_tmp_t)
 type systemd_machined_devpts_t;
 term_login_pty(systemd_machined_devpts_t)
 
+systemd_domain_template(systemd_userdbd)
+
+type systemd_userdbd_unit_file_t;
+systemd_unit_file(systemd_userdbd_unit_file_t)
+
+type systemd_userdbd_runtime_t;
+files_pid_file(systemd_userdbd_runtime_t)
+
 #######################################
 #
 # Systemd_logind local policy
@@ -291,6 +299,7 @@ init_config_transient_files(systemd_logind_t)
 getty_systemctl(systemd_logind_t)
 
 systemd_config_generic_services(systemd_logind_t)
+systemd_userdbd_stream_connect(systemd_logind_t)
 
 # /run/user/.*
 # Actually only have proof of it creating dirs and symlinks (/run/user/$USER/X11/display)
@@ -1200,3 +1209,24 @@ optional_policy(`
 optional_policy(`
     gpg_exec(systemd_importd_t)
 ')
+
+########################################
+#
+# systemd_userdbd local policy
+#
+allow systemd_userdbd_t self:capability dac_read_search;
+
+manage_dirs_pattern(systemd_userdbd_t, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+manage_files_pattern(systemd_userdbd_t, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+manage_sock_files_pattern(systemd_userdbd_t, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+init_named_pid_filetrans(systemd_userdbd_t, systemd_userdbd_runtime_t, dir, "userdb")
+
+kernel_dgram_send(systemd_userdbd_t)
+
+auth_read_shadow(systemd_userdbd_t)
+auth_use_nsswitch(systemd_userdbd_t)
+
+can_exec(systemd_userdbd_t systemd_userdbd_exec_t)
+
+init_stream_connectto(systemd_userdbd_t)
+


### PR DESCRIPTION
The systemd-userdbd.service is a new service in systemd v245,
allowing rich user and group records. It is a lightweight system service
to translate UNIX/glibc NSS records to JSON user records, eventually
used by other systemd services.

This commit adds the following interfaces:
systemd_userdbd_rw_data() to allow access to userdb data,
systemd_userdbd_data_manage_sock_files() and systemd_userdbd_stream_connect()
to allow communication using userdb sockets,
systemd_userdbd_data_pid_filetrans() for its data directory transition.

Resolves: rhbz#1798883