### PR TITLE
Allow unconfined_service_t confidentiality and integrity lockdown

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -17,6 +17,8 @@ unconfined_stub_role()
 
 role unconfined_r types unconfined_service_t;
 
+allow unconfined_service_t self:lockdown { confidentiality integrity };
+
 corecmd_bin_entry_type(unconfined_service_t)
 corecmd_shell_entry_type(unconfined_service_t)
 


### PR DESCRIPTION
Allow unconfined_service_t the confidentiality and integrity lockdown
permissions. Currently, the permissions are allowed for unconfined_t,
but not for a similar unconfined_service_t domain, so this change is
merely for the sake of consistency.