### PR TITLE
Allow domain and unconfined_domain_type watch /proc/PID dirs

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -122,7 +122,7 @@ neverallow ~{ domain unlabeled_t } *:process *;
 #
 
 # read /proc/(pid|self) entries
-allow domain self:dir list_dir_perms;
+allow domain self:dir { list_dir_perms watch_dir_perms };
 allow domain self:lnk_file { read_lnk_file_perms lock ioctl };
 allow domain self:file rw_file_perms;
 allow domain self:fifo_file rw_fifo_file_perms;
@@ -282,7 +282,7 @@ allow unconfined_domain_type domain:{ sem msgq shm } *;
 allow unconfined_domain_type domain:msg { send receive };
 
 # For /proc/pid
-allow unconfined_domain_type domain:dir list_dir_perms;
+allow unconfined_domain_type domain:dir { list_dir_perms watch_dir_perms };
 allow unconfined_domain_type domain:file manage_file_perms;
 allow unconfined_domain_type domain:lnk_file { read_lnk_file_perms ioctl lock };
 


### PR DESCRIPTION
Processes may need to watch their own domain PID directories.
Additionaly, processes in the unconfined_domain_type may need
to watch any process PID directory.
In both cases the watch_dir_perms pattern was added next to the
already existing list_dirs_pattern.

Resolves: rhbz#1948222