### PR TITLE
Allow dhcpc_t domain transition to chronyc_t

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -198,6 +198,7 @@ optional_policy(`
 	chronyd_initrc_domtrans(dhcpc_t)
 	chronyd_systemctl(dhcpc_t)
 	chronyd_domtrans(dhcpc_t)
+	chronyd_domtrans_chronyc(dhcpc_t)
 	chronyd_read_keys(dhcpc_t)
 ')
 


### PR DESCRIPTION
This permission is required when dhclient-script executes
the chrony.sh script from /etc/dhcp/dhclient.d.

Resolves: rhbz#1897388