### PR TITLE
Add write permisson to userfaultfd_anon_inode_perms

### DIFF
--- a/policy/support/obj_perm_sets.spt
+++ b/policy/support/obj_perm_sets.spt
@@ -280,7 +280,7 @@ define(`watch_reads_chr_file_perms',`{ getattr watch_reads }')
 #
 # Anonymous inode files (anon_inode)
 #
-define(`userfaultfd_anon_inode_perms',`{ create getattr ioctl read }')
+define(`userfaultfd_anon_inode_perms',`{ create getattr ioctl read write }')
 
 ########################################
 #


### PR DESCRIPTION
The userfaultfd() syscall creates a file descriptor for handling page
faults in user space. It turned out that the fd is created read/write,
so after transferring that fd, selinux_file_receive() checks that all
fd's mode bits are allowed, so it checks for read and write.
Therefore the userfaultfd_anon_inode_perms objects permissions set was
updated to include also write.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(24.6.2021 09:07:18.210:507) : proctitle=uffdtest
type=SYSCALL msg=audit(24.6.2021 09:07:18.210:507) : arch=x86_64 syscall=recvmsg success=yes exit=1 a0=0x4 a1=0x7ffeed5dfb90 a2=0x0 a3=0x7ff41be46bf0 items=0 ppid=1899 pid=1900 auid=root uid=user1 gid=user1 euid=user1 suid=user1 fsuid=user1 egid=user1 sgid=user1 fsgid=user1 tty=pts0 ses=2 comm=uffdtest exe=uffdtest subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(24.6.2021 09:07:18.210:507) : avc:  denied  { write } for  pid=1900 comm=uffdtest path=anon_inode:[userfaultfd] dev="anon_inodefs" ino=33109 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:unconfined_t:s0 tclass=anon_inode permissive=1

Resolves: rhbz#1974559