### PR TITLE
Removed adding to attribute unpriv_userdomain from userdom_unpriv_type template

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4827,7 +4827,6 @@ template(`userdom_unpriv_type',`
     gen_require(`
         attribute unpriv_userdomain, userdomain;
     ')
-    typeattribute $1  unpriv_userdomain;
     typeattribute $1  userdomain;
 
     auth_use_nsswitch($1)


### PR DESCRIPTION
When is secure_mode boolean enabled the attribute unpriv_userdomain allow transition
only between unprivileged users. But one member this attribute was unconfined_t
domain, which had allow privilege operations. Solution was that from userdom_unpriv_type
template was remove adding domains to attribute unpriv_userdomain. This template is used only
for unconfined_t, so affected only uncofined domain.

New PR of reverted commit:
https://github.com/fedora-selinux/selinux-policy/pull/459#issuecomment-712374187

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1840851