### PR TITLE
access_vectors: Add new capabilities to cap2

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -130,7 +130,7 @@ common x_device
 #
 common cap
 {
-	# The capabilities are defined in include/linux/capability.h
+	# The capabilities are defined in include/uapi/linux/capability.h
 	# Capabilities >= 32 are defined in the cap2 common.
 	# Care should be taken to ensure that these are consistent with
 	# those definitions. (Order matters)
@@ -177,6 +177,9 @@ common cap2
 	wake_alarm
 	block_suspend
 	audit_read
+	perfmon
+	bpf
+	checkpoint_restore
 }
 
 #

--- a/policy/modules/contrib/linuxptp.te
+++ b/policy/modules/contrib/linuxptp.te
@@ -154,7 +154,7 @@ allow ptp4l_t self:packet_socket create_socket_perms;
 allow ptp4l_t self:unix_stream_socket create_stream_socket_perms;
 allow ptp4l_t self:shm create_shm_perms;
 allow ptp4l_t self:udp_socket create_socket_perms;
-allow ptp4l_t self:capability { net_admin net_raw sys_admin sys_time };
+allow ptp4l_t self:capability { net_admin net_raw sys_time };
 allow ptp4l_t self:capability2 { wake_alarm };
 allow ptp4l_t self:netlink_route_socket rw_netlink_socket_perms;
 

--- a/policy/modules/contrib/linuxptp.te
+++ b/policy/modules/contrib/linuxptp.te
@@ -155,7 +155,7 @@ allow ptp4l_t self:unix_stream_socket create_stream_socket_perms;
 allow ptp4l_t self:shm create_shm_perms;
 allow ptp4l_t self:udp_socket create_socket_perms;
 allow ptp4l_t self:capability { net_admin net_raw sys_time };
-allow ptp4l_t self:capability2 { wake_alarm };
+allow ptp4l_t self:capability2 { bpf wake_alarm };
 allow ptp4l_t self:netlink_route_socket rw_netlink_socket_perms;
 
 allow ptp4l_t phc2sys_t:unix_dgram_socket sendto;

--- a/policy/modules/contrib/openvswitch.te
+++ b/policy/modules/contrib/openvswitch.te
@@ -33,7 +33,7 @@ systemd_unit_file(openvswitch_unit_file_t)
 #
 
 allow openvswitch_t self:capability { dac_override dac_read_search fowner net_broadcast net_admin ipc_lock sys_module sys_nice sys_rawio sys_resource chown setgid setpcap setuid kill };
-allow openvswitch_t self:capability2 block_suspend;
+allow openvswitch_t self:capability2 { block_suspend perfmon };
 allow openvswitch_t self:process { fork setsched setrlimit signal setcap };
 allow openvswitch_t self:fifo_file rw_fifo_file_perms;
 allow openvswitch_t self:unix_stream_socket { create_stream_socket_perms connectto };

--- a/policy/modules/contrib/pcp.te
+++ b/policy/modules/contrib/pcp.te
@@ -108,6 +108,7 @@ tunable_policy(`pcp_bind_all_unreserved_ports',`
 #
 
 allow pcp_pmcd_t self:capability { dac_read_search dac_override ipc_owner net_admin sys_admin sys_ptrace };
+allow pcp_pmcd_t self:capability2 perfmon;
 allow pcp_pmcd_t self:process { setsched };
 allow pcp_pmcd_t self:unix_dgram_socket create_socket_perms;
 allow pcp_pmcd_t self:cap_userns sys_ptrace;

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -16,6 +16,7 @@ allow sysadm_t self:tipc_socket create_socket_perms;
 allow sysadm_t self:sctp_socket create_socket_perms;
 allow sysadm_t self:rawip_socket create_socket_perms;
 
+allow sysadm_t self:capability2 perfmon;
 allow sysadm_t self:perf_event manage_perf_event_perms;
 
 allow sysadm_t self:system all_system_perms;


### PR DESCRIPTION
Updated location of capability definitions to point to current location within kernel source code.

CAP_BPF and CAP_PERFMON mainlined in: cb8e59cc87201af93dfbb6c3dccc8fcad72a09c2, original commit: a17b53c4a4b55ec322c132b6670743612229ee9c
CAP_CHECKPOINT_RESTORE mainlined in: 74858abbb1032222f922487fd1a24513bbed80f9, original commit: 124ea650d3072b005457faed69909221c2905a1f

The missing capabilities were noticed on archlinux with kernel 5.8.14-arch1-1.

Signed-off-by: Dannick Pomerleau <dannickp@hotmail.com>

Resolves: rhbz#1915264