### PR TITLE
Add 'make validate' step to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
       - run: git clone --depth=1 https://github.com/containers/container-selinux.git /tmp/container-selinux
       - run: cp /tmp/container-selinux/container.* policy/modules/contrib
       - run: make -j $(nproc) policy
+      - run: make -j $(nproc) validate
       - run: make -j $(nproc) container.pp
   build-rpm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Doesn't seem likely that this would break, but add it to CI just in
case. It takes only ~30 seconds when performed after all modules have
been built.