### PR TITLE
Add 2 addl. interfaces to lvm

### DIFF
--- a/policy/modules/system/lvm.if
+++ b/policy/modules/system/lvm.if
@@ -452,4 +452,40 @@ interface(`lvm_manage_lock',`
 ')
 
 
+########################################
+## <summary>
+##	Allow dbus send for lvm dbus API (only send needed)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`lvm_dbus_send_msg',`
+	gen_require(`
+		type lvm_t;
+		class dbus send_msg;
+	')
+    allow $1 lvm_t:dbus send_msg;
 
+')
+
+########################################
+## <summary>
+##	Allow lvm hints file access
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`lvm_rw_var_run',`
+	gen_require(`
+		type lvm_t;
+		type lvm_var_run_t;
+	')
+    allow $1 lvm_var_run_t:file { rw_file_perms };
+
+')


### PR DESCRIPTION
We need interfaces to allow applications the ability to:
* Update the lvm hints file
* Send dbus messages

This is needed for targetd storage daemon.

Signed-off-by: Tony Asleson <tasleson@redhat.com>