### PR TITLE
Add additional interfaces for watching /boot

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2982,6 +2982,42 @@ interface(`files_dontaudit_manage_boot_dirs',`
 
 ########################################
 ## <summary>
+##	Watch directories in /boot.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_boot_dirs',`
+	gen_require(`
+		type boot_t;
+	')
+
+	allow $1 boot_t:dir watch_dir_perms;
+')
+
+########################################
+## <summary>
+##	Watch_with_perm directories in /boot.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_with_perm_boot_dirs',`
+	gen_require(`
+		type boot_t;
+	')
+
+	allow $1 boot_t:dir watch_with_perm_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Create a private type object in boot
 ##	with an automatic type transition
 ## </summary>


### PR DESCRIPTION
These interfaces are required for fapolicyd working correctly.
Namely the files_watch_boot_dirs() and files_watch_with_perm_boot_dirs()
interfaces were added.

Helps to address denials like this:

type=SYSCALL msg=audit(02/24/2021 11:02:02.332:445) : arch=x86_64 syscall=fanotify_mark
success=yes exit=0 a0=0x8 a1=0x11 a2=0x50000 a3=0xffffffff items=1 ppid=1 pid=2481
auid=unset uid=fapolicyd gid=fapolicyd euid=fapolicyd suid=fapolicyd fsuid=fapolicyd
egid=fapolicyd sgid=fapolicyd fsgid=fapolicyd tty=(none) ses=unset comm=fapolicyd
exe=/usr/sbin/fapolicyd subj=system_u:system_r:fapolicyd_t:s0 key=(null)
type=AVC msg=audit(02/24/2021 11:02:02.332:445) :
avc:  denied  { watch_mount watch_with_perm } for  pid=2481 comm=fapolicyd path=/boot
dev="vda1" ino=128 scontext=system_u:system_r:fapolicyd_t:s0
tcontext=system_u:object_r:boot_t:s0 tclass=dir permissive=1