### PR TITLE
Fix docstring for init_watch_dir()

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3340,15 +3340,15 @@ interface(`init_prog_run_bpf',`
 ')
 
 #######################################
-# <summary>
-#     Allow systemd to watch directories of given type.
-#     Intended for systemd path units - see systemd.path(5).
-# </summary>
-# <param name="type">
-#     <summary>
-#     Type allowed to watch.
-#     </summary>
-# </param>
+## <summary>
+##     Allow systemd to watch directories of given type.
+##     Intended for systemd path units - see systemd.path(5).
+## </summary>
+## <param name="type">
+##     <summary>
+##     Type allowed to watch.
+##     </summary>
+## </param>
 #
 interface(`init_watch_dir',`
       gen_require(`


### PR DESCRIPTION
The lines must begin with two #s, not just one.

Fixes:
support/segenxml.py: warning: unable to find XML for interface init_watch_dir()