### PR TITLE
Add new interfaces with watch_mount and watch_with_perm permissions

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -3000,6 +3000,24 @@ interface(`files_watch_boot_dirs',`
 
 ########################################
 ## <summary>
+##	Watch_mount directories in /boot.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_mount_boot_dirs',`
+	gen_require(`
+		type boot_t;
+	')
+
+	allow $1 boot_t:dir watch_mount_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Watch_with_perm directories in /boot.
 ## </summary>
 ## <param name="domain">
@@ -4925,6 +4943,42 @@ interface(`files_watch_home',`
 	')
 
 	allow $1 home_root_t:dir watch_dir_perms;
+')
+
+########################################
+## <summary>
+##	Watch_mount home directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_mount_home',`
+	gen_require(`
+		type home_root_t;
+	')
+
+	allow $1 home_root_t:dir watch_mount_dir_perms;
+')
+
+########################################
+## <summary>
+##	Watch_with_perm home directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_with_perm_home',`
+	gen_require(`
+		type home_root_t;
+	')
+
+	allow $1 home_root_t:dir watch_with_perm_dir_perms;
 ')
 
 ########################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -2210,6 +2210,42 @@ interface(`fs_manage_dos_dirs',`
 
 ########################################
 ## <summary>
+##	Watch_mount dirs on a DOS filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_watch_mount_dos_dirs',`
+	gen_require(`
+		type dosfs_t;
+	')
+
+	watch_mount_dirs_pattern($1, dosfs_t, dosfs_t)
+')
+
+########################################
+## <summary>
+##	Watch_with_perm dirs on a DOS filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_watch_with_perm_dos_dirs',`
+	gen_require(`
+		type dosfs_t;
+	')
+
+	watch_with_perm_dirs_pattern($1, dosfs_t, dosfs_t)
+')
+
+########################################
+## <summary>
 ##	Mmap files on a DOS filesystem.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The permissions are required for fapolicyd.
The following interfaces were added:
- files_watch_mount_boot_dirs
- files_watch_mount_home files_watch_with_perm_home
- fs_watch_mount_dos_dirs fs_watch_with_perm_dos_dirs