### PR TITLE
Allow confined users login into graphic session

### DIFF
--- a/policy/modules/contrib/dbus.if
+++ b/policy/modules/contrib/dbus.if
@@ -97,7 +97,7 @@ template(`dbus_role_template',`
     allow $3 $1_dbusd_t:process { noatsecure rlimitinh siginh };
     allow $1_dbusd_t $3:dbus send_msg;
     allow $3 $1_dbusd_t:dbus send_msg;
-    allow $1_dbusd_t $3:system start;
+    allow $1_dbusd_t $3:system { start reload };
     allow $1_dbusd_t session_dbusd_tmp_t:service { start stop };
     allow $3 session_dbusd_tmp_t:dir manage_dir_perms;
     allow $3 session_dbusd_tmp_t:file manage_file_perms;
@@ -122,12 +122,18 @@ template(`dbus_role_template',`
 
 	auth_use_nsswitch($1_dbusd_t)
 
+	files_config_all_files($1_dbusd_t)
+
 	logging_send_syslog_msg($1_dbusd_t)
 
 	dontaudit $1_dbusd_t self:capability net_admin;
 
 	optional_policy(`
 		mozilla_domtrans_spec($1_dbusd_t, $1_t)
+	')
+
+	optional_policy(`
+		systemd_start_systemd_services($1_dbusd_t)
 	')
 ')
 

--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -108,7 +108,8 @@ template(`gnome_role_template',`
 	# Gkeyringd policy
 	#
 
-    allow $1_gkeyringd_t $3:unix_stream_socket { connectto create_stream_socket_perms };
+	allow $1_gkeyringd_t $3:unix_stream_socket { connectto create_stream_socket_perms };
+	allow $1_gkeyringd_t self:process setsched;
 
 	domtrans_pattern($3, gkeyringd_exec_t, $1_gkeyringd_t)
 


### PR DESCRIPTION
Allow dbus role as (user_dbusd_t, staff_dbusd_t and etc.) start systemd services,
modify the systemd configuration of any file and reload the services.
Allow the gkeyringd role as (user_gkeyringd_t, staff_gkeyringd_t and etc.)
set the schedule on self process. Also fix wrong tab space in gnome.if.

allow $1_gkeyringd_t self:process setsched;

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1767874
Migrated PR from selinux-policy-contrib.
