### PR TITLE
Add file context for ~/.config/Yubico

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -1,7 +1,9 @@
 HOME_DIR/\.yubico(/.*)?				    gen_context(system_u:object_r:auth_home_t,s0)
+HOME_DIR/\.config/Yubico(/.*)?			    gen_context(system_u:object_r:auth_home_t,s0)
 HOME_DIR/\.google_authenticator			gen_context(system_u:object_r:auth_home_t,s0)
 HOME_DIR/\.google_authenticator~		gen_context(system_u:object_r:auth_home_t,s0)
 /root/\.yubico(/.*)?                    gen_context(system_u:object_r:auth_home_t,s0)
+/root/\.config/Yubico(/.*)?		gen_context(system_u:object_r:auth_home_t,s0)
 /root/\.google_authenticator			gen_context(system_u:object_r:auth_home_t,s0)
 /root/\.google_authenticator~			gen_context(system_u:object_r:auth_home_t,s0)
 

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2313,6 +2313,7 @@ interface(`auth_filetrans_admin_home_content',`
 	userdom_admin_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator")
 	userdom_admin_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~")
 	userdom_admin_home_dir_filetrans($1, auth_home_t, dir, ".yubico")
+	userdom_admin_home_dir_filetrans($1, auth_home_t, dir, ".config/Yubico")
 ')
 
 
@@ -2377,6 +2378,7 @@ interface(`auth_filetrans_home_content',`
 	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator")
 	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~")
 	userdom_user_home_dir_filetrans($1, auth_home_t, dir, ".yubico")
+	userdom_user_home_dir_filetrans($1, auth_home_t, dir, ".config/Yubico")
 ')
 
 ########################################


### PR DESCRIPTION
Add file context specification for ~/.config/Yubico in addition to
existing ~/.yubico. Update the auth_filetrans_home_content() and
auth_filetrans_admin_home_content() interfaces accordingly.

Resolves: rhbz#1860888