### PR TITLE
Allow sssd watch /run/systemd

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -150,6 +150,7 @@ auth_watch_passwd(sssd_t)
 # sssd uses inotify to watch for changes in /run/systemd/resolve
 init_list_pid_dirs(sssd_t)
 init_read_utmp(sssd_t)
+init_watch_pid_dir(sssd_t)
 
 logging_send_syslog_msg(sssd_t)
 logging_send_audit_msgs(sssd_t)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2579,6 +2579,24 @@ interface(`init_delete_pid_dir_entry',`
 
 #######################################
 ## <summary>
+##  Watch the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`init_watch_pid_dir',`
+    gen_require(`
+        type init_var_run_t;
+    ')
+
+    allow $1 init_var_run_t:dir watch_dir_perms;
+')
+
+#######################################
+## <summary>
 ##  Create objects in /run/systemd directory
 ##  with an automatic type transition to
 ##  a specified private type.


### PR DESCRIPTION
The init_watch_pid_dir() interface was added.

Resolves: rhbz#1959068