### PR TITLE
Label SDC(scini) Dell Driver

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -259,6 +259,10 @@ ifndef(`distro_redhat',`
 /usr/src/kernels/.+/lib(/.*)?	gen_context(system_u:object_r:usr_t,s0)
 ')
 
+# Deploy Dell EMC PowerFlex - SDC(scini) driver configuration
+# https://cpsdocs.dellemc.com/bundle/VXF_DEPLOY/page/GUID-DC80A2E9-6B92-46F8-9276-1704B41E148E.html
+/usr/bin/emc/scaleio/(.*)\.ko  --		gen_context(system_u:object_r:modules_object_t,s0)
+
 #
 # /var
 #


### PR DESCRIPTION
Label custom Dell EMC PowerFlex v3.5.x modules with default label
modules_object_t, this will allo use scini driver on SELinux enabled RHEL-based SDC nodes.

More information:
https://cpsdocs.dellemc.com/bundle/VXF_DEPLOY/page/GUID-DC80A2E9-6B92-46F8-9276-1704B41E148E.html