### PR TITLE
Add default file context specification for dnf log files

### DIFF
--- a/policy/modules/contrib/rpm.fc
+++ b/policy/modules/contrib/rpm.fc
@@ -62,6 +62,9 @@ ifdef(`distro_redhat', `
 /var/lib/yum(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
 /var/lib/dnf(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
 
+/var/log/dnf.log.*		--	gen_context(system_u:object_r:rpm_log_t,s0)
+/var/log/dnf.librepo.log.*	--	gen_context(system_u:object_r:rpm_log_t,s0)
+/var/log/dnf.rpm.log.*		--	gen_context(system_u:object_r:rpm_log_t,s0)
 /var/log/hawkey.*		--	gen_context(system_u:object_r:rpm_log_t,s0)
 /var/log/yum\.log.*		--	gen_context(system_u:object_r:rpm_log_t,s0)
 /var/log/up2date.*		--	gen_context(system_u:object_r:rpm_log_t,s0)

--- a/policy/modules/contrib/rpm.if
+++ b/policy/modules/contrib/rpm.if
@@ -473,6 +473,9 @@ interface(`rpm_named_filetrans',`
 		type rpm_var_cache_t;
 		type rpm_var_lib_t;
 	')
+	logging_log_named_filetrans($1, rpm_log_t, file, "dnf.log")
+	logging_log_named_filetrans($1, rpm_log_t, file, "dnf.librepo.log")
+	logging_log_named_filetrans($1, rpm_log_t, file, "dnf.rpm.log")
 	logging_log_named_filetrans($1, rpm_log_t, file, "yum.log")
 	logging_log_named_filetrans($1, rpm_log_t, file, "hawkey.log")
 	logging_log_named_filetrans($1, rpm_log_t, file, "up2date")


### PR DESCRIPTION
Default file context for these log files used by dnf
was missing in the policy:
/var/log/dnf.log
/var/log/dnf.librepo.log
/var/log/dnf.rpm.log

so the files got the generic var_log_t type.
This commit assigns them the rpm_var_log_t type.
The change is also backed by named file transition rules.