### PR TITLE
Removed adding to attribute unpriv_userdomain from userdom_unpriv_type template

### DIFF
--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -91,6 +91,8 @@ logging_send_syslog_msg(unconfined_t)
 
 systemd_config_all_services(unconfined_t)
 
+ssh_dyntransition_to(unconfined_t)
+
 unconfined_domain_noaudit(unconfined_t)
 domain_named_filetrans(unconfined_t)
 domain_transition_all(unconfined_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4825,7 +4825,6 @@ template(`userdom_unpriv_type',`
     gen_require(`
         attribute unpriv_userdomain, userdomain;
     ')
-    typeattribute $1  unpriv_userdomain;
     typeattribute $1  userdomain;
 
     auth_use_nsswitch($1)


### PR DESCRIPTION
Removing attribute in previous commit affected connecting via ssh to unconfined user.
Missed dyntransition from sshd domain to unconfined domain.
Added ssh_dyntransition_to() interface.