### PR TITLE
Align gen_tunable() syntax with sepolgen

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1019,7 +1019,7 @@ template(`userdom_login_user_template', `
 	userdom_manage_tmp_role($1_r, $1_usertype)
 
 	ifelse(`$1',`unconfined',`',`
-		gen_tunable($1_exec_content, true)
+		gen_tunable(`$1_exec_content', true)
 
 		tunable_policy(`$1_exec_content',`
 			userdom_exec_user_tmp_files($1_usertype)
@@ -6557,7 +6557,7 @@ template(`userdom_confined_admin_template',`
 	auth_use_nsswitch($1_t)
 
 	ifelse(`$1',`unconfined',`',`
-		gen_tunable($1_exec_content, true)
+		gen_tunable(`$1_exec_content', true)
 
 		tunable_policy(`$1_exec_content',`
 			userdom_exec_user_tmp_files($1_t)


### PR DESCRIPTION
After userspace commit [5adc269f95bb](https://github.com/SELinuxProject/selinux/commit/5adc269f95bb128c4f65c1d24766f56f57221fe6) ("sepolgen: parse gen_tunable as
bool"), running `sepolgen-ifgen` over the policy produces these errors
(visible during the `%post` scriptlet of `selinux-policy-devel`):
```
/usr/share/selinux/devel/include/system/userdomain.if: Syntax error on line 1022 $1_exec_content [type=IDENTIFIER]
/usr/share/selinux/devel/include/system/userdomain.if: Syntax error on line 1035 ' [type=SQUOTE]
/usr/share/selinux/devel/include/system/userdomain.if: Syntax error on line 1164 ' [type=SQUOTE]
/usr/share/selinux/devel/include/system/userdomain.if: Syntax error on line 6560 $1_exec_content [type=IDENTIFIER]
/usr/share/selinux/devel/include/system/userdomain.if: Syntax error on line 6573 ' [type=SQUOTE]
```
Fix it by quoting the first argument to `gen_tunable()` as `sepolgen`
expects it.