### PR TITLE
Allow login_userdomain watch generic device dirs

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -382,6 +382,8 @@ tunable_policy(`deny_bluetooth',`',`
 	allow login_userdomain self:bluetooth_socket rw_stream_socket_perms;
 ')
 
+dev_watch_generic_dirs(login_userdomain)
+
 files_watch_etc_dirs(login_userdomain)
 files_watch_usr_dirs(login_userdomain)
 files_watch_var_lib_dirs(login_userdomain)


### PR DESCRIPTION
This permission is required for pipewire-media-session to
watch the /dev/snd directory.

type=AVC msg=audit(03/03/2021 18:11:53.956:794) : avc:  denied  { watch }
for  pid=83293 comm=pipewire-media- path=/dev/snd dev="devtmpfs"
ino=341 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023
tcontext=system_u:object_r:device_t:s0 tclass=dir permissive=1