### PR TITLE
Remove container interface calling by named_filetrans_domain.

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -299,10 +299,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-    container_filetrans_named_content(named_filetrans_domain)
-')
-
-optional_policy(`
     ipa_filetrans_named_content(named_filetrans_domain)
 ')
 


### PR DESCRIPTION
This allow rule should be moved to container-selinux package.