### PR TITLE
Add a comment on virt_sandbox booleans with empty content

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -145,6 +145,10 @@ gen_tunable(virt_sandbox_use_audit, true)
 ## </desc>
 gen_tunable(virt_sandbox_use_netlink, false)
 
+# The following three tunables are not used anywhere in selinux-policy,
+# but they are referred to from container-selinux
+# virt_sandbox_use_sys_admin virt_sandbox_use_mknod virt_sandbox_use_all_caps
+ 
 ## <desc>
 ## <p>
 ## Allow sandbox containers to use sys_admin system calls, for example mount


### PR DESCRIPTION
There are 3 booleans which are not used anywhere in selinux-policy,
but they are referred to from container-selinux, so a comment was added
to the virt.te file to resist the urge of removing them for the sake of
optimization.

virt_sandbox_use_sys_admin
virt_sandbox_use_mknod
virt_sandbox_use_all_caps

Related: rhbz#1869965