### PR TITLE
Allow systemd-logind manage efivarfs files

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6981,6 +6981,25 @@ interface(`fs_read_efivarfs_files',`
         read_files_pattern($1, efivarfs_t, efivarfs_t)
 ')
 
+#######################################
+## <summary>
+##      Manage efivarfs files 
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_manage_efivarfs_files',`
+        gen_require(`
+                type efivarfs_t;
+        ')
+
+        manage_files_pattern($1, efivarfs_t, efivarfs_t)
+')
+
 ########################################
 ## <summary>
 ##	Search efivarfs directories.

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -269,6 +269,7 @@ domain_destroy_all_semaphores(systemd_logind_t)
 fs_manage_cgroup_dirs(systemd_logind_t)
 # write getattr open setattr
 fs_manage_cgroup_files(systemd_logind_t)
+fs_manage_efivarfs_files(systemd_logind_t)
 fs_getattr_tmpfs(systemd_logind_t)
 fs_read_tmpfs_symlinks(systemd_logind_t)
 fs_mount_tmpfs(systemd_logind_t)


### PR DESCRIPTION
Add new fs_manage_efivarfs_files() interface.
Allow systemd_logind_t fs_manage_efivarfs_files().

Resolves: rhbz#1840278