### PR TITLE
Allow netutils_t create netlink generic socket

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -36,6 +36,7 @@ init_system_domain(traceroute_t, traceroute_exec_t)
 allow netutils_t self:capability { chown dac_read_search net_admin net_raw setuid setgid sys_chroot  setpcap };
 dontaudit netutils_t self:capability { sys_admin sys_tty_config };
 allow netutils_t self:process { setcap signal_perms };
+allow netutils_t self:netlink_generic_socket create_socket_perms;
 allow netutils_t self:netlink_rdma_socket create_socket_perms;
 allow netutils_t self:netlink_route_socket create_netlink_socket_perms;
 allow netutils_t self:netlink_socket create_socket_perms;


### PR DESCRIPTION
This permissions required when linux user is mapped to a confined
SELinux user since there is a transition to the netutils_t domain.

Addresses the following AVC:

type=PROCTITLE msg=audit(03/10/2021 09:08:35.582:503) :
proctitle=/usr/sbin/tcpdump -i lo -Z tcpdump -w ./capturefile
type=SYSCALL msg=audit(03/10/2021 09:08:35.582:503) : arch=x86_64
syscall=socket success=no exit=EACCES(Permission denied) a0=netlink a1=SOCK_RAW
a2=chaos a3=0x561010810830 items=0 ppid=9486 pid=9490 auid=root uid=root
gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts1
ses=3 comm=tcpdump exe=/usr/sbin/tcpdump subj=system_u:system_r:netutils_t:s0
key=(null)
type=AVC msg=audit(03/10/2021 09:08:35.582:503) : avc:  denied  { create }
for pid=9490 comm=tcpdump scontext=system_u:system_r:netutils_t:s0
tcontext=system_u:system_r:netutils_t:s0 tclass=netlink_generic_socket
permissive=0