### PR TITLE
Allow certmonger fsetid capability

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -33,7 +33,7 @@ files_tmp_file(certmonger_tmp_t)
 #
 
 # certmonger requires DAC override to access /etc/pki/pki-tomcat/alias
-allow certmonger_t self:capability { chown dac_read_search dac_override fowner setgid setuid kill sys_nice };
+allow certmonger_t self:capability { chown dac_read_search dac_override fowner fsetid setgid setuid kill sys_nice };
 dontaudit certmonger_t self:capability sys_tty_config;
 allow certmonger_t self:capability2 block_suspend;
 


### PR DESCRIPTION
Along with fowner, fsetid capability is required during ipa server
installation process when certificates for postfix are created and
ownership+permissions are adjusted.

Resolves: rhbz#1873211