### PR TITLE
Label /usr/bin/qemu-storage-daemon with virtd_exec_t

### DIFF
--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -28,6 +28,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/libexec/libvirt_lxc --	gen_context(system_u:object_r:virtd_lxc_exec_t,s0)
 /usr/libexec/qemu-bridge-helper		gen_context(system_u:object_r:virt_bridgehelper_exec_t,s0)
 /usr/libexec/qemu-pr-helper	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/bin/qemu-storage-daemon -- gen_context(system_u:object_r:virtd_exec_t,s0)
 
 /usr/sbin/libvirtd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtlockd --  gen_context(system_u:object_r:virtlogd_exec_t,s0)


### PR DESCRIPTION
The qemu-storage-daemon is introduced since QEMU v5.0.0, providing disk
image functionality without running a machine. As it is used for disk
image management in virtualization, label it with virtd_exec_t.

Resolves: rhbz#1977245

Signed-off-by: Han Han <hhan@redhat.com>