### PR TITLE
Label /run/systemd/default-hostname with hostname_etc_t

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2561,6 +2561,24 @@ interface(`init_create_pid_dirs',`
 
 #######################################
 ## <summary>
+##  Remove entries from the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`init_delete_pid_dir_entry',`
+    gen_require(`
+        type init_var_run_t;
+    ')
+
+    allow $1 init_var_run_t:dir del_entry_dir_perms;
+')
+
+#######################################
+## <summary>
 ##  Create objects in /run/systemd directory
 ##  with an automatic type transition to
 ##  a specified private type.

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -31,6 +31,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/dracut/modules.d/.*\.service	gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/systemd/system(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
+/run/systemd/default-hostname	--	gen_context(system_u:object_r:hostname_etc_t,s0)
 /run/systemd/transient(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /run/systemd/units(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/systemd/system/systemd-machined\.service	--	gen_context(system_u:object_r:systemd_machined_unit_file_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1608,6 +1608,7 @@ interface(`systemd_filetrans_named_content',`
 
 	files_pid_filetrans($1, systemd_logind_var_run_t, file, "nologin")
 	files_pid_filetrans($1, systemd_logind_var_run_t, file, "shutdown")
+	init_named_pid_filetrans($1, hostname_etc_t, file, "default-hostname")
 	init_named_pid_filetrans($1, systemd_passwd_var_run_t, dir, "ask-password-block")
 	init_named_pid_filetrans($1, systemd_passwd_var_run_t, dir, "ask-password")
 	files_etc_filetrans($1, hostname_etc_t, file, "hostname" )

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -834,6 +834,7 @@ dev_read_sysfs(systemd_hostnamed_t)
 
 fs_read_xenfs_files(systemd_hostnamed_t)
 
+init_delete_pid_dir_entry(systemd_hostnamed_t)
 init_status(systemd_hostnamed_t)
 init_stream_connect(systemd_hostnamed_t)
 


### PR DESCRIPTION
The /run/systemd/default-hostname file is created by systemd
during boot time and can be removed later by systemd-hostnamed.
Accordingly, the file transition is defined for systemd and
systemd-hostnamed is allowed to delete pid dir entries.

Resolves: rhbz#1953060