### PR TITLE
Allow ipsec_t connectto ipsec_mgmt_t

### DIFF
--- a/policy/modules/system/ipsec.fc
+++ b/policy/modules/system/ipsec.fc
@@ -66,3 +66,4 @@
 /var/run/racoon\.pid		--	gen_context(system_u:object_r:ipsec_var_run_t,s0)
 /var/run/pluto/ipsec\.info -- gen_context(system_u:object_r:ipsec_mgmt_var_run_t, s0)
 /var/run/pluto/ipsec_setup\.pid -- gen_context(system_u:object_r:ipsec_mgmt_var_run_t, s0)
+/var/run/strongswan(/.*)?		gen_context(system_u:object_r:ipsec_var_run_t,s0)

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -121,6 +121,8 @@ manage_sock_files_pattern(ipsec_t, ipsec_var_run_t, ipsec_var_run_t)
 files_pid_filetrans(ipsec_t, ipsec_var_run_t, { dir file sock_file })
 allow ipsec_t ipsec_var_run_t:file { map };
 
+stream_connect_pattern(ipsec_t, ipsec_var_run_t, ipsec_var_run_t, ipsec_mgmt_t)
+
 can_exec(ipsec_t, ipsec_mgmt_exec_t)
 can_exec(ipsec_t, ipsec_exec_t)
 


### PR DESCRIPTION
Allow ipsec_t connectto ipsec_mgmt_t using unix_stream_socket.
Label /run/strongswan with ipsec_var_run_t.

Resolves: rhbz#1815983