### PR TITLE
Relabel /usr/sbin/charon-systemd as ipsec_exec_t

### DIFF
--- a/policy/modules/system/ipsec.fc
+++ b/policy/modules/system/ipsec.fc
@@ -50,7 +50,7 @@
 /usr/libexec/strongswan/.*      --	gen_context(system_u:object_r:ipsec_exec_t,s0)
 /usr/libexec/strongimcv/.*      --  gen_context(system_u:object_r:ipsec_exec_t,s0)
 
-/usr/sbin/charon-systemd	-- 	gen_context(system_u:object_r:ipsec_mgmt_exec_t,s0)
+/usr/sbin/charon-systemd	-- 	gen_context(system_u:object_r:ipsec_exec_t,s0)
 /usr/sbin/ipsec			-- 	gen_context(system_u:object_r:ipsec_mgmt_exec_t,s0)
 /usr/sbin/racoon		--	gen_context(system_u:object_r:racoon_exec_t,s0)
 /usr/sbin/setkey		--	gen_context(system_u:object_r:setkey_exec_t,s0)


### PR DESCRIPTION
This causes StrongSwan to be run with the `ipsec_exec_t` context, which allows it to bind to its sockets.