### PR TITLE
Label /run/fsck with fsadm_var_run_t

### DIFF
--- a/policy/modules/system/fstools.fc
+++ b/policy/modules/system/fstools.fc
@@ -90,3 +90,4 @@
 /var/log/fsck(/.*)?		gen_context(system_u:object_r:fsadm_log_t,s0)
 
 /var/run/blkid(/.*)?		gen_context(system_u:object_r:fsadm_var_run_t,s0)
+/var/run/fsck(/.*)?		gen_context(system_u:object_r:fsadm_var_run_t,s0)

--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -228,4 +228,5 @@ interface(`fstools_filetrans_named_content_fsadm',`
 	')
 
 	files_pid_filetrans($1, fsadm_var_run_t, dir, "blkid")
+	files_pid_filetrans($1, fsadm_var_run_t, dir, "fsck")
 ')


### PR DESCRIPTION
The /run/fsck directory is usually created by the systemd-fsck-root
service or fsck command with the expected fsadm_var_run_t type, but
the default file context specification does not include this directory.

The fstools_filetrans_named_content_fsadm() interface was updated to
include also /run/fsck.