### PR TITLE
Allow login_pgm create and bind on netlink_selinux_socket

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -575,6 +575,7 @@ corecmd_getattr_all_executables(login_pgm)
 domain_kill_all_domains(login_pgm)
 
 allow login_pgm self:netlink_kobject_uevent_socket create_socket_perms;
+allow login_pgm self:netlink_selinux_socket create_socket_perms; 
 allow login_pgm self:capability ipc_lock;
 dontaudit login_pgm self:capability net_admin;
 allow login_pgm self:process setkeycreate;


### PR DESCRIPTION
Required for the latest pam version which started to use
selinux_check_access() instead of security_compute_av().

Resolves: rhbz#1813023