### PR TITLE
Set default file context for /var/lib/ipsec/nss

### DIFF
--- a/policy/modules/system/ipsec.fc
+++ b/policy/modules/system/ipsec.fc
@@ -58,6 +58,8 @@
 /usr/sbin/swanctl	--	gen_context(system_u:object_r:ipsec_mgmt_exec_t,s0)
 /usr/sbin/strongimcv    --  gen_context(system_u:object_r:ipsec_mgmt_exec_t,s0)
 
+/var/lib/ipsec/nss(/.*)?	gen_context(system_u:object_r:ipsec_key_file_t,s0)
+
 /var/lock/subsys/ipsec		--	gen_context(system_u:object_r:ipsec_mgmt_lock_t,s0)
 /var/lock/subsys/strongswan		--	gen_context(system_u:object_r:ipsec_mgmt_lock_t,s0)
 


### PR DESCRIPTION
The NSS database used by libreswan has moved from /etc/ipsec.d
to /var/lib/ipsec/nss since libreswan 4.0. The default file context
specification needs to be adjusted accordingly in selinux-policy.

Resolves: rhbz#1903154