### PR TITLE
Add kernel_rw_key() interface to access to kernel keyrings

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -477,6 +477,24 @@ interface(`kernel_dontaudit_link_key',`
 
 ########################################
 ## <summary>
+##	Allow append, read, view, and write the kernel key ring.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_rw_key',`
+	gen_require(`
+		type kernel_t;
+	')
+
+	allow $1 kernel_t:key { append read view write };
+')
+
+########################################
+## <summary>
 ##	Allow view the kernel key ring.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Add kernel_rw_key() interface to allow view, read, and write access
to kernel keyrings.