### PR TITLE
Run frr service as frr_t and add new bfd_multi port

### DIFF
--- a/policy/modules.conf
+++ b/policy/modules.conf
@@ -3092,3 +3092,10 @@ rhcd = module
 # wireguard
 #
 wireguard = module
+
+# Module: frr
+#
+# FRRouting (FRR) is an IP routing protocol suite.
+#
+frr = module
+

--- a/policy/modules/contrib/frr.fc
+++ b/policy/modules/contrib/frr.fc
@@ -1,0 +1,25 @@
+/usr/libexec/frr(/.*)?              gen_context(system_u:object_r:frr_exec_t,s0)
+
+/usr/lib/systemd/system/frr.*   gen_context(system_u:object_r:frr_unit_file_t,s0)
+
+/etc/frr(/.*)?                  gen_context(system_u:object_r:frr_conf_t,s0)
+
+/var/log/frr(/.*)?              gen_context(system_u:object_r:frr_log_t,s0)
+/var/tmp/frr(/.*)?              gen_context(system_u:object_r:frr_tmp_t,s0)
+
+/var/lock/subsys/bfdd       --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/bgpd       --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/eigrpd     --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/fabricd    --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/isisd      --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/nhrpd      --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/ospf6d     --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/ospfd      --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/pbrd       --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/pimd       --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/ripd       --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/ripngd     --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/staticd    --  gen_context(system_u:object_r:frr_lock_t,s0)
+/var/lock/subsys/zebra      --  gen_context(system_u:object_r:frr_lock_t,s0)
+
+/var/run/frr(/.*)?              gen_context(system_u:object_r:frr_var_run_t,s0)

--- a/policy/modules/contrib/frr.if
+++ b/policy/modules/contrib/frr.if
@@ -1,0 +1,162 @@
+## <summary>policy for frr</summary>
+
+########################################
+## <summary>
+##	Execute frr_exec_t in the frr domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`frr_domtrans',`
+	gen_require(`
+		type frr_t, frr_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, frr_exec_t, frr_t)
+')
+
+######################################
+## <summary>
+##	Execute frr in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`frr_exec',`
+	gen_require(`
+		type frr_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, frr_exec_t)
+')
+
+########################################
+## <summary>
+##	Read frr's log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`frr_read_log',`
+	gen_require(`
+		type frr_log_t;
+	')
+
+	read_files_pattern($1, frr_log_t, frr_log_t)
+	optional_policy(`
+		logging_search_logs($1)
+	')
+')
+
+########################################
+## <summary>
+##	Append to frr log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`frr_append_log',`
+	gen_require(`
+		type frr_log_t;
+	')
+
+	append_files_pattern($1, frr_log_t, frr_log_t)
+	optional_policy(`
+		logging_search_logs($1)
+	')
+')
+
+########################################
+## <summary>
+##	Manage frr log files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`frr_manage_log',`
+	gen_require(`
+		type frr_log_t;
+	')
+
+	manage_dirs_pattern($1, frr_log_t, frr_log_t)
+	manage_files_pattern($1, frr_log_t, frr_log_t)
+	manage_lnk_files_pattern($1, frr_log_t, frr_log_t)
+	optional_policy(`
+		logging_search_logs($1)
+	')
+')
+
+########################################
+## <summary>
+##	Read frr PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`frr_read_pid_files',`
+	gen_require(`
+		type frr_var_run_t;
+	')
+
+	files_search_pids($1)
+	read_files_pattern($1, frr_var_run_t, frr_var_run_t)
+')
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an frr environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`frr_admin',`
+	gen_require(`
+		type frr_t;
+		type frr_log_t;
+		type frr_var_run_t;
+	')
+
+	allow $1 frr_t:process { signal_perms };
+	ps_process_pattern($1, frr_t)
+
+	tunable_policy(`deny_ptrace',`',`
+		allow $1 frr_t:process ptrace;
+	')
+
+	admin_pattern($1, frr_log_t)
+
+	files_search_pids($1)
+	admin_pattern($1, frr_var_run_t)
+	optional_policy(`
+		logging_search_logs($1)
+	')
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/policy/modules/contrib/frr.te
+++ b/policy/modules/contrib/frr.te
@@ -1,0 +1,114 @@
+policy_module(frr, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type frr_t;
+type frr_exec_t;
+init_daemon_domain(frr_t, frr_exec_t)
+
+type frr_log_t;
+logging_log_file(frr_log_t)
+
+type frr_tmp_t;
+files_tmp_file(frr_tmp_t)
+
+type frr_lock_t;
+files_lock_file(frr_lock_t)
+
+type frr_conf_t;
+files_config_file(frr_conf_t)
+
+type frr_unit_file_t;
+systemd_unit_file(frr_unit_file_t)
+
+type frr_var_run_t;
+files_pid_file(frr_var_run_t)
+
+########################################
+#
+# frr local policy
+#
+allow frr_t self:capability { chown dac_override dac_read_search kill net_bind_service net_raw setgid setuid };
+allow frr_t self:netlink_route_socket rw_netlink_socket_perms;
+allow frr_t self:packet_socket create;
+allow frr_t self:process { setcap setpgid };
+allow frr_t self:rawip_socket create_socket_perms;
+allow frr_t self:tcp_socket { connect connected_stream_socket_perms };
+allow frr_t self:udp_socket create_socket_perms;
+allow frr_t self:unix_stream_socket connectto;
+
+allow frr_t frr_conf_t:dir list_dir_perms;
+read_files_pattern(frr_t, frr_conf_t, frr_conf_t)
+read_lnk_files_pattern(frr_t, frr_conf_t, frr_conf_t)
+
+manage_dirs_pattern(frr_t, frr_log_t, frr_log_t)
+manage_files_pattern(frr_t, frr_log_t, frr_log_t)
+manage_lnk_files_pattern(frr_t, frr_log_t, frr_log_t)
+logging_log_filetrans(frr_t, frr_log_t, { dir file lnk_file })
+
+allow frr_t frr_tmp_t:file map;
+manage_dirs_pattern(frr_t, frr_tmp_t, frr_tmp_t)
+manage_files_pattern(frr_t, frr_tmp_t, frr_tmp_t)
+files_tmp_filetrans(frr_t, frr_tmp_t, file)
+
+manage_files_pattern(frr_t, frr_lock_t, frr_lock_t)
+manage_lnk_files_pattern(frr_t, frr_lock_t, frr_lock_t)
+files_lock_filetrans(frr_t, frr_lock_t, { file lnk_file })
+
+manage_dirs_pattern(frr_t, frr_var_run_t, frr_var_run_t)
+manage_files_pattern(frr_t, frr_var_run_t, frr_var_run_t)
+manage_lnk_files_pattern(frr_t, frr_var_run_t, frr_var_run_t)
+manage_sock_files_pattern(frr_t, frr_var_run_t, frr_var_run_t)
+files_pid_filetrans(frr_t, frr_var_run_t, { dir file lnk_file })
+
+allow frr_t frr_exec_t:dir search_dir_perms;
+can_exec(frr_t, frr_exec_t)
+
+kernel_read_network_state(frr_t)
+kernel_read_net_sysctls(frr_t)
+kernel_read_system_state(frr_t)
+
+auth_use_nsswitch(frr_t)
+
+corecmd_exec_bin(frr_t)
+
+corenet_tcp_bind_appswitch_emp_port(frr_t)
+corenet_udp_bind_bfd_control_port(frr_t)
+corenet_udp_bind_bfd_echo_port(frr_t)
+corenet_udp_bind_bfd_multi_port(frr_t)
+corenet_tcp_bind_bgp_port(frr_t)
+corenet_tcp_bind_cmadmin_port(frr_t)
+corenet_udp_bind_cmadmin_port(frr_t)
+corenet_tcp_bind_firepower_port(frr_t)
+corenet_tcp_bind_priority_e_com_port(frr_t)
+corenet_udp_bind_router_port(frr_t)
+corenet_tcp_bind_qpasa_agent_port(frr_t)
+corenet_tcp_bind_smntubootstrap_port(frr_t)
+corenet_tcp_bind_versa_tek_port(frr_t)
+corenet_tcp_bind_zebra_port(frr_t)
+
+domain_use_interactive_fds(frr_t)
+
+fs_read_nsfs_files(frr_t)
+
+sysnet_exec_ifconfig(frr_t)
+
+userdom_read_admin_home_files(frr_t)
+
+optional_policy(`
+	logging_send_syslog_msg(frr_t)
+')
+
+optional_policy(`
+	modutils_exec_kmod(frr_t)
+	modutils_getattr_module_deps(frr_t)
+	modutils_read_module_config(frr_t)
+	modutils_read_module_deps_files(frr_t)
+')
+
+optional_policy(`
+	networkmanager_read_state(frr_t)
+')


### PR DESCRIPTION
Confined frr service as frr_t and create policy files and rules for frr service.
FRRouting (FRR) is an IP routing protocol which
includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.
Add new port called bfd_multi for bfdd daemon, which is use in frr service.