### PR TITLE
Allow openvswitch_t perf_event write permission

### DIFF
--- a/policy/modules/contrib/openvswitch.te
+++ b/policy/modules/contrib/openvswitch.te
@@ -42,7 +42,7 @@ allow openvswitch_t self:netlink_socket create_socket_perms;
 allow openvswitch_t self:netlink_route_socket rw_netlink_socket_perms;
 allow openvswitch_t self:netlink_generic_socket create_socket_perms;
 allow openvswitch_t self:netlink_netfilter_socket create_socket_perms;
-allow openvswitch_t self:perf_event open;
+allow openvswitch_t self:perf_event write_perf_event_perms;
 allow openvswitch_t self:tun_socket { create_socket_perms relabelfrom relabelto };
 allow openvswitch_t self:system { module_load };
 

--- a/policy/support/obj_perm_sets.spt
+++ b/policy/support/obj_perm_sets.spt
@@ -295,4 +295,5 @@ define(`manage_service_perms', `{ start stop status reload enable disable } ')
 #
 # perf_event
 #
+define(`write_perf_event_perms', `{ open write }')
 define(`manage_perf_event_perms', `{ cpu kernel open read tracepoint write }')


### PR DESCRIPTION
The permission is required for the ovsdb-server.