### PR TITLE
Split the path regexp for arping to 2 lines

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -2,7 +2,10 @@
 /bin/tracepath.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /bin/traceroute.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 
-/s?bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
+# regexp can't be used as fixfiles converts any quantifier early in the path to the
+# "/*" wildcard, effecting in complete filesystem restorecon on the package update
+/bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
+/sbin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
 
 /usr/bin/lft		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/mtr		--	gen_context(system_u:object_r:traceroute_exec_t,s0)


### PR DESCRIPTION
Split the "/s?bin/arping" file context regexp to 2 lines to prevent
from relabeling the complete filesystem on the package update as regexp
quantifiers are replaced with "*" wildcards in fixfiles.

Resolves: rhbz#1832790