### PR TITLE
Allow staff_u run pam_console_apply

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -65,7 +65,7 @@ storage_write_scsi_generic(staff_t)
 term_use_unallocated_ttys(staff_t)
 term_use_generic_ptys(staff_t)
 
-auth_domtrans_pam_console(staff_t)
+auth_run_pam_console(staff_t, staff_r)
 
 init_dbus_chat(staff_t)
 init_dbus_chat_script(staff_t)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -1307,6 +1307,30 @@ interface(`auth_domtrans_pam_console',`
 
 ########################################
 ## <summary>
+##	Execute pam_console in the pam timestamp domain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to allow transitioning into the pam_console_t domain.
+##	</summary>
+## </param>
+#
+interface(`auth_run_pam_console',`
+	gen_require(`
+		type pam_console_t;
+	')
+
+	auth_domtrans_pam_console($1)
+	role $2 types pam_console_t;
+')
+
+########################################
+## <summary>
 ##	Search the contents of the
 ##	pam_console data directory.
 ## </summary>


### PR DESCRIPTION
Until now, the staff_u user had the permission to execute
pam_console_apply, but the staff_r role was not associated
appropriately, so the transition did not finish successfully.