### PR TITLE
Dontaudit vhostmd to write in /var/lib/rpm/ dir and allow signull rpm

### DIFF
--- a/policy/modules/contrib/vhostmd.te
+++ b/policy/modules/contrib/vhostmd.te
@@ -70,6 +70,10 @@ optional_policy(`
 optional_policy(`
 	rpm_exec(vhostmd_t)
 	rpm_read_db(vhostmd_t)
+	#vhostmd work properly without allowing this permissions, so dontaudit
+	rpm_dontaudit_manage_db(vhostmd_t)
+	rpm_signull(vhostmd_t)
+
 ')
 
 optional_policy(`


### PR DESCRIPTION
Add rpm_dontaudit_manage_db() interface to do not audit attempts to create, read,
write, and delete the RPM package database for vhostmd_t domain.

Add interface rpm_signull() to send a null signal to rpm for vhostmd_t
domain.