### PR TITLE
Label /etc/resolv.conf as net_conf_t only if it is a plain file

### DIFF
--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -23,9 +23,9 @@ ifdef(`distro_debian',`
 /etc/hosts[^/]*		--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/hosts\.deny.*	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/denyhosts.*	--	gen_context(system_u:object_r:net_conf_t,s0)
-/etc/resolv\.conf.*		gen_context(system_u:object_r:net_conf_t,s0)
-/etc/resolv-secure.conf.*		gen_context(system_u:object_r:net_conf_t,s0)
-/etc/\.resolv\.conf.*		gen_context(system_u:object_r:net_conf_t,s0)
+/etc/resolv\.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
+/etc/resolv-secure.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
+/etc/\.resolv\.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/yp\.conf.*		--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/ntp\.conf		--	gen_context(system_u:object_r:net_conf_t,s0)
 

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -454,7 +454,6 @@ interface(`sysnet_read_config',`
         files_search_all_pids($1)
         init_search_pid_dirs($1)
 		allow $1 net_conf_t:dir list_dir_perms;
-		allow $1 net_conf_t:lnk_file read_lnk_file_perms;
 		read_files_pattern($1, net_conf_t, net_conf_t)
 	')
 ')
@@ -1148,9 +1147,6 @@ interface(`sysnet_filetrans_named_content',`
 	files_etc_filetrans($1, net_conf_t, file, "resolv-secure.conf")
 	files_etc_filetrans($1, net_conf_t, file, ".resolv.conf.dnssec-trigger")
 	files_etc_filetrans($1, net_conf_t, file, ".resolv-secure.conf.dnssec-trigger")
-	files_etc_filetrans($1, net_conf_t, lnk_file, ".resolv.conf")
-	files_etc_filetrans($1, net_conf_t, lnk_file, "resolv.conf")
-	files_etc_filetrans($1, net_conf_t, lnk_file, ".resolv.conf.NetworkManager")
 	files_etc_filetrans($1, net_conf_t, file, "denyhosts")
 	files_etc_filetrans($1, net_conf_t, file, "hosts")
 	files_etc_filetrans($1, net_conf_t, file, "hosts.deny")


### PR DESCRIPTION
With systemd-resolved in place, /etc/resolv.conf is a symlink to
../run/systemd/resolve/stub-resolv.conf. Some domains allowed access to
the net_conf_t type class file do not have access to the same type class
lnk_file, while all domains have access to etc_t type class lnk_file.