### PR TITLE
Allow unconfined_t read other processes perf_event records

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1806,3 +1806,21 @@ interface(`domain_dyntrans',`
 
     dyntrans_pattern($1, domain)
 ')
+
+########################################
+## <summary>
+##	Allow read perf_event file descriptors from all domains 
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`domain_read_perf_event_all_domains',`
+	gen_require(`
+		attribute domain;
+	')
+
+	allow $1 domain:perf_event read;
+')

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -81,6 +81,8 @@ kernel_rw_unlabeled_rawip_socket(unconfined_t)
 kernel_rw_unlabeled_smc_socket(unconfined_t)
 kernel_rw_unlabeled_vsock_socket(unconfined_t)
 
+domain_read_perf_event_all_domains(unconfined_t)
+
 files_create_boot_flag(unconfined_t)
 files_create_default_dir(unconfined_t)
 files_root_filetrans_default(unconfined_t, dir)


### PR DESCRIPTION
Perf events are represented by a file descriptor which can be passed
between processes, e.g. via a UNIX socket or DBus. The perf event's
label is inherited from the creating process at the time of creation.

This permission is required for sysprof, executed from command line,
to get elevated access to perf_event file descriptors provided by
sysprofd daemon which had created the perf_event file descriptors and
passed them to the client.

The domain_read_perf_event_all_domains() interface was added.

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/614