### PR TITLE
Allow nftables read NetworkManager unnamed pipes

### DIFF
--- a/policy/modules/contrib/networkmanager.if
+++ b/policy/modules/contrib/networkmanager.if
@@ -79,6 +79,24 @@ interface(`networkmanager_rw_routing_sockets',`
 
 ########################################
 ## <summary>
+##	Read networkmanager unnamed pipes
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`networkmanager_read_pipes',`
+	gen_require(`
+		type NetworkManager_t;
+	')
+
+	allow $1 NetworkManager_t:fifo_file read_fifo_file_perms;
+')
+
+########################################
+## <summary>
 ##	Execute NetworkManager with a domain transition.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -154,6 +154,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	networkmanager_read_pipes(iptables_t)
     NetworkManager_read_state(iptables_t)
 ')
 


### PR DESCRIPTION
NetworkManager can use nftables for configuring NAT. For that,
NetworkManager spawns `/usr/sbin/nft -f -` and tries to feed the input
via stdin, therefore the open and read SELinux permissions are required.

Addresses the following AVC denial:
audit[63450]: AVC avc:  denied  { open } for  pid=63450 comm="nft" path="pipe:[217017]" dev="pipefs" ino=217017 scontext=system_u:system_r:iptables_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=fifo_file permissive=0