### PR TITLE
Add groupadd_t fowner capability

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -212,7 +212,7 @@ optional_policy(`
 # Groupadd local policy
 #
 
-allow groupadd_t self:capability { dac_read_search dac_override chown kill setuid sys_resource audit_write };
+allow groupadd_t self:capability { dac_read_search dac_override chown fowner kill setuid sys_resource audit_write };
 dontaudit groupadd_t self:capability { fsetid sys_tty_config };
 allow groupadd_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execheap execstack };
 allow groupadd_t self:process { setrlimit setfscreate };


### PR DESCRIPTION
The sssd daemon is configured to run as a non-root user. Its database
files need to have ownership changed accordingly, as a result some
capabilities may be required to change metadata of the files.

When sss_cache is called as a child of groupadd executed from a confined
domain, e. g. rpm_script_t, it needs the fowner capability for groupadd_t
to complete the groupadd command and run utime() syscall.

Resolves: rhbz#1884179