### PR TITLE
Define file context for /var/run/netns directory only

### DIFF
--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -102,6 +102,8 @@ ifdef(`distro_debian',`
 /var/run/network(/.*)?	gen_context(system_u:object_r:net_conf_t,s0)
 ')
 
-/var/run/netns(/.*)?		gen_context(system_u:object_r:ifconfig_var_run_t,s0)
+/var/run/netns	-d 		gen_context(system_u:object_r:ifconfig_var_run_t,s0)
+/var/run/netns/[^/]+       	<<none>>
+
 /etc/firestarter/firestarter\.sh gen_context(system_u:object_r:dhcpc_helper_exec_t,s0)
 


### PR DESCRIPTION
Define file context specification for /var/run/netns directory only,
not for files in this directory as the files, created by different
processes, can have arbitrary types unknown beforehand.