### PR TITLE
Allow login_userdomain watch systemd login session dirs

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -402,6 +402,10 @@ optional_policy(`
 	gnome_watch_home_config_files(login_userdomain)
 ')
 
+optional_policy(`
+	systemd_login_watch_session_dirs(login_userdomain)
+')
+
 ############################################################
 # Local Policy Confined Admin
 #


### PR DESCRIPTION
Addresses the following denial:

----
type=PROCTITLE msg=audit(03/15/2021 21:52:03.061:8142) :
proctitle=/usr/libexec/gnome-session-binary --systemd-service --session=gnome
type=PATH msg=audit(03/15/2021 21:52:03.061:8142) : item=0
name=/run/systemd/sessions/ inode=68 dev=00:1a mode=dir,755 ouid=root
ogid=root rdev=00:00 obj=system_u:object_r:systemd_logind_sessions_t:s0
nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0
cap_frootid=0
type=CWD msg=audit(03/15/2021 21:52:03.061:8142) : cwd=/home/user
type=SYSCALL msg=audit(03/15/2021 21:52:03.061:8142) : arch=x86_64
syscall=inotify_add_watch success=yes exit=1 a0=0x6 a1=0x7f7b79ccabd4
a2=0x280 a3=0x7 items=1 ppid=44830 pid=44912 auid=user uid=user gid=user
euid=user suid=user fsuid=user egid=user sgid=user fsgid=user tty=(none)
ses=33 comm=gnome-session-b exe=/usr/libexec/gnome-session-binary
subj=user_u:user_r:user_t:s0 key=(null)
type=AVC msg=audit(03/15/2021 21:52:03.061:8142) : avc:  denied  { watch }
for  pid=44912 comm=gnome-session-b path=/run/systemd/sessions
dev="tmpfs" ino=68 scontext=user_u:user_r:user_t:s0
tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=dir permissive=1