### PR TITLE
Dontaudit domain the fowner capability

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -129,6 +129,11 @@ allow domain self:fifo_file rw_fifo_file_perms;
 allow domain self:sem create_sem_perms;
 allow domain self:shm create_shm_perms;
 
+# This is a temporary rule to work around a problem in kernel/xfs
+# triggering a false fowner capability AVC
+# https://bugzilla.redhat.com/show_bug.cgi?id=1933437
+dontaudit domain self:capability fowner;
+
 kernel_getattr_proc(domain)
 kernel_read_proc_symlinks(domain)
 kernel_read_crypto_sysctls(domain)


### PR DESCRIPTION
This is a temporary rule to work around a problem in kernel/xfs
triggering a false fowner capability AVC. Once the problem is resolved,
this commit needs to be reverted.

Resolves: rhbz#1908527