### PR TITLE
Modify kernel_rw_key() not to include append permission

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -477,7 +477,7 @@ interface(`kernel_dontaudit_link_key',`
 
 ########################################
 ## <summary>
-##	Allow append, read, view, and write the kernel key ring.
+##	Allow read, view, and write the kernel key ring.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -490,7 +490,7 @@ interface(`kernel_rw_key',`
 		type kernel_t;
 	')
 
-	allow $1 kernel_t:key { append read view write };
+	allow $1 kernel_t:key { read view write };
 ')
 
 ########################################


### PR DESCRIPTION
Modify the kernel_rw_key() interface not to include append permission
which is not defined for the class key.