### PR TITLE
Allow systemd the audit_control capability conditionally

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -51,6 +51,13 @@ gen_tunable(daemons_enable_cluster_mode, false)
 ## </desc>
 gen_tunable(init_create_dirs, true)
 
+## <desc>
+## <p>
+## Allow init audit_control capability
+## </p>
+## </desc>
+gen_tunable(init_audit_control, false)
+
 # used for direct running of init scripts
 # by admin domains
 attribute direct_run_init;
@@ -552,6 +559,10 @@ tunable_policy(`init_create_dirs',`
     files_create_non_security_dirs(init_t)
     files_mounton_non_security(init_t)
     files_setattr_non_security_dirs(init_t)
+')
+
+tunable_policy(`init_audit_control',`
+	allow init_t self:capability audit_control;
 ')
 
 allow init_t self:system all_system_perms;


### PR DESCRIPTION
When the pam_tty_audit pam module is enabled for a session, systemd
needs the audit_control capability to be able to control kernel audit
configuration and and rules.

Without this capability, the systemd user service manager fails to
start, errors are logged and AVC denials audited.
While it is still possible to log in using console or ssh, graphical
display managers fail to start as they use the systemd user session to
spawn the greeter so using graphical user interface is not possible.

The capability is allowed when the init_audit_control boolean is turned on.
This boolean is off by default.

Resolves: rhbz#1861771