### PR TITLE
Dontaudit daemon open and read init_t file

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1836,6 +1836,7 @@ ifdef(`hide_broken_symptoms',`
 	')
 
 	dontaudit daemon init_t:dir search_dir_perms;
+	dontaudit daemon init_t:file read_file_perms;
 ')
 
 optional_policy(`


### PR DESCRIPTION
When a daemon wants to access /proc/1/environ and the system is in
permissive mode, SELinux dontaudits daemon access to the directory, but
subsequent file access denials are audited. This commit dontaudits
the file access, too.

Resolves: rhbz#1932689