### PR TITLE
Add missing declaration in rpm_named_filetrans()

### DIFF
--- a/policy/modules/contrib/rpm.if
+++ b/policy/modules/contrib/rpm.if
@@ -470,6 +470,7 @@ interface(`rpm_manage_log',`
 interface(`rpm_named_filetrans',`
 	gen_require(`
 		type rpm_log_t;
+		type rpm_var_cache_t;
 		type rpm_var_lib_t;
 	')
 	logging_log_named_filetrans($1, rpm_log_t, file, "yum.log")


### PR DESCRIPTION
In the rpm_named_filetrans() interface, the rpm_var_cache_t type was
used, but not previously declared.

As a result, the interface test compile failed using sepolicy-interface:

$ sepolicy interface -c -i rpm_named_filetrans
Compiling rpm_named_filetrans interface
Compiling targeted compiletest module
compiletest.te:43:ERROR 'unknown type rpm_var_cache_t used in transition definition' at token ';' on line 4641:
        type_transition sepolicy_domain_t var_t:dir rpm_var_cache_t "dnf";
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
make: *** [/usr/share/selinux/devel/include/Makefile:157: tmp/compiletest.mod] Error 1
Compile test for rpm_named_filetrans failed.

Resolves: rhbz#1801249