### PR TITLE
allow systemd-sleep to set timer for suspend-then-hibernate

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1333,6 +1333,8 @@ systemd_read_efivarfs(systemd_userdbd_t)
 #
 
 allow systemd_sleep_t self:capability sys_resource;
+# systemd-sleep needs to set timer for suspend-then-hibernate
+allow systemd_sleep_t self:capability2 wake_alarm;
 dontaudit systemd_sleep_t self:capability sys_ptrace;
 # systemd-sleep needs the permission to change sleep state
 allow systemd_sleep_t self:lockdown integrity;


### PR DESCRIPTION
- tested with `HibernateDelaySec=15min` in `/etc/systemd/sleep.conf`
- suspend-then-hibernate not working in F34 beta
  (systemd-sleep fails with `Error creating timerfd: Operation not permitted`)
- fixed by allowing wake_alarm capability

fixup of #426

Also see: [[Fedora 34 beta] suspend-then-hibernate fails with Error creating timerfd: Operation not permitted - Discussions in English / on using Fedora - Ask Fedora](https://ask.fedoraproject.org/t/fedora-34-beta-suspend-then-hibernate-fails-with-error-creating-timerfd-operation-not-permitted/13179)