### PR TITLE
Fix snapper on silverblue.

### DIFF
--- a/policy/modules/contrib/snapper.fc
+++ b/policy/modules/contrib/snapper.fc
@@ -7,7 +7,7 @@
 
 /var/log/snapper\.log.* --  gen_context(system_u:object_r:snapperd_log_t,s0)
 
-/mnt/(.*/)?\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
+/(var/)?mnt/(.*/)?\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
 /\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
 /usr/\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)
 /var/\.snapshots(/.*)?   gen_context(system_u:object_r:snapperd_data_t,s0)


### PR DESCRIPTION
On Fedora Silverblue, /mnt is a symlink to /var/mnt.
The regex for snapper contexts does not work for this use case.

Adjust the regex to work for filesystems under both /mnt/ and /var/mnt/