### PR TITLE
Allow domain stat the /sys filesystem

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -150,6 +150,11 @@ dev_rw_null(domain)
 dev_rw_zero(domain)
 term_use_controlling_term(domain)
 
+# Allow all domains stat /sys. It is needed by services reading hardware
+# state information, but there is no harm to allow it to all domains in general.
+
+dev_getattr_sysfs_fs(domain)
+
 # Allow all domains to read /dev/urandom. It is needed by all apps/services
 # linked to libgcrypt. There is no harm to allow it by default.
 dev_read_urand(domain)


### PR DESCRIPTION
Checking for the availability of the /sys filesystem is requested
by all services that want to read hardware state information.
As such, adding this permission would semantically fit into the
dev_read_sysfs() interface to allow the getattr permission for each
domain calling this interface. This would, however, add about 300 new
rules into the policy, so the permission is allowed for the domain
attribute instead not to affect performance much. It seems safe allow
it for all domains.

Example of such services are rngd, pcscd, usbmuxd.

Resolves: rhbz#1928572
Resolves: rhbz#1928611
Resolves: rhbz#1930992