### PR TITLE
Allow systemd watch generic directories

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7288,6 +7288,24 @@ interface(`files_manage_var_dirs',`
 
 ########################################
 ## <summary>
+##	Watch generic directories in /var.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_var_dirs',`
+	gen_require(`
+		type var_t;
+	')
+
+	watch_dirs_pattern($1, var_t, var_t)
+')
+
+########################################
+## <summary>
 ##	Read files in the /var directory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -311,6 +311,7 @@ files_watch_etc_dirs(init_t)
 files_read_usr_files(init_t)
 files_watch_root_dirs(init_t)
 files_write_root_dirs(init_t)
+files_watch_var_dirs(init_t)
 # file descriptors inherited from the rootfs:
 files_dontaudit_rw_root_files(init_t)
 files_dontaudit_rw_root_chr_files(init_t)


### PR DESCRIPTION
The files_watch_var_dirs() interface was added.