### PR TITLE
Allow systemd-coredump getattr nsfs files and net_admin capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1022,7 +1022,7 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # sys_ptrace - to read /proc/<pid>/exe of the dumped process
 # setgid setuid - to set own credentials to match the dumped process credentials
 # setpcap - to drop capabilities
-allow systemd_coredump_t self:capability { dac_read_search setgid setpcap setuid sys_ptrace };
+allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_ptrace };
 allow systemd_coredump_t self:cap_userns sys_ptrace;
 
 # To set its capability set
@@ -1047,6 +1047,8 @@ domain_read_all_domains_state(systemd_coredump_t)
 # (can be basically any file type)
 files_read_non_security_files(systemd_coredump_t)
 files_map_non_security_files(systemd_coredump_t)
+
+fs_getattr_nsfs_files(systemd_coredump_t)
 
 optional_policy(`
 	logging_send_syslog_msg(systemd_coredump_t)


### PR DESCRIPTION
The net_admin capability is required by systemd-coredump to increase
the send buffer in setsockopt(); refer to socket(7):

       SO_SNDBUFFORCE (since Linux 2.6.14)
              Using this socket option, a privileged (CAP_NET_ADMIN)  process  can  perform  the
              same task as SO_SNDBUF, but the wmem_max limit can be overridden.

Resolves: rhbz#1952163