### PR TITLE
Add missing dac_override capability for iscsi mod

### DIFF
--- a/policy/modules/contrib/iscsi.te
+++ b/policy/modules/contrib/iscsi.te
@@ -35,7 +35,7 @@ files_pid_file(iscsi_var_run_t)
 # Local policy
 #
 
-allow iscsid_t self:capability { dac_read_search  ipc_lock net_admin net_raw sys_admin sys_nice sys_module sys_resource };
+allow iscsid_t self:capability { dac_read_search dac_override ipc_lock net_admin net_raw sys_admin sys_nice sys_module sys_resource };
 allow iscsid_t self:process { setrlimit setsched signal };
 allow iscsid_t self:fifo_file rw_fifo_file_perms;
 allow iscsid_t self:unix_stream_socket { accept connectto listen };


### PR DESCRIPTION
This PR should fix the issue raised in https://github.com/fedora-selinux/selinux-policy/issues/525 and https://github.com/coreos/fedora-coreos-tracker/issues/705.