### PR TITLE
Allow ipsec the lockdown confidentiality permission

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -82,6 +82,7 @@ files_type(ipsec_mgmt_devpts_t)
 
 allow ipsec_t self:capability { net_admin dac_read_search dac_override setpcap sys_admin sys_nice net_raw setuid setgid };
 dontaudit ipsec_t self:capability sys_tty_config;
+allow ipsec_t self:lockdown confidentiality;
 allow ipsec_t self:process { getcap setcap getsched signal signull setsched sigkill };
 allow ipsec_t self:tcp_socket create_stream_socket_perms;
 allow ipsec_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
XFRM is an IP framework for transforming packets.
The concept is used in the IPsec protocol implementation.
The permission is required for the ipsec_t domain for pluto
to be able to redact XFRM SA secret.

Added into kernel:
https://www.spinics.net/lists/linux-security-module/msg39063.html

Addresses the following denial:

type=PROCTITLE msg=audit(04/20/2021 03:10:29.406:636) :
proctitle=/usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork
type=SYSCALL msg=audit(04/20/2021 03:10:29.406:636) : arch=x86_64
syscall=write success=yes exit=40 a0=0xb a1=0x7ffe31e05000 a2=0x28
a3=0x7f3f8be843e0 items=0 ppid=1 pid=8102 auid=unset uid=root gid=root
euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none)
ses=unset comm=pluto exe=/usr/libexec/ipsec/pluto
subj=system_u:system_r:ipsec_t:s0 key=(null)
type=MAC_IPSEC_EVENT msg=audit(04/20/2021 03:10:29.406:636) : op=SAD-delete
auid=unset ses=unset subj=system_u:system_r:ipsec_t:s0 src=10.0.138.148
dst=10.0.138.68 spi=754605297(0x2cfa5cf1) res=yes
type=AVC msg=audit(04/20/2021 03:10:29.406:636) : avc:  denied  { confidentiality }
for  pid=8102 comm=pluto lockdown_reason="xfrm SA secret"
scontext=system_u:system_r:ipsec_t:s0 tcontext=system_u:system_r:ipsec_t:s0
tclass=lockdown permissive=0