### PR TITLE
Allow udev to watch fixed disk devices

### DIFF
--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -217,6 +217,25 @@ interface(`storage_raw_rw_fixed_disk',`
 
 ########################################
 ## <summary>
+##	Allow the caller to watch fixed disk device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`storage_watch_fixed_disk_dev',`
+	gen_require(`
+		type fixed_disk_device_t;
+	')
+
+	dev_list_all_dev_nodes($1)
+	allow $1 fixed_disk_device_t:blk_file watch_blk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Allow the caller to create fixed disk device nodes.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -186,6 +186,8 @@ seutil_read_default_contexts(udev_t)
 seutil_read_file_contexts(udev_t)
 seutil_domtrans_setfiles(udev_t)
 
+storage_watch_fixed_disk_dev(udev_t)
+
 sysnet_domtrans_ifconfig(udev_t)
 sysnet_domtrans_dhcpc(udev_t)
 sysnet_rw_dhcp_config(udev_t)


### PR DESCRIPTION
Fixes denials such as:
```
type=PROCTITLE msg=audit(01.05.2021 18:34:44.535:646) : proctitle=/usr/lib/systemd/systemd-udevd
type=PATH msg=audit(01.05.2021 18:34:44.535:646) : item=0 name=/dev/sda inode=687 dev=00:05 mode=block,660 ouid=root ogid=disk rdev=08:00 obj=system_u:object_r:fixed_disk_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(01.05.2021 18:34:44.535:646) : cwd=/
type=SYSCALL msg=audit(01.05.2021 18:34:44.535:646) : arch=x86_64 syscall=inotify_add_watch success=yes exit=14 a0=0x8 a1=0x5581a7aa9010 a2=0x8 a3=0x0 items=1 ppid=7187 pid=46724 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-udevd exe=/usr/bin/udevadm subj=system_u:system_r:udev_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(01.05.2021 18:34:44.535:646) : avc:  denied  { watch } for  pid=46724 comm=systemd-udevd path=/dev/sda dev="devtmpfs" ino=687 scontext=system_u:system_r:udev_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1
```

This happens with the unconfined module disabled when e.g. a USB disk is
inserted into the USB port.