### PR TITLE
Revert "Removed adding to attribute unpriv_userdomain from userdom_un…

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4825,6 +4825,7 @@ template(`userdom_unpriv_type',`
     gen_require(`
         attribute unpriv_userdomain, userdomain;
     ')
+    typeattribute $1  unpriv_userdomain;
     typeattribute $1  userdomain;
 
     auth_use_nsswitch($1)


### PR DESCRIPTION
…priv_type template"

This reverts commit 6b048173767701ec7f37dbe302316bdfbb2f9b4d as the
change prevents unconfined users from logging in in GUI, being a result
of missing transition from xdm_t to unconfined_t.