### PR TITLE
Modify systemd_delete_private_tmp() to use delete_*_pattern macros

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2251,11 +2251,11 @@ interface(`systemd_delete_private_tmp',`
 		attribute systemd_private_tmp_type;
 	')
 
-	allow $1 systemd_private_tmp_type:dir delete_dir_perms;
-	allow $1 systemd_private_tmp_type:fifo_file delete_fifo_file_perms;
-	allow $1 systemd_private_tmp_type:file delete_file_perms;
-	allow $1 systemd_private_tmp_type:lnk_file delete_lnk_file_perms;
-	allow $1 systemd_private_tmp_type:sock_file delete_sock_file_perms;
+	delete_dirs_pattern($1, systemd_private_tmp_type, systemd_private_tmp_type)
+	delete_fifo_files_pattern($1, systemd_private_tmp_type, systemd_private_tmp_type)
+	delete_files_pattern($1, systemd_private_tmp_type, systemd_private_tmp_type)
+	delete_lnk_files_pattern($1, systemd_private_tmp_type, systemd_private_tmp_type)
+	delete_sock_files_pattern($1, systemd_private_tmp_type, systemd_private_tmp_type)
 ')
 #
 ######################################


### PR DESCRIPTION
Modify the systemd_delete_private_tmp() interface to use delete_*_pattern
macros instead of simple allow rules to allow all permissions related to
removing files.