### PR TITLE
Dontaudit domain write to dirs labeled as "lib_t"

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -211,6 +211,8 @@ optional_policy(`
 	libs_use_ld_so(domain)
 	libs_use_shared_libs(domain)
 	libs_read_lib_files(domain)
+    # dontaudit access when python is trying to create "bytecode cache"
+    libs_dontaudit_write_lib_dirs(domain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Python generates a "bytecode cache" file when a module is imported.  We currently pre-generate and ship all cache files Python might attempt to create. This makes imports faster. But, we'd like to make these files optional, so that we can minimize disk size (and sacrifice speed) in minimal containers. If the cache files are missing, Python will try to create them. For RPM-installed
modules, the cache is written in /usr/lib/, where normal users can't write.