### PR TITLE
iptables.fc: Add missing legacy-restore entries

### DIFF
--- a/policy/modules/system/iptables.fc
+++ b/policy/modules/system/iptables.fc
@@ -19,6 +19,8 @@
 /usr/sbin/conntrack		    --	gen_context(system_u:object_r:iptables_exec_t,s0)
 /usr/sbin/ebtables		    --	gen_context(system_u:object_r:iptables_exec_t,s0)
 /usr/sbin/ebtables-legacy	    --	gen_context(system_u:object_r:iptables_exec_t,s0)
+/usr/sbin/ebtables-legacy-restore  --  gen_context(system_u:object_r:iptables_exec_t,s0)
+/usr/sbin/ebtables-legacy-save	--	gen_context(system_u:object_r:iptables_exec_t,s0)
 /usr/sbin/ebtables-restore	--	gen_context(system_u:object_r:iptables_exec_t,s0)
 /usr/sbin/ipchains.*		--	gen_context(system_u:object_r:iptables_exec_t,s0)
 /usr/sbin/ip6?tables.*		--	gen_context(system_u:object_r:iptables_exec_t,s0)


### PR DESCRIPTION
/usr/sbin/arptables-restore is miss labeled now. It is a link file that can link two differenet file.

On fc 34:

Remove iptables-nft and install ebtables-legacy:
ll /sbin/ebtables-restore 
lrwxrwxrwx. 1 root root 34 Apr 23 06:56 /sbin/ebtables-restore -> /etc/alternatives/ebtables-restore
ll /etc/alternatives/ebtables-restore
lrwxrwxrwx. 1 root root 33 Jun 10 20:31 /etc/alternatives/ebtables-restore -> /usr/sbin/ebtables-legacy-restore

Remove ebtables-legacy and install iptables-nft:
ll /sbin/ebtables-restore
lrwxrwxrwx. 1 root root 34 Apr 23 06:56 /sbin/ebtables-restore -> /etc/alternatives/ebtables-restore
ll /etc/alternatives/ebtables-restore
lrwxrwxrwx. 1 root root 30 Jun 10 20:35 /etc/alternatives/ebtables-restore -> /usr/sbin/ebtables-nft-restore
ll /usr/sbin/ebtables-nft-restore
lrwxrwxrwx. 1 root root 17 Jan 28 08:48 /usr/sbin/ebtables-nft-restore -> xtables-nft-multi

And the label of /usr/sbin/ebtables-legacy-restore is lack.