### PR TITLE
Allow IPsec and Certmonger to use opencryptoki services

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -247,6 +247,10 @@ optional_policy(`
 	')
 ')
 
+optional_policy(`
+	pkcs_use_opencryptoki(ipsec_t)
+')
+
 ########################################
 #
 # ipsec_mgmt Local policy


### PR DESCRIPTION
Add to certmonger and ipsec policy interface pkcs_use_opencryptoki(),
which allow use opencryptoki. Opencryptoki implements PKCS#11
standard.

The original commit has been split in 2 parts, this is the part for ipsec.

Resolves: rhbz#1952311