### PR TITLE
Add missing watch permissions for restorecond

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1914,6 +1914,24 @@ interface(`files_list_non_auth_dirs',`
 
 ########################################
 ## <summary>
+##	Watch non-authentication related directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_non_auth_dirs',`
+	gen_require(`
+		attribute non_auth_file_type;
+	')
+
+	watch_dirs_pattern($1, non_auth_file_type, non_auth_file_type)
+')
+
+########################################
+## <summary>
 ##	Read all non-authentication related
 ##	files.
 ## </summary>

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -369,6 +369,9 @@ allow restorecond_t self:fifo_file rw_fifo_file_perms;
 allow restorecond_t restorecond_var_run_t:file manage_file_perms;
 files_pid_filetrans(restorecond_t, restorecond_var_run_t, file)
 
+# for watching /etc/selinux/restorecond.conf
+watch_files_pattern(restorecond_t, selinux_config_t, selinux_config_t)
+
 kernel_use_fds(restorecond_t)
 kernel_rw_pipes(restorecond_t)
 kernel_read_system_state(restorecond_t)

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -394,6 +394,8 @@ selinux_compute_user_contexts(restorecond_t)
 
 files_relabel_non_auth_files(restorecond_t )
 files_read_non_auth_files(restorecond_t)
+# For watching directory components of paths from /etc/selinux/restorecond.conf
+files_watch_non_auth_dirs(restorecond_t)
 
 auth_use_nsswitch(restorecond_t)
 


### PR DESCRIPTION
Found via dogfooding. I verified that with these two commits I no longer get any restorecond-related AVCs.