### PR TITLE
Allow systemd-modules to load kernel modules

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1135,12 +1135,17 @@ kernel_dgram_send(systemd_modules_load_t)
 kernel_load_module(systemd_modules_load_t)
 kernel_ib_access_unlabeled_pkeys(systemd_modules_load_t)
 
+corecmd_exec_bin(systemd_modules_load_t)
+corecmd_exec_shell(systemd_modules_load_t)
+
 dev_read_sysfs(systemd_modules_load_t)
 
 init_read_pid_files(systemd_modules_load_t)
 
 files_map_kernel_modules(systemd_modules_load_t)
 files_read_kernel_modules(systemd_modules_load_t)
+
+modutils_exec_kmod(systemd_modules_load_t)
 modutils_read_module_config(systemd_modules_load_t)
 modutils_read_module_deps_files(systemd_modules_load_t)
 


### PR DESCRIPTION
Allow systemd-modules to load kernel modules at boot time
according to settings in /etc/modules-load.d.

This includes the following permission groups:
- execute generic programs in bin directories in the caller domain,
- execute shells in the caller domain,
- execute insmod in the caller domain.