### PR TITLE
Modify path for arping in netutils.fc to match both bin and sbin

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -2,7 +2,7 @@
 /bin/tracepath.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /bin/traceroute.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 
-/sbin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
+/s?bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
 
 /usr/bin/lft		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/mtr		--	gen_context(system_u:object_r:traceroute_exec_t,s0)


### PR DESCRIPTION
In iputils newer than iputils-20180629 the arping command moved from
/sbin to /bin, hence the path in the netutils.fc file needs to be
adjusted so that it matches both possible paths for the actual file.
Symlink can have bin_t assigned.

Resolves: rhbz#1820191