### PR TITLE
Unconfined domains should not be confined

### DIFF
--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -65,8 +65,6 @@ typealias unconfined_t alias unconfined_crontab_t;
 dontaudit unconfined_t self:dir write;
 dontaudit unconfined_t self:file setattr;
 
-allow unconfined_t self:lockdown { confidentiality integrity };
-
 allow unconfined_t self:system syslog_read;
 dontaudit unconfined_t self:capability sys_module;
 

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -30,6 +30,8 @@ interface(`unconfined_domain_noaudit',`
 	allow $1 self:file manage_file_perms;
 	allow $1 self:dir rw_dir_perms;
 
+	allow $1 self:lockdown { confidentiality integrity };
+
 	# Userland object managers
 	allow $1 self:nscd all_nscd_perms;
 	allow $1 self:dbus all_dbus_perms;

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -17,8 +17,6 @@ unconfined_stub_role()
 
 role unconfined_r types unconfined_service_t;
 
-allow unconfined_service_t self:lockdown { confidentiality integrity };
-
 corecmd_bin_entry_type(unconfined_service_t)
 corecmd_shell_entry_type(unconfined_service_t)
 


### PR DESCRIPTION
Unconfined domains should have full permissions on lockdown.

Fixes: https://github.com/containers/oci-seccomp-bpf-hook/issues/84

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>