### PR TITLE
Allow traceroute_t and ping_t to bind generic nodes.

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -139,6 +139,7 @@ corenet_raw_sendrecv_generic_node(ping_t)
 corenet_tcp_sendrecv_generic_node(ping_t)
 corenet_raw_bind_generic_node(ping_t)
 corenet_tcp_sendrecv_all_ports(ping_t)
+corenet_icmp_bind_generic_node(ping_t)
 
 fs_dontaudit_getattr_xattr_fs(ping_t)
 fs_dontaudit_rw_anon_inodefs_files(ping_t)
@@ -244,6 +245,7 @@ corenet_tcp_connect_all_ports(traceroute_t)
 corenet_sendrecv_all_client_packets(traceroute_t)
 corenet_sendrecv_traceroute_server_packets(traceroute_t)
 corenet_sctp_bind_generic_node(traceroute_t)
+corenet_icmp_bind_generic_node(traceroute_t)
 
 corecmd_exec_bin(traceroute_t)
 

--- a/policy/modules/kernel/corenetwork.if.in
+++ b/policy/modules/kernel/corenetwork.if.in
@@ -863,6 +863,24 @@ interface(`corenet_sctp_bind_generic_node',`
 
 ########################################
 ## <summary>
+##	Bind ICMP sockets to generic nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corenet_icmp_bind_generic_node',`
+	gen_require(`
+		type node_t;
+	')
+
+	allow $1 node_t:icmp_socket node_bind;
+')
+
+########################################
+## <summary>
 ##	Bind TCP sockets to generic nodes.
 ## </summary>
 ## <desc>


### PR DESCRIPTION
Use newly created macro corenet_icmp_bind_generic_node() for ping_t and traceroute_t.
This macro allowing bind generic nodes in node_t domain.