### PR TITLE
Allow xdm_t watch systemd-logind session dirs

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -738,6 +738,7 @@ systemd_status_power_services(xdm_t)
 systemd_hwdb_mmap_config(xdm_t)
 systemd_hwdb_read_config(xdm_t)
 systemd_coredump_domtrans(xdm_t)
+systemd_login_watch_session_dirs(xdm_t)
 
 userdom_dontaudit_use_unpriv_user_fds(xdm_t)
 userdom_create_all_users_keys(xdm_t)


### PR DESCRIPTION
The inotify call is executed by the display manager before a user logs
in, i. e. still in the xdm_t domain.

Addresses the following denial:

----
type=PROCTITLE msg=audit(03/17/2021 21:16:08.002:201) :
proctitle=/usr/bin/gnome-shell
type=PATH msg=audit(03/17/2021 21:16:08.002:201) : item=0
name=/run/systemd/sessions/ inode=68 dev=00:1a mode=dir,755 ouid=root ogid=root
rdev=00:00 obj=system_u:object_r:systemd_logind_sessions_t:s0 nametype=NORMAL
cap_fp=none cap_fi=none cap_fe=0 cap_fver=0
cap_frootid=0 type=CWD msg=audit(03/17/2021 21:16:08.002:201) : cwd=/var/lib/gdm
type=SYSCALL msg=audit(03/17/2021 21:16:08.002:201) : arch=x86_64
syscall=inotify_add_watch success=no exit=EACCES(Permission denied)
a0=0x39 a1=0x7fab19391bd4 a2=0x280 a3=0x7ffe30b5a080 items=1 ppid=760
pid=795 auid=unset uid=gdm gid=gdm euid=gdm suid=gdm fsuid=gdm egid=gdm
sgid=gdm fsgid=gdm tty=tty1 ses=unset comm=gnome-shell
exe=/usr/bin/gnome-shell subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(03/17/2021 21:16:08.002:201) : avc:  denied  { watch }
 for  pid=795 comm=gnome-shell path=/run/systemd/sessions dev="tmpfs"
ino=68 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023
tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=dir permissive=0