### PR TITLE
Enable systemd-sysctl domtrans for udev

### DIFF
--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -200,6 +200,7 @@ sysnet_manage_config(udev_t)
 systemd_login_read_pid_files(udev_t)
 systemd_getattr_unit_files(udev_t)
 systemd_hwdb_manage_config(udev_t)
+systemd_domtrans_sysctl(udev_t)
 
 userdom_dontaudit_search_user_home_content(udev_t)
 userdom_rw_inherited_user_tmp_pipes(udev_t)


### PR DESCRIPTION
On my machine, systemd-udevd executes systemd-sysctl, so give it the
right domain transition.