### PR TITLE
Allow httpd_sys_script_t read, write, and map hugetlbfs files

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -666,7 +666,9 @@ files_read_etc_runtime_files(httpd_t)
 # for tomcat
 files_read_var_lib_symlinks(httpd_t)
 
+fs_rw_hugetlbfs_files(httpd_sys_script_t)
 fs_search_auto_mountpoints(httpd_sys_script_t)
+
 # php uploads a file to /tmp and then execs programs to acton them
 manage_dirs_pattern(httpd_sys_script_t, httpd_tmp_t, httpd_tmp_t)
 manage_files_pattern(httpd_sys_script_t, httpd_tmp_t, httpd_tmp_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(05/26/2021 05:55:04.131:550) : proctitle=/usr/bin/php-cgi
type=SYSCALL msg=audit(05/26/2021 05:55:04.131:550) : arch=x86_64 syscall=mmap
success=no exit=ENOMEM(Cannot allocate memory) a0=0x41e00000 a1=0x8000000
a2=PROT_READ|PROT_WRITE a3=MAP_SHARED|MAP_FIXED|MAP_ANONYMOUS|MAP_32BIT|MAP_HUGETLB
items=0 ppid=19740 pid=20056 auid=unset uid=apache gid=apache euid=apache suid=apache
fsuid=apache egid=apache sgid=apache fsgid=apache tty=(none) ses=unset comm=php-cgi
exe=/usr/bin/php-cgi subj=system_u:system_r:httpd_sys_script_t:s0 key=(null)
type=AVC msg=audit(05/26/2021 05:55:04.131:550) : avc:  denied  { read write }
for  pid=20056 comm=php-cgi path=/anon_hugepage (deleted) dev="hugetlbfs" ino=46110
scontext=system_u:system_r:httpd_sys_script_t:s0
tcontext=system_u:object_r:hugetlbfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(05/26/2021 05:55:04.131:550) : avc:  denied  { map }
for  pid=20056 comm=php-cgi path=/anon_hugepage (deleted) dev="hugetlbfs" ino=46110
scontext=system_u:system_r:httpd_sys_script_t:s0
tcontext=system_u:object_r:hugetlbfs_t:s0 tclass=file permissive=1

Resolves: rhbz#1964890