### PR TITLE
Label /etc/redis as redis_conf_t

### DIFF
--- a/policy/modules/contrib/redis.fc
+++ b/policy/modules/contrib/redis.fc
@@ -1,5 +1,6 @@
 /etc/rc\.d/init\.d/redis	--	gen_context(system_u:object_r:redis_initrc_exec_t,s0)
 
+/etc/redis(/.*)?			gen_context(system_u:object_r:redis_conf_t,s0)
 /etc/redis-sentinel.*		--	gen_context(system_u:object_r:redis_conf_t,s0)
 
 /usr/lib/systemd/system/redis.*		--	gen_context(system_u:object_r:redis_unit_file_t,s0)


### PR DESCRIPTION
With a new redis version, the configuration file in the /etc/redis
directory are used instead if individual configuration files in /etc.
This change needs to be backed with proper labeling of /etc/redis.

Example of a denial which is being addresses by this commit:

type=PROCTITLE msg=audit(04/09/2021 11:12:52.959:517) :
proctitle=/usr/bin/redis-sentinel *:26379 [sentinel]
type=PATH msg=audit(04/09/2021 11:12:52.959:517) : item=0 name=/etc/redis/sentinel.conf
inode=16824738 dev=fd:02 mode=file,640 ouid=redis ogid=root rdev=00:00
obj=system_u:object_r:etc_t:s0 nametype=NORMAL
cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(04/09/2021 11:12:52.959:517) : cwd=/tmp
type=SYSCALL msg=audit(04/09/2021 11:12:52.959:517) : arch=x86_64 syscall=access
success=no exit=EACCES(Permission denied) a0=0x7f054ee0e2a1 a1=W_OK a2=0x0 a3=0x8
items=1 ppid=1 pid=3747 auid=unset uid=redis gid=redis euid=redis suid=redis fsuid=redis
egid=redis sgid=redis fsgid=redis tty=(none) ses=unset comm=redis-sentinel
exe=/usr/bin/redis-server subj=system_u:system_r:redis_t:s0 key=(null)
type=AVC msg=audit(04/09/2021 11:12:52.959:517) : avc:  denied  { write }
for  pid=3747 comm=redis-sentinel name=sentinel.conf dev="vda2" ino=16824738
scontext=system_u:system_r:redis_t:s0 tcontext=system_u:object_r:etc_t:s0
tclass=file permissive=0
