### PR TITLE
Revert "Allow getty watch its private runtime files"

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -149,7 +149,6 @@ manage_lnk_files_pattern(abrt_t, abrt_var_cache_t, abrt_var_cache_t)
 files_var_filetrans(abrt_t, abrt_var_cache_t, { file dir })
 files_spool_filetrans(abrt_t, abrt_var_cache_t, dir)
 files_tmp_filetrans(abrt_t, abrt_var_cache_t, dir, "abrt")
-allow abrt_t abrt_var_cache_t:dir watch_dir_perms;
 allow abrt_t abrt_var_cache_t:file map;
 
 # abrt pid files

--- a/policy/modules/contrib/cachefilesd.te
+++ b/policy/modules/contrib/cachefilesd.te
@@ -67,7 +67,6 @@ files_create_as_is_all_files(cachefilesd_t)
 # Allow access to cache superstructure
 manage_dirs_pattern(cachefilesd_t, cachefiles_var_t, cachefiles_var_t)
 manage_files_pattern(cachefilesd_t, cachefiles_var_t, cachefiles_var_t)
-allow cachefilesd_t cachefiles_var_t:dir watch_dir_perms;
 
 dev_rw_cachefiles(cachefilesd_t)
 

--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -318,7 +318,6 @@ userdom_filetrans_home_content(gpg_agent_t)
 userdom_manage_user_home_content_dirs(gpg_agent_t)
 userdom_manage_user_home_content_files(gpg_agent_t)
 userdom_manage_all_user_tmp_content(gpg_agent_t)
-userdom_watch_tmp_files(gpg_agent_t)
 
 ifdef(`hide_broken_symptoms',`
 	userdom_dontaudit_read_user_tmp_files(gpg_agent_t)

--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -152,8 +152,6 @@ optional_policy(`
 # polkit_auth local policy
 #
 
-allow policykit_auth_t policykit_var_lib_t:dir watch_dir_perms;
-
 allow policykit_auth_t self:capability { sys_nice ipc_lock setgid setuid };
 dontaudit policykit_auth_t self:capability sys_tty_config;
 allow policykit_auth_t self:process { setsched getsched signal };
@@ -175,6 +173,7 @@ manage_files_pattern(policykit_auth_t, policykit_tmp_t, policykit_tmp_t)
 files_tmp_filetrans(policykit_auth_t, policykit_tmp_t, { file dir })
 
 manage_files_pattern(policykit_auth_t, policykit_var_lib_t, policykit_var_lib_t)
+watch_dirs_pattern(policykit_auth_t, policykit_var_lib_t, policykit_var_lib_t)
 
 manage_dirs_pattern(policykit_auth_t, policykit_var_run_t, policykit_var_run_t)
 manage_files_pattern(policykit_auth_t, policykit_var_run_t, policykit_var_run_t)

--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -63,7 +63,6 @@ allow getty_t getty_tmp_t:file manage_file_perms;
 allow getty_t getty_tmp_t:dir manage_dir_perms;
 files_tmp_filetrans(getty_t, getty_tmp_t, { file dir })
 
-allow getty_t getty_var_run_t:file watch_file_perms;
 manage_files_pattern(getty_t, getty_var_run_t, getty_var_run_t)
 files_pid_filetrans(getty_t, getty_var_run_t, file)
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -332,24 +332,6 @@ interface(`userdom_manage_tmp_files',`
 
 #######################################
 ## <summary>
-##	Watch user temporary files
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`userdom_watch_tmp_files',`
-	gen_require(`
-		type user_tmp_t;
-	')
-
-	watch_files_pattern($1, user_tmp_t, user_tmp_t)
-')
-
-#######################################
-## <summary>
 ##	Watch user temporary directories
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This reverts commit 87c07c527954eeb256e022b68d7186b7ca9f78fc.

After commit 3ee12bf25f68 ("Add watch permissions to manage_* object
permissions sets"), the watch permission is provided implictly by the
existing manage_files_pattern(getty_t, getty_var_run_t, getty_var_run_t)
call.