### PR TITLE
Allow systemd nnp_transition to login_userdomain

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -416,6 +416,7 @@ userdom_delete_user_home_content_files(init_t)
 userdom_connectto_stream(init_t)
 
 userdom_transition_login_userdomain(init_t)
+userdom_nnp_transition_login_userdomain(init_t)
 userdom_noatsecure_login_userdomain(init_t)
 userdom_sigchld_login_userdomain(init_t)
 userdom_use_user_ptys(init_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -6502,6 +6502,24 @@ interface(`userdom_transition',`
 
 ########################################
 ## <summary>
+##	Allow caller to nnp_transition to login userdomain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_nnp_transition_login_userdomain',`
+	gen_require(`
+		attribute login_userdomain;
+	')
+
+	allow $1 login_userdomain:process2 nnp_transition;
+')
+
+########################################
+## <summary>
 ##	Allow caller to transition to login userdomain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Until now, transition for login user domains were allowed, but not
nnp_transition which is required when nonewprivs item is applied
for a user in limits.conf.

Resolves: rhbz#1958819