### PR TITLE
Add dev_lock_all_blk_files() interface

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -1169,6 +1169,26 @@ interface(`dev_getattr_all_blk_files',`
 
 ########################################
 ## <summary>
+##	Lock on all block file device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`dev_lock_all_blk_files',`
+	gen_require(`
+		attribute device_node;
+		type device_t;
+	')
+
+	lock_blk_files_pattern($1, device_t, device_node)
+')
+
+########################################
+## <summary>
 ##	Read on all block file device nodes.
 ## </summary>
 ## <param name="domain">

--- a/policy/support/file_patterns.spt
+++ b/policy/support/file_patterns.spt
@@ -408,6 +408,11 @@ define(`setattr_blk_files_pattern',`
 	allow $1 $3:blk_file setattr_blk_file_perms;
 ')
 
+define(`lock_blk_files_pattern',`
+	allow $1 $2:dir search_dir_perms;
+	allow $1 $3:blk_file lock_blk_file_perms;
+')
+
 define(`read_blk_files_pattern',`
 	allow $1 $2:dir search_dir_perms;
 	allow $1 $3:blk_file read_blk_file_perms;

--- a/policy/support/obj_perm_sets.spt
+++ b/policy/support/obj_perm_sets.spt
@@ -233,6 +233,7 @@ define(`relabel_sock_file_perms',`{ getattr relabelfrom relabelto }')
 #
 define(`getattr_blk_file_perms',`{ getattr }')
 define(`setattr_blk_file_perms',`{ setattr }')
+define(`lock_blk_file_perms',`{ getattr lock }')
 define(`read_blk_file_perms',`{ getattr open read lock ioctl }')
 define(`append_blk_file_perms',`{ getattr open append lock ioctl }')
 define(`write_blk_file_perms',`{ getattr open write append lock ioctl }')


### PR DESCRIPTION
For use in the dev_lock_all_blk_files() interface, create the
lock_blk_files_pattern and lock_blk_file_perms object permissions set.