### PR TITLE
Allow tgtd read and write infiniband devices

### DIFF
--- a/policy/modules/contrib/tgtd.te
+++ b/policy/modules/contrib/tgtd.te
@@ -73,6 +73,7 @@ corenet_sendrecv_iscsi_client_packets(tgtd_t)
 corenet_tcp_connect_isns_port(tgtd_t)
 
 dev_read_sysfs(tgtd_t)
+dev_rw_infiniband_dev(tgtd_t)
 
 files_list_mnt(tgtd_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(04/30/2021 07:17:17.956:273) : proctitle=/usr/sbin/tgtd -f
type=PATH msg=audit(04/30/2021 07:17:17.956:273) : item=0 name=/dev/infiniband/rdma_cm
inode=547 dev=00:05 mode=character,666 ouid=root ogid=root rdev=0a:7d
obj=system_u:object_r:infiniband_device_t:s0 nametype=NORMAL
cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(04/30/2021 07:17:17.956:273) : cwd=/
type=SYSCALL msg=audit(04/30/2021 07:17:17.956:273) : arch=x86_64 syscall=openat
success=yes exit=6 a0=0xffffff9c a1=0x1afee40 a2=O_RDWR|O_CLOEXEC a3=0x0 items=1
ppid=1 pid=57646 auid=unset uid=root gid=root euid=root suid=root fsuid=root
egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tgtd exe=/usr/sbin/tgtd
subj=system_u:system_r:tgtd_t:s0 key=(null)
type=AVC msg=audit(04/30/2021 07:17:17.956:273) : avc:  denied  { open }
for  pid=57646 comm=tgtd path=/dev/infiniband/rdma_cm dev="devtmpfs" ino=547
scontext=system_u:system_r:tgtd_t:s0
tcontext=system_u:object_r:infiniband_device_t:s0 tclass=chr_file permissive=1

Resolves: rhbz#1754411