### PR TITLE
Allow sys_admin capability for domain labeled systemd_bootchart_t

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1141,6 +1141,7 @@ modutils_read_module_deps_files(systemd_modules_load_t)
 # systemd_modules_load domain
 #
 
+allow systemd_bootchart_t self:capability sys_admin;
 allow systemd_bootchart_t self:capability2 wake_alarm;
 allow systemd_bootchart_t self:unix_dgram_socket create_socket_perms;
 


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1757050