### PR TITLE
Split the arping path regexp to 2 lines to prevent from relabeling

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -2,7 +2,10 @@
 /bin/tracepath.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /bin/traceroute.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 
-/s?bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
+# regexp can't be used as fixfiles converts any quantifier early in the path to the
+# "/*" wildcard, effecting in complete filesystem restorecon on the package update
+/bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
+/sbin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
 
 /usr/bin/lft		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/mtr		--	gen_context(system_u:object_r:traceroute_exec_t,s0)


### PR DESCRIPTION
Split the "/s?bin/arping" file context regexp to 2 lines without
a quantifier to prevent from relabeling the complete filesystem on the
selinux-policy package update.
In the %post rpm scriptlet, a list of files necessary to relabel is made
as narrow as possible, fixfiles however replaces regexp quantifiers with
"*" wildcards, so "/s?bin/arping" becomes "/*".

Resolves: rhbz#1832790
Works around: rhbz#1832327