### PR TITLE
Introduce daemons_dontaudit_scheduling boolean

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -11,6 +11,13 @@ gen_require(`
 
 ## <desc>
 ## <p>
+## Dontaudit all daemons scheduling requests (setsched, sys_nice).
+## </p>
+## </desc>
+gen_tunable(daemons_dontaudit_scheduling, true)
+
+## <desc>
+## <p>
 ## Allow all daemons to use tcp wrappers.
 ## </p>
 ## </desc>
@@ -1271,6 +1278,11 @@ domain_dontaudit_use_interactive_fds(daemon)
 userdom_dontaudit_list_admin_dir(daemon)
 userdom_dontaudit_search_user_tmp(daemon)
 
+tunable_policy(`daemons_dontaudit_scheduling',`
+	dontaudit daemon self:process { setsched };
+	dontaudit daemon self:capability { sys_nice };
+')
+
 tunable_policy(`daemons_use_tcp_wrapper',`
     corenet_tcp_connect_auth_port(daemon)
 ')
@@ -1881,8 +1893,6 @@ allow daemon initrc_domain:fd use;
 allow daemon initrc_domain:fifo_file rw_inherited_fifo_file_perms;
 allow daemon initrc_domain:process sigchld;
 allow initrc_domain direct_init_entry:file { getattr open read map execute };
-
-dontaudit daemon self:process { setsched };
 
 allow systemprocess initrc_domain:fd use;
 allow systemprocess initrc_domain:fifo_file rw_inherited_fifo_file_perms;


### PR DESCRIPTION
Introduce daemons_dontaudit_scheduling boolean to dontaudit daemons
the setsched process permission and sys_nice capability which are requested
to modify various scheduling information.

With a change introduced to glib2 [1], all daemons using this library start
to require the setsched permission and sys_nice capability. As allowing them
to all daemons is too generic, dontauditing is used instead, but still can be
allowed for particular domain types. With later glib2 updates, library call
fallbacks to different code path if the permission is not allowed so a daemon
does not crash. For more info, see the discussion in rhbz#1795524.

[1] https://gitlab.gnome.org/GNOME/glib/issues/1834

With this update, the previous dontaudit setsched rule was moved to a tunable
block and a dontaudit sys_nice rule was added. The boolean is enabled by default
meaning the denied permissions will be dontaudited. After turning it off,
the denials start to be audited.

Resolves: rhbz#1811407