### PR TITLE
Label /run/libvirt/common with virt_common_var_run_t

### DIFF
--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -67,6 +67,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /var/run/libvirtd\.pid	--	gen_context(system_u:object_r:virt_var_run_t,s0)
 /var/run/virtlogd\.pid	--	gen_context(system_u:object_r:virtlogd_var_run_t,s0)
 /var/run/libvirt(/.*)?		gen_context(system_u:object_r:virt_var_run_t,s0)
+/var/run/libvirt/common(/.*)?		gen_context(system_u:object_r:virt_common_var_run_t,s0)
 /var/run/libvirt/qemu(/.*)? 	gen_context(system_u:object_r:qemu_var_run_t,s0-mls_systemhigh)
 /var/run/libvirt/lxc(/.*)?	gen_context(system_u:object_r:virt_lxc_var_run_t,s0)
 /var/run/libvirt/virtlogd-sock	-s 		gen_context(system_u:object_r:virtlogd_var_run_t,s0)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -245,6 +245,9 @@ files_lock_file(virt_lock_t)
 type virt_var_run_t, virt_file_type;
 files_pid_file(virt_var_run_t)
 
+type virt_common_var_run_t, virt_file_type;
+files_pid_file(virt_common_var_run_t)
+
 type virt_var_lib_t, virt_file_type;
 files_mountpoint(virt_var_lib_t)
 
@@ -494,6 +497,14 @@ manage_dirs_pattern(virtd_t, virt_var_run_t, virt_var_run_t)
 manage_files_pattern(virtd_t, virt_var_run_t, virt_var_run_t)
 manage_sock_files_pattern(virtd_t, virt_var_run_t, virt_var_run_t)
 files_pid_filetrans(virtd_t, virt_var_run_t, { file dir sock_file })
+
+allow virtd_t virt_common_var_run_t:file append_file_perms;
+manage_dirs_pattern(virtd_t, virt_common_var_run_t, virt_common_var_run_t)
+manage_files_pattern(virtd_t, virt_common_var_run_t, virt_common_var_run_t)
+filetrans_pattern(virtd_t, virt_var_run_t, virt_common_var_run_t, dir, "common")
+
+allow virtlogd_t virt_common_var_run_t:file append_file_perms;
+manage_files_pattern(virtlogd_t, virt_common_var_run_t, virt_common_var_run_t)
 
 manage_dirs_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t)
 manage_files_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t)


### PR DESCRIPTION
The /run/libvirt/common directory contains files shared between all
libvirt services, but not with other non-libvirt services that might
otherwise access /run/libvirt.

Namely it contains the system.token file, created by whichever of the
libvirt related daemons is the first to need it. This file contains
a short random set of bytes that provide a secret token shared between
any of the libvirt daemons. It should be accessible to all libvirt
daemons: Essentially it is a way for 1 libvirt daemon to validate that
it is talking to another libvirt, as opposed to a 3rd party libvirt
client. Libvirtd will acquire fcntl() locks on this file when first
creating it to ensure race-free access.

The first libvirtd daemon that starts up will create this file, and
others will later read its content. Any of the libvirt daemons
(libvirtd, and virt{qemu,lxc,log,lock,etc...}d) should be allowed to
both create and read this file, and acquire fcntl locks on it.
No access should be allowed to any non-libvirt daemon process.

Resolves: rhbz#1964317