### PR TITLE
Allow dmidecode_t integrity lockdown permission

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -3163,6 +3163,7 @@ interface(`dev_read_raw_memory',`
 
 	read_chr_files_pattern($1, device_t, memory_device_t)
 	allow $1 memory_device_t:chr_file map;
+	allow $1 self:lockdown integrity;
 
 	allow $1 self:capability sys_rawio;
 	typeattribute $1 memory_raw_read;


### PR DESCRIPTION
Allow biosdecode, ownership, vpddecode the lockdown permission
from the integrity class.
This permission is required to open /dev/mem, /dev/kmem, and /dev/port.