### PR TITLE
Revert "Label /var/run/zincati/public/motd.d/* as motd_var_run_t"

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -85,7 +85,3 @@ ifdef(`distro_gentoo', `
 /var/run/sudo(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/(db|adm)/sudo(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/lib/sudo(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
-
-# Allow services not running as root to write MOTD messages via symlink
-# out of /run/motd.d/. https://github.com/coreos/zincati/pull/276
-/var/run/zincati/public/motd\.d(/.*)?	gen_context(system_u:object_r:motd_var_run_t,s0)


### PR DESCRIPTION
This reverts commit 540ea957bd85105213929f442dd6df5f9255c1b7.

This change [1] was initially required to enable a future Zincati feature [2] that was eventually redesigned to work differently, with a lesser reliance on arbitrary symlinks [3].

The first change [4] from [1] is still valid and can be kept as is.

[1] https://github.com/fedora-selinux/selinux-policy/pull/398
[2] https://github.com/coreos/zincati/pull/276
[3] https://github.com/coreos/zincati/pull/367
[4] https://github.com/fedora-selinux/selinux-policy/commit/8b9c6a9df672d84d4f717a044da2314ca84eb3e9