### PR TITLE
Add file context specification for /usr/libexec/realmd

### DIFF
--- a/policy/modules/contrib/realmd.fc
+++ b/policy/modules/contrib/realmd.fc
@@ -1,5 +1,7 @@
 /usr/lib/realmd/realmd		--	gen_context(system_u:object_r:realmd_exec_t,s0)
 
+/usr/libexec/realmd		--	gen_context(system_u:object_r:realmd_exec_t,s0)
+
 /var/cache/realmd(/.*)?			gen_context(system_u:object_r:realmd_var_cache_t,s0)
 
 /var/lib/ipa-client(/.*)?		gen_context(system_u:object_r:realmd_var_lib_t,s0)


### PR DESCRIPTION
With realmd version 0.17 and the "paths: install realmd in libexecdir"
commit, the realmd executable is installed in libexecdir instead of
privatedir.

https://gitlab.freedesktop.org/realmd/realmd/-/commit/a1ad06ae039133e9ef6cb1f28dc2fd6252b7ba22