### PR TITLE
Allow radius map its library files

### DIFF
--- a/policy/modules/contrib/radius.te
+++ b/policy/modules/contrib/radius.te
@@ -72,6 +72,7 @@ manage_files_pattern(radiusd_t, radiusd_log_t, radiusd_log_t)
 logging_log_filetrans(radiusd_t, radiusd_log_t, { file dir })
 
 manage_files_pattern(radiusd_t, radiusd_var_lib_t, radiusd_var_lib_t)
+allow radiusd_t radiusd_var_lib_t:file map;
 
 manage_sock_files_pattern(radiusd_t, radiusd_var_run_t, radiusd_var_run_t)
 manage_dirs_pattern(radiusd_t, radiusd_var_run_t, radiusd_var_run_t)


### PR DESCRIPTION
While radiusd_t has already been allowed to manage radiusd_var_lib_t
files, the map permission is not a part of the used pattern macro.

Resolves: rhbz#1854650