### PR TITLE
Allow systemd set efivarfs files attributes

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -7002,6 +7002,25 @@ interface(`fs_search_efivarfs_dirs',`
 
 ########################################
 ## <summary>
+##	Set the attributes of efivarfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_setattr_efivarfs_files',`
+	gen_require(`
+		type efivarfs_t;
+
+	')
+
+	allow $1 efivarfs_t:file setattr;
+')
+
+########################################
+## <summary>
 ##	Read and write sockets of ONLOAD file system pipes.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -314,6 +314,7 @@ fs_list_inotifyfs(init_t)
 fs_write_ramfs_sockets(init_t)
 
 fs_read_efivarfs_files(init_t)
+fs_setattr_efivarfs_files(init_t)
 fs_read_nfsd_files(init_t)
 
 fstools_getattr_swap_files(init_t)


### PR DESCRIPTION
Create the fs_setattr_efivarfs_files() interface to allow setting
the attributes of efivarfs files.
Allow init_t fs_setattr_efivarfs_files().

Resolves: rhbz#1775780