### PR TITLE
Allow init dbus chat with kernel

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -392,9 +392,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	init_dbus_chat(kernel_t)
 	init_sigchld(kernel_t)
 	init_dyntrans(kernel_t)
-    init_dontaudit_dbus_chat(kernel_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
With systemd as user and group names resolver, bidirectional
dbus communication between systemd and kernel is required.
    
This commit reverts previously introduced commit
f4b4b99846308b75fd9bb2f50d6e9897459f87a5 to dontaudit one direction
of the communication, resulting in dbus timeouts.
    
Resolves: rhbz#1694681