### PR TITLE
Label /dev/dma_heap with dma_device_dir_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -24,7 +24,7 @@
 /dev/crash		-c	gen_context(system_u:object_r:crash_device_t,mls_systemhigh)
 /dev/dahdi/.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/dlm.*		-c	gen_context(system_u:object_r:dlm_control_device_t,s0)
-/dev/dma_heap		-d	gen_context(system_u:object_r:dma_device_t,s0)
+/dev/dma_heap		-d	gen_context(system_u:object_r:dma_device_dir_t,s0)
 /dev/dma_heap/.+	-c	gen_context(system_u:object_r:dma_device_t,s0)
 /dev/dmfm.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/dmmidi.*		-c	gen_context(system_u:object_r:sound_device_t,s0)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -6522,6 +6522,7 @@ gen_require(`
 	type device_t;
 	type acpi_device_t;
 	type dma_device_t;
+	type dma_device_dir_t;
 	type usb_device_t;
     type uhid_device_t;
 	type sound_device_t;
@@ -6669,7 +6670,8 @@ gen_require(`
 	filetrans_pattern($1, device_t, dlm_control_device_t, chr_file, "dlm7")
 	filetrans_pattern($1, device_t, dlm_control_device_t, chr_file, "dlm8")
 	filetrans_pattern($1, device_t, dlm_control_device_t, chr_file, "dlm9")
-	filetrans_pattern($1, device_t, dma_device_t, dir, "dma_heap")
+	filetrans_pattern($1, device_t, dma_device_dir_t, dir, "dma_heap")
+	filetrans_pattern($1, dma_device_dir_t, dma_device_t, chr_file)
 	filetrans_pattern($1, device_t, sound_device_t, chr_file, "dmfm")
 	filetrans_pattern($1, device_t, sound_device_t, chr_file, "dmmidi0")
 	filetrans_pattern($1, device_t, sound_device_t, chr_file, "dmmidi1")

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -93,6 +93,8 @@ dev_node(dlm_control_device_t)
 #
 type dma_device_t;
 dev_node(dma_device_t)
+type dma_device_dir_t;
+files_type(dma_device_dir_t)
 
 type dri_device_t;
 dev_node(dri_device_t)


### PR DESCRIPTION
With commit a091bcda8d9 (Label /dev/dma_heap/* char devices with dma_device_t)
a new dma_device_t type was assigned to the /dev/dma_heap directory
and all files in it. The basic dev_node() interface called for dma_device_t
just assigns the type to the device_node attribute, which prevents many
domains from searching the directory with the same label.

This commits labels the /dev/dma_heap directory with the new
dma_device_dir_t type and adds it to the file_type, non_auth_file_type,
and non_security_file_type attributes, allowing the access for domains
requiring this access, and adds unnamed file transition to dma_device_t
for block files created in this directory.

An example AVC denial after the directory was labeled dma_device_t:

type=PROCTITLE msg=audit(05/31/2021 09:03:08.452:397) :
proctitle=/usr/bin/python3 -Es /usr/sbin/setroubleshootd -f
type=PATH msg=audit(05/31/2021 09:03:08.452:397) : item=0 name=/dev/dma_heap/*
nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/31/2021 09:03:08.452:397) : arch=x86_64 syscall=newfstatat
success=no exit=EACCES(Permission denied) a0=0xffffff9c a1=0x7fd607775ec0
a2=0x7fd60774bf60 a3=0x0 items=1 ppid=1 pid=2498 auid=unset uid=setroubleshoot
gid=setroubleshoot euid=setroubleshoot suid=setroubleshoot fsuid=setroubleshoot
egid=setroubleshoot sgid=setroubleshoot fsgid=setroubleshoot tty=(none) ses=unset
comm=setroubleshootd exe=/usr/bin/python3.9 subj=system_u:system_r:setroubleshootd_t:s0
type=AVC msg=audit(05/31/2021 09:03:08.452:397) : avc:  denied  { search }
for  pid=2498 comm=setroubleshootd name=dma_heap dev="devtmpfs" ino=102
scontext=system_u:system_r:setroubleshootd_t:s0
tcontext=system_u:object_r:dma_device_t:s0 tclass=dir permissive=0

Resolves: rhbz#1967536