### PR TITLE
Allow systemd and systemd-resolved watch dbus pid object

### DIFF
--- a/policy/modules/contrib/dbus.if
+++ b/policy/modules/contrib/dbus.if
@@ -544,6 +544,44 @@ interface(`dbus_read_pid_sock_files',`
 
 ########################################
 ## <summary>
+##	Watch system dbus pid socket files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dbus_watch_pid_sock_files',`
+	gen_require(`
+		type system_dbusd_var_run_t;
+	')
+
+	files_search_pids($1)
+	allow $1 system_dbusd_var_run_t:sock_file watch_sock_file_perms;
+')
+
+########################################
+## <summary>
+##	Watch system dbus pid directory
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dbus_watch_pid_dirs',`
+	gen_require(`
+		type system_dbusd_var_run_t;
+	')
+
+	files_search_pids($1)
+	allow $1 system_dbusd_var_run_t:dir watch_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to connect to
 ##	session bus types with a unix
 ##	stream socket.

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -765,6 +765,8 @@ optional_policy(`
 	dbus_system_bus_client(init_t)
 	dbus_delete_pid_files(init_t)
     dbus_manage_session_tmp_dirs(init_t)
+	dbus_read_pid_sock_files(init_t)
+	dbus_watch_pid_sock_files(init_t)
 
 	optional_policy(`
 		devicekit_dbus_chat_power(init_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1083,6 +1083,9 @@ corenet_udp_bind_howl_port(systemd_resolved_t)
 dev_write_kmsg(systemd_resolved_t)
 dev_read_sysfs(systemd_resolved_t)
 
+files_watch_root_dirs(systemd_resolved_t)
+files_watch_var_run_dirs(systemd_resolved_t)
+
 sysnet_manage_config(systemd_resolved_t)
 sysnet_filetrans_systemd_resolved(systemd_resolved_t)
 
@@ -1095,6 +1098,8 @@ optional_policy(`
 	dbus_connect_system_bus(systemd_resolved_t)
     dbus_read_pid_files(systemd_resolved_t)
     dbus_read_pid_sock_files(systemd_resolved_t)
+	dbus_watch_pid_sock_files(systemd_resolved_t)
+	dbus_watch_pid_dirs(systemd_resolved_t)
     systemd_dbus_chat_logind(systemd_resolved_t)
 ')
 


### PR DESCRIPTION
The init_t domain was allowed to read and watch pid socket files.
The systemd_resolved_t domain was allowed to:
- watch root dirs
- watch /var/run dirs
- watch pid socket files and directories
The following interfaces were added:
- files_watch_root_dirs(systemd_resolved_t)
- files_watch_var_run_dirs(systemd_resolved_t)