### PR TITLE
Allow initrc_t tlp_filetrans_named_content()

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -814,6 +814,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tlp_filetrans_named_content(initrc_t)
+')
+
+optional_policy(`
 	udev_read_db(init_t)
 	udev_relabelto_db(init_t)
 	udev_create_kobject_uevent_socket(init_t)


### PR DESCRIPTION
NetworkManager dispatcher scripts have the
NetworkManager_initrc_exec_t type which transitions to initrc_t.
This update adds tlp_filetrans_named_content() for initrc_t.

Resolves: rhbz#1806123