### PR TITLE
Allow domain write to an automount unnamed pipe

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -568,6 +568,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# A workaround to handle additional permissions check
+	# introduced as an involuntary result of a kernel change
+	automount_write_pipes(domain)
+')
+
+optional_policy(`
 	sosreport_append_tmp_files(domain)
 ')
 


### PR DESCRIPTION
With the kernel commit 13c164b1a186 ("autofs: switch to kernel_write"),
an additional LSM permission check is done when a process tries to
access a directory on an autofs volume, which has not been mounted yet,
and it results in a write operation to the automount pipe.

This commit allows any domain write to the unnamed pipe kernel uses to
communicate with automount to service the directory access request and
should be considered a temporary workaround until a different
implementation in kernel is found.