### PR TITLE
Allow virtlogd_t to create virt_var_lockd_t dir

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -245,6 +245,7 @@ type virt_var_lib_t, virt_file_type;
 files_mountpoint(virt_var_lib_t)
 
 type virt_var_lockd_t, virt_file_type;
+files_type(virt_var_lockd_t)
 
 type virtd_t, virt_system_domain;
 type virtd_exec_t, virt_file_type;
@@ -483,6 +484,7 @@ allow virtd_t virt_var_lib_t:file { relabelfrom relabelto };
 
 manage_dirs_pattern(virtlogd_t, virt_var_lockd_t, virt_var_lockd_t)
 manage_files_pattern(virtlogd_t, virt_var_lockd_t, virt_var_lockd_t)
+filetrans_pattern(virtlogd_t, virt_var_lib_t, virt_var_lockd_t, dir, "lockd")
 
 manage_dirs_pattern(virtd_t, virt_var_run_t, virt_var_run_t)
 manage_files_pattern(virtd_t, virt_var_run_t, virt_var_run_t)


### PR DESCRIPTION
Allow virtlogd_t to create dir named "lockd" with label virt_var_lockd_t in parent directory labeled as virt_var_lib_t.

Make the virt_var_lockd_t type usable for files in a filesystem.

Fixed [BZ1941464](https://bugzilla.redhat.com/show_bug.cgi?id=1941464).

Tested on RHEL8.4.

Signed-off-by: Nikola Knazekova <nknazeko@redhat.com>