### PR TITLE
Add new watch interfaces in the base and userdomain policy

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2672,6 +2672,44 @@ interface(`files_watch_root_dirs',`
 	allow $1 root_t:dir watch_dir_perms;
 ')
 
+##########################################
+## <summary>
+## 	Watch_mount the root directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+##
+#
+interface(`files_watch_mount_root_dirs',`
+	gen_require(`
+		type root_t;
+	')
+
+	allow $1 root_t:dir watch_mount_dir_perms;
+')
+
+##########################################
+## <summary>
+## 	Watch_with_perm the root directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+##
+#
+interface(`files_watch_with_perm_root_dirs',`
+	gen_require(`
+		type root_t;
+	')
+
+	allow $1 root_t:dir watch_with_perm_dir_perms;
+')
+
 ########################################
 ## <summary>
 ##	Relabel a rootfs filesystem.
@@ -5973,6 +6011,63 @@ interface(`files_manage_generic_tmp_dirs',`
 	')
 
 	manage_dirs_pattern($1, tmp_t, tmp_t)
+')
+
+##########################################
+## <summary>
+## 	Watch generic directories in /tmp
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+##
+#
+interface(`files_watch_generic_tmp_dirs',`
+	gen_require(`
+		type tmp_t;
+	')
+
+	allow $1 tmp_t:dir watch_dir_perms;
+')
+
+##########################################
+## <summary>
+## 	Watch_mount generic directories in /tmp
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+##
+#
+interface(`files_watch_mount_generic_tmp_dirs',`
+	gen_require(`
+		type tmp_t;
+	')
+
+	allow $1 tmp_t:dir watch_mount_dir_perms;
+')
+
+##########################################
+## <summary>
+## 	Watch_with_perm generic directories in /tmp
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+##
+#
+interface(`files_watch_with_perm_generic_tmp_dirs',`
+	gen_require(`
+		type tmp_t;
+	')
+
+	allow $1 tmp_t:dir watch_with_perm_dir_perms;
 ')
 
 ########################################

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -351,6 +351,63 @@ interface(`userdom_watch_tmp_files',`
 
 #######################################
 ## <summary>
+##	Watch user temporary directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolebase/>
+#
+interface(`userdom_watch_tmp_dirs',`
+	gen_require(`
+		type user_tmp_t;
+	')
+
+	watch_dirs_pattern($1, user_tmp_t, user_tmp_t)
+')
+
+#######################################
+## <summary>
+##	Watch_mount user temporary directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolebase/>
+#
+interface(`userdom_watch_mount_tmp_dirs',`
+	gen_require(`
+		type user_tmp_t;
+	')
+
+	watch_mount_dirs_pattern($1, user_tmp_t, user_tmp_t)
+')
+
+#######################################
+## <summary>
+##	Watch_with_perm user temporary directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolebase/>
+#
+interface(`userdom_watch_with_perm_tmp_dirs',`
+	gen_require(`
+		type user_tmp_t;
+	')
+
+	watch_with_perm_dirs_pattern($1, user_tmp_t, user_tmp_t)
+')
+
+#######################################
+## <summary>
 ##	Mmap user temporary files
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The following interfaces were added:
- files_watch_mount_root_dirs
- files_watch_with_perm_root_dirs
- files_watch_generic_tmp_dirs
- files_watch_mount_generic_tmp_dirs
- files_watch_with_perm_generic_tmp_dirs
- userdom_watch_tmp_dirs
- userdom_watch_with_perm_tmp_dirs
- userdom_watch_mount_tmp_dirs