### PR TITLE
 Confine systemd-sleep service

### DIFF
--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -157,6 +157,24 @@ interface(`fstools_getattr_swap_files',`
 
 ########################################
 ## <summary>
+##	Read/Write swapfile
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fstools_rw_swap_files',`
+	gen_require(`
+		type swapfile_t;
+	')
+
+	allow $1 swapfile_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete the FSADM pid files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -68,6 +68,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/system-generators/systemd-gpt-auto-generator	--	gen_context(system_u:object_r:systemd_gpt_generator_exec_t,s0)
 /usr/lib/systemd/systemd-resolve(d|-host)			gen_context(system_u:object_r:systemd_resolved_exec_t,s0)
 /usr/lib/systemd/systemd-importd		--	gen_context(system_u:object_r:systemd_importd_exec_t,s0)
+/usr/lib/systemd/systemd-sleep		--	gen_context(system_u:object_r:systemd_sleep_exec_t,s0)
 
 /var/lib/machines(/.*)?			gen_context(system_u:object_r:systemd_machined_var_lib_t,s0)
 /var/lib/systemd/rfkill(/.*)?         gen_context(system_u:object_r:systemd_rfkill_var_lib_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -189,6 +189,8 @@ systemd_unit_file(systemd_userdbd_unit_file_t)
 type systemd_userdbd_runtime_t;
 files_pid_file(systemd_userdbd_runtime_t)
 
+systemd_domain_template(systemd_sleep)
+
 #######################################
 #
 # Systemd_logind local policy
@@ -1266,3 +1268,17 @@ init_stream_connectto(systemd_userdbd_t)
 logging_send_syslog_msg(systemd_userdbd_t)
 
 systemd_read_efivarfs(systemd_userdbd_t)
+
+########################################
+#
+# systemd_sleep local policy
+#
+
+allow systemd_sleep_t self:capability sys_resource;
+
+kernel_dgram_send(systemd_sleep_t)
+
+dev_rw_sysfs(systemd_sleep_t)
+dev_write_kmsg(systemd_sleep_t)
+
+fstools_rw_swap_files(systemd_sleep_t)


### PR DESCRIPTION
Create new SELinux security policy for systemd-sleep service to allow hibarnate system to swapfile in enforcing mode.


@zpytela  we want to introduce this change only in fedora-rawhide (not F33.)
