### PR TITLE
Allow user domains transition to rpmdb_t

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -492,6 +492,7 @@ optional_policy(`
 	rpm_run(sysadm_t, sysadm_r)
 	rpm_dbus_chat(sysadm_t, sysadm_r)
     rpm_hawkey_named_filetrans(sysadm_t)
+	rpmdb_run_rpmdb(sysadm_t, sysadm_r)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -361,6 +361,7 @@ optional_policy(`
 	# Allow SELinux aware applications to request rpm_script execution
 	rpm_transition_script(unconfined_t, unconfined_r)
 	rpm_dbus_chat(unconfined_t)
+	rpmdb_run_rpmdb(unconfined_t, unconfined_r)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow unconfined_t and sysadm_t user domains transition to rpmdb_t
on executing the rpmdb command.