### PR TITLE
Take back excessive permissions for user_u and staff_u

### DIFF
--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -13,7 +13,6 @@
 #
 template(`cron_common_crontab_template',`
 	gen_require(`
-		attribute crontab_domain;
 		type crontab_exec_t;
 	')
 
@@ -22,7 +21,6 @@ template(`cron_common_crontab_template',`
 	# Declarations
 	#
 
-	typeattribute $1_t crontab_domain;
 	userdom_user_application_domain($1_t, crontab_exec_t)
 
 	##############################
@@ -155,6 +153,7 @@ interface(`cron_role',`
 #
 interface(`cron_unconfined_role',`
 	gen_require(`
+		attribute crontab_domain;
 		type unconfined_cronjob_t, crontab_t, crontab_exec_t;
         type crond_t, user_cron_spool_t;
         bool cron_userdomain_transition;
@@ -183,6 +182,7 @@ interface(`cron_unconfined_role',`
 	allow $2_t unconfined_cronjob_t:process signal_perms;
 
     cron_common_crontab_template($2)
+	typeattribute $2_t crontab_domain;
 
 	tunable_policy(`deny_ptrace',`',`
 		allow $2_t unconfined_cronjob_t:process ptrace;
@@ -235,6 +235,7 @@ interface(`cron_unconfined_role',`
 #
 interface(`cron_admin_role',`
 	gen_require(`
+		attribute crontab_domain;
 		type cronjob_t, crontab_exec_t, admin_crontab_t, admin_crontab_tmp_t;
 		type user_cron_spool_t, crond_t;
 		class passwd crontab;
@@ -265,6 +266,7 @@ interface(`cron_admin_role',`
 	allow $2_t admin_crontab_t:process signal_perms;
 
     cron_common_crontab_template($2)
+	typeattribute $2_t crontab_domain;
 
 	tunable_policy(`deny_ptrace',`',`
 		allow $2_t admin_crontab_t:process ptrace;

--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -97,7 +97,7 @@ application_executable_file(crontab_exec_t)
 type admin_crontab_tmp_t;
 files_tmp_file(admin_crontab_tmp_t)
 
-type admin_crontab_t;
+type admin_crontab_t, crontab_domain;
 cron_common_crontab_template(admin_crontab)
 typealias admin_crontab_t alias sysadm_crontab_t;
 typealias admin_crontab_tmp_t alias sysadm_crontab_tmp_t;
@@ -105,7 +105,7 @@ typealias admin_crontab_tmp_t alias sysadm_crontab_tmp_t;
 type crontab_tmp_t;
 files_tmp_file(crontab_tmp_t)
 
-type crontab_t;
+type crontab_t, crontab_domain;
 cron_common_crontab_template(crontab)
 typealias crontab_t alias { user_crontab_t staff_crontab_t };
 typealias crontab_t alias { auditadm_crontab_t secadm_crontab_t };

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -421,10 +421,6 @@ ifndef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		su_role_template(staff, staff_r, staff_t)
-	')
-
-	optional_policy(`
 		systemd_systemctl_entrypoint(staff_t)
 	')
 

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -250,13 +250,6 @@ ifndef(`distro_redhat',`
 	optional_policy(`
 		ssh_role_template(user, user_r, user_t)
 	')
-	optional_policy(`
-		su_role_template(user, user_r, user_t)
-	')
-
-	optional_policy(`
-		sudo_role_template(user, user_r, user_t)
-	')
 
 	optional_policy(`
 		systemd_systemctl_entrypoint(user_t)


### PR DESCRIPTION
Since 2010, user_u and staff_u are allowed to run both su and sudo
which contradicts the documentation and disrupts the SELinux users
intended plan.

Since this commit, user in the user_r role is not allowed su neither
sudo and user in the staff_r role is only allowed sudo, along with the
documentation.

Resolves: rhbz#1907517