### PR TITLE
Allow keepalived read inherited nsfs files

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -84,6 +84,7 @@ dev_read_urand(keepalived_t)
 
 files_dontaudit_mounton_rootfs(keepalived_var_run_t)
 files_mounton_rootfs(keepalived_t)
+fs_read_nsfs_files(keepalived_t)
 fs_unmount_tmpfs(keepalived_t)
 
 modutils_domtrans_kmod(keepalived_t)


### PR DESCRIPTION
This permission is required when keepalived is configured
to using network namespaces.

The fs_read_inherited_nsfs_files() interface was added.

Resolves: rhbz#1921218