### PR TITLE
Fix range for unreserved ports

### DIFF
--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -409,10 +409,10 @@ portcon udp 1-511 gen_context(system_u:object_r:reserved_port_t, s0)
 portcon sctp 1-511 gen_context(system_u:object_r:reserved_port_t, s0)
 portcon tcp 1024-32767 gen_context(system_u:object_r:unreserved_port_t, s0)
 portcon tcp 32768-60999 gen_context(system_u:object_r:ephemeral_port_t, s0)
-portcon tcp 61001-65535 gen_context(system_u:object_r:unreserved_port_t, s0)
+portcon tcp 61000-65535 gen_context(system_u:object_r:unreserved_port_t, s0)
 portcon udp 1024-32767 gen_context(system_u:object_r:unreserved_port_t, s0)
 portcon udp 32768-60999 gen_context(system_u:object_r:ephemeral_port_t, s0)
-portcon udp 61001-65535 gen_context(system_u:object_r:unreserved_port_t, s0)
+portcon udp 61000-65535 gen_context(system_u:object_r:unreserved_port_t, s0)
 
 ########################################
 #


### PR DESCRIPTION
With commit 17994ab421f6d9516523f6d75d5d79e50b6c1140, the range for
ephemeral ports changed to match the default value of the
net.ipv4.ip_local_port_range kernel tunable: 32768-60999.
However, the range for the subsequent range for unreserved ports was not
adjusted accordingly, so that currently the port 61000, both udp and
tcp, gets the generic label port_t with very few domains being able to
work with it. In this commit, the unreserved ports range now starts with
61000 instead of 61001.