### PR TITLE
Revert "Change arping path regexp to work around fixfiles incorrect h…

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -2,7 +2,7 @@
 /bin/tracepath.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /bin/traceroute.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 
-/(s)?bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
+/s?bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
 
 /usr/bin/lft		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/mtr		--	gen_context(system_u:object_r:traceroute_exec_t,s0)


### PR DESCRIPTION
…andling"

This reverts commit de454edb84972514a86a27252ff82cc10c1f5589.
The proposed change did not work around the fixfiles behaviour as expected
since any quantifier early in the file context path specification will be
replaced with the '*' wildcard. Moreover, it would introduce additional,
needless relabeling on the next update.