### PR TITLE
Extend fs_manage_nfsd_fs() to allow managing dirs as well

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -4700,7 +4700,7 @@ interface(`fs_unmount_nsfs',`
 
 ########################################
 ## <summary>
-##	Manage NFS server files.
+##	Manage NFS server files and directories.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -4713,6 +4713,7 @@ interface(`fs_manage_nfsd_fs',`
 		type nfsd_fs_t;
 	')
 
+	manage_dirs_pattern($1, nfsd_fs_t, nfsd_fs_t)
 	manage_files_pattern($1, nfsd_fs_t, nfsd_fs_t)
 ')
 


### PR DESCRIPTION
In Rawhide, rpc.mountd needs to watch the /proc/fs/nfsd/clients
directory, otherwise mounting an NFS filesystem hangs. To fix it, extend
fs_manage_nfsd_fs() to allow managing directoris in addition to files.
It fits the name of the interface and adds the needed watch permission,
so it seems as the best solution. Note that fs_manage_nfsd_fs(nfsd_t) in
policy/modules/contrib/rpc.te is the only caller of this interface.

Reproducer (requires nfs-utils):
```
setenforce 0
systemctl start nfs-server
exportfs -o rw,no_root_squash,security_label localhost:/etc
mount -t nfs -o nfsvers=4.2 localhost:/etc /mnt
```

AVC seen:
type=AVC msg=audit(03/22/2021 16:34:10.186:375) : avc:  denied  { watch } for  pid=7269 comm=rpc.mountd path=/proc/fs/nfsd/clients dev="nfsd" ino=113 scontext=system_u:system_r:nfsd_t:s0 tcontext=system_u:object_r:nfsd_fs_t:s0 tclass=dir permissive=1