### PR TITLE
Make usbmuxd_t a daemon

### DIFF
--- a/policy/modules/contrib/usbmuxd.te
+++ b/policy/modules/contrib/usbmuxd.te
@@ -10,8 +10,7 @@ roleattribute system_r usbmuxd_roles;
 
 type usbmuxd_t;
 type usbmuxd_exec_t;
-init_system_domain(usbmuxd_t, usbmuxd_exec_t)
-application_domain(usbmuxd_t, usbmuxd_exec_t)
+init_daemon_domain(usbmuxd_t, usbmuxd_exec_t)
 role usbmuxd_roles types usbmuxd_t;
 
 type usbmuxd_var_run_t;


### PR DESCRIPTION
The init_system_domain() interface call for usbmuxd_t was replaced by
init_daemon_domain() as it seems to be more appropriate although they
have a bit different content for usbmuxd is not a short-running process,
but a daemon.

Resolves: rhbz#1959747