### PR TITLE
Allow systemd-machined create userdbd runtime sock files

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2374,3 +2374,21 @@ interface(`systemd_userdbd_stream_connect',`
 
 	allow $1 systemd_userdbd_t:unix_stream_socket connectto;
 ')
+
+#######################################
+## <summary>
+##	Create a named socket in userdbd runtime directory
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_create_userdbd_runtime_sock_files',`
+	gen_require(`
+        	type systemd_userdbd_runtime_t;
+	')
+
+	create_sock_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -415,6 +415,7 @@ init_manage_config_transient_files(systemd_machined_t)
 logging_dgram_send(systemd_machined_t)
 
 systemd_read_efivarfs(systemd_machined_t)
+systemd_create_userdbd_runtime_sock_files(systemd_machined_t)
 
 userdom_dbus_send_all_users(systemd_machined_t)
 


### PR DESCRIPTION
Create the systemd_create_userdbd_runtime_sock_files() interface.

Resolves: rhbz#1862686