### PR TITLE
Allow systemd-importd manage machines.lock file

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1232,6 +1232,9 @@ manage_files_pattern(systemd_importd_t, systemd_importd_var_run_t, systemd_impor
 manage_sock_files_pattern(systemd_importd_t, systemd_importd_var_run_t, systemd_importd_var_run_t)
 init_pid_filetrans(systemd_importd_t, systemd_importd_var_run_t, dir)
 
+manage_files_pattern(systemd_importd_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
+init_named_pid_filetrans(systemd_importd_t, systemd_machined_var_run_t, file, "machines.lock")
+
 manage_dirs_pattern(systemd_importd_t, systemd_importd_tmp_t, systemd_importd_tmp_t)
 manage_files_pattern(systemd_importd_t, systemd_importd_tmp_t, systemd_importd_tmp_t)
 files_tmp_filetrans(systemd_importd_t, systemd_importd_tmp_t, { dir file })
@@ -1248,7 +1251,6 @@ corenet_tcp_connect_http_port(systemd_importd_t)
 fs_getattr_xattr_fs(systemd_importd_t)
 
 init_read_state(systemd_importd_t)
-init_named_pid_filetrans(systemd_importd_t, systemd_machined_var_run_t, file, "machines.lock")
 
 logging_send_syslog_msg(systemd_importd_t)
 


### PR DESCRIPTION
Although systemd importd was allowed a named file transition for the
machines.lock file in /run/systemd, the actual permissions for managing
the file was missing.