### PR TITLE
Change param description in cron interfaces to userdomain_prefix

### DIFF
--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -50,9 +50,10 @@ template(`cron_common_crontab_template',`
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="userdomain_prefix">
 ##	<summary>
-##	User domain for the role
+##	The prefix of the user domain (e.g., user
+##	is the prefix for user_t).
 ##	</summary>
 ## </param>
 ## <rolecap/>
@@ -144,9 +145,10 @@ interface(`cron_role',`
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="userdomain_prefix">
 ##	<summary>
-##	User domain for the role
+##	The prefix of the user domain (e.g., user
+##	is the prefix for user_t).
 ##	</summary>
 ## </param>
 ## <rolecap/>
@@ -223,9 +225,10 @@ interface(`cron_unconfined_role',`
 ##	Role allowed access
 ##	</summary>
 ## </param>
-## <param name="domain">
+## <param name="userdomain_prefix">
 ##	<summary>
-##	User domain for the role
+##	The prefix of the user domain (e.g., user
+##	is the prefix for user_t).
 ##	</summary>
 ## </param>
 ## <rolecap/>


### PR DESCRIPTION
In the cron_role(), cron_unconfined_role(), and cron_admin_role()
interfaces the second parameter name was incorrectly stated as "domain"
while it should rather be "userdomain_prefix". As an example, "user" is
the userdomain prefix for the "user_t" domain.

As a result, test compile of these interfaces failed using sepolicy-interface:

$ sepolicy interface -c -i cron_unconfined_role
Compiling cron_unconfined_role interface
Compiling targeted compiletest module
compiletest.te:43:ERROR 'unknown type sepolicy_domain_t_t' at token ';' on line 4423:
	typeattribute sepolicy_domain_t_t crontab_domain;
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
make: *** [/usr/share/selinux/devel/include/Makefile:157: tmp/compiletest.mod] Error 1
Compile test for cron_unconfined_role failed.

Resolves: rhbz#1801249