### PR TITLE
Allow systemd-sleep transition to appropriate domains

### DIFF
--- a/policy/modules/contrib/sysstat.if
+++ b/policy/modules/contrib/sysstat.if
@@ -54,3 +54,22 @@ interface(`sysstat_admin',`
 	logging_search_logs($1)
 	admin_pattern($1, sysstat_log_t)
 ')
+
+########################################
+## <summary>
+##	Execute sysstat_exec_t in the sysstat domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`sysstat_domtrans',`
+	gen_require(`
+		type sysstat_t, sysstat_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, sysstat_exec_t, sysstat_t)
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1349,3 +1349,7 @@ fstools_rw_swap_files(systemd_sleep_t)
 
 # systemd-sleep needs to getattr swap partitions
 storage_getattr_fixed_disk_dev(systemd_sleep_t)
+
+optional_policy(`
+	unconfined_server_domtrans(systemd_sleep_t)
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1351,5 +1351,9 @@ fstools_rw_swap_files(systemd_sleep_t)
 storage_getattr_fixed_disk_dev(systemd_sleep_t)
 
 optional_policy(`
+	tlp_domtrans(systemd_sleep_t)
+')
+
+optional_policy(`
 	unconfined_server_domtrans(systemd_sleep_t)
 ')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1351,6 +1351,10 @@ fstools_rw_swap_files(systemd_sleep_t)
 storage_getattr_fixed_disk_dev(systemd_sleep_t)
 
 optional_policy(`
+	sysstat_domtrans(systemd_sleep_t)
+')
+
+optional_policy(`
 	tlp_domtrans(systemd_sleep_t)
 ')
 


### PR DESCRIPTION
The /usr/lib/systemd/system-sleep directory is a place for local
scripts/binaries, executed immediately before entering and after
leaving system suspend/hibernation.

Resolves: rhbz#1927551