### PR TITLE
Allow systemd-logind integrity lockdown permission

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -200,6 +200,13 @@ systemd_domain_template(systemd_sleep)
 #  is for /run/user/$USER ($USER ownership is $USER:$USER)
 allow systemd_logind_t self:capability { chown kill dac_read_search dac_override fowner sys_tty_config sys_admin };
 allow systemd_logind_t self:capability2 block_suspend;
+
+# systemd-logind reads state from /sys/power, which changes output based on
+# whether hibernations is available, which tries to take the lockdown state
+# into account. So the permission is somewhat unnecessary (systemd-logind
+# doesn't actually try to change anything), but it's better to allow it so that
+# systemd-logind sees the right system state.
+allow systemd_logind_t self:lockdown integrity;
 allow systemd_logind_t self:process getcap;
 allow systemd_logind_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow systemd_logind_t self:unix_dgram_socket create_socket_perms;
@@ -1294,6 +1301,8 @@ systemd_read_efivarfs(systemd_userdbd_t)
 
 allow systemd_sleep_t self:capability sys_resource;
 dontaudit systemd_sleep_t self:capability sys_ptrace;
+# systemd-sleep needs the permission to change sleep state
+allow systemd_sleep_t self:lockdown integrity;
 
 kernel_dgram_send(systemd_sleep_t)
 


### PR DESCRIPTION
The integrity lockdown permission is required for the hibernation
feature allowing userspace to modify the kernel.

Resolves: rhbz#1927557