### PR TITLE
Allow syslogd_t domain to read/write tmpfs systemd-bootchart files

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -720,6 +720,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_rw_bootchart_tmpfs_files(syslogd_t)
+	systemd_map_bootchart_tmpfs_files(syslogd_t)
+')
+
+optional_policy(`
     daemontools_search_svc_dir(syslogd_t)
 ')
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2096,6 +2096,42 @@ interface(`systemd_rw_coredump_tmpfs_files',`
 
 ########################################
 ## <summary>
+##	Mmap to systemd-bootchart temporary file system.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_map_bootchart_tmpfs_files',`
+	gen_require(`
+		type systemd_bootchart_tmpfs_t;
+	')
+
+	allow $1 systemd_bootchart_tmpfs_t:file map;
+')
+
+########################################
+## <summary>
+##	Read and write to systemd-bootchart temporary file system.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_rw_bootchart_tmpfs_files',`
+	gen_require(`
+		type systemd_bootchart_tmpfs_t;
+	')
+
+	allow $1 systemd_bootchart_tmpfs_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
 ##	Allow process to read hwdb config file.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Create the two interfaces to allow mapping and r/w permisions.
Add this two interfaces to the policy for domain syslogd_t.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1838163

The one way how can the systemd-journald get a log data from any services is by socket /run/systemd/journal/socket. But when the message is bigger than max size of datagram, it must be done differently. It is by filedescriptor, which is connected to the datagram and in the file to which the file descriptor refers are the log data that were not sent. The file is created by memfd_create() syscall and in kernel the file is implemented as tmpfs.

That means any service can communicate in this way.