### PR TITLE
Allow xdm_t watch accountsd lib directories

### DIFF
--- a/policy/modules/contrib/accountsd.if
+++ b/policy/modules/contrib/accountsd.if
@@ -81,6 +81,25 @@ interface(`accountsd_search_lib',`
 
 ########################################
 ## <summary>
+##	Watch accountsd lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`accountsd_watch_lib',`
+	gen_require(`
+		type accountsd_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	watch_dirs_pattern($1, accountsd_var_lib_t, accountsd_var_lib_t)
+')
+
+########################################
+## <summary>
 ##	Read accountsd lib files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -937,6 +937,7 @@ tunable_policy(`xdm_bind_vnc_tcp_port',`
 optional_policy(`
 	accountsd_read_lib_files(xdm_t)
 	accountsd_dbus_chat(xdm_t)
+	accountsd_watch_lib(xdm_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The accountsd_watch_lib() interface was added.

Addresses the following denial:
----
type=AVC msg=audit(1613337033.540:631): avc:  denied  { watch } for  pid=1037
comm="gmain" path="/var/lib/AccountsService/icons" dev="sda2" ino=155654
scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023
tcontext=system_u:object_r:accountsd_var_lib_t:s0 tclass=dir permissive=0

Resolves: rhbz#1928563