### PR TITLE
Add context for new mariadbd executable files

### DIFF
--- a/policy/modules/contrib/mysql.fc
+++ b/policy/modules/contrib/mysql.fc
@@ -34,6 +34,15 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/sbin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 #
+# /usr - mariadb
+#
+/usr/bin/mariadbd-safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
+/usr/bin/mariadbd-safe-helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+
+/usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+
+#
 # /var
 #
 /var/lib/mysql(-files|-keyring)?(/.*)?		gen_context(system_u:object_r:mysqld_db_t,s0)


### PR DESCRIPTION
Since MariaDB 10.5 the symlinks were swapped between mariadbd and mysqld files
(executable files <-> symlinks), we need to add context to the new
executable files.

The change is noted here:
https://mariadb.com/kb/en/changes-improvements-in-mariadb-105/#binaries-named-mariadb-mysql-symlinked