### PR TITLE
Introduce systemd_read_efivarfs_type attribute

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2257,6 +2257,24 @@ interface(`systemd_delete_private_tmp',`
 	allow $1 systemd_private_tmp_type:lnk_file delete_lnk_file_perms;
 	allow $1 systemd_private_tmp_type:sock_file delete_sock_file_perms;
 ')
+#
+######################################
+## <summary>
+##	Make the specified type usable as a systemd read efivarfs type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Type to be used as a read efivarfs type.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_efivarfs',`
+	gen_require(`
+		attribute systemd_read_efivarfs_type;
+	')
+
+	typeattribute $1 systemd_read_efivarfs_type;
+')
 
 #######################################
 ## <summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -11,6 +11,9 @@ attribute systemctl_domain;
 attribute systemd_mount_directory;
 attribute systemd_private_tmp_type;
 
+attribute systemd_read_efivarfs_type;
+fs_read_efivarfs_files(systemd_read_efivarfs_type)
+
 systemd_domain_template(systemd_logger)
 systemd_domain_template(systemd_logind)
 
@@ -270,7 +273,6 @@ fs_getattr_tmpfs(systemd_logind_t)
 fs_read_tmpfs_symlinks(systemd_logind_t)
 fs_mount_tmpfs(systemd_logind_t)
 fs_delete_tmpfs_files(systemd_logind_t)
-fs_read_efivarfs_files(systemd_logind_t)
 userdom_mounton_tmp_dirs(systemd_logind_t)
 
 storage_setattr_removable_dev(systemd_logind_t)
@@ -298,6 +300,7 @@ init_config_transient_files(systemd_logind_t)
 getty_systemctl(systemd_logind_t)
 
 systemd_config_generic_services(systemd_logind_t)
+systemd_read_efivarfs(systemd_logind_t)
 systemd_userdbd_stream_connect(systemd_logind_t)
 
 # /run/user/.*
@@ -389,7 +392,6 @@ manage_files_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_mac
 manage_lnk_files_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
 init_var_lib_filetrans(systemd_machined_t, systemd_machined_var_lib_t, dir, "machines")
 
-fs_read_efivarfs_files(systemd_machined_t)
 fs_read_nsfs_files(systemd_machined_t)
 
 kernel_dgram_send(systemd_machined_t)
@@ -406,6 +408,8 @@ init_stop(systemd_machined_t)
 init_manage_config_transient_files(systemd_machined_t)
 
 logging_dgram_send(systemd_machined_t)
+
+systemd_read_efivarfs(systemd_machined_t)
 
 userdom_dbus_send_all_users(systemd_machined_t)
 
@@ -476,7 +480,6 @@ corenet_tcp_bind_dhcpd_port(systemd_networkd_t)
 corenet_udp_bind_dhcpd_port(systemd_networkd_t)
 
 fs_read_xenfs_files(systemd_networkd_t)
-fs_read_efivarfs_files(systemd_networkd_t)
 
 dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)
@@ -487,6 +490,7 @@ sysnet_manage_config(systemd_networkd_t)
 sysnet_manage_config_dirs(systemd_networkd_t)
 
 systemd_dbus_chat_hostnamed(systemd_networkd_t)
+systemd_read_efivarfs(systemd_networkd_t)
 
 init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "netif")
 
@@ -757,8 +761,6 @@ dev_write_kmsg(systemd_localed_t)
 
 files_mmap_usr_files(systemd_localed_t)
 
-fs_read_efivarfs_files(systemd_localed_t)
-
 init_dbus_chat(systemd_localed_t)
 init_reload_services(systemd_localed_t)
 
@@ -769,6 +771,8 @@ allow systemd_localed_t systemd_vconsole_unit_file_t:service start;
 
 miscfiles_manage_localization(systemd_localed_t)
 miscfiles_etc_filetrans_localization(systemd_localed_t)
+
+systemd_read_efivarfs(systemd_localed_t)
 
 userdom_dbus_send_all_users(systemd_localed_t)
 
@@ -801,13 +805,14 @@ kernel_read_sysctl(systemd_hostnamed_t)
 dev_write_kmsg(systemd_hostnamed_t)
 dev_read_sysfs(systemd_hostnamed_t)
 
-fs_read_efivarfs_files(systemd_hostnamed_t)
 fs_read_xenfs_files(systemd_hostnamed_t)
 
 init_status(systemd_hostnamed_t)
 init_stream_connect(systemd_hostnamed_t)
 
 logging_send_syslog_msg(systemd_hostnamed_t)
+
+systemd_read_efivarfs(systemd_hostnamed_t)
 
 userdom_read_all_users_state(systemd_hostnamed_t)
 userdom_dbus_send_all_users(systemd_hostnamed_t)
@@ -839,11 +844,12 @@ dev_read_sysfs(systemd_rfkill_t)
 dev_rw_wireless(systemd_rfkill_t)
 dev_write_kmsg(systemd_rfkill_t)
 
-fs_read_efivarfs_files(systemd_rfkill_t)
 
 init_search_var_lib_dirs(systemd_rfkill_t)
 
 logging_dgram_send(systemd_rfkill_t)
+
+systemd_read_efivarfs(systemd_rfkill_t)
 
 optional_policy(`
     udev_read_db(systemd_rfkill_t)
@@ -886,7 +892,6 @@ dev_write_kmsg(systemd_timedated_t)
 dev_read_sysfs(systemd_timedated_t)
 
 fs_getattr_xattr_fs(systemd_timedated_t)
-fs_read_efivarfs_files(systemd_timedated_t)
 
 init_dbus_chat(systemd_timedated_t)
 init_status(systemd_timedated_t)
@@ -897,6 +902,8 @@ logging_send_syslog_msg(systemd_timedated_t)
 
 miscfiles_manage_localization(systemd_timedated_t)
 miscfiles_etc_filetrans_localization(systemd_timedated_t)
+
+systemd_read_efivarfs(systemd_timedated_t)
 
 userdom_read_all_users_state(systemd_timedated_t)
 
@@ -966,11 +973,11 @@ dev_write_kmsg(systemd_sysctl_t)
 
 domain_use_interactive_fds(systemd_sysctl_t)
 
-fs_read_efivarfs_files(systemd_sysctl_t)
-
 init_stream_connect(systemd_sysctl_t)
 
 logging_send_syslog_msg(systemd_sysctl_t)
+
+systemd_read_efivarfs(systemd_sysctl_t)
 
 #######################################
 #
@@ -993,7 +1000,7 @@ manage_files_pattern(systemd_hwdb_t, systemd_hwdb_etc_t, systemd_hwdb_etc_t)
 allow systemd_hwdb_t systemd_hwdb_etc_t:file {relabelfrom relabelto};
 files_etc_filetrans(systemd_hwdb_t, systemd_hwdb_etc_t, file)
 
-fs_read_efivarfs_files(systemd_hwdb_t)
+systemd_read_efivarfs(systemd_hwdb_t)
 
 #######################################
 #
@@ -1007,7 +1014,6 @@ dev_write_kmsg(systemd_gpt_generator_t)
 dev_read_nvme(systemd_gpt_generator_t)
 dev_read_rand(systemd_gpt_generator_t)
 
-fs_read_efivarfs_files(systemd_gpt_generator_t)
 
 fstools_exec(systemd_gpt_generator_t)
 
@@ -1018,6 +1024,7 @@ storage_raw_read_fixed_disk(systemd_gpt_generator_t)
 storage_raw_read_removable_device(systemd_gpt_generator_t)
 
 allow systemd_gpt_generator_t systemd_gpt_generator_unit_file_t:file manage_file_perms;
+systemd_read_efivarfs(systemd_gpt_generator_t)
 systemd_unit_file_filetrans(systemd_gpt_generator_t, systemd_gpt_generator_unit_file_t, file)
 systemd_create_unit_file_dirs(systemd_gpt_generator_t)
 systemd_create_unit_file_lnk(systemd_gpt_generator_t)
@@ -1135,7 +1142,6 @@ files_read_kernel_modules(systemd_modules_load_t)
 modutils_read_module_config(systemd_modules_load_t)
 modutils_read_module_deps_files(systemd_modules_load_t)
 
-
 #######################################
 #
 # systemd_modules_load domain
@@ -1241,9 +1247,8 @@ auth_use_nsswitch(systemd_userdbd_t)
 
 can_exec(systemd_userdbd_t systemd_userdbd_exec_t)
 
-fs_read_efivarfs_files(systemd_userdbd_t)
-
 init_stream_connectto(systemd_userdbd_t)
 
 logging_send_syslog_msg(systemd_userdbd_t)
 
+systemd_read_efivarfs(systemd_userdbd_t)


### PR DESCRIPTION
Introduce systemd_read_efivarfs_type attribute for domains to read efivarfs.
Create a systemd_read_efivarfs() interface to allow a domain be part of
the systemd_read_efivarfs_type attribute.
Replace fs_read_efivarfs_files() calls in systemd.te
with systemd_read_efivarfs().