### PR TITLE
Label /usr/bin/Xwayland with xserver_exec_t

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -111,6 +111,7 @@ HOME_DIR/\.dmrc.*	--	gen_context(system_u:object_r:xdm_home_t,s0)
 /usr/bin/xauth		--	gen_context(system_u:object_r:xauth_exec_t,s0)
 /usr/bin/Xorg		--	gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/bin/Xvnc		--	gen_context(system_u:object_r:xserver_exec_t,s0)
+/usr/bin/Xwayland	--	gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/bin/x11vnc		--	gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/bin/nvidia.*	--	gen_context(system_u:object_r:xserver_exec_t,s0)
 


### PR DESCRIPTION
Until now, there was no particular label for /usr/bin/Xwayland,
so it had the generic bin_t type. This commit makes the label
aligned with /usr/bin/Xorg.