### PR TITLE
Add kerberos object filetrans for nsswitchdomain

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -529,6 +529,9 @@ optional_policy(`
 # can not wrap nis_use_ypbind or kerberos_use, but they both have booleans you can turn off.
 optional_policy(`
 	kerberos_use(nsswitch_domain)
+	kerberos_tmp_filetrans_host_rcache(nsswitch_domain, "krb5_0.rcache2")
+	kerberos_tmp_filetrans_host_rcache(nsswitch_domain, "krb5_23.rcache2")
+	kerberos_tmp_filetrans_host_rcache(nsswitch_domain, "krb5_55.rcache2")
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow kerberos host rcache filetransition for nsswitch domain.
Filetranstion specify for which object is use, because domains from
local policies can use own general tmp filetrans.
Add for nsswitch domain, because all domains which use kerberos are
part of nsswitch domain.

COPR build: https://download.copr.fedorainfracloud.org/results/pkoncity/selinux-policy/fedora-rawhide-x86_64/02049910-selinux-policy/
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1878348