### PR TITLE
Allow kdump_t net_admin capability

### DIFF
--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -41,7 +41,7 @@ files_tmp_file(kdumpctl_tmp_t)
 # kdump local policy
 #
 
-allow kdump_t self:capability { sys_admin sys_boot dac_read_search  };
+allow kdump_t self:capability { sys_admin sys_boot dac_read_search net_admin };
 #allow kdump_t self:capability2 compromise_kernel;
 
 allow kdump_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
kdump_t needs net_admin capability to run ifdown.

When I test rebooting with kexec on fedora 29:
```
# kexec -l /boot/vmlinuz-... --initrd /boot/initramfs-... --append="`cat /proc/cmdline`"
# reboot
```
"Operation not permitted" information is printed on serial output.
```
......
ifdown: shutdown ens3: Operation not permitted
kexec_core: Starting new kernel
......
```
This problem is not easy to analyze because the auditd service has beed stopped at that time. After a few attempts, I found that the kexec needs net_admin capability to run ifdown. So after I install a policy module as follow, the problem can be solved:
```
module demo 1.0;
require
{
    type kdump_t;
    class capability {net_admin};
};

allow kdump self:capability net_admin;
```

