### PR TITLE
Allow kdump create /var/lib/kdump with a transition

### DIFF
--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -53,6 +53,7 @@ manage_lnk_files_pattern(kdump_t, kdump_crash_t, kdump_crash_t)
 files_var_filetrans(kdump_t, kdump_crash_t, dir, "crash")
 
 manage_files_pattern(kdump_t, kdump_var_lib_t, kdump_var_lib_t)
+files_var_lib_filetrans(kdump_t, kdump_var_lib_t, dir, "kdump")
 
 read_files_pattern(kdump_t, kdump_etc_t, kdump_etc_t)
 


### PR DESCRIPTION
With commit af7e4b6492b ("Label /var/lib/kdump with kdump_var_lib_t"),
the kdump service was allowed to write initramfs files in case /boot
was read only. In that case though the kdump service creates
the /var/lib/kdump directory as it is not shipped in the rpm package,
so it requires appropriate permissions, together with a named file
transition, too.