### PR TITLE
Allow apcupsd get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/contrib/apcupsd.te
+++ b/policy/modules/contrib/apcupsd.te
@@ -97,6 +97,8 @@ domain_signull_all_domains(apcupsd_t)
 files_manage_etc_runtime_files(apcupsd_t)
 files_etc_filetrans_etc_runtime(apcupsd_t, file, "nologin")
 
+fs_getattr_cgroup(apcupsd_t)
+
 term_use_all_terms(apcupsd_t)
 term_use_usb_ttys(apcupsd_t)
 


### PR DESCRIPTION
Resolves: rhbz#1965722