### PR TITLE
Allow domain dbus chat with systemd-resolved

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -504,6 +504,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_dbus_chat_resolved(domain)
 	systemd_login_status(unconfined_domain_type)
 	systemd_login_reboot(unconfined_domain_type)
 	systemd_login_halt(unconfined_domain_type)

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1006,7 +1006,6 @@ interface(`sysnet_dns_name_resolve',`
 
 	optional_policy(`
 		dbus_stream_connect_system_dbusd($1)
-		systemd_dbus_chat_resolved($1)
 	')
 
 	optional_policy(`

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -202,10 +202,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_dbus_chat_resolved(userdomain)
-')
-
-optional_policy(`
 	telepathy_filetrans_home_content(userdomain)
 ')
 


### PR DESCRIPTION
Allow all types in the domain attribute dbus chat with systemd-resolved.
This is required for gethostby* functions when nsswitch is configured to
call systemd-resolved using the resolve entry e. g. for the hosts database.

Remove all duplicate references to systemd_dbus_chat_resolved():
- for userdomain,
- in the sysnet_dns_name_resolve() interface.