### PR TITLE
Allow userdomain watch various filesystem objects

### DIFF
--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -768,6 +768,24 @@ interface(`gnome_read_generic_data_home_dirs',`
     list_dirs_pattern($1, { gconf_home_t data_home_t }, data_home_t)
 ')
 
+######################################
+## <summary>
+##	Watch generic data home dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`gnome_watch_generic_data_home_dirs',`
+    gen_require(`
+        type data_home_t;
+    ')
+
+    watch_dirs_pattern($1, data_home_t, data_home_t)
+')
+
 #######################################
 ## <summary>
 ##	Manage gconf data home files
@@ -1397,6 +1415,42 @@ interface(`gnome_manage_home_config_dirs',`
 	')
 
 	manage_dirs_pattern($1, config_home_t, config_home_t)
+')
+
+########################################
+## <summary>
+##	Watch gnome homedir content directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`gnome_watch_home_config_dirs',`
+	gen_require(`
+		type config_home_t;
+	')
+
+	watch_dirs_pattern($1, config_home_t, config_home_t)
+')
+
+########################################
+## <summary>
+##	Watch gnome homedir content files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`gnome_watch_home_config_files',`
+	gen_require(`
+		type config_home_t;
+	')
+
+	watch_files_pattern($1, config_home_t, config_home_t)
 ')
 
 ########################################

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7697,6 +7697,24 @@ interface(`files_manage_var_lib_symlinks',`
 	manage_lnk_files_pattern($1,var_lib_t,var_lib_t)
 ')
 
+########################################
+## <summary>
+##	Watch generic directories in /var/lib.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_var_lib_dirs',`
+	gen_require(`
+		type var_lib_t;
+	')
+
+	watch_dirs_pattern($1, var_lib_t, var_lib_t)
+')
+
 # cjp: the next two interfaces really need to be fixed
 # in some way.  They really neeed their own types.
 

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -371,6 +371,11 @@ optional_policy(`
 
 ############################################################
 # login_userdomain local policy
+
+files_watch_etc_dirs(login_userdomain)
+files_watch_usr_dirs(login_userdomain)
+files_watch_var_lib_dirs(login_userdomain)
+
 fs_watch_cgroup_files(login_userdomain)
 
 miscfiles_watch_localization_symlinks(login_userdomain)
@@ -378,6 +383,12 @@ miscfiles_watch_localization_symlinks(login_userdomain)
 mount_watch_pid_dirs(login_userdomain)
 mount_watch_pid_files(login_userdomain)
 mount_watch_reads_pid_files(login_userdomain)
+
+optional_policy(`
+	gnome_watch_generic_data_home_dirs(login_userdomain)
+	gnome_watch_home_config_dirs(login_userdomain)
+	gnome_watch_home_config_files(login_userdomain)
+')
 
 ############################################################
 # Local Policy Confined Admin


### PR DESCRIPTION
Watch permissions are required for confined users running user sessions.

Usage examples are desktop environment or a web browser, watching system
configuration or user config and data.

The following interfaces were added:
- gnome_watch_generic_data_home_dirs
- gnome_watch_home_config_dirs
- gnome_watch_home_config_files
- files_watch_var_lib_dirs