### PR TITLE
Add file context specification for /var/tmp/tmp-inst

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -317,6 +317,7 @@ ifndef(`distro_redhat',`
 /var/tmp		-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /var/tmp		-l	gen_context(system_u:object_r:tmp_t,s0)
 /var/tmp-inst		-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
+/var/tmp/tmp-inst	-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /var/tmp/.*			<<none>>
 /var/tmp/lost\+found	-d	gen_context(system_u:object_r:lost_found_t,mls_systemhigh)
 /var/tmp/lost\+found/.*		<<none>>


### PR DESCRIPTION
The pam_namespace.so module allows setup of private namespaces with
polyinstantiated directories. Directories can be polyinstantiated based
on user name or, in the case of SELinux, user name, sensitivity level or
complete security context.

Previously, file context specification for /var/tmp-inst was defined
in SELinux policy instead of /var/tmp/tmp-inst, although pam_namespace
is pre-configured for using /var/tmp/tmp-inst. It is noted in the
/etc/security/namespace.conf file as well as in documentation.

Resolves: rhbz#1919253