### PR TITLE
Allow journalctl watch generic log dirs and /run/log/journal dir

### DIFF
--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -40,8 +40,10 @@ auth_use_nsswitch(journalctl_t)
 miscfiles_read_localization(journalctl_t)
 
 logging_read_generic_logs(journalctl_t)
+logging_watch_generic_log_dirs(journalctl_t)
 logging_read_syslog_pid(journalctl_t)
 logging_mmap_journal(journalctl_t)
+logging_watch_journal_dir(journalctl_t)
 
 userdom_list_user_home_dirs(journalctl_t)
 userdom_read_user_home_content_files(journalctl_t)

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -1684,7 +1684,24 @@ interface(`logging_mmap_journal',`
 	')
 
 	allow $1 syslogd_var_run_t:file map;
+')
 
+#######################################
+## <summary>
+##	Watch the /run/log/journal directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_watch_journal_dir',`
+	gen_require(`
+		type syslogd_var_run_t;
+	')
+
+	allow $1 syslogd_var_run_t:dir watch_dir_perms;
 ')
 
 ########################################


### PR DESCRIPTION
The logging_watch_journal() interface was added.