### PR TITLE
Allow systemd-modules-load read/write tracefs files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1207,6 +1207,8 @@ init_read_pid_files(systemd_modules_load_t)
 files_map_kernel_modules(systemd_modules_load_t)
 files_read_kernel_modules(systemd_modules_load_t)
 
+fs_rw_tracefs_files(systemd_modules_load_t)
+
 modutils_exec_kmod(systemd_modules_load_t)
 modutils_read_module_config(systemd_modules_load_t)
 modutils_read_module_deps_files(systemd_modules_load_t)


### PR DESCRIPTION
Using the fs_rw_tracefs_files() interface, systemd-modules-load is also
allowed the confidentiality lockdown permission.

Addresses the following denial:

type=AVC msg=audit(1616133452.608:146): avc:  denied  { confidentiality }
for  pid=763 comm="systemd-modules" lockdown_reason="use of tracefs"
scontext=system_u:system_r:systemd_modules_load_t:s0
tcontext=system_u:system_r:systemd_modules_load_t:s0 tclass=lockdown permissive=0
