### PR TITLE
[WIP] Allow userdomain transition to cups named home content

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -305,6 +305,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cups_filetrans_admin_home_content(userdomain)
+	cups_filetrans_home_content(userdomain)
+')
+
+optional_policy(`
 	cvs_filetrans_home_content(userdom_filetrans_type)
 ')
 


### PR DESCRIPTION
Allow the userdomain attribute file transition to cups named content
in user's home and root's home directories.