### PR TITLE
Add default file context for "/var/run/chrony-dhcp(/.*)?"

### DIFF
--- a/policy/modules/contrib/chronyd.fc
+++ b/policy/modules/contrib/chronyd.fc
@@ -14,6 +14,7 @@
 /var/log/chrony(/.*)?	gen_context(system_u:object_r:chronyd_var_log_t,s0)
 
 /var/run/chrony(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
+/var/run/chrony-dhcp(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
 /var/run/chronyd(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
 /var/run/chrony-helper(/.*)?	gen_context(system_u:object_r:chronyd_var_run_t,s0)
 /var/run/chronyd\.pid	--	gen_context(system_u:object_r:chronyd_var_run_t,s0)


### PR DESCRIPTION
With the 25d2a5c01c commit, a file transition for /var/run/chrony-dhcp
was added, but it was not backed by the default file context
specification.

Resolves: rhbz#1895825