### PR TITLE
Add watch_mount_dirs_pattern file pattern

### DIFF
--- a/policy/support/file_patterns.spt
+++ b/policy/support/file_patterns.spt
@@ -80,6 +80,10 @@ define(`watch_dirs_pattern',`
 	allow $1 $2:dir search_dir_perms;
 	allow $1 $3:dir watch_dir_perms;
 ')
+define(`watch_mount_dirs_pattern',`
+	allow $1 $2:dir search_dir_perms;
+	allow $1 $3:dir watch_mount_dir_perms;
+')
 define(`watch_reads_dirs_pattern',`
 	allow $1 $2:dir search_dir_perms;
 	allow $1 $3:dir watch_reads_dir_perms;


### PR DESCRIPTION
This pattern was referred to from userdom_watch_mount_tmp_dirs(),
but it has not been defined.