### PR TITLE
Add to map non_security_files to the userdom_admin_user_template temp…

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1685,10 +1685,12 @@ template(`userdom_admin_user_template',`
 	# Manage almost all files
 	files_manage_non_security_dirs($1_t)
 	files_manage_non_security_files($1_t)
+	# Map almost all files
+	files_map_non_security_files($1_t)
 	# Relabel almost all files
 	files_relabel_non_security_files($1_t)
 
-    files_mounton_rootfs($1_t)
+	files_mounton_rootfs($1_t)
 
 	init_telinit($1_t)
 


### PR DESCRIPTION
…late

If domain can manage non_security_files, from perspective of security it is correct to allow mapping of the files.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1873964