### PR TITLE
Update miscfiles_manage_all_certs() to include creating directories

### DIFF
--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -81,7 +81,7 @@ interface(`miscfiles_manage_all_certs',`
 		attribute cert_type;
 	')
 
-	allow $1 cert_type:dir list_dir_perms;
+	manage_dirs_pattern($1, cert_type, cert_type)
 	manage_files_pattern($1, cert_type, cert_type)
 	manage_lnk_files_pattern($1, cert_type, cert_type)
 ')


### PR DESCRIPTION
Update the miscfiles_manage_all_certs() so that it contains also rules
for creating directories.