### PR TITLE
Allow sysadm_t nnp_domtrans to systemd_tmpfiles_t

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -575,6 +575,7 @@ optional_policy(`
 	systemd_login_undefined(sysadm_t)
 	systemd_systemctl_entrypoint(sysadm_t)
 	systemd_tmpfiles_run(sysadm_t, sysadm_r)
+	systemd_tmpfiles_nnp_domtrans(sysadm_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -754,6 +754,24 @@ interface(`systemd_tmpfiles_domtrans',`
 
 #######################################
 ## <summary>
+##	Allow caller nnp_transition to systemd_tmpfiles_t
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`systemd_tmpfiles_nnp_domtrans',`
+	gen_require(`
+		type systemd_tmpfiles_t;
+	')
+
+	allow $1 systemd_tmpfiles_t:process2 nnp_transition;
+')
+
+#######################################
+## <summary>
 ##  Execute a domain transition to run systemd-localed.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This permission is required when limits.conf have the nonewprivs item
enabled for sysadm_u user as systemd-tmpfiles-setup.service is started
by the systemd user manager. It is required for sysadm_u only as other
user domain do not transition on systemd_tmpfiles execution.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(05/14/2021 05:02:26.078:1964) : proctitle=systemd-tmpfiles
--user --create --remove --boot
type=PATH msg=audit(05/14/2021 05:02:26.078:1964) : item=1
name=/lib64/ld-linux-x86-64.so.2 inode=5804 dev=fc:01 mode=file,755 ouid=root ogid=root
rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none
cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(05/14/2021 05:02:26.078:1964) : item=0
name=/usr/bin/systemd-tmpfiles inode=14445 dev=fc:01 mode=file,755 ouid=root ogid=root
rdev=00:00 obj=system_u:object_r:systemd_tmpfiles_exec_t:s0 nametype=NORMAL cap_fp=none
cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/14/2021 05:02:26.078:1964) : cwd=/home/sysadm
type=EXECVE msg=audit(05/14/2021 05:02:26.078:1964) : argc=5 a0=systemd-tmpfiles
a1=--user a2=--create a3=--remove a4=--boot
type=SYSCALL msg=audit(05/14/2021 05:02:26.078:1964) : arch=x86_64 syscall=execve
success=yes exit=0 a0=0x5569e49aed90 a1=0x5569e49a20a0 a2=0x5569e49d5ce0 a3=0x10 items=2
ppid=16000 pid=16008 auid=user1377 uid=user1377 gid=user1377 euid=user1377 suid=user1377
fsuid=user1377 egid=user1377 sgid=user1377 fsgid=user1377 tty=(none) ses=45
comm=systemd-tmpfile exe=/usr/bin/systemd-tmpfiles
subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null)
type=SELINUX_ERR msg=audit(05/14/2021 05:02:26.078:1964) :
op=security_bounded_transition seresult=denied
oldcontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
newcontext=sysadm_u:sysadm_r:systemd_tmpfiles_t:s0-s0:c0.c1023
type=AVC msg=audit(05/14/2021 05:02:26.078:1964) : avc:  denied  { nnp_transition }
for  pid=16008 comm=(tmpfiles) scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
tcontext=sysadm_u:sysadm_r:systemd_tmpfiles_t:s0-s0:c0.c1023 tclass=process2
permissive=0