### PR TITLE
Create the systemd_dbus_chat_resolved() compatibility interface

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2313,6 +2313,22 @@ interface(`systemd_chat_resolved',`
 	ps_process_pattern(systemd_resolved_t, $1)
 ')
 
+########################################
+## <summary>
+##	Exchange messages with
+##	systemd resolved over dbus (deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_dbus_chat_resolved',`
+	refpolicywarn(`$0($*) has been deprecated, use systemd_chat_resolved() instead.')
+	systemd_chat_resolved($1)
+')
+
 ######################################
 ## <summary>
 ##	Make the specified type usable as a systemd private tmp type.


### PR DESCRIPTION
With the 3d60f6dad3c1af246ecf11419cde5fc907aec8c1 commit,
the systemd_dbus_chat_resolved interface was renamed to
systemd_chat_resolved and all references in the selinux-policy were
updated. This interface, however, can be used in other project's
policy or in custom policy modules, already installed on a system,
so the interface needs to be available with the original name, too,
for compatibility reasons.

Resolves: rhbz#1906189