### PR TITLE
Allow xdm a file transition in a tmpfs_t directory

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -493,6 +493,7 @@ manage_files_pattern(xdm_t, xdm_rw_etc_t, xdm_rw_etc_t)
 userdom_manage_all_user_tmp_content(xdm_t)
 userdom_exec_user_tmp_files(xdm_t)
 
+fs_tmpfs_filetrans(xdm_t, xdm_tmpfs_t, { dir file })
 manage_dirs_pattern(xdm_t, xdm_tmpfs_t, xdm_tmpfs_t)
 manage_files_pattern(xdm_t, xdm_tmpfs_t, xdm_tmpfs_t)
 manage_lnk_files_pattern(xdm_t, xdm_tmpfs_t, xdm_tmpfs_t)


### PR DESCRIPTION
This permission is required to read/write xdm private memfd: objects
which have the tmpfs_t type.

Addresses the following denial:

----
type=PROCTITLE msg=audit(03/22/2021 11:40:04.276:194) : proctitle=/usr/bin/gnome-shell
type=SYSCALL msg=audit(03/22/2021 11:40:04.276:194) : arch=x86_64 syscall=recvmsg
success=yes exit=760 a0=0x37 a1=0x7ffd7ec48f40 a2=MSG_DONTWAIT|MSG_CMSG_CLOEXEC a3=0x0
items=0 ppid=760 pid=796 auid=unset uid=gdm gid=gdm euid=gdm suid=gdm fsuid=gdm egid=gdm
sgid=gdm fsgid=gdm tty=tty1 ses=unset comm=gnome-shell exe=/usr/bin/gnome-shell
subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(03/22/2021 11:40:04.276:194) : avc:  denied  { read write }
for  pid=796 comm=gnome-shell path=/memfd:wayland-cursor (deleted) dev="tmpfs" ino=461
scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:tmpfs_t:s0
tclass=file permissive=0