### PR TITLE
Allow domains to get attributes in proc_t

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -332,6 +332,7 @@ allow passwd_t crack_db_t:dir list_dir_perms;
 read_files_pattern(passwd_t, crack_db_t, crack_db_t)
 
 kernel_read_kernel_sysctls(passwd_t)
+kernel_getattr_proc(passwd_t)
 
 # for SSP
 dev_read_urand(passwd_t)

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -332,7 +332,6 @@ allow passwd_t crack_db_t:dir list_dir_perms;
 read_files_pattern(passwd_t, crack_db_t, crack_db_t)
 
 kernel_read_kernel_sysctls(passwd_t)
-kernel_read_system_state(passwd_t)
 
 # for SSP
 dev_read_urand(passwd_t)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -607,6 +607,7 @@ auth_filetrans_home_content(login_pgm)
 # needed for afs - https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=253321
 kernel_search_network_sysctl(login_pgm)
 kernel_rw_afs_state(login_pgm)
+kernel_getattr_proc(login_pgm)
 
 tunable_policy(`authlogin_radius',`
 	corenet_udp_bind_all_unreserved_ports(login_pgm)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -607,7 +607,6 @@ auth_filetrans_home_content(login_pgm)
 # needed for afs - https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=253321
 kernel_search_network_sysctl(login_pgm)
 kernel_rw_afs_state(login_pgm)
-kernel_read_system_state(login_pgm)
 
 tunable_policy(`authlogin_radius',`
 	corenet_udp_bind_all_unreserved_ports(login_pgm)


### PR DESCRIPTION
**Commit 1**: Allow passwd to get attributes in proc_t

Add interface kernel_getattr_proc() to passwd policy.
This macro allow paswd get attributes on filesystem /proc.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1858738

**Commit 2**: Allow login_pgm attribute to get attributes in proc_t

Allow login_pgm attribute, which contain domain like local_login_t
and cockpit_session_t, get attributes on filesystem /proc.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1853730


**Fix of previous merge**: https://github.com/fedora-selinux/selinux-policy/pull/411

Issue of previous merge: 

- Attribute cannot be assigned to attribute. So attribute login_pgm cannot be add to kernel_read_system_state().
- Also interface kernel_read_system_state() didn't allow same stuff as kernel_getattr_proc().
