### PR TITLE
Allow sssd get cgroup filesystems attributes and search cgroup dirs

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -115,6 +115,8 @@ files_read_etc_runtime_files(sssd_t)
 files_list_var_lib(sssd_t)
 files_watch_etc_dirs(sssd_t)
 
+fs_getattr_cgroup(sssd_t)
+fs_search_cgroup_dirs(sssd_t)
 fs_list_inotifyfs(sssd_t)
 fs_getattr_xattr_fs(sssd_t)
 


### PR DESCRIPTION
Resolves: rhbz#1931954