### PR TITLE
Allow additional rules for use opencryptoki

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -89,6 +89,7 @@ files_list_tmp(certmonger_t)
 files_list_home(certmonger_t)
 files_dontaudit_write_etc_runtime_files(certmonger_t)
 
+fs_getattr_tmpfs(certmonger_t)
 fs_getattr_xattr_fs(certmonger_t)
 fs_search_cgroup_dirs(certmonger_t)
 
@@ -171,7 +172,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-    pkcs_use_opencryptoki(certmonger_t)
+	pkcs_tmpfs_filetrans(certmonger_t)
+	pkcs_use_opencryptoki(certmonger_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/pkcs.fc
+++ b/policy/modules/contrib/pkcs.fc
@@ -1,3 +1,5 @@
+dev/shm/var\.lib\.opencryptoki.*	gen_context(system_u:object_r:pkcs_slotd_tmpfs_t,s0)
+
 /etc/rc\.d/init\.d/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_initrc_exec_t,s0)
 
 /usr/sbin/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_exec_t,s0)

--- a/policy/modules/contrib/pkcs.if
+++ b/policy/modules/contrib/pkcs.if
@@ -118,6 +118,29 @@ interface(`pkcs_getattr_exec_files',`
 
 ########################################
 ## <summary>
+##	Create and manage objects in the tmpfs directories
+##	with a private type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pkcs_tmpfs_filetrans',`
+	gen_require(`
+		type pkcs_slotd_tmpfs_t;
+	')
+	allow $1 pkcs_slotd_tmpfs_t:file map;
+
+	manage_files_pattern($1, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, { file dir })
+
+	fs_manage_tmpfs_dirs($1)
+')
+
+########################################
+## <summary>
 ##	Use opencryptoki services
 ## </summary>
 ## <param name="domain">
@@ -136,6 +159,8 @@ interface(`pkcs_use_opencryptoki',`
 
     kernel_search_proc($1)
     ps_process_pattern(pkcs_slotd_t, $1)
+
+    corenet_tcp_connect_tcs_port($1)
 
     dev_rw_crypto($1)
 

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -80,7 +80,7 @@ files_type(ipsec_mgmt_devpts_t)
 # ipsec Local policy
 #
 
-allow ipsec_t self:capability { net_admin dac_read_search dac_override setpcap sys_admin sys_nice net_raw setuid setgid };
+allow ipsec_t self:capability { chown net_admin dac_read_search dac_override setpcap sys_admin sys_nice net_raw setuid setgid };
 dontaudit ipsec_t self:capability sys_tty_config;
 allow ipsec_t self:process { getcap setcap getsched signal signull setsched sigkill };
 allow ipsec_t self:tcp_socket create_stream_socket_perms;
@@ -250,6 +250,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	pkcs_tmpfs_filetrans(ipsec_t)
 	pkcs_use_opencryptoki(ipsec_t)
 ')
 


### PR DESCRIPTION
Commit 1:
The var.lib.opencryptoki.* files are located in /dev/shm/ are now labeled as
pkcs_slotd_tmpfs_t.
New interface pkcs_tmpfs_filetrans() allow create and manage objects in
the tmpfs directories with a private type (pkcs_slotd_tmpfs_t) and also
allow manage tmpfs dirs.
In pkcs_use_opencryptoki add permission allowing domain to tcp connect
tcs port.

Commit 2:
Certmonger and Ipsec need more permission for proper usage of opencryptoki.
Allow certmonger_t to get attributes of tmpfs (fs_getattr_tmpfs) and also certmonger allow
create and manage objects in the tmpfs directories with a private type
pkcs_slotd_tmpfs_t (pkcs_tmpfs_filetrans). Also certmonger can proper
use opencryptoki (pkcs_use_opencryptoki).

Allow ipsec_t change owner of file via chown capability.
Also ipsec allow create and manage objects in the tmpfs directories
with a private type pkcs_slotd_tmpfs_t (pkcs_tmpfs_filetrans).


COPR build: https://download.copr.fedorainfracloud.org/results/pkoncity/selinux-policy/fedora-rawhide-x86_64/02052708-selinux-policy/
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1894132