### PR TITLE
   Allow unconfined_t and kprop_t to create krb5_0.rcache2 with the right context

### DIFF
--- a/policy/modules/contrib/kerberos.if
+++ b/policy/modules/contrib/kerberos.if
@@ -589,6 +589,7 @@ interface(`kerberos_filetrans_named_content',`
 	kerberos_tmp_filetrans_host_rcache($1, "HTTP_23")
 	kerberos_tmp_filetrans_host_rcache($1, "HTTP_48")
 	kerberos_tmp_filetrans_host_rcache($1, "imap_0")
+	kerberos_tmp_filetrans_host_rcache($1, "krb5_0.rcache2")
 	kerberos_tmp_filetrans_host_rcache($1, "nfs_0")
 	kerberos_tmp_filetrans_host_rcache($1, "ldapmap1_0")
 	kerberos_tmp_filetrans_host_rcache($1, "ldap_487")

--- a/policy/modules/contrib/kerberos.te
+++ b/policy/modules/contrib/kerberos.te
@@ -397,4 +397,5 @@ seutil_read_file_contexts(kpropd_t)
 
 sysnet_dns_name_resolve(kpropd_t)
 
+kerberos_tmp_filetrans_host_rcache(kpropd_t, "krb5_0.rcache2")
 kerberos_use(kpropd_t)


### PR DESCRIPTION
In specific scenarios, processed labeled unconfined_t or kprop_t
may create files with a wrong file context.
Use an interface kerberos_tmp_filetrans_host_rcache() in case of krop_t
which allow kerberos content in the /var/tmp with an correct label.
Add an interface kerberos_tmp_filetrans_host_rcache() to kerberos_filetrans_named_content()
which allow kerberos content in the /var/tmp with an correct label. This
solution in this case avoid duplication of the magic filename in the
future. Then unconfined and kprop can create /var/tmp/krb5_0.rcache2
with proper selinux context.

Bugzillas:
https://bugzilla.redhat.com/show_bug.cgi?id=1874527
https://bugzilla.redhat.com/show_bug.cgi?id=1877044