### PR TITLE
Remove duplicate code from kernel.te

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -545,18 +545,6 @@ allow kern_unconfined unlabeled_t:association *;
 allow kern_unconfined unlabeled_t:packet *;
 allow kern_unconfined unlabeled_t:process ~{ ptrace transition dyntransition execmem execstack execheap };
 
-gen_require(`
-	bool secure_mode_insmod;
-')
-
-if( ! secure_mode_insmod ) {
-    allow can_load_kernmodule self:capability sys_module;
-    # load_module() calls stop_machine() which
-    # calls sched_setscheduler()
-    allow can_load_kernmodule self:capability sys_nice;
-    kernel_setsched(can_load_kernmodule)
-}
-
 #######################################
 #
 # Kernel system state reader policy


### PR DESCRIPTION
The duplicity probably arose from merging 995d6fea9210 ("Clean up
handling of secure_mode_insmod and secure_mode_policyload") and
1c5dacd2c0eb ("Change secure_mode_insmod to control sys_module
capability rather than controlling domain transitions to insmod.").
