### PR TITLE
Allow unconfined and confined users bind ICMP sockets to generic nodes in node_t domain

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -140,6 +140,7 @@ corenet_raw_sendrecv_generic_node(ping_t)
 corenet_tcp_sendrecv_generic_node(ping_t)
 corenet_raw_bind_generic_node(ping_t)
 corenet_tcp_sendrecv_all_ports(ping_t)
+corenet_icmp_bind_generic_node(ping_t)
 
 fs_dontaudit_getattr_xattr_fs(ping_t)
 fs_dontaudit_rw_anon_inodefs_files(ping_t)
@@ -245,6 +246,7 @@ corenet_tcp_connect_all_ports(traceroute_t)
 corenet_sendrecv_all_client_packets(traceroute_t)
 corenet_sendrecv_traceroute_server_packets(traceroute_t)
 corenet_sctp_bind_generic_node(traceroute_t)
+corenet_icmp_bind_generic_node(traceroute_t)
 
 corecmd_exec_bin(traceroute_t)
 

--- a/policy/modules/kernel/corenetwork.if.in
+++ b/policy/modules/kernel/corenetwork.if.in
@@ -863,6 +863,24 @@ interface(`corenet_sctp_bind_generic_node',`
 
 ########################################
 ## <summary>
+##	Bind ICMP sockets to generic nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corenet_icmp_bind_generic_node',`
+	gen_require(`
+		type node_t;
+	')
+
+	allow $1 node_t:icmp_socket node_bind;
+')
+
+########################################
+## <summary>
 ##	Bind TCP sockets to generic nodes.
 ## </summary>
 ## <desc>

--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -465,7 +465,7 @@ allow corenet_unconfined_type port_type:udp_socket { send_msg recv_msg };
 
 # Bind to any network address.
 allow corenet_unconfined_type port_type:{ dccp_socket tcp_socket udp_socket rawip_socket sctp_socket} name_bind;
-allow corenet_unconfined_type node_type:{ dccp_socket tcp_socket udp_socket rawip_socket sctp_socket } node_bind;
+allow corenet_unconfined_type node_type:{ dccp_socket icmp_socket tcp_socket udp_socket rawip_socket sctp_socket } node_bind;
 
 # Infiniband
 corenet_ib_access_all_pkeys(corenet_unconfined_type)


### PR DESCRIPTION

Commit 1 - Allow unconfined_t to node_bind icmp_sockets in node_t domain 
When uncofined user run ping or traceroute, this process get label unconfined_t.
Allow to ping or traceroute, which run as unconfined_t, to node_bind icmp_sockets in node_t domain.

Commit 2 - Create macro corenet_icmp_bind_generic_node()
This macro allowing bind ICMP sockets to generic nodes in node_t domain.

Commit 3 -  Allow traceroute_t and ping_t to bind generic nodes.
Use newly created macro corenet_icmp_bind_generic_node() for ping_t and traceroute_t.
This macro allowing bind generic nodes in node_t domain.


Bugzila: https://bugzilla.redhat.com/show_bug.cgi?id=1848929#c0