### PR TITLE
Allow staff_u and user_u setattr generic usb devices

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -44,6 +44,7 @@ dev_read_cpuid(staff_t)
 dev_read_kmsg(staff_t)
 dev_map_video_dev(staff_t)
 dev_rwx_zero(staff_t)
+dev_setattr_generic_usb_dev(staff_t)
 
 domain_read_all_domains_state(staff_t)
 domain_getcap_all_domains(staff_t)

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -22,6 +22,8 @@ userdom_unpriv_user_template(user)
 kernel_read_numa_state(user_t)
 kernel_write_numa_state(user_t)
 
+dev_setattr_generic_usb_dev(user_t)
+
 files_dontaudit_manage_boot_dirs(user_t)
 fs_exec_noxattr(user_t)
 fs_read_hugetlbfs_files(user_t)


### PR DESCRIPTION
Allow the staff_u and user_u confined users change file attributes
of generic usb devices. This is required for spice to be able to
forward client devices.