### PR TITLE
Allow stub-resolv.conf to be a symlink

### DIFF
--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -38,7 +38,7 @@ ifdef(`distro_redhat',`
 /etc/sysconfig/network-scripts(/.*)? gen_context(system_u:object_r:net_conf_t,s0)
 /var/run/systemd/network(/.*)?  gen_context(system_u:object_r:net_conf_t,s0)
 /var/run/systemd/resolve/resolv\.conf   --  gen_context(system_u:object_r:net_conf_t,s0)
-/var/run/systemd/resolve/stub-resolv\.conf   --  gen_context(system_u:object_r:net_conf_t,s0)
+/var/run/systemd/resolve/stub-resolv\.conf  gen_context(system_u:object_r:net_conf_t,s0)
 ')
 /var/run/NetworkManager/resolv\.conf.*   --  gen_context(system_u:object_r:net_conf_t,s0)
 

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -455,6 +455,7 @@ interface(`sysnet_read_config',`
         init_search_pid_dirs($1)
 		allow $1 net_conf_t:dir list_dir_perms;
 		read_files_pattern($1, net_conf_t, net_conf_t)
+		read_lnk_files_pattern($1, net_conf_t, net_conf_t)
 	')
 ')
 
@@ -1143,7 +1144,7 @@ interface(`sysnet_filetrans_systemd_resolved',`
 	optional_policy(`
 		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf")
 		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
-		systemd_resolved_pid_filetrans($1, net_conf_t, file, "stub-resolv.conf")
+		systemd_resolved_pid_filetrans($1, net_conf_t, { file lnk_file }, "stub-resolv.conf")
 	')
 ')
 

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1126,6 +1126,29 @@ interface(`sysnet_role_transition_dhcpc',`
 
 ########################################
 ## <summary>
+##	Set up filename transitions for systemd-resolved network
+##	configuration content.
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_filetrans_systemd_resolved',`
+	gen_require(`
+		type net_conf_t;
+	')
+
+	optional_policy(`
+		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf")
+		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
+		systemd_resolved_pid_filetrans($1, net_conf_t, file, "stub-resolv.conf")
+	')
+')
+
+########################################
+## <summary>
 ##	Transition to sysnet named content
 ## </summary>
 ## <param name="domain">
@@ -1137,7 +1160,6 @@ interface(`sysnet_role_transition_dhcpc',`
 interface(`sysnet_filetrans_named_content',`
 	gen_require(`
 		type net_conf_t;
-		type systemd_resolved_var_run_t;
 	')
 
 	files_etc_filetrans($1, net_conf_t, file, "resolv.conf")
@@ -1156,15 +1178,11 @@ interface(`sysnet_filetrans_named_content',`
 	init_pid_filetrans($1, net_conf_t, dir, "network")
 
 	optional_policy(`
-	    networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf")
-	    networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
-    ')
+		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf")
+		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
+	')
 
-    optional_policy(`
-        sysnet_filetrans_config_fromdir($1,systemd_resolved_var_run_t, file, "resolv.conf")
-        sysnet_filetrans_config_fromdir($1,systemd_resolved_var_run_t, file, "resolv.conf.tmp")
-        sysnet_filetrans_config_fromdir($1,systemd_resolved_var_run_t, file, "stub-resolv.conf")
-    ')
+	sysnet_filetrans_systemd_resolved($1)
 ')
 
 ########################################

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -336,6 +336,40 @@ interface(`systemd_resolved_write_pid_sock_files',`
 	write_sock_files_pattern($1, systemd_resolved_var_run_t, systemd_resolved_var_run_t)
 ')
 
+########################################
+## <summary>
+##	Create objects in /var/run/systemd/resolve with a private
+##	type using a type_transition.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="file_type">
+##	<summary>
+##	Private file type.
+##	</summary>
+## </param>
+## <param name="class">
+##	<summary>
+##	Object classes to be created.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`systemd_resolved_pid_filetrans',`
+	gen_require(`
+		type systemd_resolved_var_run_t;
+	')
+
+	filetrans_pattern($1, systemd_resolved_var_run_t, $2, $3, $4)
+')
+
 ######################################
 ## <summary>
 ##	Read systemd_login PID files.

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1080,9 +1080,7 @@ dev_write_kmsg(systemd_resolved_t)
 dev_read_sysfs(systemd_resolved_t)
 
 sysnet_manage_config(systemd_resolved_t)
-sysnet_filetrans_config_fromdir(systemd_resolved_t,systemd_resolved_var_run_t, file, "resolv.conf")
-sysnet_filetrans_config_fromdir(systemd_resolved_t,systemd_resolved_var_run_t, file, "stub-resolv.conf")
-sysnet_filetrans_config_fromdir(systemd_resolved_t,systemd_resolved_var_run_t, file, "resolv.conf.tmp")
+sysnet_filetrans_systemd_resolved(systemd_resolved_t)
 
 systemd_read_efivarfs(systemd_resolved_t)
 


### PR DESCRIPTION
(And a small cleanup to remove a reference to `systemd_resolved_var_run_t` from `sysnetwork.if`.)

Tested on a Rawhide VM image by replacing `/var/run/systemd/resolve/stub-resolv.conf` with a symlink to `resolv.conf` and restarting `chronyd.service`.