### PR TITLE
Allow initrc_t create /run/chronyd-dhcp directory with a transition

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1210,6 +1210,10 @@ ifdef(`distro_redhat',`
 	')
 
 	optional_policy(`
+		chronyd_pid_filetrans(initrc_t)
+	')
+
+	optional_policy(`
 		cyrus_write_data(initrc_t)
 	')
 


### PR DESCRIPTION
Chronyd is required to read preferred sources files stored in
/run/chronyd-dhcp to be able to get correct time settings
from the dhcp server and have them applied.

Resolves: rhbz#1880948