### PR TITLE
Allow kmod_t and udev_t confidentiality lockdown permission

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -248,6 +248,8 @@ allow unconfined_domain_type self:bpf { map_create map_read map_write prog_load 
 
 allow unconfined_domain_type self:lnk_file setattr;
 
+allow unconfined_domain_type self:lockdown confidentiality;
+
 allow unconfined_domain_type self:perf_event manage_perf_event_perms;
 
 # Use/sendto/connectto sockets created by any domain.

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6894,6 +6894,7 @@ interface(`fs_rw_tracefs_files',`
 	')
 
 	rw_files_pattern($1, tracefs_t, tracefs_t)
+	allow $1 self:lockdown confidentiality;
 ')
 
 ########################################
@@ -6914,6 +6915,7 @@ interface(`fs_manage_tracefs_dirs',`
 	')
 
 	manage_dirs_pattern($1, tracefs_t, tracefs_t)
+	allow $1 self:lockdown confidentiality;
 ')
 
 ########################################

--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -133,6 +133,7 @@ files_kernel_modules_filetrans(kmod_t, modules_dep_t, file)
 fs_getattr_xattr_fs(kmod_t)
 fs_dontaudit_use_tmpfs_chr_dev(kmod_t)
 fs_mount_rpc_pipefs(kmod_t)
+fs_rw_tracefs_files(kmod_t)
 fs_search_rpc(kmod_t)
 
 auth_use_nsswitch(kmod_t)

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -146,6 +146,7 @@ fs_rw_anon_inodefs_files(udev_t)
 fs_list_auto_mountpoints(udev_t)
 fs_list_hugetlbfs(udev_t)
 fs_read_cgroup_files(udev_t)
+fs_rw_tracefs_files(udev_t)
 
 mls_file_read_all_levels(udev_t)
 mls_file_write_all_levels(udev_t)


### PR DESCRIPTION
The confidentiality permission from the lockdown class is required
for modprobe and systemd-udevd to use tracefs.
