### PR TITLE
Allow xdm watch its private lib dirs, /etc, /usr

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7000,6 +7000,24 @@ interface(`files_watch_usr_dirs',`
 
 ########################################
 ## <summary>
+##	Watch generic files in /usr.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_usr_files',`
+	gen_require(`
+		type usr_t;
+	')
+
+	allow $1 usr_t:file watch_file_perms;
+')
+
+########################################
+## <summary>
 ##	Install a system.map into the /boot directory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -514,7 +514,7 @@ manage_sock_files_pattern(xdm_t, xdm_var_lib_t, xdm_var_lib_t)
 files_var_lib_filetrans(xdm_t, xdm_var_lib_t, { file dir })
 # Read machine-id
 files_read_var_lib_files(xdm_t)
-allow xdm_t xdm_var_lib_t:dir map;
+allow xdm_t xdm_var_lib_t:dir { map watch_dir_perms };
 
 manage_dirs_pattern(xdm_t, xdm_var_run_t, xdm_var_run_t)
 manage_files_pattern(xdm_t, xdm_var_run_t, xdm_var_run_t)
@@ -639,7 +639,10 @@ files_read_var_files(xdm_t)
 files_read_etc_runtime_files(xdm_t)
 files_exec_etc_files(xdm_t)
 files_list_mnt(xdm_t)
+files_watch_etc_dirs(xdm_t)
+files_watch_etc_files(xdm_t)
 files_watch_usr_dirs(xdm_t)
+files_watch_usr_files(xdm_t)
 files_mounton_non_security(xdm_t)
 # Read /usr/share/terminfo/l/linux and /usr/share/icons/default/index.theme...
 files_read_usr_files(xdm_t)


### PR DESCRIPTION
The following watch permissions were added for xdm_t:
- xdm_var_lib_t directories (e. g. /var/lib/sddm/.config)
- etc_t files and dirs (/etc and /etc/fstab)
- usr files (e. g. /usr/share/plasma/desktoptheme/default/metadata.desktop)

Resolves: rhbz#1927534