### PR TITLE
Allow accountsd watch xdm config directories

### DIFF
--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -97,4 +97,5 @@ optional_policy(`
 	xserver_read_state_xdm(accountsd_t)
 	xserver_dbus_chat_xdm(accountsd_t)
 	xserver_manage_xdm_etc_files(accountsd_t)
+	xserver_watch_xdm_etc_dirs(accountsd_t)
 ')

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -1330,6 +1330,25 @@ interface(`xserver_manage_xdm_etc_files',`
 
 ########################################
 ## <summary>
+##	Watch xdm config directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit
+##	</summary>
+## </param>
+#
+interface(`xserver_watch_xdm_etc_dirs',`
+	gen_require(`
+		type xdm_etc_t;
+	')
+
+	files_search_etc($1)
+	watch_dirs_pattern($1, xdm_etc_t, xdm_etc_t)
+')
+
+########################################
+## <summary>
 ##	Read xdm temporary files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The xserver_watch_xdm_etc_dirs() was added.

Resolves: rhbz#1928546