### PR TITLE
Cleanup setrlimit permission for executing systemctl

### DIFF
--- a/policy/modules/contrib/cockpit.te
+++ b/policy/modules/contrib/cockpit.te
@@ -37,7 +37,6 @@ domain_entry_file(cockpit_session_t,cockpit_session_exec_t)
 #
 
 allow cockpit_ws_t self:capability net_admin;
-allow cockpit_ws_t self:process setrlimit;
 allow cockpit_ws_t self:tcp_socket create_stream_socket_perms;
 
 kernel_read_system_state(cockpit_ws_t)

--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -67,9 +67,6 @@ allow logrotate_t self:capability { chown dac_read_search dac_override kill fset
 dontaudit logrotate_t self:capability { sys_resource net_admin };
 dontaudit logrotate_t self:cap_userns { sys_ptrace };
 
-# dontaudited due to systemctl command.
-dontaudit logrotate_t self:process setrlimit;
-
 allow logrotate_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
 
 allow logrotate_t self:passwd { passwd };

--- a/policy/modules/contrib/pcp.te
+++ b/policy/modules/contrib/pcp.te
@@ -259,7 +259,7 @@ userdom_read_user_tmp_files(pcp_pmie_t)
 #
 
 allow pcp_pmlogger_t self:capability { dac_read_search dac_override chown fowner sys_ptrace };
-allow pcp_pmlogger_t self:process { setpgid setrlimit };
+allow pcp_pmlogger_t self:process setpgid;
 allow pcp_pmlogger_t self:netlink_route_socket {create_socket_perms nlmsg_read };
 
 allow pcp_pmlogger_t pcp_pmcd_t:unix_stream_socket connectto;

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -103,6 +103,8 @@ interface(`systemd_exec_systemctl',`
 	systemd_passwd_agent_exec($1)
 
 	dontaudit $1 self:capability { net_admin sys_ptrace };
+	# systemctl tries to adjust its RLIMIT_NOFILE right when it is started
+	dontaudit $1 self:process setrlimit;
 ')
 #
 ########################################


### PR DESCRIPTION
Rather than adding this permission one by one to individual domains, it should have been added to the interface instead (as dontaudit),