### PR TITLE
Allow systemd-timedated watch root dirs

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -8430,6 +8430,25 @@ interface(`files_watch_var_run_dirs',`
         allow $1 var_run_t:dir watch_dir_perms;
 ')
 
+#######################################
+## <summary>
+##      Watch generic pid directory and its parents.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`files_watch_var_run_path',`
+        gen_require(`
+                type var_run_t;
+        ')
+
+	files_watch_root_dirs($1)
+	files_watch_var_run_dirs($1)
+')
+
 ########################################
 ## <summary>
 ##	List the contents of the runtime process

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -923,6 +923,8 @@ dev_rw_realtime_clock(systemd_timedated_t)
 dev_write_kmsg(systemd_timedated_t)
 dev_read_sysfs(systemd_timedated_t)
 
+files_watch_var_run_path(systemd_timedated_t)
+
 fs_getattr_xattr_fs(systemd_timedated_t)
 
 init_dbus_chat(systemd_timedated_t)


### PR DESCRIPTION
Addresses the following denial:

type=PROCTITLE msg=audit(14.4.2021 08:53:31.128:151) :
proctitle=/usr/lib/systemd/systemd-timesyncd
type=PATH msg=audit(14.4.2021 08:53:31.128:151) : item=0 name=/ inode=256
dev=00:1f mode=dir,555 ouid=root ogid=root rdev=00:00
obj=system_u:object_r:root_t:s0 nametype=NORMAL cap_fp=none cap_fi=none
cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(14.4.2021 08:53:31.128:151) : cwd=/
type=SYSCALL msg=audit(04/14/21 08:53:31.128:151) : arch=x86_64
syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0xb
a1=0x7f45e33a8d42 a2=0x180 a3=0x7fffc39742f4 items=1 ppid=1 pid=635 auid=unset
uid=systemd-timesync gid=systemd-timesync euid=systemd-timesync
suid=systemd-timesync fsuid=systemd-timesync egid=systemd-timesync
sgid=systemd-timesync fsgid=systemd-timesync tty=(none) ses=unset
comm=systemd-timesyn exe=/usr/lib/systemd/systemd-timesyncd
subj=system_u:system_r:systemd_timedated_t:s0 key=(null)
type=AVC msg=audit(14.4.2021 08:53:31.128:151) : avc:  denied  { watch }
for  pid=635 comm=systemd-timesyn path=/ dev="vda2" ino=256
scontext=system_u:system_r:systemd_timedated_t:s0
tcontext=system_u:object_r:root_t:s0 tclass=dir permissive=0

Resolves: rhbz#1949315