### PR TITLE
Allow logrotate rotate container log files

### DIFF
--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -378,6 +378,11 @@ optional_policy(`
 	virt_manage_cache(logrotate_t)
 ')
 
+optional_policy(`
+	tunable_policy(`logrotate_read_inside_containers',`
+		container_manage_lib_files(logrotate_t)
+	')
+')
 
 optional_policy(`
 	tunable_policy(`logrotate_read_inside_containers',`


### PR DESCRIPTION
Logrotate can be configured to rotate container logfiles which
have the container_var_lib_t type.

The permissions to run the rotate job are only allowed when the
logrotate_read_inside_containers boolean is turned on.

Addresses denials like this:
type=AVC msg=audit(1602816340.741:42012): avc:  denied  { read } for  pid=71978 comm="logrotate" name="overlay-containers" dev="dm-8" ino=4229964 scontext=system_u:system_r:logrotate_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:container_var_lib_t:s0 tclass=dir permissive=0
type=SYSCALL msg=audit(1602816340.741:42012): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=7fff0aaa9dd0 a2=90800 a3=0 items=1 ppid=71976 pid=71978 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="logrotate" exe="/usr/sbin/logrotate" subj=system_u:system_r:logrotate_t:s0-s0:c0.c1023 key=(null)
type=CWD msg=audit(1602816340.741:42012): cwd="/etc/logrotate.d"
type=PATH msg=audit(1602816340.741:42012): item=0 name="/var/lib/containers/storage/overlay-containers" inode=4229964 dev=fd:08 mode=040700 ouid=0 ogid=0 rdev=00:00 obj=unconfined_u:object_r:container_var_lib_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PROCTITLE msg=audit(1602816340.741:42012): proctitle=2F7573722F7362696E2F6C6F67726F74617465002F6574632F6C6F67726F746174652E636F6E66