### PR TITLE
allow google authenticator tmpfile

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -1,11 +1,11 @@
 HOME_DIR/\.yubico(/.*)?				    gen_context(system_u:object_r:auth_home_t,s0)
 HOME_DIR/\.config/Yubico(/.*)?			    gen_context(system_u:object_r:auth_home_t,s0)
 HOME_DIR/\.google_authenticator			gen_context(system_u:object_r:auth_home_t,s0)
-HOME_DIR/\.google_authenticator~		gen_context(system_u:object_r:auth_home_t,s0)
+HOME_DIR/\.google_authenticator~.*		gen_context(system_u:object_r:auth_home_t,s0)
 /root/\.yubico(/.*)?                    gen_context(system_u:object_r:auth_home_t,s0)
 /root/\.config/Yubico(/.*)?		gen_context(system_u:object_r:auth_home_t,s0)
 /root/\.google_authenticator			gen_context(system_u:object_r:auth_home_t,s0)
-/root/\.google_authenticator~			gen_context(system_u:object_r:auth_home_t,s0)
+/root/\.google_authenticator~.*			gen_context(system_u:object_r:auth_home_t,s0)
 
 /bin/login		--	gen_context(system_u:object_r:login_exec_t,s0)
 

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2311,7 +2311,7 @@ interface(`auth_filetrans_admin_home_content',`
 	')
 
 	userdom_admin_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator")
-	userdom_admin_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~")
+	userdom_admin_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~.*")
 	userdom_admin_home_dir_filetrans($1, auth_home_t, dir, ".yubico")
 ')
 
@@ -2375,7 +2375,7 @@ interface(`auth_filetrans_home_content',`
 	')
 
 	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator")
-	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~")
+	userdom_user_home_dir_filetrans($1, auth_home_t, file, ".google_authenticator~.*")
 	userdom_user_home_dir_filetrans($1, auth_home_t, dir, ".yubico")
 ')
 


### PR DESCRIPTION
Google Authenticator started writing to a new tmpfile, which should
also be allowed.

See https://bugzilla.redhat.com/show_bug.cgi?id=1840113 &
https://github.com/google/google-authenticator-libpam/issues/101