### PR TITLE
Allow /tmp file transition for dbus-daemon also for sock_file

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -79,7 +79,7 @@ read_lnk_files_pattern(system_dbusd_t, dbusd_etc_t, dbusd_etc_t)
 
 manage_dirs_pattern(system_dbusd_t, system_dbusd_tmp_t, system_dbusd_tmp_t)
 manage_files_pattern(system_dbusd_t, system_dbusd_tmp_t, system_dbusd_tmp_t)
-files_tmp_filetrans(system_dbusd_t, system_dbusd_tmp_t, { file dir })
+files_tmp_filetrans(system_dbusd_t, system_dbusd_tmp_t, { dir file sock_file })
 
 manage_files_pattern(system_dbusd_t, system_dbusd_tmpfs_t, system_dbusd_tmpfs_t)
 manage_dirs_pattern(system_dbusd_t, system_dbusd_tmpfs_t, system_dbusd_tmpfs_t)


### PR DESCRIPTION
Addresses the following denial:

type=PROCTITLE msg=audit(04/01/2021 22:47:20.888:196) : proctitle=/usr/bin/dbus-daemon --config-file=/usr/share/defaults/at-spi2/accessibility.conf --nofork --print-address 3
type=SOCKADDR msg=audit(04/01/2021 22:47:20.888:196) : saddr={ saddr_fam=local path=/tmp/dbus-pFzUtJejsp }
type=SYSCALL msg=audit(04/01/2021 22:47:20.888:196) : arch=x86_64 syscall=bind
success=no exit=EACCES(Permission denied) a0=0x8 a1=0x7fffa4d40e20 a2=0x16 a3=0x0
items=2 ppid=1161 pid=1171 auid=unset uid=gdm gid=gdm euid=gdm suid=gdm fsuid=gdm
egid=gdm sgid=gdm fsgid=gdm tty=(none) ses=unset comm=dbus-daemon
exe=/usr/bin/dbus-daemon subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(04/01/2021 22:47:20.888:196) : avc:  denied  { create }
for  pid=1171 comm=dbus-daemon name=dbus-pFzUtJejsp
scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
tcontext=system_u:object_r:tmp_t:s0 tclass=sock_file permissive=0