### PR TITLE
Label /run/agetty.reload as getty_var_run_t

### DIFF
--- a/policy/modules/system/getty.fc
+++ b/policy/modules/system/getty.fc
@@ -12,6 +12,7 @@
 
 /var/run/mgetty\.pid.*	--	gen_context(system_u:object_r:getty_var_run_t,s0)
 /var/run/agetty\.reload.*	--	gen_context(system_u:object_r:getty_var_run_t,s0)
+/run/agetty\.reload.*	--	gen_context(system_u:object_r:getty_var_run_t,s0)
 
 /var/spool/fax(/.*)?		gen_context(system_u:object_r:getty_var_run_t,s0)
 /var/spool/voice(/.*)?		gen_context(system_u:object_r:getty_var_run_t,s0)


### PR DESCRIPTION
The file is created as /run/agetty.reload, so the rule for
/var/run/agetty.reload does not match and the file gets the wrong label.