### PR TITLE
Allow pulseaudio watch /dev and systemd-logind session dirs

### DIFF
--- a/policy/modules/contrib/pulseaudio.te
+++ b/policy/modules/contrib/pulseaudio.te
@@ -85,7 +85,7 @@ dev_read_sound(pulseaudio_t)
 dev_write_sound(pulseaudio_t)
 dev_read_sysfs(pulseaudio_t)
 dev_read_urand(pulseaudio_t)
-
+dev_watch_generic_dirs(pulseaudio_t)
 
 fs_rw_anon_inodefs_files(pulseaudio_t)
 fs_getattr_tmpfs(pulseaudio_t)
@@ -182,6 +182,7 @@ optional_policy(`
 optional_policy(`
 	systemd_read_logind_sessions_files(pulseaudio_t)
 	systemd_login_read_pid_files(pulseaudio_t)
+	systemd_login_watch_session_dirs(pulseaudio_t)
 ')
 
 optional_policy(`

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -321,6 +321,24 @@ interface(`dev_create_generic_dirs',`
 
 ########################################
 ## <summary>
+##	Watch generic device directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_watch_generic_dirs',`
+	gen_require(`
+		type device_t;
+	')
+
+	watch_dirs_pattern($1, device_t, device_t)
+')
+
+########################################
+## <summary>
 ##	Delete a directory in the device directory.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The dev_watch_generic_dirs() interface was added.