### PR TITLE
Allow freshclam get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/contrib/antivirus.te
+++ b/policy/modules/contrib/antivirus.te
@@ -173,6 +173,7 @@ files_dontaudit_read_security_files(antivirus_domain)
 files_read_etc_runtime_files(antivirus_domain)
 files_search_spool(antivirus_domain)
 
+fs_getattr_cgroup(antivirus_t)
 fs_getattr_xattr_fs(antivirus_domain)
 
 auth_use_nsswitch(antivirus_t)


### PR DESCRIPTION
Resolves: rhbz#1954621