### PR TITLE
Remove files_mmap_usr_files() call for systemd domains

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -762,8 +762,6 @@ allow systemd_localed_t self:unix_dgram_socket create_socket_perms;
 
 dev_write_kmsg(systemd_localed_t)
 
-files_mmap_usr_files(systemd_localed_t)
-
 init_dbus_chat(systemd_localed_t)
 init_reload_services(systemd_localed_t)
 
@@ -1102,7 +1100,6 @@ fs_getattr_all_fs(systemd_domain)
 files_read_etc_files(systemd_domain)
 files_read_etc_runtime_files(systemd_domain)
 files_read_usr_files(systemd_domain)
-files_mmap_usr_files(systemd_domain)
 
 init_search_pid_dirs(systemd_domain)
 init_start_transient_unit(systemd_domain)


### PR DESCRIPTION
Remove all files_mmap_usr_files() calls in favor of the new, more
generic rule files_mmap_usr_files(domain). This applies to the following
types and domains:
systemd_localed_t systemd_domain

Related: https://github.com/fedora-selinux/selinux-policy/pull/371