### PR TITLE
Allow ibacm the net_raw and sys_rawio capabilities

### DIFF
--- a/policy/modules/contrib/ibacm.te
+++ b/policy/modules/contrib/ibacm.te
@@ -25,7 +25,7 @@ files_tmpfs_file(ibacm_tmpfs_t)
 #
 # ibacm local policy
 #
-allow ibacm_t self:capability ipc_lock;
+allow ibacm_t self:capability { ipc_lock net_raw sys_rawio };
 allow ibacm_t self:fifo_file rw_fifo_file_perms;
 allow ibacm_t self:unix_stream_socket create_stream_socket_perms;
 allow ibacm_t ibacm_t:netlink_rdma_socket { create_socket_perms };


### PR DESCRIPTION
These permissions are required for the mlx5 driver.
The net_raw capability is needed for the netlink socket
used by kernel to query the path record from the ibacm service.
The sys_rawio capability is required for mlx5_ib_create_wq()
to finish successfully.

Addresses the following denials:
```
type=PROCTITLE msg=audit(02/25/2021 10:04:05.832:361) : proctitle=/usr/sbin/ibacm --systemd
type=SYSCALL msg=audit(02/25/2021 10:04:05.832:361) : arch=x86_64 syscall=ioctl success=yes exit=0 a0=0x7 a1=0xc0181b01 a2=0x7ffe6b3513e0 a3=0x7ffe6b351560 items=0 ppid=1 pid=53564 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ibacm exe=/usr/sbin/ibacm subj=system_u:system_r:ibacm_t:s0 key=(null)
type=AVC msg=audit(02/25/2021 10:04:05.832:361) : avc:  denied  { sys_rawio } for  pid=53564 comm=ibacm capability=sys_rawio  scontext=system_u:system_r:ibacm_t:s0 tcontext=system_u:system_r:ibacm_t:s0 tclass=capability permissive=1
type=AVC msg=audit(02/25/2021 10:04:05.832:361) : avc:  denied  { net_raw } for  pid=53564 comm=ibacm capability=net_raw  scontext=system_u:system_r:ibacm_t:s0 tcontext=system_u:system_r:ibacm_t:s0 tclass=capability permissive=1
```