### PR TITLE
Allow NetworkManager_t to watch /etc

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -182,6 +182,7 @@ domain_use_interactive_fds(NetworkManager_t)
 domain_read_all_domains_state(NetworkManager_t)
 
 files_read_etc_runtime_files(NetworkManager_t)
+files_watch_etc_dirs(NetworkManager_t)
 files_read_system_conf_files(NetworkManager_t)
 files_read_usr_src_files(NetworkManager_t)
 files_read_isid_type_files(NetworkManager_t)


### PR DESCRIPTION
Fixes the following AVC found by my test with latest policy:
type=AVC msg=audit(1620887504.145:1647): avc:  denied  { watch } for  pid=4611 comm="gmain" path="/etc" dev="sda3" ino=67154049 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=0

Signed-off-by: Yang Xu <xuyang2018.jy@fujitsu.com>