### PR TITLE
Allow amanda get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/contrib/amanda.te
+++ b/policy/modules/contrib/amanda.te
@@ -142,6 +142,7 @@ files_read_all_chr_files(amanda_t)
 files_getattr_all_pipes(amanda_t)
 files_getattr_all_sockets(amanda_t)
 
+fs_getattr_cgroup(amanda_t)
 fs_getattr_xattr_fs(amanda_t)
 fs_list_all(amanda_t)
 fs_getattr_tmpfs(amanda_t)


### PR DESCRIPTION
Resolves: rhbz#1960513