### PR TITLE
Allow udev integrity lockdown permission

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -405,6 +405,21 @@ interface(`kernel_load_module',`
 
 ########################################
 ## <summary>
+##	Allows caller to load unsigned kernel modules
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_load_unsigned_module',`
+	allow $1 self:lockdown integrity;
+	kernel_load_module($1)
+')
+
+########################################
+## <summary>
 ##	Allow search the kernel key ring.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -75,7 +75,7 @@ can_exec(kmod_t, update_modules_exec_t)
 manage_files_pattern(kmod_t,kmod_tmpfs_t,kmod_tmpfs_t)
 fs_tmpfs_filetrans(kmod_t,kmod_tmpfs_t,file)
 
-kernel_load_module(kmod_t)
+kernel_load_unsigned_module(kmod_t)
 files_manage_kernel_modules(kmod_t)
 files_map_kernel_modules(kmod_t)
 kernel_read_system_state(kmod_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1163,7 +1163,7 @@ read_lnk_files_pattern(systemd_domain, systemd_home_t, systemd_home_t)
 allow systemd_modules_load_t self:system module_load;
 
 kernel_dgram_send(systemd_modules_load_t)
-kernel_load_module(systemd_modules_load_t)
+kernel_load_unsigned_module(systemd_modules_load_t)
 kernel_ib_access_unlabeled_pkeys(systemd_modules_load_t)
 
 corecmd_exec_bin(systemd_modules_load_t)

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -87,7 +87,7 @@ allow udev_t udev_var_run_t:dir mounton;
 allow udev_t udev_var_run_t:lnk_file relabel_lnk_file_perms;
 dev_filetrans(udev_t, udev_var_run_t, { file lnk_file } )
 
-kernel_load_module(udev_t)
+kernel_load_unsigned_module(udev_t)
 kernel_read_system_state(udev_t)
 kernel_request_load_module(udev_t)
 kernel_getattr_core_if(udev_t)


### PR DESCRIPTION
The integrity lockdown permission is required for udev to
load proprietary Nvidia driver.