### PR TITLE
Allow domain mmap usr_t files

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -161,6 +161,7 @@ files_search_base_file_types(domain)
 
 files_read_inherited_tmp_files(domain)
 files_append_inherited_tmp_files(domain)
+files_mmap_usr_files(domain)
 files_read_all_base_ro_files(domain)
 files_dontaudit_getattr_kernel_symbol_table(domain)
 


### PR DESCRIPTION
This commit adds the map permission for domain to usr_t, similar to one permissions group they already have:
```
files_read_all_base_ro_files(domain)
```
typically for files like `/usr/share/p11-kit/modules/p11-kit-trust.module` where the other permission have already been allowed.
