### PR TITLE
Allow systemd-sleep create hardware state information files

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5075,6 +5075,24 @@ interface(`dev_rw_sysfs',`
 
 ########################################
 ## <summary>
+##	Allow caller create hardware state information files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_create_sysfs_files',`
+	gen_require(`
+		type sysfs_t;
+	')
+
+	create_files_pattern($1, sysfs_t, sysfs_t)
+')
+
+########################################
+## <summary>
 ##	Relabel hardware state directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1339,8 +1339,8 @@ allow systemd_sleep_t self:lockdown integrity;
 
 kernel_dgram_send(systemd_sleep_t)
 
+dev_create_sysfs_files(systemd_sleep_t)
 dev_rw_sysfs(systemd_sleep_t)
-dev_write_sysfs_dirs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)


### PR DESCRIPTION
This permission is required to be able to create the /sys/power/state file.

Resolves: rhbz#1944526