### PR TITLE
Additional permission for confined users loging into graphic session

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -74,6 +74,7 @@ init_status(staff_t)
 miscfiles_read_hwdata(staff_t)
 
 mount_sigkill(staff_t)
+mount_signal(staff_t)
 
 ifndef(`enable_mls',`
 	selinux_read_policy(staff_t)

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -36,6 +36,8 @@ seutil_read_module_store(user_t)
 init_dbus_chat(user_t)
 init_status(user_t)
 
+mount_signal(user_t)
+
 tunable_policy(`selinuxuser_execmod',`
 	userdom_execmod_user_home_files(user_t)
 ')


### PR DESCRIPTION
Allow for staff_t and user_t send a generic signal to mount.

Related with PR: https://github.com/fedora-selinux/selinux-policy-contrib/pull/346

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1767874
Fedora COPR: https://copr.fedorainfracloud.org/coprs/pkoncity/selinux-policy/build/1726586/