### PR TITLE
Allow sanlock get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/contrib/sanlock.te
+++ b/policy/modules/contrib/sanlock.te
@@ -95,6 +95,7 @@ domain_use_interactive_fds(sanlock_t)
 
 files_read_mnt_symlinks(sanlock_t)
 
+fs_getattr_cgroup(sanlock_t)
 fs_rw_cephfs_files(sanlock_t)
 
 storage_raw_rw_fixed_disk(sanlock_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(05/27/2021 09:54:31.226:646) : proctitle=/usr/sbin/sanlock daemon
type=PATH msg=audit(05/27/2021 09:54:31.226:646) : item=0 name=/sys/fs/cgroup/ inode=1
dev=00:1a mode=dir,555 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cgroup_t:s0
nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/27/2021 09:54:31.226:646) : cwd=/
type=SYSCALL msg=audit(05/27/2021 09:54:31.226:646) : arch=x86_64 syscall=statfs
success=no exit=EACCES(Permission denied) a0=0x7f01cee24512 a1=0x7ffde8df23e0
a2=0x7f01cee5c1a0 a3=0x0 items=1 ppid=1 pid=4163 auid=unset uid=root gid=root euid=root
suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sanlock
exe=/usr/sbin/sanlock subj=system_u:system_r:sanlock_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(05/27/2021 09:54:31.226:646) : avc:  denied  { getattr }
for  pid=4163 comm=sanlock name=/ dev="cgroup2" ino=1
scontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023
tcontext=system_u:object_r:cgroup_t:s0 tclass=filesystem permissive=0