### PR TITLE
Allow xdm_t transition to system_dbusd_t 

### DIFF
--- a/policy/modules/contrib/dbus.if
+++ b/policy/modules/contrib/dbus.if
@@ -36,6 +36,25 @@ interface(`dbus_exec_dbusd',`
 
 ########################################
 ## <summary>
+##	Execute dbus-daemon in the systemd_dbusd_t domain.
+## </summary>
+## <param name="domain" unused="true">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`dbus_exec_system_dbusd',`
+	gen_require(`
+        	type dbusd_exec_t, system_dbusd_t;
+	')
+
+ 	corecmd_search_bin($1)
+	domtrans_pattern($1, dbusd_exec_t, system_dbusd_t)
+')
+
+########################################
+## <summary>
 ##	Role access for dbus
 ## </summary>
 ## <param name="role_prefix">

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -790,6 +790,7 @@ tunable_policy(`use_ecryptfs_home_dirs',`
 userdom_filetrans_generic_home_content(xdm_t)
 
 optional_policy(`
+    dbus_exec_system_dbusd(xdm_t)
     dbus_stream_connect_session_bus(xdm_t)
     dbus_systemctl(xdm_t)
 ')


### PR DESCRIPTION
The dbus_exec_system_dbusd() interface was added.

Resolves: rhbz#1928547