### PR TITLE
Allow nsswitch_domain read cgroup files

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -465,6 +465,8 @@ files_list_var_lib(nsswitch_domain)
 # read /etc/nsswitch.conf
 files_read_etc_files(nsswitch_domain)
 
+fs_read_cgroup_files(nsswitch_domain)
+
 init_stream_connectto(nsswitch_domain)
 
 sysnet_dns_name_resolve(nsswitch_domain)


### PR DESCRIPTION
This permission is required when the systemd nss module is used
in nsswitch.conf for users or groups. The module checks whether
the current process is running in the root cgroup, or if rather
cgroup namespaces are in place.

Resolves: rhbz#1895061