### PR TITLE
Revert "Remove openhpi module"

### DIFF
--- a/policy/modules/contrib/openhpi.fc
+++ b/policy/modules/contrib/openhpi.fc
@@ -1,0 +1,7 @@
+/etc/rc\.d/init\.d/openhpid	--	gen_context(system_u:object_r:openhpid_initrc_exec_t,s0)
+
+/usr/sbin/openhpid	--	gen_context(system_u:object_r:openhpid_exec_t,s0)
+
+/var/lib/openhpi(/.*)?	gen_context(system_u:object_r:openhpid_var_lib_t,s0)
+
+/var/run/openhpid\.pid	--	gen_context(system_u:object_r:openhpid_var_run_t,s0)

--- a/policy/modules/contrib/openhpi.if
+++ b/policy/modules/contrib/openhpi.if
@@ -1,0 +1,39 @@
+## <summary>Open source implementation of the Service Availability Forum Hardware Platform Interface.</summary>
+
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate an openhpi environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`openhpi_admin',`
+	gen_require(`
+		type openhpid_t, openhpid_initrc_exec_t, openhpid_var_lib_t;
+		type openhpid_var_run_t;
+	')
+
+	allow $1 openhpid_t:process { ptrace signal_perms };
+	ps_process_pattern($1, openhpid_t)
+
+	init_labeled_script_domtrans($1, openhpid_initrc_exec_t)
+	domain_system_change_exemption($1)
+	role_transition $2 openhpid_initrc_exec_t system_r;
+	allow $2 system_r;
+
+	files_search_var_lib($1)
+	admin_pattern($1, openhpid_var_lib_t)
+
+	files_search_pids($1)
+	admin_pattern($1, openhpid_var_run_t)
+')

--- a/policy/modules/contrib/openhpi.te
+++ b/policy/modules/contrib/openhpi.te
@@ -1,0 +1,61 @@
+policy_module(openhpi, 1.1.0)
+
+########################################
+#
+# Declarations
+#
+
+type openhpid_t;
+type openhpid_exec_t;
+init_daemon_domain(openhpid_t, openhpid_exec_t)
+
+type openhpid_initrc_exec_t;
+init_script_file(openhpid_initrc_exec_t)
+
+type openhpid_var_lib_t;
+files_type(openhpid_var_lib_t)
+
+type openhpid_var_run_t;
+files_pid_file(openhpid_var_run_t)
+
+########################################
+#
+# Local policy
+#
+
+allow openhpid_t self:capability kill;
+allow openhpid_t self:process signal;
+allow openhpid_t self:fifo_file rw_fifo_file_perms;
+allow openhpid_t self:netlink_route_socket r_netlink_socket_perms;
+allow openhpid_t self:unix_stream_socket { accept listen };
+allow openhpid_t self:tcp_socket create_stream_socket_perms;
+allow openhpid_t self:udp_socket create_socket_perms;
+
+manage_dirs_pattern(openhpid_t, openhpid_var_lib_t, openhpid_var_lib_t)
+manage_files_pattern(openhpid_t, openhpid_var_lib_t, openhpid_var_lib_t)
+files_var_lib_filetrans(openhpid_t, openhpid_var_lib_t, dir)
+
+manage_files_pattern(openhpid_t, openhpid_var_run_t, openhpid_var_run_t)
+files_pid_filetrans(openhpid_t, openhpid_var_run_t, file)
+
+kernel_read_system_state(openhpid_t)
+
+corenet_all_recvfrom_unlabeled(openhpid_t)
+corenet_all_recvfrom_netlabel(openhpid_t)
+corenet_tcp_sendrecv_generic_if(openhpid_t)
+corenet_tcp_sendrecv_generic_node(openhpid_t)
+corenet_tcp_bind_generic_node(openhpid_t)
+
+corenet_sendrecv_openhpid_server_packets(openhpid_t)
+corenet_tcp_bind_openhpid_port(openhpid_t)
+corenet_tcp_sendrecv_openhpid_port(openhpid_t)
+
+dev_read_urand(openhpid_t)
+
+logging_send_syslog_msg(openhpid_t)
+
+miscfiles_read_localization(openhpid_t)
+
+optional_policy(`
+    snmp_read_snmp_var_lib_files(openhpid_t)
+')


### PR DESCRIPTION
This reverts commit 1e6afd814132ddb080635307bfa24ef728e72515.

There should be a transition period, so it should not be done
during F34 development phase.