### PR TITLE
Fix context of /run/systemd/timesync

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -57,6 +57,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/systemd-sysctl		--	gen_context(system_u:object_r:systemd_sysctl_exec_t,s0)
 /usr/lib/systemd/systemd-timedated	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
 /usr/lib/systemd/systemd-timesyncd	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
+/usr/lib/systemd/systemd-time-wait-sync	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
 /usr/lib/systemd/systemd-logind		--	gen_context(system_u:object_r:systemd_logind_exec_t,s0)
 /usr/lib/systemd/systemd-user-runtime-dir		--	gen_context(system_u:object_r:systemd_logind_exec_t,s0)
 /usr/lib/systemd/systemd-localed	--	gen_context(system_u:object_r:systemd_localed_exec_t,s0)
@@ -94,6 +95,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)
 /var/run/systemd/netif(/.*)?	gen_context(system_u:object_r:systemd_networkd_var_run_t,s0)
 /var/run/systemd/import(/.*)?		gen_context(system_u:object_r:systemd_importd_var_run_t,s0)
+/var/run/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_run_t,s0)
 
 /var/run/log/bootchart.*	--	gen_context(system_u:object_r:systemd_bootchart_var_run_t,s0)
 


### PR DESCRIPTION
It seems /usr/lib/systemd/systemd-time-wait-sync creates
/run/systemd/timesync before /usr/lib/systemd/systemd-timesyncd reaches
there, so changing the systemd-time-wait-sync type to systemd_timedated_exec_t
to be in line.

This avoids:

Would relabel /run/systemd/timesync/synchronized from system_u:object_r:systemd_timedated_var_run_t:s0 to system_u:object_r:init_var_run_t:s0

Also start systemd_timedated_var_run_t from /run/systemd/timesync make
it neat.