### PR TITLE
Allow transition from xdm domain to unconfined_t domain.

### DIFF
--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -91,6 +91,29 @@ interface(`unconfined_shell_domtrans',`
 
 ########################################
 ## <summary>
+##	Execute an Xserver session in unconfined domain.  This
+##	is an explicit transition, requiring the
+##	caller to use setexeccon().
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`unconfined_xsession_spec_domtrans',`
+		gen_require(`
+		type unconfined_t;
+	')
+
+	xserver_xsession_spec_domtrans($1, unconfined_t)
+	allow unconfined_t $1:fd use;
+	allow unconfined_t $1:fifo_file rw_file_perms;
+	allow unconfined_t $1:process sigchld;
+')
+
+########################################
+## <summary>
 ##	Allow unconfined to execute the specified program in
 ##	the specified domain.
 ## </summary>

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -1102,6 +1102,7 @@ optional_policy(`
 
 optional_policy(`
 	unconfined_signal(xdm_t)
+	unconfined_xsession_spec_domtrans(xdm_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
After removing unconfined_t domain from unpriv_userdomain
attribute (BG: https://bugzilla.redhat.com/show_bug.cgi?id=1840851),
missed in policy transition from xdm_t to unconfined_t.
Create interface unconfined_xsession_spec_domtrans(), which allow
execute an Xserver session in unconfined_t domain.
Use this interface in xdm_t policy to allow transition from
xdm_t to unconfined_t.

Fedora COPR: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1714064/
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1886196