### PR TITLE
Allow collectd bind tcp sockets

### DIFF
--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -52,6 +52,7 @@ allow collectd_t self:unix_stream_socket { accept listen connectto };
 allow collectd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 allow collectd_t self:netlink_generic_socket create_socket_perms;
 allow collectd_t self:udp_socket create_socket_perms;
+allow collectd_t self:tcp_socket { accept listen };
 allow collectd_t self:rawip_socket create_socket_perms;
 
 manage_dirs_pattern(collectd_t, collectd_log_t, collectd_log_t)
@@ -79,6 +80,7 @@ corecmd_exec_bin(collectd_t)
 corenet_udp_bind_generic_node(collectd_t)
 corenet_udp_bind_collectd_port(collectd_t)
 corenet_tcp_connect_lmtp_port(collectd_t)
+corenet_tcp_bind_generic_node(collectd_t)
 corenet_tcp_bind_bacula_port(collectd_t)
 
 dev_read_rand(collectd_t)


### PR DESCRIPTION
This allows using collectd with write_prometheus plugin which binds to TCP port 9103 (bacula_port_t).