### PR TITLE
Allow to sendmail read/write kerberos host rcache files

### DIFF
--- a/policy/modules/contrib/kerberos.if
+++ b/policy/modules/contrib/kerberos.if
@@ -329,6 +329,25 @@ interface(`kerberos_read_host_rcache',`
 
 ########################################
 ## <summary>
+##	Read/Write the kerberos host rcache files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kerberos_rw_host_rcache',`
+	gen_require(`
+		type krb5_host_rcache_t;
+	')
+
+    allow $1 krb5_host_rcache_t:dir search_dir_perms;
+    allow $1 krb5_host_rcache_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
 ##	Read the kerberos kdc configuration file (/etc/krb5kdc.conf).
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/sendmail.te
+++ b/policy/modules/contrib/sendmail.te
@@ -172,6 +172,7 @@ optional_policy(`
 
 optional_policy(`
 	kerberos_read_keytab(sendmail_t)
+	kerberos_rw_host_rcache(sendmail_t)
 	kerberos_use(sendmail_t)
 ')
 


### PR DESCRIPTION
Create interface which allow read/write the kerberos host rcache files.
Use this interface to allow sendmail read/write kerberos host rcache
files.

COPR build: https://download.copr.fedorainfracloud.org/results/pkoncity/selinux-policy/fedora-rawhide-x86_64/02053957-selinux-policy/
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1893333