### PR TITLE
Makefile: fix tmp/%.mod.fc target

### DIFF
--- a/support/Makefile.devel
+++ b/support/Makefile.devel
@@ -157,6 +157,7 @@ tmp/%.mod: $(m4support) tmp/all_interfaces.conf %.te
 	$(verbose) $(CHECKMODULE) -m $(@:.mod=.tmp) -o $@
 
 tmp/%.mod.fc: $(m4support) %.fc
+	@test -d $(@D) || mkdir -p $(@D)
 	$(verbose) $(M4) $(M4PARAM) $^ > $@
 
 %.pp: tmp/%.mod tmp/%.mod.fc


### PR DESCRIPTION
%.pp target requires both "tmp/%.mod" and "tmp/%.mod.fc", however only the
former creates the tmp directory when it does not exist. This may lead to
failure since order of satisfying dependencies is not defined.

Fixes:
   #git clone https://github.com/fedora-selinux/selinux-policy-contrib.git -b rawhide
   #cd selinux-policy-contrib
   #make -f /usr/share/selinux/devel/Makefile tmp/ipa.mod.fc
   /bin/sh: tmp/ipa.mod.fc: No such file or directory
   make: *** [/usr/share/selinux/devel/include/Makefile:160: tmp/ipa.mod.fc] Error 1