### PR TITLE
Allow vnstatd_t map vnstatd_var_lib_t files

### DIFF
--- a/policy/modules/contrib/vnstatd.te
+++ b/policy/modules/contrib/vnstatd.te
@@ -39,6 +39,7 @@ allow vnstatd_t self:unix_stream_socket { accept listen };
 manage_dirs_pattern(vnstatd_t, vnstatd_var_lib_t, vnstatd_var_lib_t)
 manage_files_pattern(vnstatd_t, vnstatd_var_lib_t, vnstatd_var_lib_t)
 files_var_lib_filetrans(vnstatd_t, vnstatd_var_lib_t, dir)
+allow vnstatd_t vnstatd_var_lib_t:file map;
 
 manage_files_pattern(vnstatd_t, vnstatd_var_run_t, vnstatd_var_run_t)
 manage_dirs_pattern(vnstatd_t, vnstatd_var_run_t, vnstatd_var_run_t)


### PR DESCRIPTION
Resolves: https://github.com/fedora-selinux/selinux-policy/issues/711