### PR TITLE
Allow nsswitch_domain to connect to systemd-machined using a unix socket

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -563,6 +563,7 @@ optional_policy(`
 
 optional_policy(`
 	systemd_userdbd_stream_connect(nsswitch_domain)
+	systemd_machined_stream_connect(nsswitch_domain)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2001,6 +2001,25 @@ interface(`systemd_machined_rw_devpts_chr_files',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain to connect to
+##	systemd_machined with a unix socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_machined_stream_connect',`
+	gen_require(`
+		type systemd_machined_t;
+	')
+
+	allow $1 systemd_machined_t:unix_stream_socket connectto;
+')
+
+########################################
+## <summary>
 ##	Send and receive messages from
 ##	systemd machined over dbus.
 ## </summary>


### PR DESCRIPTION
Create the systemd_machined_stream_connect() interface.

Resolves: rhbz#1865748