### PR TITLE
Allow keepalived read/write its private memfd: objects

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -29,6 +29,9 @@ application_executable_file(keepalived_unconfined_script_exec_t)
 type keepalived_tmp_t;
 files_tmp_file(keepalived_tmp_t)
 
+type keepalived_tmpfs_t;
+files_tmpfs_file(keepalived_tmpfs_t)
+
 ########################################
 #
 # keepalived local policy
@@ -48,6 +51,10 @@ manage_dirs_pattern(keepalived_t, keepalived_var_run_t, keepalived_var_run_t)
 manage_files_pattern(keepalived_t, keepalived_var_run_t, keepalived_var_run_t)
 files_pid_filetrans(keepalived_t, keepalived_var_run_t, { dir file })
 allow keepalived_t keepalived_var_run_t:dir mounton;
+
+manage_files_pattern(keepalived_t, keepalived_tmpfs_t, keepalived_tmpfs_t)
+manage_dirs_pattern(keepalived_t, keepalived_tmpfs_t, keepalived_tmpfs_t)
+fs_tmpfs_filetrans(keepalived_t, keepalived_tmpfs_t, { dir file })
 
 kernel_read_system_state(keepalived_t)
 kernel_read_network_state(keepalived_t)


### PR DESCRIPTION
Keepalived version 2.2 require read and write access to the
/memfd:/keepalived/consolidated_configuration file.
Without this access, a fallback tmpdir file access is used,
but the preferred way is memfd.

Resolves: rhbz#1920397