### PR TITLE
Allow bacula get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/contrib/bacula.te
+++ b/policy/modules/contrib/bacula.te
@@ -122,6 +122,7 @@ files_dontaudit_getattr_all_pipes(bacula_t)
 files_read_all_files(bacula_t)
 files_read_all_symlinks(bacula_t)
 
+fs_getattr_cgroup(bacula_t)
 fs_getattr_xattr_fs(bacula_t)
 fs_list_all(bacula_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(06/28/2021 10:21:34.273:500) : proctitle=/usr/sbin/bacula-sd -f -c /etc/bacula/bacula-sd.conf -u bacula -g tape
type=PATH msg=audit(06/28/2021 10:21:34.273:500) : item=0 name=/sys/fs/cgroup/ inode=1 dev=00:1a mode=dir,555 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(06/28/2021 10:21:34.273:500) : cwd=/
type=SYSCALL msg=audit(06/28/2021 10:21:34.273:500) : arch=x86_64 syscall=statfs success=no exit=EACCES(Permission denied) a0=0x7f07f83e2512 a1=0x7fff70095f10 a2=0x7f07f8efbb60 a3=0x0 items=1 ppid=1 pid=31170 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=bacula-sd exe=/usr/sbin/bacula-sd subj=system_u:system_r:bacula_t:s0 key=(null)
type=AVC msg=audit(06/28/2021 10:21:34.273:500) : avc:  denied  { getattr } for  pid=31170 comm=bacula-sd name=/ dev="cgroup2" ino=1 scontext=system_u:system_r:bacula_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=filesystem permissive=0