### PR TITLE
kernel/filesystem: Add exfat support (no extended attributes)

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -261,7 +261,7 @@ genfscon cifs / gen_context(system_u:object_r:cifs_t,s0)
 genfscon smbfs / gen_context(system_u:object_r:cifs_t,s0)
 
 #
-# dosfs_t is the type for fat and vfat
+# dosfs_t is the type for fat, vfat and exfat
 # filesystems and their files.
 #
 type dosfs_t;
@@ -275,6 +275,7 @@ genfscon msdos / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon ntfs-3g / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon ntfs / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon vfat / gen_context(system_u:object_r:dosfs_t,s0)
+genfscon exfat / gen_context(system_u:object_r:dosfs_t,s0)
 
 type fusefs_t;
 fs_noxattr_type(fusefs_t)


### PR DESCRIPTION
According to [1], the exfat filesystem does not support extended
attributes so it should be handled like fat/vfat/ntfs.

[1] https://en.wikipedia.org/wiki/Comparison_of_file_systems