### PR TITLE
Allow systemd watch and watch_reads unallocated ttys

### DIFF
--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -1301,6 +1301,42 @@ interface(`term_dontaudit_ioctl_unallocated_ttys',`
 
 ########################################
 ## <summary>
+##	Watch unallocated tty device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`term_watch_unallocated_ttys',`
+	gen_require(`
+		type tty_device_t;
+	')
+
+	allow $1 tty_device_t:chr_file watch_chr_file_perms;
+')
+
+########################################
+## <summary>
+##	Watch_reads unallocated tty device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`term_watch_reads_unallocated_ttys',`
+	gen_require(`
+		type tty_device_t;
+	')
+
+	allow $1 tty_device_t:chr_file watch_reads_chr_file_perms;
+')
+
+########################################
+## <summary>
 ##	Relabel from and to the unallocated
 ##	tty type.
 ## </summary>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -371,6 +371,8 @@ term_use_usb_ttys(init_t)
 term_use_all_ptys(init_t)
 term_setattr_all_ptys(init_t)
 term_use_virtio_console(init_t)
+term_watch_unallocated_ttys(init_t)
+term_watch_reads_unallocated_ttys(init_t)
 
 # Run init scripts.
 init_domtrans_script(init_t)

--- a/policy/support/obj_perm_sets.spt
+++ b/policy/support/obj_perm_sets.spt
@@ -275,6 +275,7 @@ define(`relabelfrom_chr_file_perms',`{ getattr relabelfrom }')
 define(`relabelto_chr_file_perms',`{ getattr relabelto }')
 define(`relabel_chr_file_perms',`{ getattr relabelfrom relabelto }')
 define(`watch_chr_file_perms',`{ getattr watch }')
+define(`watch_reads_chr_file_perms',`{ getattr watch_reads }')
 
 ########################################
 #


### PR DESCRIPTION
The missing permission prevented early debug-shell from working.

The following interfaces were added:
- term_watch_reads_unallocated_ttys
- term_watch_unallocated_ttys

Resolves: rhbz#1933902