### PR TITLE
Allow unconfined_t write other processes perf_event records

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1809,7 +1809,7 @@ interface(`domain_dyntrans',`
 
 ########################################
 ## <summary>
-##	Allow read perf_event file descriptors from all domains 
+##	Allow read and write perf_event file descriptors from all domains
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -1817,10 +1817,10 @@ interface(`domain_dyntrans',`
 ##	</summary>
 ## </param>
 #
-interface(`domain_read_perf_event_all_domains',`
+interface(`domain_rw_perf_event_all_domains',`
 	gen_require(`
 		attribute domain;
 	')
 
-	allow $1 domain:perf_event read;
+	allow $1 domain:perf_event rw_inherited_perf_event_perms;
 ')

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -81,7 +81,7 @@ kernel_rw_unlabeled_rawip_socket(unconfined_t)
 kernel_rw_unlabeled_smc_socket(unconfined_t)
 kernel_rw_unlabeled_vsock_socket(unconfined_t)
 
-domain_read_perf_event_all_domains(unconfined_t)
+domain_rw_perf_event_all_domains(unconfined_t)
 
 files_create_boot_flag(unconfined_t)
 files_create_default_dir(unconfined_t)

--- a/policy/support/obj_perm_sets.spt
+++ b/policy/support/obj_perm_sets.spt
@@ -312,5 +312,6 @@ define(`manage_service_perms', `{ start stop status reload enable disable } ')
 #
 # perf_event
 #
+define(`rw_inherited_perf_event_perms', `{ read write }')
 define(`write_perf_event_perms', `{ open write }')
 define(`manage_perf_event_perms', `{ cpu kernel open read tracepoint write }')


### PR DESCRIPTION
This commit adds the write permission to previously added read
and renames domain_read_perf_event_all_domains() interface to
domain_rw_perf_event_all_domains().

The rw_inherited_perf_event_perms object permission set was added.

Addresses the following denial:

type=PROCTITLE msg=audit(05/06/2021 03:46:27.203:546) : proctitle=sysprof-cli
type=SYSCALL msg=audit(05/06/2021 03:46:27.203:546) : arch=x86_64 syscall=ioctl
success=yes exit=0 a0=0xe a1=0x80082407 a2=0x7ffe685eca18 a3=0x1 items=0 ppid=40162
pid=41714 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root
sgid=root fsgid=root tty=pts1 ses=5 comm=sysprof-cli exe=/usr/bin/sysprof-cli
subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(05/06/2021 03:46:27.203:546) : avc:  denied  { write }
for  pid=41714 comm=sysprof-cli
scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
tcontext=system_u:system_r:unconfined_service_t:s0 tclass=perf_event
permissive=1