### PR TITLE
Allow strongswan use tun/tap devices and keys

### DIFF
--- a/policy/modules/system/ipsec.fc
+++ b/policy/modules/system/ipsec.fc
@@ -11,6 +11,13 @@
 /etc/ipsec\.conf		--	gen_context(system_u:object_r:ipsec_conf_file_t,s0)
 /etc/strongswan/ipsec\.secrets.*		--	gen_context(system_u:object_r:ipsec_key_file_t,s0)
 /etc/strongswan/ipsec\.conf		--	gen_context(system_u:object_r:ipsec_conf_file_t,s0)
+/etc/strongswan/swanctl/bliss/(/.*)?	gen_context(system_u:object_r:ipsec_key_file_t,s0)
+/etc/strongswan/swanctl/ecdsa(/.*)?	gen_context(system_u:object_r:ipsec_key_file_t,s0)
+/etc/strongswan/swanctl/pkcs.*		gen_context(system_u:object_r:ipsec_key_file_t,s0)
+/etc/strongswan/swanctl/private(/.*)?	gen_context(system_u:object_r:ipsec_key_file_t,s0)
+/etc/strongswan/swanctl/pubkey(/.*)?	gen_context(system_u:object_r:ipsec_key_file_t,s0)
+/etc/strongswan/swanctl/rsa(/.*)?	gen_context(system_u:object_r:ipsec_key_file_t,s0)
+/etc/strongswan/swanctl/x509.*		gen_context(system_u:object_r:ipsec_key_file_t,s0)
 /etc/racoon/psk\.txt		--	gen_context(system_u:object_r:ipsec_key_file_t,s0)
 
 /etc/racoon(/.*)?			gen_context(system_u:object_r:ipsec_conf_file_t,s0)

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -133,6 +133,7 @@ can_exec(ipsec_t, ipsec_exec_t)
 corecmd_shell_domtrans(ipsec_t, ipsec_mgmt_t)
 allow ipsec_t ipsec_mgmt_t:process2 nnp_transition;
 
+allow ipsec_mgmt_t self:tun_socket create_socket_perms;
 allow ipsec_mgmt_t ipsec_t:fd use;
 allow ipsec_mgmt_t ipsec_t:fifo_file rw_fifo_file_perms;
 allow ipsec_mgmt_t ipsec_t:unix_stream_socket { read write };
@@ -325,6 +326,7 @@ kernel_dontaudit_request_load_module(ipsec_mgmt_t)
 corenet_udp_bind_dhcpc_port(ipsec_mgmt_t)
 corenet_udp_bind_ipsecnat_port(ipsec_mgmt_t)
 corenet_udp_bind_isakmp_port(ipsec_mgmt_t)
+corenet_rw_tun_tap_dev(ipsec_mgmt_t)
 
 domain_dontaudit_getattr_all_sockets(ipsec_mgmt_t)
 domain_dontaudit_getattr_all_pipes(ipsec_mgmt_t)


### PR DESCRIPTION
Allow ipsec_mgmt_t create tun_socket.
Allow ipsec_mgmt_t read and write tun_tap_device_t devices.
Label directories with keys in /etc/strongswan/swanctl/ as
ipsec_key_file_t.