### PR TITLE
Revert "Add permission open to files_read_inherited_tmp_files() inter…

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6338,7 +6338,7 @@ interface(`files_read_inherited_tmp_files',`
 		attribute tmpfile;
 	')
 
-	allow $1 tmpfile:file { append open read_inherited_file_perms };
+	allow $1 tmpfile:file { append read_inherited_file_perms };
 ')
 
 ########################################


### PR DESCRIPTION
…face"

Permission "open" is way to loose for tmpfile attribute, this allows
caller domain to open all tmp files. Also,
files_read_inherited_tmp_files() interface is used by attribute "domain"
which includes all SELinux types for processes.

This reverts commit e9558906a7f97b45f1cc8fa6f15efd7c6c7f5a6c.