### PR TITLE
Allow nsswitch_domain read init pid lnk_files

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -525,6 +525,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	init_read_pid_lnk_files(nsswitch_domain)
+')
+
+optional_policy(`
 	likewise_stream_connect_lsassd(nsswitch_domain)
 ')
 

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2891,6 +2891,24 @@ interface(`init_manage_pid_files',`
 	manage_files_pattern($1, init_var_run_t, init_var_run_t)
 ')
 
+#######################################
+## <summary>
+##	Read init pid lnk_files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_read_pid_lnk_files',`
+	gen_require(`
+		type init_var_run_t;
+	')
+
+	read_lnk_files_pattern($1, init_var_run_t, init_var_run_t)
+')
+
 ########################################
 ## <summary>
 ##	Read init unnamed pipes.


### PR DESCRIPTION
This permission is required when a service uses the systemd nss module
to resolve user records and a symlink in the /run/systemd/dynamic-uid
directory needs to be dereferenced.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(07/27/2020 09:06:58.618:335) : proctitle=/usr/bin/dbus-daemon
--system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
type=PATH msg=audit(07/27/2020 09:06:58.618:335) : item=0
name=/run/systemd/dynamic-uid/direct:62803 inode=38503 dev=00:18 mode=link,777 ouid=root
ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=NORMAL cap_fp=none
cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(07/27/2020 09:06:58.618:335) : cwd=/
type=SYSCALL msg=audit(07/27/2020 09:06:58.618:335) : arch=x86_64 syscall=readlinkat
success=no exit=EACCES(Permission denied) a0=0xffffff9c a1=0x7ffe508dcb30
a2=0x55974a9ca6f0 a3=0x63 items=1 ppid=1 pid=673 auid=unset uid=dbus gid=dbus euid=dbus
suid=dbus fsuid=dbus egid=dbus sgid=dbus fsgid=dbus tty=(none) ses=unset
comm=dbus-daemon exe=/usr/bin/dbus-daemon
subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(07/27/2020 09:06:58.618:335) : avc:  denied  { read }
for  pid=673 comm=dbus-daemon name=direct:62803 dev="tmpfs" ino=38503
scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023
tcontext=system_u:object_r:init_var_run_t:s0 tclass=lnk_file permissive=0

Resolves: rhbz#1860924