### PR TITLE
Fix several issues found while dogfooding with latest GitHub policy

### DIFF
--- a/policy/modules/contrib/dnsmasq.te
+++ b/policy/modules/contrib/dnsmasq.te
@@ -101,6 +101,7 @@ dev_read_urand(dnsmasq_t)
 domain_use_interactive_fds(dnsmasq_t)
 
 files_read_etc_runtime_files(dnsmasq_t)
+files_watch_etc_dirs(dnsmasq_t)
 files_manage_mnt_files(dnsmasq_t)
 
 fs_getattr_all_fs(dnsmasq_t)

--- a/policy/modules/contrib/networkmanager.if
+++ b/policy/modules/contrib/networkmanager.if
@@ -343,6 +343,25 @@ interface(`networkmanager_manage_pid_sock_files',`
 
 ########################################
 ## <summary>
+##	Watch NetworkManager PID directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`networkmanager_watch_pid_dirs',`
+	gen_require(`
+		type NetworkManager_var_run_t;
+	')
+
+	files_search_pids($1)
+	watch_dirs_pattern($1, NetworkManager_var_run_t, NetworkManager_var_run_t)
+')
+
+########################################
+## <summary>
 ##	Create objects in /etc with a private
 ##	type using a type_transition.
 ## </summary>

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -206,6 +206,7 @@ optional_policy(`
 
 optional_policy(`
 	networkmanager_read_pid_files(sssd_t)
+	networkmanager_watch_pid_dirs(sssd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -23,7 +23,7 @@ ifdef(`distro_debian',`
 /etc/hosts[^/]*		--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/hosts\.deny.*	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/denyhosts.*	--	gen_context(system_u:object_r:net_conf_t,s0)
-/etc/resolv\.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
+/etc/resolv\.conf.*		gen_context(system_u:object_r:net_conf_t,s0)
 /etc/resolv-secure.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/\.resolv\.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
 /etc/yp\.conf.*		--	gen_context(system_u:object_r:net_conf_t,s0)

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -442,20 +442,18 @@ interface(`sysnet_read_config',`
 	')
 
 	files_search_etc($1)
-	allow $1 net_conf_t:file read_file_perms;
+	read_files_pattern($1, net_conf_t, net_conf_t)
+	read_lnk_files_pattern($1, net_conf_t, net_conf_t)
 
 	ifdef(`distro_debian',`
 		files_search_pids($1)
-		allow $1 net_conf_t:dir list_dir_perms;
-		read_files_pattern($1, net_conf_t, net_conf_t)
+		list_dirs_pattern($1, net_conf_t, net_conf_t)
 	')
 
 	ifdef(`distro_redhat',`
-        files_search_all_pids($1)
-        init_search_pid_dirs($1)
-		allow $1 net_conf_t:dir list_dir_perms;
-		read_files_pattern($1, net_conf_t, net_conf_t)
-		read_lnk_files_pattern($1, net_conf_t, net_conf_t)
+		files_search_all_pids($1)
+		init_search_pid_dirs($1)
+		list_dirs_pattern($1, net_conf_t, net_conf_t)
 	')
 ')
 
@@ -475,6 +473,7 @@ interface(`sysnet_dontaudit_read_config',`
 	')
 
 	dontaudit $1 net_conf_t:file read_file_perms;
+	dontaudit $1 net_conf_t:lnk_file read_lnk_file_perms;
 ')
 
 #######################################
@@ -511,8 +510,9 @@ interface(`sysnet_create_config',`
 		type net_conf_t;
 	')
 
-	files_search_etc($1)
+	files_rw_etc_dirs($1)
 	allow $1 net_conf_t:file create_file_perms;
+	allow $1 net_conf_t:lnk_file create_lnk_file_perms;
 ')
 
 #######################################
@@ -608,22 +608,11 @@ interface(`sysnet_filetrans_config_fromdir',`
 interface(`sysnet_manage_config',`
 	gen_require(`
 		type net_conf_t;
-        ')
-
-	allow $1 net_conf_t:file manage_file_perms;
-
-	ifdef(`distro_debian',`
-		files_search_pids($1)
-		manage_files_pattern($1, net_conf_t, net_conf_t)
 	')
 
-	ifdef(`distro_redhat',`
-        files_search_all_pids($1)
-        init_search_pid_dirs($1)
-		allow $1 net_conf_t:dir list_dir_perms;
-		manage_files_pattern($1, net_conf_t, net_conf_t)
-		manage_lnk_files_pattern($1, net_conf_t, net_conf_t)
-	')
+	sysnet_read_config($1)
+	manage_files_pattern($1, net_conf_t, net_conf_t)
+	manage_lnk_files_pattern($1, net_conf_t, net_conf_t)
 ')
 
 #######################################
@@ -641,19 +630,8 @@ interface(`sysnet_manage_config_dirs',`
 		type net_conf_t;
 	')
 
-	allow $1 net_conf_t:dir manage_dir_perms;
-
-	ifdef(`distro_debian',`
-		files_search_pids($1)
-		manage_dirs_pattern($1, net_conf_t, net_conf_t)
-	')
-
-	ifdef(`distro_redhat',`
-        files_search_all_pids($1)
-        init_search_pid_dirs($1)
-		allow $1 net_conf_t:dir list_dir_perms;
-		manage_dirs_pattern($1, net_conf_t, net_conf_t)
-	')
+	sysnet_read_config($1)
+	manage_dirs_pattern($1, net_conf_t, net_conf_t)
 ')
 
 #######################################
@@ -1183,7 +1161,7 @@ interface(`sysnet_filetrans_named_content',`
 		type net_conf_t;
 	')
 
-	files_etc_filetrans($1, net_conf_t, file, "resolv.conf")
+	sysnet_etc_filetrans_config($1, "resolv.conf")
 	files_etc_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
 	files_etc_filetrans($1, net_conf_t, file, "resolv.conf.fp-tmp")
 	files_etc_filetrans($1, net_conf_t, file, "resolv.conf.fp-saved")


### PR DESCRIPTION
This fixes a few of the AVCs that appeared on my F33 machine after I installed selinux-policy built directly from the rawhide branch [1] (plus updated SELinux userspace from F34 repos). Most of the rest have already been reported, one is related to snappy-selinux, and one will need further investigation.

[1] https://copr.fedorainfracloud.org/coprs/omos/selinux-policy-latest/