### PR TITLE
Allow sssd_t get attributes of tmpfs filesystems

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -118,6 +118,7 @@ files_watch_etc_dirs(sssd_t)
 fs_getattr_cgroup(sssd_t)
 fs_search_cgroup_dirs(sssd_t)
 fs_list_inotifyfs(sssd_t)
+fs_getattr_tmpfs(sssd_t)
 fs_getattr_xattr_fs(sssd_t)
 
 selinux_validate_context(sssd_t)


### PR DESCRIPTION
This permission is required when the system booted with cgroups v1.