### PR TITLE
Add an alias for nvme_device_t

### DIFF
--- a/policy/modules/kernel/storage.te
+++ b/policy/modules/kernel/storage.te
@@ -16,6 +16,8 @@ attribute storage_unconfined_type;
 # /dev/hd* and /dev/sd*.
 #
 type fixed_disk_device_t;
+# Obsoleted in F34: nvme_device_t was merged into fixed_disk_device_t
+typealias fixed_disk_device_t alias nvme_device_t;
 dev_node(fixed_disk_device_t)
 
 neverallow ~{ fixed_disk_raw_read storage_unconfined_type } fixed_disk_device_t:{ chr_file blk_file } read;


### PR DESCRIPTION
Commit 9613e80506e7 ("Label NVMe devices as fixed_disk_device_t")
removed the nvme_device_t type in favor of fixed_disk_device_t, which
caused issues after a policy update [1], because the label wasn't fixed
up by fixfiles.

To avoid further problems, add a compatibility type alias, which may be
removed in a later release.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1933226