### PR TITLE
Allow login programs to read MOTD files and symlinks, and label /var/run/zincati/public/motd.d/*

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -74,8 +74,8 @@ ifdef(`distro_gentoo', `
 
 /var/run/console(/.*)?	 	gen_context(system_u:object_r:pam_var_console_t,s0)
 /var/run/faillock(/.*)?		gen_context(system_u:object_r:faillog_t,s0)
-/var/run/motd		--	gen_context(system_u:object_r:pam_var_run_t,s0)
-/var/run/motd\.d(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
+/var/run/motd		--	gen_context(system_u:object_r:motd_var_run_t,s0)
+/var/run/motd\.d(/.*)?		gen_context(system_u:object_r:motd_var_run_t,s0)
 /var/run/pam_mount(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_ssh(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/run/pam_timestamp(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -83,3 +83,7 @@ ifdef(`distro_gentoo', `
 /var/run/sudo(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/(db|adm)/sudo(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/lib/sudo(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
+
+# Allow services not running as root to write MOTD messages via symlink
+# out of /run/motd.d/. https://github.com/coreos/zincati/pull/276
+/var/run/zincati/public/motd\.d(/.*)?	gen_context(system_u:object_r:motd_var_run_t,s0)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -77,6 +77,11 @@ files_pid_file(pam_var_console_t)
 type pam_var_run_t;
 files_pid_file(pam_var_run_t)
 
+# For MOTD files read by login programs, e.g. sshd, located in
+# /run/motd.d/, or symlinked out from /run/motd.d/
+type motd_var_run_t;
+files_type(motd_var_run_t);
+
 type shadow_t;
 files_auth_file(shadow_t)
 neverallow ~can_read_shadow_passwords shadow_t:file read;
@@ -640,6 +645,10 @@ selinux_compute_user_contexts(login_pgm)
 
 auth_manage_faillog(login_pgm)
 auth_manage_pam_pid(login_pgm)
+
+list_dirs_pattern(login_pgm, motd_var_run_t, motd_var_run_t);
+read_files_pattern(login_pgm, motd_var_run_t, motd_var_run_t);
+read_lnk_files_pattern(login_pgm, motd_var_run_t, motd_var_run_t);
 
 init_rw_utmp(login_pgm)
 


### PR DESCRIPTION
The first commit is a more general fix - login programs should be able to read symlinks out of `/run/motd.d/` e.g. `/run/motd.d/my.motd -> /run/path/to/my.motd`, but currently `sshd` gets an AVC denial (trying on Fedora 32) on dereferencing the symlink. Since this requires extending the allowed rules for the type used for the runtime MOTD file/directory, I think this warrants a new type, `motd_var_run_t` (which had been suggested in https://github.com/fedora-selinux/selinux-policy/pull/244).

The second commit uses the new label, and will enable functionality in https://github.com/coreos/zincati/pull/276.

Please see commit messages for further details.

Will require backporting this to F32, if accepted.