### PR TITLE
Allow machinectl pull-tar a container image

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1959,6 +1959,7 @@ interface(`systemd_machined_manage_lib_files',`
         files_search_var_lib($1)
         manage_dirs_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
         manage_files_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
+        manage_lnk_files_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
 ')
 
 ########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1171,7 +1171,7 @@ init_stream_connectto(systemd_initctl_t)
 #
 # systemd_importd local policy
 #
-allow systemd_importd_t self:capability { chown fowner fsetid mknod setpcap sys_admin };
+allow systemd_importd_t self:capability { chown dac_override fowner fsetid mknod setfcap setpcap sys_admin };
 allow systemd_importd_t self:process { setcap setfscreate };
 allow systemd_importd_t self:unix_stream_socket create_stream_socket_perms;
 allow systemd_importd_t self:unix_dgram_socket create_socket_perms;
@@ -1213,6 +1213,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+    dbus_manage_session_tmp_dirs(systemd_importd_t)
     dbus_system_bus_client(systemd_importd_t)
     dbus_acquire_svc_system_dbusd(systemd_importd_t)
     unconfined_dbus_send(systemd_importd_t)


### PR DESCRIPTION
Allow systemd_importd_t dbus_manage_session_tmp_dirs().
Allow systemd_machined_t domain_read_all_domains_state().
Update systemd_machined_manage_lib_files() interface to manage also lnk_files.

Resolves: rhbz#1724247