### PR TITLE
Handle NVMe devices as in refpolicy

### DIFF
--- a/policy/modules/contrib/blkmapd.te
+++ b/policy/modules/contrib/blkmapd.te
@@ -29,7 +29,6 @@ files_pid_filetrans(blkmapd_t, blkmapd_var_run_t, file)
 kernel_read_system_state(blkmapd_t)
 
 dev_list_sysfs(blkmapd_t)
-dev_read_nvme(blkmapd_t)
 
 fs_list_rpc(blkmapd_t)
 fs_rw_rpc_named_pipes(blkmapd_t)

--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -103,8 +103,6 @@ dev_read_sysfs(system_dbusd_t)
 dev_rw_inherited_input_dev(system_dbusd_t)
 dev_rw_inherited_dri(system_dbusd_t)
 
-dev_rw_nvme(system_dbusd_t)
-
 files_rw_inherited_non_security_files(system_dbusd_t)
 files_watch_usr_dirs(system_dbusd_t)
 

--- a/policy/modules/contrib/hddtemp.te
+++ b/policy/modules/contrib/hddtemp.te
@@ -37,8 +37,6 @@ corenet_tcp_bind_hddtemp_port(hddtemp_t)
 corenet_sendrecv_hddtemp_server_packets(hddtemp_t)
 corenet_tcp_sendrecv_hddtemp_port(hddtemp_t)
 
-dev_read_nvme(hddtemp_t)
-
 storage_raw_read_fixed_disk(hddtemp_t)
 storage_raw_read_removable_device(hddtemp_t)
 

--- a/policy/modules/contrib/kdumpgui.te
+++ b/policy/modules/contrib/kdumpgui.te
@@ -46,7 +46,6 @@ dev_dontaudit_getattr_all_chr_files(kdumpgui_t)
 dev_read_sysfs(kdumpgui_t)
 dev_read_urand(kdumpgui_t)
 dev_getattr_all_blk_files(kdumpgui_t)
-dev_read_nvme(kdumpgui_t)
 
 files_manage_boot_files(kdumpgui_t)
 files_manage_boot_symlinks(kdumpgui_t)

--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -99,7 +99,6 @@ dev_read_generic_files(mdadm_t)
 dev_read_generic_usb_dev(mdadm_t)
 dev_read_urand(mdadm_t)
 dev_read_rand(mdadm_t)
-dev_rw_nvme(mdadm_t)
 
 domain_read_all_domains_state(mdadm_t)
 domain_use_interactive_fds(mdadm_t)

--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -272,7 +272,6 @@ corenet_tcp_bind_mountd_port(nfsd_t)
 dev_dontaudit_getattr_all_blk_files(nfsd_t)
 dev_dontaudit_getattr_all_chr_files(nfsd_t)
 dev_rw_lvm_control(nfsd_t)
-dev_read_nvme(nfsd_t)
 
 # does not really need this, but it is easier to just allow it
 files_search_pids(nfsd_t)

--- a/policy/modules/contrib/smartmon.te
+++ b/policy/modules/contrib/smartmon.te
@@ -71,7 +71,6 @@ corenet_udp_sendrecv_all_ports(fsdaemon_t)
 
 dev_read_sysfs(fsdaemon_t)
 dev_read_urand(fsdaemon_t)
-dev_read_nvme(fsdaemon_t)
 
 domain_use_interactive_fds(fsdaemon_t)
 

--- a/policy/modules/contrib/stratisd.te
+++ b/policy/modules/contrib/stratisd.te
@@ -39,7 +39,6 @@ kernel_request_load_module(stratisd_t)
 
 dev_read_lvm_control(stratisd_t)
 dev_read_sysfs(stratisd_t)
-dev_read_nvme(stratisd_t)
 dev_read_rand(stratisd_t)
 
 fs_mount_xattr_fs(stratisd_t)

--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -55,7 +55,6 @@ dev_list_sysfs(tlp_t)
 dev_manage_sysfs(tlp_t)
 dev_rw_cpu_microcode(tlp_t)
 dev_rw_wireless(tlp_t)
-dev_rw_nvme(tlp_t)
 
 files_read_kernel_modules(tlp_t)
 files_map_kernel_modules(tlp_t)
@@ -68,6 +67,7 @@ modutils_read_module_deps_files(tlp_t)
 logging_send_syslog_msg(tlp_t)
 
 storage_raw_read_fixed_disk(tlp_t)
+storage_raw_write_fixed_disk(tlp_t)
 storage_raw_read_removable_device(tlp_t)
 storage_raw_write_removable_device(tlp_t)
 

--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -67,9 +67,7 @@ modutils_read_module_deps_files(tlp_t)
 logging_send_syslog_msg(tlp_t)
 
 storage_raw_read_fixed_disk(tlp_t)
-storage_raw_write_fixed_disk(tlp_t)
 storage_raw_read_removable_device(tlp_t)
-storage_raw_write_removable_device(tlp_t)
 
 sysnet_exec_ifconfig(tlp_t)
 

--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -98,8 +98,6 @@
 /dev/noz.* 		-c	gen_context(system_u:object_r:modem_device_t,s0)
 /dev/null		-c	gen_context(system_u:object_r:null_device_t,s0)
 /dev/nvidia.*		-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
-/dev/nvme.*     -c  gen_context(system_u:object_r:nvme_device_t,s0)
-/dev/nvme.*     -b  gen_context(system_u:object_r:nvme_device_t,s0)
 /dev/nvram		-c	gen_context(system_u:object_r:nvram_device_t,mls_systemhigh)
 /dev/ndctl[0-9]		-c	gen_context(system_u:object_r:nvram_device_t,mls_systemhigh)
 /dev/oldmem		-c	gen_context(system_u:object_r:memory_device_t,mls_systemhigh)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -3955,8 +3955,11 @@ interface(`dev_config_null_dev_service',`
 
 ########################################
 ## <summary>
-##	Read Non-Volatile Memory Host Controller Interface.
+##	Read Non-Volatile Memory Host Controller Interface. (Deprecated)
 ## </summary>
+## <desc>
+##	Use storage_raw_read_fixed_disk() instead.
+## </desc>
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
@@ -3964,18 +3967,18 @@ interface(`dev_config_null_dev_service',`
 ## </param>
 #
 interface(`dev_read_nvme',`
-	gen_require(`
-		type nvme_device_t;
-	')
-
-	read_chr_files_pattern($1, device_t, nvme_device_t)
-	read_blk_files_pattern($1, device_t, nvme_device_t)
+	refpolicywarn(`$0($*) has been replaced with storage_raw_read_fixed_disk().')
+	storage_raw_read_fixed_disk($1)
 ')
 
 ########################################
 ## <summary>
-##	Read/Write Non-Volatile Memory Host Controller Interface.
+##	Read/Write Non-Volatile Memory Host Controller Interface. (Deprecated)
 ## </summary>
+## <desc>
+##	Use storage_raw_read_fixed_disk() and
+##	storage_raw_write_fixed_disk() instead.
+## </desc>
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.
@@ -3983,12 +3986,9 @@ interface(`dev_read_nvme',`
 ## </param>
 #
 interface(`dev_rw_nvme',`
-	gen_require(`
-		type nvme_device_t;
-	')
-
-	rw_chr_files_pattern($1, device_t, nvme_device_t)
-	rw_blk_files_pattern($1, device_t, nvme_device_t)
+	refpolicywarn(`$0($*) has been replaced with storage_raw_read_fixed_disk() and storage_raw_write_fixed_disk().')
+	storage_raw_read_fixed_disk($1)
+	storage_raw_write_fixed_disk($1)
 ')
 
 ########################################

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -250,12 +250,6 @@ type nvram_device_t;
 dev_node(nvram_device_t)
 
 #
-# Type for controller device nodes
-#
-type nvme_device_t;
-dev_node(nvme_device_t)
-
-#
 # Type for /dev/op_panel
 # Type for /dev/opal-prd
 #

--- a/policy/modules/kernel/storage.fc
+++ b/policy/modules/kernel/storage.fc
@@ -36,6 +36,8 @@
 /dev/mtd.*		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/mtd.*		-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/nb[^/]+		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
+/dev/nvme[0-9]+		-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
+/dev/nvme[0-9]n[^/]+	-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/optcd		-b	gen_context(system_u:object_r:removable_device_t,s0)
 /dev/p[fg][0-3]		-b	gen_context(system_u:object_r:removable_device_t,s0)
 /dev/pcd[0-3]		-b	gen_context(system_u:object_r:removable_device_t,s0)

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -621,7 +621,6 @@ dev_getattr_power_mgmt_dev(xdm_t)
 dev_setattr_power_mgmt_dev(xdm_t)
 dev_getattr_null_dev(xdm_t)
 dev_setattr_null_dev(xdm_t)
-dev_read_nvme(xdm_t)
 dev_getattr_loop_control(xdm_t)
 dev_manage_xserver_misc(xdm_t)
 dev_filetrans_xserver_misc(xdm_t)
@@ -677,9 +676,16 @@ mount_read_pid_files(xdm_t)
 mls_socket_write_to_clearance(xdm_t)
 mls_trusted_object(xdm_t)
 
+# getattr needs to be allowed, see:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1380951
+# "Looks like this prevents the NVMe SSD from being properly detected by
+# gvfs or storaged (instead partitions on it show up as removable devices
+# in nautils)."
+storage_getattr_fixed_disk_dev(xdm_t)
 storage_dontaudit_read_fixed_disk(xdm_t)
 storage_dontaudit_write_fixed_disk(xdm_t)
 storage_dontaudit_setattr_fixed_disk_dev(xdm_t)
+storage_getattr_removable_dev(xdm_t)
 storage_dontaudit_raw_read_removable_device(xdm_t)
 storage_dontaudit_raw_write_removable_device(xdm_t)
 storage_dontaudit_setattr_removable_dev(xdm_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -253,7 +253,6 @@ corenet_tcp_bind_flash_port(systemd_logind_t)
 dev_getattr_all_chr_files(systemd_logind_t)
 dev_getattr_all_blk_files(systemd_logind_t)
 dev_rw_sysfs(systemd_logind_t)
-dev_read_nvme(systemd_logind_t)
 dev_rw_input_dev(systemd_logind_t)
 dev_rw_dri(systemd_logind_t)
 dev_setattr_all_chr_files(systemd_logind_t)
@@ -1037,7 +1036,6 @@ allow systemd_gpt_generator_t self:capability sys_rawio;
 
 dev_read_sysfs(systemd_gpt_generator_t)
 dev_write_kmsg(systemd_gpt_generator_t)
-dev_read_nvme(systemd_gpt_generator_t)
 dev_read_rand(systemd_gpt_generator_t)
 
 


### PR DESCRIPTION
Refpolicy doesn't have a separate nvme_device_t type and just labels
these devices as fixed_disk_t. That is much more sane than having to add
dev_something_nvme() all over the place, when it could have been covered
by the existing storage_*_fixed_disk() interfaces.

So switch the labeling rules to match refpolicy and deprecate the
dev_read_nvme() and dev_rw_nvme() interfaces. All existing callers of
these already had the equivalent storage_*() calls, with two exceptions:
1. tlp_t had dev_rw_nvme(tlp_t), but only
   storage_raw_read_fixed_disk(tlp_t). I added
   storage_raw_write_fixed_disk(tlp_t) to balance it.
2. xdm_t had dev_read_nvme(xdm_t), but
   storage_dontaudit_read_fixed_disk(xdm_t). I left only the dontaudit
   rules - xdm_t probably doesn't actually need the permission.