### PR TITLE
Allow login_userdomain listen on bluetooth sockets

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -378,6 +378,10 @@ create_fifo_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
 create_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
 create_sock_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
 
+tunable_policy(`deny_bluetooth',`',`
+	allow login_userdomain self:bluetooth_socket rw_stream_socket_perms;
+')
+
 files_watch_etc_dirs(login_userdomain)
 files_watch_usr_dirs(login_userdomain)
 files_watch_var_lib_dirs(login_userdomain)


### PR DESCRIPTION
This permission is required for pipewire-media-session.

type=AVC msg=audit(03/03/2021 18:11:13.597:757) : avc:  denied  { listen }
for  pid=83208 comm=pipewire-media- scontext=user_u:user_r:user_t:s0
tcontext=user_u:user_r:user_t:s0 tclass=bluetooth_socket permissive=1