### PR TITLE
Allow unconfined_u and sysadm_u users manage perf_events

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -16,6 +16,8 @@ allow sysadm_t self:tipc_socket create_socket_perms;
 allow sysadm_t self:sctp_socket create_socket_perms;
 allow sysadm_t self:rawip_socket create_socket_perms;
 
+allow sysadm_t self:perf_event manage_perf_event_perms;
+
 allow sysadm_t self:system all_system_perms;
 
 

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -74,6 +74,8 @@ allow unconfined_t self:cap_userns all_cap_userns_perms;
 
 allow unconfined_t self:bpf { map_create map_read map_write prog_load prog_run };
 
+allow unconfined_t self:perf_event manage_perf_event_perms;
+
 kernel_rw_unlabeled_socket(unconfined_t)
 kernel_rw_unlabeled_rawip_socket(unconfined_t)
 kernel_rw_unlabeled_smc_socket(unconfined_t)


### PR DESCRIPTION
Resolves: rhbz#1901957