### PR TITLE
Label /usr/bin/arping plain file with netutils_exec_t

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -7,6 +7,7 @@
 /bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
 /sbin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
 
+/usr/bin/arping		--	gen_context(system_u:object_r:netutils_exec_t,s0)
 /usr/bin/lft		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/mtr		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/nmap		--	gen_context(system_u:object_r:traceroute_exec_t,s0)


### PR DESCRIPTION
In iputils newer than iputils-20180629, the arping command moved
from /usr/sbin to /usr/bin, keeping the symlink in sbin.