### PR TITLE
Allow nmap create and use rdma socket

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -210,6 +210,7 @@ optional_policy(`
 
 allow traceroute_t self:capability { net_admin net_raw setuid setgid };
 dontaudit traceroute_t self:capability { sys_admin };
+allow traceroute_t self:netlink_rdma_socket create_socket_perms;
 allow traceroute_t self:rawip_socket create_socket_perms;
 allow traceroute_t self:packet_socket { create_socket_perms map };
 allow traceroute_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(05/26/2021 03:22:01.346:3202) : proctitle=nmap -sU 127.0.0.1
type=SYSCALL msg=audit(05/26/2021 03:22:01.346:3202) : arch=x86_64 syscall=socket
success=yes exit=6 a0=netlink a1=SOCK_RAW a2=hmp a3=0x0 items=0 ppid=39380 pid=39383
auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root
fsgid=root tty=pts0 ses=5 comm=nmap exe=/usr/bin/nmap
subj=system_u:system_r:traceroute_t:s0 key=(null)
type=AVC msg=audit(05/26/2021 03:22:01.346:3202) : avc:  denied  { create }
for  pid=39383 comm=nmap scontext=system_u:system_r:traceroute_t:s0
tcontext=system_u:system_r:traceroute_t:s0 tclass=netlink_rdma_socket permissive=1