### PR TITLE
Allow systemd-journald read dbus session links

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -670,6 +670,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dbus_read_session_tmp_lnk_files(syslogd_t)
+')
+
+optional_policy(`
 	inn_manage_log(syslogd_t)
 	inn_generic_log_filetrans_innd_log(syslogd_t, file, "news.crit")
 	inn_generic_log_filetrans_innd_log(syslogd_t, file, "news.err")


### PR DESCRIPTION
Allow syslogd_t read session_dbusd_tmp_t lnk_files

Resolves: rhbz#1816383