### PR TITLE
Allow systemd-timesyncd watch dbus runtime dir

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -964,6 +964,7 @@ optional_policy(`
         dbus_system_bus_client(systemd_timedated_t)
         dbus_connect_system_bus(systemd_timedated_t)
         dbus_read_pid_sock_files(systemd_timedated_t)
+	dbus_watch_pid_dirs(systemd_timedated_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
systemd-timesyncd, like any dbus client, wants to connect() to
/run/dbus/system_bus_socket; if the socket file is not present,
the service establishes an inotify_add_watch() syscall to monitor
when the socket is created by the dbus broker.

Resolves: rhbz#1965720