### PR TITLE
Allow login_userdomain write inaccessible nodes

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -370,6 +370,14 @@ optional_policy(`
 ')
 
 ############################################################
+# login_userdomain local policy
+
+create_blk_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
+create_chr_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
+create_fifo_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
+create_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
+create_sock_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
+
 # Local Policy Confined Admin
 #
 gen_require(`


### PR DESCRIPTION
The permissions for creating blk_file, chr_file, fifo_file, sock_file
and regular file were added for systemd to create inaccessible nodes
in /run/user/*/systemd/inaccessible.

Addresses the following denial:

type=PATH msg=audit(22.2.2021 09:15:47.751:332) : item=1
name=/run/user/1000/systemd/inaccessible/chr inode=8 dev=00:29
mode=character,000 ouid=user ogid=user rdev=00:00
obj=system_u:object_r:user_tmp_t:s0 nametype=CREATE cap_fp=none
cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=AVC msg=audit(22.2.2021 09:15:47.751:332) : avc:  denied  { create }
for  pid=1714 comm=systemd name=chr scontext=user_u:user_r:user_t:s0-s0:c0.c1023
tcontext=system_u:object_r:user_tmp_t:s0 tclass=chr_file permissive=1