### PR TITLE
Allow plymouthd_t exec generic program in bin directories

### DIFF
--- a/policy/modules/contrib/plymouthd.te
+++ b/policy/modules/contrib/plymouthd.te
@@ -60,6 +60,8 @@ kernel_read_system_state(plymouthd_t)
 kernel_request_load_module(plymouthd_t)
 kernel_change_ring_buffer_level(plymouthd_t)
 
+corecmd_exec_bin(plymouthd_t)
+
 dev_rw_dri(plymouthd_t)
 dev_read_sysfs(plymouthd_t)
 dev_read_framebuffer(plymouthd_t)


### PR DESCRIPTION
This permission is required for plymouthd execute helper binaries from
/usr/libexec/plymouth which are labeled bin_t.

Resolves: rhbz#1945585