### PR TITLE
Revert "Removed adding to attribute unpriv_userdomain from userdom_un…

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4827,6 +4827,7 @@ template(`userdom_unpriv_type',`
     gen_require(`
         attribute unpriv_userdomain, userdomain;
     ')
+    typeattribute $1  unpriv_userdomain;
     typeattribute $1  userdomain;
 
     auth_use_nsswitch($1)


### PR DESCRIPTION
…priv_type template"

This reverts commit f28692cd4a5d8d380a2c78e6a208119ce46d9722 as the
change prevents unconfined users from logging in in GUI, being a result
of missing transition from xdm_t to unconfined_t.