### PR TITLE
Change file context for /var/run/pam_ssh to match file transition

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -77,7 +77,7 @@ ifdef(`distro_gentoo', `
 /var/run/motd		--	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/motd\.d(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_mount(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
-/var/run/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
+/var/run/pam_ssh(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_timestamp(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/sepermit(/.*)? 	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/sudo(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)


### PR DESCRIPTION
File context for /var/run/pam_ssh was added by 153ed8751a. The file
transitions in auth_manage_pam_pid() were updated with c3bb30721e
including pam_ssh, but the fc file was not updated accordingly.