### PR TITLE
Add watch_with_perm_dirs_pattern file pattern

### DIFF
--- a/policy/support/file_patterns.spt
+++ b/policy/support/file_patterns.spt
@@ -88,6 +88,10 @@ define(`watch_reads_dirs_pattern',`
 	allow $1 $2:dir search_dir_perms;
 	allow $1 $3:dir watch_reads_dir_perms;
 ')
+define(`watch_with_perm_dirs_pattern',`
+	allow $1 $2:dir search_dir_perms;
+	allow $1 $3:dir watch_with_perm_dir_perms;
+')
 
 #
 # Regular file patterns (file)


### PR DESCRIPTION
This pattern was referred to from userdom_watch_with_perm_tmp_dirs(),
but it has not been defined.