### PR TITLE
Allow udev create /run/gdm with proper type

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -2416,3 +2416,20 @@ interface(`xserver_rw_xdm_keys',`
 	allow $1 xdm_t:key { read write setattr };
 ')
 
+######################################
+## <summary>
+##	Transition to xdm named content
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xserver_filetrans_named_content',`
+	gen_require(`
+		type xdm_var_run_t;
+	')
+
+	files_pid_filetrans($1, xdm_var_run_t, dir, "gdm")
+')

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -380,6 +380,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	xserver_filetrans_named_content(udev_t)
 	xserver_read_xdm_pid(udev_t)
     xserver_domtrans_xdm(udev_t)
 ')


### PR DESCRIPTION
There is /usr/lib/udev/rules.d/61-gdm.rules udev rule
with the following or similar content:

DRIVER=="nvidia", RUN+="/usr/libexec/gdm-runtime-config set daemon WaylandEnable false"

In this case, as far as the nvidia driver is in place, it is udev that
creates the /run/gdm directory which happens before gdm is started.
In cases it is gdm or gdm-session-worker to create /run/gdm, an existing
transition covers the situation:

files_pid_filetrans(xdm_t, xdm_var_run_t, { dir file fifo_file sock_file })

The xserver_filetrans_named_content() interface was added.
Based on the idea and information by Markus Linnala.

Resolves: rhbz#1944694