### PR TITLE
Allow sssd read /run/systemd directory

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -144,6 +144,8 @@ auth_manage_cache(sssd_t)
 auth_login_manage_key(sssd_t)
 dontaudit sssd_t init_t:dbus send_msg;
 
+# sssd uses inotify to watch for changes in /run/systemd/resolve
+init_list_pid_dirs(sssd_t)
 init_read_utmp(sssd_t)
 
 logging_send_syslog_msg(sssd_t)


### PR DESCRIPTION
The nsswitch_domain is already allowed search /run/systemd, sssd however
requires the read permission, granted by the list_dir_perms pattern.

Resolves: rhbz#1903335