### PR TITLE
Allow login_userdomain create cgroup files

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -995,6 +995,25 @@ interface(`fs_relabel_cgroup_files',`
 
 ########################################
 ## <summary>
+##	Create cgroup files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_create_cgroup_files',`
+	gen_require(`
+		type cgroup_t;
+	')
+
+	dev_search_sysfs($1)
+	create_files_pattern($1, cgroup_t, cgroup_t)
+')
+
+########################################
+## <summary>
 ##	Manage cgroup files.
 ## </summary>
 ## <param name="domain">
@@ -1006,7 +1025,6 @@ interface(`fs_relabel_cgroup_files',`
 interface(`fs_manage_cgroup_files',`
 	gen_require(`
 		type cgroup_t;
-
 	')
 
 	manage_files_pattern($1, cgroup_t, cgroup_t)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -388,6 +388,7 @@ files_watch_etc_dirs(login_userdomain)
 files_watch_usr_dirs(login_userdomain)
 files_watch_var_lib_dirs(login_userdomain)
 
+fs_create_cgroup_files(login_userdomain)
 fs_watch_cgroup_files(login_userdomain)
 
 miscfiles_watch_localization_symlinks(login_userdomain)


### PR DESCRIPTION
The following denial is addressed:
----
type=PROCTITLE msg=audit(03/29/2021 22:23:34.751:14063) : proctitle=(systemd)
type=PATH msg=audit(03/29/2021 22:23:34.751:14063) : item=1
name=/sys/fs/cgroup/user.slice/user-1005.slice/user@1005.service/app.slice/dbus.socket/cgroup.subtree_control
inode=97209 dev=00:1b mode=file,644 ouid=staff3 ogid=staff3 rdev=00:00
obj=staff_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none
cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(03/29/2021 22:23:34.751:14063) : arch=x86_64
syscall=openat success=yes exit=26 a0=0xffffff9c a1=0x55dee85f0fe0
a2=O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC a3=0x1b6 items=2 ppid=1 pid=55547
auid=staff3 uid=staff3 gid=staff3 euid=staff3 suid=staff3 fsuid=staff3
egid=staff3 sgid=staff3 fsgid=staff3 tty=(none) ses=5 comm=systemd
exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023
key=(null)
type=AVC msg=audit(03/29/2021 22:23:34.751:14063) : avc:  denied  { create }
for  pid=55547 comm=systemd name=cgroup.subtree_control
scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023
tcontext=staff_u:object_r:cgroup_t:s0 tclass=file permissive=0