### PR TITLE
Adds rule to allow glusterd to access RDMA socket

### DIFF
--- a/policy/modules/contrib/glusterd.te
+++ b/policy/modules/contrib/glusterd.te
@@ -79,6 +79,7 @@ allow glusterd_t self:tcp_socket { accept listen };
 allow glusterd_t self:unix_stream_socket { accept listen connectto };
 allow glusterd_t self:rawip_socket create_socket_perms;
 allow glusterd_t self:unix_stream_socket create_stream_socket_perms;
+allow glusterd_t self:netlink_rdma_socket create_socket_perms;
 
 manage_dirs_pattern(glusterd_t, glusterd_conf_t, glusterd_conf_t)
 manage_files_pattern(glusterd_t, glusterd_conf_t, glusterd_conf_t)


### PR DESCRIPTION
Resolves: rhbz#1779052

Signed-off-by: Lev Veyde <lveyde@redhat.com>