### PR TITLE
Allow NetworkManager read and write z90crypt device

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -163,6 +163,7 @@ dev_read_rand(NetworkManager_t)
 dev_read_urand(NetworkManager_t)
 dev_dontaudit_getattr_generic_blk_files(NetworkManager_t)
 dev_getattr_all_chr_files(NetworkManager_t)
+dev_rw_crypto(NetworkManager_t)
 dev_rw_wireless(NetworkManager_t)
 
 fs_getattr_all_fs(NetworkManager_t)


### PR DESCRIPTION
This permission is required on s390x systems with the Crypto Express
adapter card. The z90crypt device driver acts as the interface to the
PCI cryptography hardware and performs asynchronous encryption
operations (RSA) as used during the SSL handshake.