### PR TITLE
Allow cups-lpd read its private runtime socket files

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -569,6 +569,7 @@ files_tmp_filetrans(cupsd_lpd_t, cupsd_lpd_tmp_t, { dir file })
 manage_files_pattern(cupsd_lpd_t, cupsd_lpd_var_run_t, cupsd_lpd_var_run_t)
 files_pid_filetrans(cupsd_lpd_t, cupsd_lpd_var_run_t, file)
 
+read_sock_files_pattern(cupsd_lpd_t, cupsd_var_run_t, cupsd_var_run_t)
 stream_connect_pattern(cupsd_lpd_t, cupsd_var_run_t, cupsd_var_run_t, cupsd_t)
 
 kernel_read_kernel_sysctls(cupsd_lpd_t)


### PR DESCRIPTION
For /usr/lib/cups/daemon/cups-lpd to be able to initiate a connection
with the local CUPS server (cupsd) over the /var/run/cups/cups.sock
domain socket file, the read permission is required.

Resolves: rhbz#1919399