### PR TITLE
Allow systemd-machined manage systemd-userdbd runtime sockets

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2486,7 +2486,7 @@ interface(`systemd_userdbd_stream_connect',`
 
 #######################################
 ## <summary>
-##	Create a named socket in userdbd runtime directory
+##	Manage named sockets in userdbd runtime directory
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2494,10 +2494,10 @@ interface(`systemd_userdbd_stream_connect',`
 ##	</summary>
 ## </param>
 #
-interface(`systemd_create_userdbd_runtime_sock_files',`
+interface(`systemd_manage_userdbd_runtime_sock_files',`
 	gen_require(`
         	type systemd_userdbd_runtime_t;
 	')
 
-	create_sock_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+	manage_sock_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
 ')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -416,7 +416,7 @@ init_manage_config_transient_files(systemd_machined_t)
 logging_dgram_send(systemd_machined_t)
 
 systemd_read_efivarfs(systemd_machined_t)
-systemd_create_userdbd_runtime_sock_files(systemd_machined_t)
+systemd_manage_userdbd_runtime_sock_files(systemd_machined_t)
 
 userdom_dbus_send_all_users(systemd_machined_t)
 


### PR DESCRIPTION
Add the systemd_manage_userdbd_runtime_sock_files() interface
and remove systemd_create_userdbd_runtime_sock_files()
which is not used any longer.

Resolves: rhbz#1891182