### PR TITLE
Add rsync_sys_admin tunable to allow rsync sys_admin capability

### DIFF
--- a/policy/modules/contrib/rsync.te
+++ b/policy/modules/contrib/rsync.te
@@ -35,6 +35,14 @@ gen_tunable(rsync_anon_write, false)
 ## </desc>
 gen_tunable(rsync_full_access, false)
 
+## <desc>
+##	<p>
+##	Allow rsync sys_admin capability.
+##	This capability is required to restore files
+##	with extended attributes in the "trusted" namespace.
+##	</p>
+## </desc>
+gen_tunable(rsync_sys_admin, false)
 
 type rsync_t;
 type rsync_exec_t;
@@ -150,6 +158,10 @@ tunable_policy(`rsync_anon_write',`
 tunable_policy(`rsync_full_access',`
 	allow rsync_t self:capability {  dac_read_search };
 	files_manage_non_auth_files(rsync_t)
+')
+
+tunable_policy(`rsync_sys_admin',`
+	allow rsync_t self:capability sys_admin;
 ')
 
 tunable_policy(`rsync_export_all_ro',`


### PR DESCRIPTION
The rsync_sys_admin tunable was added to allow rsync the sys_admin
capability conditionally. This permission is required for rsync to
be able to restore files with extended attributes in all attributes
namespaces. Glusterfs makes use of the "trusted" namespace for which
the sys_admin capability is required.
The boolean is off by default.

Resolves: rhbz#1889673