### PR TITLE
Label /.k5identity file allow read of this file to rpc.gssd

### DIFF
--- a/policy/modules/contrib/kerberos.fc
+++ b/policy/modules/contrib/kerberos.fc
@@ -1,5 +1,7 @@
+HOME_DIR/\.k5identity		--	gen_context(system_u:object_r:krb5_home_t,s0)
 HOME_DIR/\.k5login		--	gen_context(system_u:object_r:krb5_home_t,s0)
 HOME_DIR/\.k5users		--	gen_context(system_u:object_r:krb5_home_t,s0)
+/root/\.k5identity			--	gen_context(system_u:object_r:krb5_home_t,s0)
 /root/\.k5login			--	gen_context(system_u:object_r:krb5_home_t,s0)
 /root/\.k5users			--	gen_context(system_u:object_r:krb5_home_t,s0)
 

--- a/policy/modules/contrib/kerberos.if
+++ b/policy/modules/contrib/kerberos.if
@@ -554,6 +554,7 @@ interface(`kerberos_filetrans_admin_home_content',`
 		type krb5_home_t;
 	')
 
+	userdom_admin_home_dir_filetrans($1, krb5_home_t, file, ".k5identity")
 	userdom_admin_home_dir_filetrans($1, krb5_home_t, file, ".k5login")
 	userdom_admin_home_dir_filetrans($1, krb5_home_t, file, ".k5users")
 ')
@@ -573,6 +574,7 @@ interface(`kerberos_filetrans_home_content',`
 		type krb5_home_t;
 	')
 
+	userdom_user_home_dir_filetrans($1, krb5_home_t, file, ".k5identity")
 	userdom_user_home_dir_filetrans($1, krb5_home_t, file, ".k5login")
 	userdom_user_home_dir_filetrans($1, krb5_home_t, file, ".k5users")
 ')

--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -417,6 +417,7 @@ optional_policy(`
 ')
 optional_policy(`
 	kerberos_manage_host_rcache(gssd_t)
+	kerberos_read_home_content(gssd_t)
 	kerberos_read_keytab(gssd_t)
 	kerberos_tmp_filetrans_host_rcache(gssd_t, "nfs_0")
 	kerberos_use(gssd_t)


### PR DESCRIPTION
Label kerberos file $HOME/.k5identity as krb5_home_t, which
is default label for kerberos files in HOME. Also add
filetransition for this specific object to
kerberos_filetrans_admin_home_content() and
kerberos_filetrans_home_content(). And also allow
read this HOME kerberos files for rpc.gssd. Rpc.gssd is
daemon, which provide strong security for RPC-based protocols
such as NFS.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1951093