### PR TITLE
Allow ipsec set the context of a SPD entry to the default context

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -202,6 +202,8 @@ auth_read_home_content(ipsec_t)
 init_use_fds(ipsec_t)
 init_use_script_ptys(ipsec_t)
 
+ipsec_setcontext_default_spd(ipsec_t)
+
 logging_send_audit_msgs(ipsec_t)
 logging_send_syslog_msg(ipsec_t)
 


### PR DESCRIPTION
Resolves: rhbz#1880474