### PR TITLE
Dontaudit firewalld dac_override capability

### DIFF
--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -36,7 +36,7 @@ systemd_unit_file(firewalld_unit_file_t)
 #
 
 allow firewalld_t self:capability { dac_read_search net_admin net_raw };
-dontaudit firewalld_t self:capability sys_tty_config;
+dontaudit firewalld_t self:capability { dac_override sys_tty_config };
 allow firewalld_t self:fifo_file rw_fifo_file_perms;
 allow firewalld_t self:unix_stream_socket { accept listen };
 allow firewalld_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
The dac_override capability is raised when firewalld tries to create
~/.cache directory. The directory is not used any later though.

Resolves: rhbz#1759010