### PR TITLE
Allow login_userdomain read and map system library files

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3266,6 +3266,25 @@ interface(`init_read_var_lib_files',`
 
 ########################################
 ## <summary>
+##	Mmap and read systemd lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_mmap_read_var_lib_files',`
+	gen_require(`
+		type init_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	mmap_read_files_pattern($1, init_var_lib_t, init_var_lib_t)
+')
+
+########################################
+## <summary>
 ##	Search systemd lib files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -400,6 +400,10 @@ mount_watch_pid_files(login_userdomain)
 mount_watch_reads_pid_files(login_userdomain)
 
 optional_policy(`
+	init_mmap_read_var_lib_files(login_userdomain)
+')
+
+optional_policy(`
 	gnome_watch_generic_data_home_dirs(login_userdomain)
 	gnome_watch_home_config_dirs(login_userdomain)
 	gnome_watch_home_config_files(login_userdomain)


### PR DESCRIPTION
These permissions are required to access systemd data files
like the journal message catalog /var/lib/systemd/catalog/database.
The init_mmap_read_var_lib_files() interface was added.

Addresses the following denial:
type=PROCTITLE msg=audit(5.5.2021 12:50:56.546:3743) : proctitle=systemctl status user@1001
type=MMAP msg=audit(5.5.2021 12:50:56.546:3743) : fd=4 flags=MAP_SHARED
type=SYSCALL msg=audit(5.5.2021 12:50:56.546:3743) : arch=x86_64 syscall=mmap
success=yes exit=139862025940992 a0=0x0 a1=0x2a000 a2=PROT_READ a3=MAP_SHARED
items=0 ppid=27335 pid=27367 auid=staff uid=staff gid=staff euid=staff suid=staff
fsuid=staff egid=staff sgid=staff fsgid=staff tty=pts1 ses=8 comm=systemctl
exe=/usr/bin/systemctl subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(5.5.2021 12:50:56.546:3743) : avc:  denied  { map }
for  pid=27367 comm=systemctl path=/var/lib/systemd/catalog/database dev="vda2"
ino=185937 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023
tcontext=unconfined_u:object_r:init_var_lib_t:s0 tclass=file permissive=1