### PR TITLE
Change transitions for ~/.config/Yubico

### DIFF
--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2313,7 +2313,6 @@ interface(`auth_filetrans_admin_home_content',`
 	userdom_admin_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator")
 	userdom_admin_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~")
 	userdom_admin_home_dir_filetrans($1, auth_home_t, dir, ".yubico")
-	userdom_admin_home_dir_filetrans($1, auth_home_t, dir, ".config/Yubico")
 ')
 
 
@@ -2378,7 +2377,27 @@ interface(`auth_filetrans_home_content',`
 	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator")
 	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~")
 	userdom_user_home_dir_filetrans($1, auth_home_t, dir, ".yubico")
-	userdom_user_home_dir_filetrans($1, auth_home_t, dir, ".config/Yubico")
+')
+
+########################################
+## <summary>
+##	Create auth directory in the config home directory
+##	with a correct label.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_filetrans_auth_home_content',`
+	gen_require(`
+		type auth_home_t;
+	')
+
+	optional_policy(`
+		gnome_config_filetrans($1, auth_home_t, dir, "Yubico")
+	')
 ')
 
 ########################################

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -603,6 +603,7 @@ manage_dirs_pattern(login_pgm, auth_home_t, auth_home_t)
 manage_files_pattern(login_pgm, auth_home_t, auth_home_t)
 auth_filetrans_admin_home_content(login_pgm)
 auth_filetrans_home_content(login_pgm)
+auth_filetrans_auth_home_content(login_pgm)
 
 # needed for afs - https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=253321
 kernel_search_network_sysctl(login_pgm)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -147,6 +147,7 @@ dontaudit unpriv_userdomain self:dir setattr;
 allow unpriv_userdomain self:file manage_file_perms;
 allow unpriv_userdomain self:key manage_key_perms;
 
+auth_filetrans_auth_home_content(userdomain)
 
 files_dontaudit_manage_boot_files(unpriv_userdomain)
 
@@ -289,6 +290,7 @@ userdom_user_home_dir_filetrans(userdom_filetrans_type, user_tmp_t, dir, "tmp")
 
 optional_policy(`
 	gnome_config_filetrans(userdom_filetrans_type, home_cert_t, dir, "certificates")
+	gnome_config_filetrans(userdom_filetrans_type, auth_home_t, dir, "Yubico")
 	#gnome_admin_home_gconf_filetrans(userdom_filetrans_type, home_bin_t, dir, "bin")
 ')
 


### PR DESCRIPTION
Created the auth_filetrans_auth_home_content() interface which is used
to allow the filename transition in gnome config directory for the
login_pgm and userdomain attributes.

This commit reverts the transitions introduced in
commit 1363710b88904f29915e39335fef0dfb673a0f70.