### PR TITLE
Create macro corenet_icmp_bind_generic_node()

### DIFF
--- a/policy/modules/kernel/corenetwork.if.in
+++ b/policy/modules/kernel/corenetwork.if.in
@@ -863,6 +863,24 @@ interface(`corenet_sctp_bind_generic_node',`
 
 ########################################
 ## <summary>
+##	Bind ICMP sockets to generic nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corenet_icmp_bind_generic_node',`
+	gen_require(`
+		type node_t;
+	')
+
+	allow $1 node_t:icmp_socket node_bind;
+')
+
+########################################
+## <summary>
 ##	Bind TCP sockets to generic nodes.
 ## </summary>
 ## <desc>


### PR DESCRIPTION
This macro allowing bind ICMP sockets to generic nodes in node_t domain.