### PR TITLE
Remove unnecessary lines from the new watch interfaces

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2662,7 +2662,6 @@ interface(`files_setattr_root_dirs',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_root_dirs',`
 	gen_require(`
@@ -2681,7 +2680,6 @@ interface(`files_watch_root_dirs',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_mount_root_dirs',`
 	gen_require(`
@@ -2700,7 +2698,6 @@ interface(`files_watch_mount_root_dirs',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_with_perm_root_dirs',`
 	gen_require(`
@@ -3918,7 +3915,6 @@ interface(`files_etc_filetrans',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_etc_dirs',`
 	gen_require(`
@@ -3937,7 +3933,6 @@ interface(`files_watch_etc_dirs',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_etc_files',`
 	gen_require(`
@@ -6022,7 +6017,6 @@ interface(`files_manage_generic_tmp_dirs',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_generic_tmp_dirs',`
 	gen_require(`
@@ -6041,7 +6035,6 @@ interface(`files_watch_generic_tmp_dirs',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_mount_generic_tmp_dirs',`
 	gen_require(`
@@ -6060,7 +6053,6 @@ interface(`files_watch_mount_generic_tmp_dirs',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_with_perm_generic_tmp_dirs',`
 	gen_require(`
@@ -9310,7 +9302,6 @@ interface(`files_manage_generic_pids_symlinks',`
 ##	Domain allowed access
 ##	</summary>
 ## </param>
-##
 #
 interface(`files_watch_all_pid',`
 	gen_require(`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -339,7 +339,6 @@ interface(`userdom_manage_tmp_files',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <rolebase/>
 #
 interface(`userdom_watch_tmp_files',`
 	gen_require(`
@@ -358,7 +357,6 @@ interface(`userdom_watch_tmp_files',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <rolebase/>
 #
 interface(`userdom_watch_tmp_dirs',`
 	gen_require(`
@@ -377,7 +375,6 @@ interface(`userdom_watch_tmp_dirs',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <rolebase/>
 #
 interface(`userdom_watch_mount_tmp_dirs',`
 	gen_require(`
@@ -396,7 +393,6 @@ interface(`userdom_watch_mount_tmp_dirs',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <rolebase/>
 #
 interface(`userdom_watch_with_perm_tmp_dirs',`
 	gen_require(`


### PR DESCRIPTION
During development of the watch permissions support in the policy,
some unnecessary empty commented lines and lines with reference
to unused xml attributes were added by mistake and spread further.