### PR TITLE
Remove setuid/setgid capabilities from mysqld_t

### DIFF
--- a/policy/modules/contrib/mysql.te
+++ b/policy/modules/contrib/mysql.te
@@ -67,7 +67,7 @@ files_pid_file(mysqlmanagerd_var_run_t)
 # Local policy
 #
 
-allow mysqld_t self:capability { dac_read_search  ipc_lock setgid setuid sys_nice sys_resource net_bind_service };
+allow mysqld_t self:capability { dac_read_search  ipc_lock sys_nice sys_resource net_bind_service };
 dontaudit mysqld_t self:capability sys_tty_config;
 allow mysqld_t self:process { setsched getsched setrlimit signal_perms rlimitinh };
 allow mysqld_t self:fifo_file rw_fifo_file_perms;
@@ -196,6 +196,7 @@ optional_policy(`
 # Local mysqld_safe policy
 #
 
+# setuig/setgid may be used in mysqld_safe and mysqld_safe_helper
 allow mysqld_safe_t self:capability { chown dac_read_search setgid setuid fowner kill sys_nice sys_resource };
 dontaudit mysqld_safe_t self:capability sys_ptrace;
 allow mysqld_safe_t self:process { setsched getsched setrlimit };


### PR DESCRIPTION
It is not needed when systemd defines user option by itself

