### PR TITLE
Allow tgtd create and use rdma socket

### DIFF
--- a/policy/modules/contrib/tgtd.te
+++ b/policy/modules/contrib/tgtd.te
@@ -36,6 +36,7 @@ allow tgtd_t self:fifo_file rw_fifo_file_perms;
 allow tgtd_t self:netlink_route_socket r_netlink_socket_perms;
 allow tgtd_t self:shm create_shm_perms;
 allow tgtd_t self:sem create_sem_perms;
+allow tgtd_t self:netlink_rdma_socket create_socket_perms;
 allow tgtd_t self:tcp_socket create_stream_socket_perms;
 allow tgtd_t self:udp_socket create_socket_perms;
 


### PR DESCRIPTION
Addresses the following denial:

type=PROCTITLE msg=audit(04/30/2021 07:15:33.939:250) : proctitle=/usr/sbin/tgtd -f
type=SYSCALL msg=audit(04/30/2021 07:15:33.939:250) : arch=x86_64 syscall=socket
success=no exit=EACCES(Permission denied) a0=netlink a1=SOCK_RAW a2=hmp a3=0x1c2dc90
items=0 ppid=1 pid=41990 auid=unset uid=root gid=root euid=root suid=root fsuid=root
egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tgtd exe=/usr/sbin/tgtd
subj=system_u:system_r:tgtd_t:s0 key=(null)
type=AVC msg=audit(04/30/2021 07:15:33.939:250) : avc:  denied  { create }
for  pid=41990 comm=tgtd scontext=system_u:system_r:tgtd_t:s0
tcontext=system_u:system_r:tgtd_t:s0 tclass=netlink_rdma_socket permissive=0