### PR TITLE
Allow user_t and staff_t bind netlink_generic_socket

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -23,6 +23,7 @@ gen_tunable(staff_use_svirt, false)
 #
 
 allow staff_t self:cap_userns { setpcap };
+allow staff_t self:netlink_generic_socket { create_socket_perms };
 
 corenet_ib_access_unlabeled_pkeys(staff_t)
 

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -19,6 +19,13 @@ role user_r;
 
 userdom_unpriv_user_template(user)
 
+########################################
+#
+# Local policy
+#
+
+allow user_t self:netlink_generic_socket { create_socket_perms };
+
 kernel_read_numa_state(user_t)
 kernel_write_numa_state(user_t)
 


### PR DESCRIPTION
This permissions are required for virsh to be able to communicate with
libvirtd when user is mapped to a confined SELinux user.

The following AVC denial and similar are addressed:

type=PROCTITLE msg=audit(8.3.2021 09:34:12.706:439) :
proctitle=/usr/sbin/libvirtd --timeout=120
type=SYSCALL msg=audit(8.3.2021 09:34:12.706:439) : arch=x86_64 syscall=socket
success=yes exit=26 a0=netlink a1=SOCK_RAW a2=chaos a3=0x7f1b781bcf20 items=0
ppid=1 pid=4753 auid=user uid=user gid=user euid=user suid=user
fsuid=user egid=user sgid=user fsgid=user tty=(none) ses=2
comm=nodedev-init exe=/usr/sbin/libvirtd
subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(8.3.2021 09:34:12.706:439) : avc:  denied  { create }
for pid=4753 comm=nodedev-init scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023
tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=netlink_generic_socket
permissive=1