### PR TITLE
Allow local_login_t get attributes of tmpfs filesystems

### DIFF
--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -113,6 +113,7 @@ files_create_home_dir(local_login_t)
 
 fs_search_auto_mountpoints(local_login_t)
 fs_getattr_cgroup(local_login_t)
+fs_getattr_tmpfs(local_login_t)
 
 storage_dontaudit_getattr_fixed_disk_dev(local_login_t)
 storage_dontaudit_setattr_fixed_disk_dev(local_login_t)


### PR DESCRIPTION
This permission is required when the system booted with cgroups v1.

Resolves: rhbz#1894759