### PR TITLE
Allow unconfined_t to node_bind icmp_sockets in node_t domain

### DIFF
--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -465,7 +465,7 @@ allow corenet_unconfined_type port_type:udp_socket { send_msg recv_msg };
 
 # Bind to any network address.
 allow corenet_unconfined_type port_type:{ dccp_socket tcp_socket udp_socket rawip_socket sctp_socket} name_bind;
-allow corenet_unconfined_type node_type:{ dccp_socket tcp_socket udp_socket rawip_socket sctp_socket } node_bind;
+allow corenet_unconfined_type node_type:{ dccp_socket icmp_socket tcp_socket udp_socket rawip_socket sctp_socket } node_bind;
 
 # Infiniband
 corenet_ib_access_all_pkeys(corenet_unconfined_type)


### PR DESCRIPTION
When uncofined user run ping or traceroute, this process get label unconfined_t.
Allow to ping or traceroute, which run as unconfined_t, to node_bind icmp_sockets in node_t domain.