### PR TITLE
Allow domain write to systemd-resolved PID socket files

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -510,6 +510,7 @@ optional_policy(`
 	systemd_login_reboot(unconfined_domain_type)
 	systemd_login_halt(unconfined_domain_type)
 	systemd_login_undefined(unconfined_domain_type)
+	systemd_resolved_write_pid_sock_files(domain)
 	systemd_filetrans_named_content(named_filetrans_domain)
 	systemd_filetrans_named_hostname(named_filetrans_domain)
 	systemd_filetrans_home_content(named_filetrans_domain)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -562,7 +562,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_resolved_write_pid_sock_files(nsswitch_domain)
 	systemd_userdbd_stream_connect(nsswitch_domain)
 	systemd_machined_stream_connect(nsswitch_domain)
 ')


### PR DESCRIPTION
Previously, the permission was allowed for the nsswitch_domain
attribute which turned out not to be sufficient.

Resolves: rhbz#1900175