### PR TITLE
Add brltty new permissions required by new upstream version

### DIFF
--- a/policy/modules/contrib/brltty.te
+++ b/policy/modules/contrib/brltty.te
@@ -25,7 +25,7 @@ systemd_unit_file(brltty_unit_file_t)
 #
 # brltty local policy
 #
-allow brltty_t self:capability { sys_admin  sys_tty_config mknod };
+allow brltty_t self:capability { setgid setuid sys_admin sys_tty_config mknod };
 allow brltty_t self:process { fork signal_perms };
 
 allow brltty_t self:fifo_file rw_fifo_file_perms;
@@ -55,9 +55,11 @@ auth_use_nsswitch(brltty_t)
 
 corenet_tcp_bind_brlp_port(brltty_t)
 
+dev_read_mouse(brltty_t)
 dev_read_sysfs(brltty_t)
 dev_rw_generic_usb_dev(brltty_t)
 dev_rw_input_dev(brltty_t)
+dev_write_sound(brltty_t)
 
 fs_getattr_all_fs(brltty_t)
 
@@ -77,4 +79,8 @@ optional_policy(`
     dbus_system_bus_client(brltty_t)
 
     bluetooth_dbus_chat(brltty_t)
+')
+
+optional_policy(`
+	policykit_dbus_chat(brltty_t)
 ')


### PR DESCRIPTION
The following permissions were added:
- setuid and setgid capabilities to support switching
  to an unprivileged user and manipulate supplemental GIDs
- read mouse devices
- write to sound devices
- dbus chat with policykit

The following AVCs and USER_AVC were addressed:

type=AVC msg=audit(04/09/2021 13:42:21.997:1123) : avc:  denied  { setgid }
for  pid=9208 comm=brltty capability=setgid  scontext=system_u:system_r:brltty_t:s0
tcontext=system_u:system_r:brltty_t:s0 tclass=capability permissive=1

type=AVC msg=audit(04/09/2021 13:42:21.997:1124) : avc:  denied  { setuid }
for  pid=9208 comm=brltty capability=setuid  scontext=system_u:system_r:brltty_t:s0
tcontext=system_u:system_r:brltty_t:s0 tclass=capability permissive=1

type=AVC msg=audit(04/09/2021 13:42:22.509:1125) : avc:  denied  { getattr }
for  pid=9208 comm=brltty path=/dev/snd/seq dev="devtmpfs" ino=311
scontext=system_u:system_r:brltty_t:s0 tcontext=system_u:object_r:sound_device_t:s0
tclass=chr_file permissive=1

type=AVC msg=audit(04/09/2021 13:42:22.509:1126) : avc:  denied  { getattr }
for  pid=9208 comm=brltty path=/dev/input/mice dev="devtmpfs" ino=109
scontext=system_u:system_r:brltty_t:s0 tcontext=system_u:object_r:mouse_device_t:s0
tclass=chr_file permissive=1

type=USER_AVC msg=audit(04/09/2021 13:42:22.590:1129) : pid=614 uid=dbus
auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:brltty_t:s0
tcontext=system_u:system_r:policykit_t:s0 tclass=dbus permissive=1
exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'
