### PR TITLE
Allow privoxy execmem

### DIFF
--- a/policy/modules/contrib/privoxy.te
+++ b/policy/modules/contrib/privoxy.te
@@ -100,6 +100,10 @@ logging_send_syslog_msg(privoxy_t)
 userdom_dontaudit_use_unpriv_user_fds(privoxy_t)
 userdom_dontaudit_search_user_home_dirs(privoxy_t)
 
+tunable_policy(`deny_execmem',`', `
+	allow privoxy_t self:process execmem;
+')
+
 tunable_policy(`privoxy_connect_any',`
 	corenet_sendrecv_all_client_packets(privoxy_t)
 	corenet_tcp_connect_all_ports(privoxy_t)


### PR DESCRIPTION
The execmem permission is required for mapping a memory region as
executable. This is not common and is possibly insecure so it is
disabled by default in selinux-policy.

Just-in-time (JIT) compiling is a heavyweight optimization that can
greatly speed up pattern matching. JIT support applies only to the
traditional Perl-compatible regular expressions (pcre).

Privoxy 3.0.29 introduces JIT support for pcre which requires the execmem
permission and cannot be disabled dinamically, just at compile time.

Resolves: rhbz#1917099