### PR TITLE
ci: Install build dependencies from koji

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           name: srpm
           path: "*.src.rpm"
-      - run: dnf builddep -y --srpm *.src.rpm
+      - run: dnf builddep --nogpgcheck --repofrompath 'koji,https://kojipkgs.fedoraproject.org/repos/rawhide/latest/$arch/' -y --srpm *.src.rpm
       - run: rpmbuild --define "_topdir $PWD/rpmbuild" -rb *.src.rpm
       - name: Store binary RPMs as artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The common rawhide composes may not contain the latest packages
referenced from the specfile. To reduce this window, use rawhide
packages from koji.