### PR TITLE
Allow sysadm read and write /dev/rfkill

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -31,6 +31,7 @@ kernel_read_all_proc(sysadm_t)
 corecmd_exec_shell(sysadm_t)
 
 dev_filetrans_all_named_dev(sysadm_t)
+dev_rw_wireless(sysadm_t)
 
 domain_dontaudit_read_all_domains_state(sysadm_t)
 


### PR DESCRIPTION
This permission is required to run rfkill which enables or disables
wireless devices.

Resolves: rhbz#1831630