### PR TITLE
Allow IPsec and Certmonger to use opencryptoki services

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -171,7 +171,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    pkcs_read_lock(certmonger_t)
+    pkcs_use_opencryptoki(certmonger_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -249,6 +249,10 @@ optional_policy(`
 	')
 ')
 
+optional_policy(`
+	pkcs_use_opencryptoki(ipsec_t)
+')
+
 ########################################
 #
 # ipsec_mgmt Local policy


### PR DESCRIPTION
Add to certmonger and ipsec policy interface pkcs_use_opencryptoki(),
which allow use opencryptoki. Opencryptoki implements PKCS#11
standard.