### PR TITLE
Deprecate duplicate dev_write_generic_sock_files() interface

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -523,7 +523,7 @@ interface(`dev_dontaudit_getattr_generic_pipes',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	Domain to not audit.
+##	Domain allowed access.
 ##	</summary>
 ## </param>
 #
@@ -573,20 +573,17 @@ interface(`dev_rename_generic_blk_files',`
 
 ########################################
 ## <summary>
-##	write generic sock files in /dev.
+##	write generic sock files in /dev. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	Domain to not audit.
+##	Domain allowed access.
 ##	</summary>
 ## </param>
 #
 interface(`dev_write_generic_sock_files',`
-	gen_require(`
-		type device_t;
-	')
-
-	write_sock_files_pattern($1, device_t, device_t)
+	refpolicywarn(`$0($*) has been replaced with dev_write_generic_sockets().')
+	dev_write_generic_sockets($1)
 ')
 
 ########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -561,7 +561,7 @@ kernel_stream_connect(systemd_passwd_agent_t)
 
 dev_create_generic_dirs(systemd_passwd_agent_t)
 dev_read_generic_files(systemd_passwd_agent_t)
-dev_write_generic_sock_files(systemd_passwd_agent_t)
+dev_write_generic_sockets(systemd_passwd_agent_t)
 dev_write_kmsg(systemd_passwd_agent_t)
 dev_list_sysfs(systemd_passwd_agent_t)
 dev_read_sysfs(systemd_passwd_agent_t)


### PR DESCRIPTION
The dev_write_generic_sock_files() interface was deprecated
in favor of dev_write_generic_sockets() with the same content and its
dev_write_generic_sock_files(systemd_passwd_agent_t) call replaced.