### PR TITLE
Allow NetworkManager watch its config dir

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -97,6 +97,7 @@ read_files_pattern(NetworkManager_t, NetworkManager_initrc_exec_t, NetworkManage
 read_lnk_files_pattern(NetworkManager_t, NetworkManager_initrc_exec_t, NetworkManager_initrc_exec_t)
 
 list_dirs_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_etc_t)
+watch_dirs_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_etc_t)
 read_files_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_etc_t)
 read_lnk_files_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_etc_t)
 


### PR DESCRIPTION
This permission is required for the inotify_add_watch() syscall on the
/etc/NetworkManager/VPN directory which does not exist by default.
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/8232c3473f93a87e2eb736bf4b63049001a20926/src/core/vpn/nm-vpn-manager.c#L217

Resolves: rhbz#1934725