### PR TITLE
Allow systemd-logind manage init's pid files

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2838,6 +2838,24 @@ interface(`init_read_pid_files',`
 
 ########################################
 ## <summary>
+##	Manage init pid files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_manage_pid_files',`
+	gen_require(`
+		type init_var_run_t;
+	')
+
+	manage_files_pattern($1, init_var_run_t, init_var_run_t)
+')
+
+########################################
+## <summary>
 ##	Read init unnamed pipes.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -297,6 +297,7 @@ init_signal_script(systemd_logind_t)
 init_getattr_script_status_files(systemd_logind_t)
 init_read_utmp(systemd_logind_t)
 init_config_transient_files(systemd_logind_t)
+init_manage_pid_files(systemd_logind_t)
 
 getty_systemctl(systemd_logind_t)
 


### PR DESCRIPTION
Added init_manage_pid_files() interface.

Resolves: rhbz#1856399