### PR TITLE
Label /dev/trng with random_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -136,6 +136,7 @@
 /dev/tlk[0-3]		-c	gen_context(system_u:object_r:v4l_device_t,s0)
 /dev/tpm[0-9]*		-c	gen_context(system_u:object_r:tpm_device_t,s0)
 /dev/tpmrm[0-9]*		-c	gen_context(system_u:object_r:tpm_device_t,s0)
+/dev/trng		-c	gen_context(system_u:object_r:random_device_t,s0)
 /dev/udmabuf		-c	gen_context(system_u:object_r:dma_device_t,s0)
 /dev/uinput		-c	gen_context(system_u:object_r:event_device_t,s0)
 /dev/uio[0-9]+		-c	gen_context(system_u:object_r:userio_device_t,s0)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -7096,6 +7096,7 @@ gen_require(`
 	filetrans_pattern($1, device_t, tpm_device_t, chr_file, "tpmrm7")
 	filetrans_pattern($1, device_t, tpm_device_t, chr_file, "tpmrm8")
 	filetrans_pattern($1, device_t, tpm_device_t, chr_file, "tpmrm9")
+	filetrans_pattern($1, device_t, random_device_t, chr_file, "trng")
 	filetrans_pattern($1, device_t, dma_device_t, chr_file, "udmabuf")
 	filetrans_pattern($1, device_t, event_device_t, chr_file, "uinput")
 	filetrans_pattern($1, device_t, userio_device_t, chr_file, "uio0")


### PR DESCRIPTION
The trng device (trng stands for "true random-number generator")
is used on some architectures like s390x where the Central Processor
Assist for Cryptographic Functions (CPACF) with Message-Security-Assist
Extension 7 (MSA 7) is available to generate high-entropy random numbers.
The label for the device node is backed by a file transition.