### PR TITLE
Allow all users to connect to systemd-userdbd with a unix socket

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -209,6 +209,10 @@ optional_policy(`
 	xserver_filetrans_home_content(userdomain)
 ')
 
+optional_policy(`
+	systemd_userdbd_stream_connect(userdomain)
+')
+
 # rules for types which can read home certs
 allow userdom_home_reader_certs_type home_cert_t:dir list_dir_perms;
 read_files_pattern(userdom_home_reader_certs_type, home_cert_t, home_cert_t)


### PR DESCRIPTION
Add interface systemd_userdbd_stream_connect() to allow communication using userdb sockets.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1835630