### PR TITLE
Allow systemd-tty-ask-password-agent read efivarfs files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -550,6 +550,8 @@ init_stream_connect(systemd_passwd_agent_t)
 
 logging_send_syslog_msg(systemd_passwd_agent_t)
 
+systemd_read_efivarfs(systemd_passwd_agent_t)
+
 userdom_use_user_ptys(systemd_passwd_agent_t)
 userdom_use_user_ttys(systemd_passwd_agent_t)
 


### PR DESCRIPTION
Allow systemd_passwd_agent_t read efivarfs_t.

Resolves: rhbz#1830255