### PR TITLE
systemd: allow all systemd services to check selinux status and read efivars

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -504,7 +504,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_dbus_chat_resolved(domain)
+	systemd_chat_resolved(domain)
 	systemd_login_status(unconfined_domain_type)
 	systemd_login_reboot(unconfined_domain_type)
 	systemd_login_halt(unconfined_domain_type)
@@ -512,7 +512,7 @@ optional_policy(`
 	systemd_filetrans_named_content(named_filetrans_domain)
 	systemd_filetrans_named_hostname(named_filetrans_domain)
 	systemd_filetrans_home_content(named_filetrans_domain)
-    systemd_dontaudit_write_inherited_logind_sessions_pipes(domain)
+	systemd_dontaudit_write_inherited_logind_sessions_pipes(domain)
 ')
 
 optional_policy(`

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -324,7 +324,7 @@ interface(`selinux_get_enforce_mode',`
 	dev_search_sysfs($1)
 	selinux_get_fs_mount($1)
 	allow $1 security_t:dir list_dir_perms;
-	allow $1 security_t:file read_file_perms;
+	allow $1 security_t:file mmap_read_file_perms;
 	allow $1 security_t:lnk_file read_lnk_file_perms;
 ')
 

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -610,7 +610,7 @@ fs_getattr_all_fs(syslogd_t)
 fs_read_efivarfs_files(syslogd_t)
 fs_search_auto_mountpoints(syslogd_t)
 fs_search_cgroup_dirs(syslogd_t)
- 
+
 miscfiles_manage_generic_cert_files(syslogd_t)
 
 mls_file_write_all_levels(syslogd_t) # Need to be able to write to /var/run/ and /var/log directories
@@ -622,6 +622,7 @@ term_write_unallocated_ttys(syslogd_t)
 term_use_generic_ptys(syslogd_t)
 
 init_stream_connect(syslogd_t)
+init_read_pid_files(syslogd_t)
 # for sending messages to logged in users
 init_read_utmp(syslogd_t)
 init_dontaudit_write_utmp(syslogd_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2291,8 +2291,8 @@ interface(`systemd_map_resolved_exec_files',`
 
 ########################################
 ## <summary>
-##	Send and receive messages from
-##	systemd resolved over dbus.
+##	Exchange messages with
+##	systemd resolved over dbus or varlink.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2300,13 +2300,14 @@ interface(`systemd_map_resolved_exec_files',`
 ##	</summary>
 ## </param>
 #
-interface(`systemd_dbus_chat_resolved',`
+interface(`systemd_chat_resolved',`
 	gen_require(`
 		type systemd_resolved_t;
 		class dbus send_msg;
 	')
 
 	allow $1 systemd_resolved_t:dbus send_msg;
+	allow $1 systemd_resolved_t:unix_stream_socket connectto;
 	allow systemd_resolved_t $1:dbus send_msg;
 	ps_process_pattern(systemd_resolved_t, $1)
 ')

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -24,6 +24,7 @@ template(`systemd_domain_template',`
     kernel_read_system_state($1_t)
 
     auth_use_nsswitch($1_t)
+    selinux_get_enforce_mode($1_t)
 ')
 
 ######################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1053,6 +1053,7 @@ allow systemd_resolved_t self:unix_dgram_socket create_socket_perms;
 
 manage_dirs_pattern(systemd_resolved_t, systemd_resolved_var_run_t, systemd_resolved_var_run_t)
 manage_files_pattern(systemd_resolved_t, systemd_resolved_var_run_t, systemd_resolved_var_run_t)
+manage_sock_files_pattern(systemd_resolved_t, systemd_resolved_var_run_t, systemd_resolved_var_run_t)
 init_pid_filetrans(systemd_resolved_t, systemd_resolved_var_run_t, dir)
 
 list_dirs_pattern(systemd_resolved_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -493,6 +493,7 @@ corenet_tcp_bind_dhcpd_port(systemd_networkd_t)
 corenet_udp_bind_dhcpd_port(systemd_networkd_t)
 
 fs_read_xenfs_files(systemd_networkd_t)
+fs_read_nsfs_files(systemd_networkd_t)
 
 dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -13,6 +13,7 @@ attribute systemd_private_tmp_type;
 
 attribute systemd_read_efivarfs_type;
 fs_read_efivarfs_files(systemd_read_efivarfs_type)
+read_files_pattern(systemd_read_efivarfs_type, init_var_run_t, init_var_run_t)
 
 systemd_domain_template(systemd_logger)
 systemd_domain_template(systemd_logind)


### PR DESCRIPTION
After https://github.com/systemd/systemd/commit/fd5e402fa9 most systemd
services fail to start with:

Oct 27 13:50:38 workstation-uefi systemd[1]: Starting systemd-hostnamed.service...
Oct 27 13:50:38 workstation-uefi systemd-hostnamed[944]: Failed to open SELinux status page: Permission denied
Oct 27 13:50:38 workstation-uefi systemd[1]: systemd-hostnamed.service: Main process exited, code=exited, status=1/FAILURE

After disabling dontaudit:

Oct 27 14:05:08 workstation-uefi audit[1043]: AVC avc:  denied  { read } for  pid=1043 comm="systemd-hostnam" name="status" dev="selinuxfs" ino=19 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:security_t:s0 tclass=file permissive=1
Oct 27 14:05:08 workstation-uefi audit[1043]: AVC avc:  denied  { open } for  pid=1043 comm="systemd-hostnam" path="/sys/fs/selinux/status" dev="selinuxfs" ino=19 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:security_t:s0 tclass=file permissive=1
Oct 27 14:05:08 workstation-uefi audit[1043]: AVC avc:  denied  { map } for  pid=1043 comm="systemd-hostnam" path="/sys/fs/selinux/status" dev="selinuxfs" ino=19 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:security_t:s0 tclass=file permissive=1

This is fully untested, but it seems it might work if
selinux_get_enforce_mode() does what the name suggests.

The check for selinux status is called from mac_selinux_init() which
is called in 16 different places, so I don't think it makes sense to
try to list them all. Similarly, the check for SystemdOptions in
efivarfs is called from shared code, so it doesn't make sense to play
the whack'a'mole game of trying to list them all.