### PR TITLE
Allow chronyc socket file transition in user temp directory

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -205,7 +205,7 @@ logging_log_filetrans(chronyc_t, chronyd_var_log_t, file)
 manage_dirs_pattern(chronyc_t, chronyd_tmp_t, chronyd_tmp_t)
 manage_files_pattern(chronyc_t, chronyd_tmp_t, chronyd_tmp_t)
 manage_sock_files_pattern(chronyc_t, chronyd_tmp_t, chronyd_tmp_t)
-userdom_user_tmp_filetrans(chronyc_t, chronyd_tmp_t, dir)
+userdom_user_tmp_filetrans(chronyc_t, chronyd_tmp_t, { dir sock_file })
 files_tmp_filetrans(chronyc_t, chronyd_tmp_t, file)
 
 kernel_read_system_state(chronyc_t)


### PR DESCRIPTION
Until now, there was only a transition rule for a directory,
this commit allows the file transition also for sockets.

Resolves: rhbz#1903145