### PR TITLE
Introduce xdm_manage_bootloader booelan

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -41,11 +41,18 @@ gen_tunable(xserver_clients_write_xshm, false)
 gen_tunable(xserver_execmem, false)
 
 ## <desc>
-## <p>
-## Allow the graphical login program to execute bootloader
-## </p>
+## 	<p>
+## 	Allow the graphical login program to execute bootloader
+##	</p>
 ## </desc>
 gen_tunable(xdm_exec_bootloader, false)
+
+## <desc>
+##	<p>
+##	Allow the graphical login program to create, read, write, and delete files in the /boot director and DOS filesystem.
+## 	</p>
+## </desc>
+gen_tunable(xdm_manage_bootloader,true)
 
 ## <desc>
 ##	<p>
@@ -651,7 +658,6 @@ fs_dontaudit_list_noxattr_fs(xdm_t)
 fs_dontaudit_read_noxattr_fs_files(xdm_t)
 fs_manage_cgroup_dirs(xdm_t)
 fs_manage_cgroup_files(xdm_t)
-fs_manage_dos_files(xdm_t)
 mount_read_pid_files(xdm_t)
 
 mls_socket_write_to_clearance(xdm_t)
@@ -877,12 +883,15 @@ tunable_policy(`use_samba_home_dirs',`
 	fs_exec_cifs_files(xdm_t)
 ')
 
-optional_policy(`
-	tunable_policy(`xdm_exec_bootloader',`
-    	bootloader_exec(xdm_t)
-    	files_read_boot_files(xdm_t)
-    	files_read_boot_symlinks(xdm_t)
-	')
+tunable_policy(`xdm_exec_bootloader',`
+	bootloader_exec(xdm_t)
+	files_read_boot_files(xdm_t)
+	files_read_boot_symlinks(xdm_t)
+')
+
+tunable_policy(`xdm_manage_bootloader',`
+    fs_manage_dos_files(xdm_t)
+    files_manage_boot_files(xdm_t)
 ')
 
 tunable_policy(`xdm_sysadm_login',`


### PR DESCRIPTION
Created xdm_manage_bootloader boolean to create, read, write, and delete files in the /boot director & DOS filesystem.

Resolves: rhbz#1822256