### PR TITLE
Allow fcoemon create sysfs files

### DIFF
--- a/policy/modules/contrib/fcoe.te
+++ b/policy/modules/contrib/fcoe.te
@@ -35,7 +35,7 @@ manage_sock_files_pattern(fcoemon_t, fcoemon_var_run_t, fcoemon_var_run_t)
 files_pid_filetrans(fcoemon_t, fcoemon_var_run_t, { dir file })
 
 dev_rw_sysfs(fcoemon_t)
-dev_write_sysfs_dirs(fcoemon_t)
+dev_create_sysfs_files(fcoemon_t)
 
 logging_send_syslog_msg(fcoemon_t)
 


### PR DESCRIPTION
This permission is required when fcoemon wants to write to the
/sys/bus/fcoe/devices/ctlr_X/enabled file and this file does not exist.

Resolves: rhbz#1952292