### PR TITLE
Revert "Add support for fuse.glusterfs"

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -40,7 +40,6 @@ fs_use_xattr overlay gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr xfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr squashfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr zfs gen_context(system_u:object_r:fs_t,s0);
-fs_use_xattr fuse.glusterfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr shiftfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr vxfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr odms gen_context(system_u:object_r:fs_t,s0);


### PR DESCRIPTION
This reverts commit 6abeed7ba23965f68294bf3cd145b26ddf3a18e0.

Filesystem subtypes are not currently supported [1], so this line never
did anything. Moreover, SELint [2] chokes on it, so let's just remove
it.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1272868
[2] https://github.com/TresysTechnology/selint