### PR TITLE
install_t: Allow NoNewPriv transition from systemd

### DIFF
--- a/policy/modules/contrib/anaconda.te
+++ b/policy/modules/contrib/anaconda.te
@@ -85,6 +85,7 @@ allow install_t self:capability2 mac_admin;
 systemd_dbus_chat_localed(install_t)
 systemd_dbus_chat_logind(install_t)
 init_dbus_chat(install_t)
+init_nnp_daemon_domain(install_t)
 
 tunable_policy(`deny_ptrace',`',`
 	domain_ptrace_all_domains(install_t)


### PR DESCRIPTION
Enable a subset of rpm-ostree commands to run as part of a systemd
service directly under an unprivilged user with DynamicUser.

This will be used for the rpm-ostree-countme service.