### PR TITLE
Allow asterisk watch localization files

### DIFF
--- a/policy/modules/contrib/asterisk.te
+++ b/policy/modules/contrib/asterisk.te
@@ -155,6 +155,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	miscfiles_watch_localization_files(asterisk_t)
 	miscfiles_watch_localization_symlinks(asterisk_t)
 ')
 

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -538,6 +538,30 @@ interface(`miscfiles_read_localization',`
 
 ########################################
 ## <summary>
+##	Allow process to watch localization files.
+## </summary>
+## <desc>
+##	<p>
+##	Allow the specified domain to watch localization files
+##	(e.g. /usr/share/zoneinfo/UTC) for changes.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`miscfiles_watch_localization_files',`
+	gen_require(`
+		type locale_t;
+	')
+
+	watch_files_pattern($1, locale_t, locale_t)
+')
+
+########################################
+## <summary>
 ##	Allow process to watch localization symlinks.
 ## </summary>
 ## <desc>
@@ -551,7 +575,6 @@ interface(`miscfiles_read_localization',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <infoflow type="read" weight="10"/>
 #
 interface(`miscfiles_watch_localization_symlinks',`
 	gen_require(`


### PR DESCRIPTION
The miscfiles_watch_localization_files() interface was added.

Addresses the following AVC denial:

type=AVC msg=audit(1623660479.330:18563): avc:  denied  { watch } for  pid=177853 comm="asterisk" path="/usr/share/zoneinfo/UTC" dev="dm-0" ino=5767559 scontext=system_u:system_r:asterisk_t:s0 tcontext=system_u:object_r:locale_t:s0 tclass=file permissive=0

Resolves: rhbz#1971621