### PR TITLE
Dontaudit setsched for rndc

### DIFF
--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -263,6 +263,7 @@ optional_policy(`
 allow ndc_t self:capability { dac_read_search  net_admin };
 allow ndc_t self:capability2 block_suspend;
 allow ndc_t self:process { fork signal_perms };
+dontaudit ndc_t self:process setsched;
 allow ndc_t self:fifo_file rw_fifo_file_perms;
 allow ndc_t self:unix_stream_socket { accept listen };
 


### PR DESCRIPTION
When rndc command is used to stop the named service, rndc calls
isc_thread_setaffinity(), but its return value is ignored.