### PR TITLE
Allow aide connect to systemd-userdbd with a unix socket

### DIFF
--- a/policy/modules/contrib/aide.te
+++ b/policy/modules/contrib/aide.te
@@ -62,6 +62,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_userdbd_stream_connect(aide_t)
+')
+
+optional_policy(`
     sssd_stream_connect(aide_t)
 ')
 


### PR DESCRIPTION
Addresses the following denials:

type=PROCTITLE msg=audit(02/08/2021 15:56:17.708:518) :
proctitle=/usr/sbin/aide --config=/etc/aide.conf --init
type=PATH msg=audit(02/08/2021 15:56:17.708:518) : item=0
name=/run/systemd/userdb/io.systemd.Home inode=606 dev=00:19 mode=socket,666
ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0
nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD
msg=audit(02/08/2021 15:56:17.708:518) : cwd=/root
type=SYSCALL msg=audit(02/08/2021 15:56:17.708:518) : arch=x86_64
syscall=connect success=yes exit=0 a0=0x7 a1=0x7fff46fb1140 a2=0x26
a3=0x55718ce5f200 items=1 ppid=12433 pid=12434 auid=unset uid=root gid=root
euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none)
ses=unset comm=aide exe=/usr/sbin/aide
subj=system_u:system_r:aide_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(02/08/2021 15:56:17.708:518) : avc:  denied  { connectto }
for  pid=12434 comm=aide path=/run/systemd/userdb/io.systemd.Home
scontext=system_u:system_r:aide_t:s0-s0:c0.c1023
tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=1
type=AVC msg=audit(02/08/2021 15:56:17.708:518) : avc:  denied  { write }
for  pid=12434 comm=aide name=io.systemd.Home dev="tmpfs" ino=606
scontext=system_u:system_r:aide_t:s0-s0:c0.c1023
tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=sock_file permissive=1
