### PR TITLE
Allow abrt-dump-journal-* watch generic log dirs and /run/log/journal…

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -583,6 +583,8 @@ logging_read_syslog_pid(abrt_dump_oops_t)
 logging_send_syslog_msg(abrt_dump_oops_t)
 logging_mmap_generic_logs(abrt_dump_oops_t)
 logging_mmap_journal(abrt_dump_oops_t)
+logging_watch_generic_log_dirs(abrt_dump_oops_t)
+logging_watch_journal_dir(abrt_dump_oops_t)
 
 init_read_var_lib_files(abrt_dump_oops_t)
 


### PR DESCRIPTION
… dir

The permission is needed by abrt-dump-journal-core,
abrt-dump-journal-oops, and abrt-dump-journal-xorg.

Resolves: rhbz#1927524