### PR TITLE
Allow strongswan chown, setgid, setuid capabilities

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -252,7 +252,7 @@ optional_policy(`
 # ipsec_mgmt Local policy
 #
 
-allow ipsec_mgmt_t self:capability { dac_read_search dac_override net_admin net_raw setpcap sys_nice sys_ptrace };
+allow ipsec_mgmt_t self:capability { chown dac_read_search dac_override net_admin net_raw setgid setpcap setuid sys_nice sys_ptrace };
 dontaudit ipsec_mgmt_t self:capability sys_tty_config;
 allow ipsec_mgmt_t self:process { getsched setrlimit setsched signal };
 allow ipsec_mgmt_t self:unix_stream_socket { create_stream_socket_perms connectto };


### PR DESCRIPTION
The setuid/setgid caps are required to change the user the daemon
switches to after startup when charon.user/group key was set.
The chown cap is required to chown /run/strongswan.