### PR TITLE
Allow libkrb5 lib read client keytabs

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -246,6 +246,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	kerberos_read_keytab(ssh_t)
+')
+
+optional_policy(`
 	xserver_user_x_domain_template(ssh, ssh_t, ssh_tmpfs_t)
 	xserver_domtrans_xauth(ssh_t)
 ')


### PR DESCRIPTION
Allow ssh processes with the ssh_t type to search directories in the
/var/kerberos/krb5 directory labeled krb5_keytab_t and read files with
the same type in subdirectories.