### PR TITLE
Add file context entry and file transition for /var/run/pam_timestamp

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -78,6 +78,7 @@ ifdef(`distro_gentoo', `
 /var/run/motd\.d(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_mount(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
+/var/run/pam_timestamp(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/sepermit(/.*)? 	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/sudo(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/(db|adm)/sudo(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -1282,6 +1282,7 @@ interface(`auth_manage_pam_pid',`
 	allow $1 pam_var_run_t:file manage_file_perms;
 	files_pid_filetrans($1, pam_var_run_t, dir, "pam_mount")
 	files_pid_filetrans($1, pam_var_run_t, dir, "pam_ssh")
+	files_pid_filetrans($1, pam_var_run_t, dir, "pam_timestamp")
 	files_pid_filetrans($1, pam_var_run_t, dir, "sepermit")
 	files_pid_filetrans($1, pam_var_run_t, dir, "sudo")
 ')


### PR DESCRIPTION
Add file context entry and file transition for /var/run/pam_timestamp
directory in order to allow pam_timestamp module to create a timestamp
file in a similar manner to how /var/run/sudo was previously used.