### PR TITLE
Allow syslogd_t watch root and var directories

### DIFF
--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -1163,6 +1163,27 @@ interface(`logging_manage_all_logs',`
     allow $1 logfile:file map;
 ')
 
+#######################################
+## <summary>
+##	Watch all directories in the path for log directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_watch_all_log_dirs_path',`
+	gen_require(`
+		attribute logfile;
+	')
+
+	files_watch_root_dirs($1)
+	files_search_var($1)
+	files_watch_var_dirs($1)
+	allow $1 logfile:dir { search_dir_perms watch_dir_perms };
+')
+
 ########################################
 ## <summary>
 ##	Read generic log files.

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -649,7 +649,7 @@ init_use_fds(syslogd_t)
 logging_send_syslog_msg(syslogd_t)
 logging_manage_all_logs(syslogd_t)
 logging_set_loginuid(syslogd_t)
-logging_watch_generic_log_dirs(syslogd_t)
+logging_watch_all_log_dirs_path(syslogd_t)
 
 userdom_dontaudit_use_unpriv_user_fds(syslogd_t)
 userdom_search_user_home_dirs(syslogd_t)


### PR DESCRIPTION
When the rsyslog imfile module is in place, it uses the inotify mode
by default to watch all directories in the path. In this commit, watch
permissions for root and var directories are added, which covers the
most common usage of /var and /srv. Watching files and directories with
the logfile attribute is already allowed in the policy.

Addresses the following issue:

type=PROCTITLE msg=audit(7.4.2021 14:05:04.282:1637) : proctitle=/usr/sbin/rsyslogd -n
type=PATH msg=audit(7.4.2021 14:05:04.282:1637) : item=0
name=/var/www/product/logs/access.log inode=169908 dev=00:1f mode=file,644
ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:httpd_sys_content_t:s0
nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(7.4.2021 14:05:04.282:1637) : cwd=/
type=SYSCALL msg=audit(7.4.2021 14:05:04.282:1637) : arch=x86_64
syscall=inotify_add_watch success=yes exit=6 a0=0x5 a1=0x7fedec0012d0 a2=0x2000002
a3=0x0 items=1 ppid=1 pid=16760 auid=unset uid=root gid=root euid=root suid=root
fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=in:imfile
exe=/usr/sbin/rsyslogd subj=system_u:system_r:syslogd_t:s0 key=(null)
type=AVC msg=audit(7.4.2021 14:05:04.282:1637) : avc:  denied  { watch }
for  pid=16760 comm=in:imfile path=/var/www/product/logs/access.log dev="vda2"
ino=169908 scontext=system_u:system_r:syslogd_t:s0
tcontext=unconfined_u:object_r:httpd_sys_content_t:s0 tclass=file permissive=1
