### PR TITLE
Allow upowerd to send syslog messages

### DIFF
--- a/policy/modules/contrib/devicekit.te
+++ b/policy/modules/contrib/devicekit.te
@@ -341,6 +341,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	logging_send_syslog_msg(devicekit_power_t)
+')
+
+optional_policy(`
 	modutils_domtrans_kmod(devicekit_power_t)
 ')
 


### PR DESCRIPTION
Fixes the following denial found while running with the unconfined
module disabled:
type=AVC msg=audit(1613549055.280:2392): avc:  denied  { sendto } for  pid=2639 comm="upowerd" path="/run/systemd/journal/socket" scontext=system_u:system_r:devicekit_power_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=1