### PR TITLE
Allow sssd, unix_chkpwd, groupadd stat /proc filesystem

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -227,6 +227,8 @@ allow groupadd_t self:unix_stream_socket create_stream_socket_perms;
 allow groupadd_t self:unix_dgram_socket sendto;
 allow groupadd_t self:unix_stream_socket connectto;
 
+kernel_getattr_proc(groupadd_t)
+
 fs_getattr_xattr_fs(groupadd_t)
 fs_search_auto_mountpoints(groupadd_t)
 

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -90,6 +90,7 @@ manage_files_pattern(sssd_t, sssd_var_run_t, sssd_var_run_t)
 manage_sock_files_pattern(sssd_t, sssd_var_run_t, sssd_var_run_t)
 files_pid_filetrans(sssd_t, sssd_var_run_t, { file dir sock_file })
 
+kernel_getattr_proc(sssd_t)
 kernel_read_network_state(sssd_t)
 kernel_read_system_state(sssd_t)
 kernel_request_load_module(sssd_t)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -124,6 +124,7 @@ allow chkpwd_t self:process { getattr signal };
 allow chkpwd_t shadow_t:file { read_file_perms map };
 files_list_etc(chkpwd_t)
 
+kernel_getattr_proc(chkpwd_t)
 kernel_read_crypto_sysctls(chkpwd_t)
 # is_selinux_enabled
 kernel_read_system_state(chkpwd_t)


### PR DESCRIPTION
With the f2d77890bfcbe5b514c6205f288eeb73fe2225af commit, the getattr
permission for the proc filesystem was allowed to the login_pgm
attribute. It is required by all services or commands working with pam
though.

Resolves: rhbz#1907365