### PR TITLE
Allow pkcs-slotd create and use netlink_kobject_uevent_socket

### DIFF
--- a/policy/modules/contrib/pkcs.te
+++ b/policy/modules/contrib/pkcs.te
@@ -47,6 +47,7 @@ systemd_unit_file(pkcs_slotd_unit_file_t)
 
 allow pkcs_slotd_t self:capability { fsetid kill chown };
 allow pkcs_slotd_t self:fifo_file rw_fifo_file_perms;
+allow pkcs_slotd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow pkcs_slotd_t self:sem create_sem_perms;
 allow pkcs_slotd_t self:shm create_shm_perms;
 allow pkcs_slotd_t self:unix_stream_socket { accept listen };


### PR DESCRIPTION
The new version of opencryptoki brings event notification support which
makes opencryptoki listen to external events like notifications that
adapter configurations have changed or that HSM master keys shall be
rotated. These changes add a dependency to libudev, which creates and
monitors a NETLINK_KOBJECT_UEVENT socket.

Addresses the following AVC denial:

type=AVC msg=audit(1621625228.991:356): avc:  denied  { create }
for  pid=16871 comm="pkcsslotd" scontext=system_u:system_r:pkcs_slotd_t:s0
tcontext=system_u:system_r:pkcs_slotd_t:s0 tclass=netlink_kobject_uevent_socket