### PR TITLE
Set default file context for /var/run/systemd instead of /run/systemd

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -31,9 +31,6 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/dracut/modules.d/.*\.service	gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/systemd/system(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
-/run/systemd/default-hostname	--	gen_context(system_u:object_r:hostname_etc_t,s0)
-/run/systemd/transient(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
-/run/systemd/units(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /usr/lib/systemd/system/systemd-machined\.service	--	gen_context(system_u:object_r:systemd_machined_unit_file_t,s0)
 /usr/lib/systemd/system/systemd-networkd\.service     gen_context(system_u:object_r:systemd_networkd_unit_file_t,s0)
 /usr/lib/systemd/system/systemd-resolved\.service     gen_context(system_u:object_r:systemd_resolved_unit_file_t,s0)
@@ -83,9 +80,11 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/var/lib/random-seed 	gen_context(system_u:object_r:random_seed_t,mls_systemhigh)
 
 /var/run/.*nologin.*		gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
+/var/run/systemd/default-hostname	--	gen_context(system_u:object_r:hostname_etc_t,s0)
 /var/run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /var/run/systemd/sessions(/.*)?	gen_context(system_u:object_r:systemd_logind_sessions_t,s0)
 /var/run/systemd/shutdown(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
+/var/run/systemd/transient(/.*)?	gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /var/run/systemd/userdb(/.*)?	gen_context(system_u:object_r:systemd_userdbd_runtime_t,s0)
 /var/run/systemd/users(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /var/run/systemd/inhibit(/.*)?	gen_context(system_u:object_r:systemd_logind_inhibit_var_run_t,s0)
@@ -103,5 +102,3 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/run/systemd/units(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 
 /var/run/initramfs(/.*)?	<<none>>
-
-/run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)


### PR DESCRIPTION
In newer Fedora systems, /run is a separate filesystem and /var/run
is a symlink to /run; the legacy settings though defines equivalency
/run = /var/run
so the primary file context settings need to be in /var/run to make
restorecon understand both variants.