### PR TITLE
Allow tcpdump sniffing offloaded (RDMA) traffic

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -36,6 +36,7 @@ init_system_domain(traceroute_t, traceroute_exec_t)
 allow netutils_t self:capability { chown dac_read_search net_admin net_raw setuid setgid sys_chroot  setpcap };
 dontaudit netutils_t self:capability { sys_admin sys_tty_config };
 allow netutils_t self:process { setcap signal_perms };
+allow netutils_t self:netlink_rdma_socket create_socket_perms;
 allow netutils_t self:netlink_route_socket create_netlink_socket_perms;
 allow netutils_t self:netlink_socket create_socket_perms;
 # For tcpdump.


### PR DESCRIPTION
Allow netutils_t create and use netlink_rdma_socket