### PR TITLE
Update .copr/make-srpm.sh to use rawhide as DISTGIT_BRANCH

### DIFF
--- a/.copr/make-srpm.sh
+++ b/.copr/make-srpm.sh
@@ -7,7 +7,7 @@ outdir="$1"; shift
 dirname="$(dirname "$0")"
 
 DISTGIT_URL=https://src.fedoraproject.org/rpms/selinux-policy
-DISTGIT_REF=master
+DISTGIT_REF=rawhide
 
 CONTAINER_URL=https://github.com/containers/container-selinux
 EXPANDER_URL=https://github.com/fedora-selinux/macro-expander


### PR DESCRIPTION
In the src.fedoraproject.org/rpms/selinux-policy packages repository,
the default branch name has changed to "rawhide".
The .copr/make-srpm.sh file was updated to use "rawhide" in the
DISTGIT_REF variable instead of "master".