### PR TITLE
Allow iscsid read all process stat

### DIFF
--- a/policy/modules/contrib/iscsi.te
+++ b/policy/modules/contrib/iscsi.te
@@ -105,7 +105,7 @@ dev_rw_userio_dev(iscsid_t)
 dev_map_userio_dev(iscsid_t)
 
 domain_use_interactive_fds(iscsid_t)
-domain_dontaudit_read_all_domains_state(iscsid_t)
+domain_read_all_domains_state(iscsid_t)
 
 files_read_kernel_modules(iscsid_t)
 files_map_kernel_modules(iscsid_t)


### PR DESCRIPTION
iscsid needs to read all process stat to find and set the priority of one thread.
My environment:
```
# cat /etc/fedora-release 
Fedora release 34 (Thirty Four)
```
Use iscsiadm to connect a target node:
```
# iscsiadm -m discovery -t st -p xxx -l
```
Then watch systemd journal:
```
......
fedora audit[2529]: AVC avc:  denied  { search } for  pid=2529 comm="iscsid" name="2496" dev="proc" ino=70130 scontext=system_u:system_r:iscsid_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=dir permissive=0
fedora audit[2529]: AVC avc:  denied  { search } for  pid=2529 comm="iscsid" name="2497" dev="proc" ino=70131 scontext=system_u:system_r:iscsid_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=dir permissive=0
fedora audit[2529]: AVC avc:  denied  { search } for  pid=2529 comm="iscsid" name="2603" dev="proc" ino=38486 scontext=system_u:system_r:iscsid_t:s0 tcontext=system_u:system_r:rpm_t:s0 tclass=dir permissive=0
fedora audit[2529]: AVC avc:  denied  { search } for  pid=2529 comm="iscsid" name="3392" dev="proc" ino=70132 scontext=system_u:system_r:iscsid_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=dir permissive=0
fedora iscsid[2529]: iscsid: Could not set session1 priority. READ/WRITE throughout and latency could be affected.
......
```
After install a policy module as follow, the problem can be solved:
```
# cat demo.te 
policy_module(demo, 1.0)

require
{
	type iscsid_t;
};

domain_read_all_domains_state(iscsid_t)
```

The relevant code:
https://github.com/open-iscsi/open-iscsi/blob/master/usr/initiator.c
function session_increase_wq_priority
