### PR TITLE
Allow additional permissions for gnome-initial-setup

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -640,7 +640,7 @@ files_read_var_files(xdm_t)
 files_read_etc_runtime_files(xdm_t)
 files_exec_etc_files(xdm_t)
 files_list_mnt(xdm_t)
-files_mounton_all_mountpoints(xdm_t)
+files_mounton_non_security(xdm_t)
 # Read /usr/share/terminfo/l/linux and /usr/share/icons/default/index.theme...
 files_read_usr_files(xdm_t)
 # Poweroff wants to create the /poweroff file when run from xdm
@@ -667,6 +667,8 @@ fs_dontaudit_list_noxattr_fs(xdm_t)
 fs_dontaudit_read_noxattr_fs_files(xdm_t)
 fs_manage_cgroup_dirs(xdm_t)
 fs_manage_cgroup_files(xdm_t)
+fs_getattr_nsfs_files(xdm_t)
+
 mount_read_pid_files(xdm_t)
 
 mls_socket_write_to_clearance(xdm_t)
@@ -681,6 +683,7 @@ storage_dontaudit_setattr_removable_dev(xdm_t)
 storage_dontaudit_rw_scsi_generic(xdm_t)
 storage_dontaudit_rw_fuse(xdm_t)
 
+term_mount_pty_fs(xdm_t)
 term_setattr_console(xdm_t)
 term_setattr_unallocated_ttys(xdm_t)
 term_use_all_terms(xdm_t)


### PR DESCRIPTION
Allow xdm getattr files on an nsfs filesystem.
Allow xdm mount a pty filesystem.
Allow xdm mount a filesystem on all non-security directories and files.

Resolves: rhbz#1870476