### PR TITLE
Allow keepalived manage its private tmp files

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -92,7 +92,7 @@ init_signal(keepalived_t)
 
 logging_send_syslog_msg(keepalived_t)
 
-allow keepalived_t keepalived_tmp_t:file { create_file_perms write_file_perms };
+manage_files_pattern(keepalived_t, keepalived_tmp_t, keepalived_tmp_t)
 files_tmp_filetrans(keepalived_t, keepalived_tmp_t, file)
 
 optional_policy(`


### PR DESCRIPTION
Previously, keepalived was only allowed create and write patterns.
To use the reload_time_file configuration statement, all permissions
are required.

Resolves: rhbz#1907424