### PR TITLE
Updates to varnishlog_t

### DIFF
--- a/policy/modules/contrib/varnishd.if
+++ b/policy/modules/contrib/varnishd.if
@@ -73,7 +73,8 @@ interface(`varnishd_read_lib_files',`
 	')
 
 	files_search_var_lib($1)
-	read_files_pattern($1, varnishd_var_lib_t, varnishd_var_lib_t)
+	list_dirs_pattern($1, varnishd_var_lib_t, varnishd_var_lib_t)
+	mmap_read_files_pattern($1, varnishd_var_lib_t, varnishd_var_lib_t)
 ')
 
 #######################################

--- a/policy/modules/contrib/varnishd.te
+++ b/policy/modules/contrib/varnishd.te
@@ -131,6 +131,7 @@ optional_policy(`
 # Log local policy
 #
 
+allow varnishlog_t self:process { execmem };
 
 manage_files_pattern(varnishlog_t, varnishlog_var_run_t, varnishlog_var_run_t)
 files_pid_filetrans(varnishlog_t, varnishlog_var_run_t, file)

--- a/policy/modules/contrib/varnishd.te
+++ b/policy/modules/contrib/varnishd.te
@@ -142,9 +142,5 @@ create_files_pattern(varnishlog_t, varnishlog_log_t, varnishlog_log_t)
 setattr_files_pattern(varnishlog_t, varnishlog_log_t, varnishlog_log_t)
 logging_log_filetrans(varnishlog_t, varnishlog_log_t, { file dir })
 
-list_dirs_pattern(varnishlog_t, varnishd_var_lib_t, varnishd_var_lib_t)
-read_files_pattern(varnishlog_t, varnishd_var_lib_t, varnishd_var_lib_t)
-allow varnishlog_t varnishd_var_lib_t:file map;
-
-files_search_var_lib(varnishlog_t)
 varnishd_read_config(varnishlog_t)
+varnishd_read_lib_files(varnishlog_t)

--- a/policy/modules/contrib/varnishd.te
+++ b/policy/modules/contrib/varnishd.te
@@ -131,7 +131,6 @@ optional_policy(`
 # Log local policy
 #
 
-allow varnishlog_t varnishd_t:process { signull };
 
 manage_files_pattern(varnishlog_t, varnishlog_var_run_t, varnishlog_var_run_t)
 files_pid_filetrans(varnishlog_t, varnishlog_var_run_t, file)


### PR DESCRIPTION
This is a small series of changes to polish the `varnishlog_t` type. The mmap change has been running in production for a while now, ever since it was discussed a year and a half ago:

https://github.com/fedora-selinux/selinux-policy-contrib/pull/110#issuecomment-493926534