### PR TITLE
Label /dev/isst_interface as cpu_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -59,6 +59,7 @@
 /dev/ipmi[0-9]+		-c	gen_context(system_u:object_r:ipmi_device_t,s0)
 /dev/ipmi/[0-9]+	-c	gen_context(system_u:object_r:ipmi_device_t,s0)
 /dev/irlpt[0-9]+	-c	gen_context(system_u:object_r:printer_device_t,s0)
+/dev/isst_interface	-c	gen_context(system_u:object_r:cpu_device_t,s0)
 /dev/jbm		-c	gen_context(system_u:object_r:mouse_device_t,s0)
 /dev/js.*		-c	gen_context(system_u:object_r:mouse_device_t,s0)
 /dev/kmem		-c	gen_context(system_u:object_r:memory_device_t,mls_systemhigh)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -6823,6 +6823,7 @@ gen_require(`
 	filetrans_pattern($1, device_t, clock_device_t, chr_file, "hpet")
 	filetrans_pattern($1, device_t, random_device_t, chr_file, "hw_random")
 	filetrans_pattern($1, device_t, random_device_t, chr_file, "hwrng")
+	filetrans_pattern($1, device_t, cpu_device_t, chr_file, "isst_interface")
 	filetrans_pattern($1, device_t, dri_device_t, chr_file, "i915")
 	filetrans_pattern($1, device_t, hsa_device_t, chr_file, "kfd")
 	filetrans_pattern($1, device_t, mouse_device_t, chr_file, "inportbm")


### PR DESCRIPTION
To support the change, an appropriate file transition was added
to the dev_filetrans_all_named_dev() interface.

Resolves: rhbz#1902227