### PR TITLE
Allow gnome-initial-setup execute in a xdm sandbox

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -432,7 +432,7 @@ optional_policy(`
 
 allow xdm_t self:capability { setgid setuid sys_resource kill sys_tty_config mknod chown dac_read_search dac_override fowner fsetid ipc_owner sys_nice sys_rawio net_bind_service net_admin sys_ptrace };
 allow xdm_t self:capability2 { block_suspend };
-allow xdm_t self:cap_userns { kill setpcap sys_admin sys_ptrace };
+allow xdm_t self:cap_userns { dac_override kill net_admin setpcap sys_admin sys_ptrace };
 dontaudit xdm_t self:capability sys_admin;
 dontaudit xdm_t self:capability2 wake_alarm;
 tunable_policy(`deny_ptrace',`',`
@@ -561,6 +561,7 @@ manage_fifo_files_pattern(xdm_t, xserver_log_t, xserver_log_t)
 files_var_filetrans(xdm_t, xserver_log_t, dir, "gdm")
 allow xdm_t xserver_log_t:file map;
 
+kernel_mount_proc(xdm_t)
 kernel_read_system_state(xdm_t)
 kernel_read_device_sysctls(xdm_t)
 kernel_read_sysctl(xdm_t)
@@ -626,6 +627,7 @@ dev_getattr_loop_control(xdm_t)
 dev_manage_xserver_misc(xdm_t)
 dev_filetrans_xserver_misc(xdm_t)
 dev_map_xserver_misc(xdm_t)
+dev_remount_sysfs_fs(xdm_t)
 
 domain_use_interactive_fds(xdm_t)
 # Do not audit denied probes of /proc.
@@ -638,6 +640,7 @@ files_read_var_files(xdm_t)
 files_read_etc_runtime_files(xdm_t)
 files_exec_etc_files(xdm_t)
 files_list_mnt(xdm_t)
+files_mounton_all_mountpoints(xdm_t)
 # Read /usr/share/terminfo/l/linux and /usr/share/icons/default/index.theme...
 files_read_usr_files(xdm_t)
 # Poweroff wants to create the /poweroff file when run from xdm
@@ -656,7 +659,8 @@ fs_getattr_all_fs(xdm_t)
 fs_search_auto_mountpoints(xdm_t)
 fs_search_all(xdm_t)
 fs_rw_anon_inodefs_files(xdm_t)
-fs_mount_tmpfs(xdm_t)
+fs_all_mount_fs_perms_tmpfs(xdm_t)
+fs_all_mount_fs_perms_xattr_fs(xdm_t)
 fs_mounton_fusefs(xdm_t)
 fs_list_inotifyfs(xdm_t)
 fs_dontaudit_list_noxattr_fs(xdm_t)


### PR DESCRIPTION
Add permissions required when /usr/libexec/gnome-initial-setup is
executed during initial setup, that is still from xdm, in a sandbox
in order to access an existing online account from the linux user's
environment.

Resolves: rhbz#1870476