### PR TITLE
Confine rhsm service and rhsm-facts service as rhsmcertd_t

### DIFF
--- a/policy/modules/contrib/rhsmcertd.fc
+++ b/policy/modules/contrib/rhsmcertd.fc
@@ -5,6 +5,8 @@
 /usr/bin/rhsmcertd	--	gen_context(system_u:object_r:rhsmcertd_exec_t,s0)
 
 /usr/libexec/rhsmd  --  gen_context(system_u:object_r:rhsmcertd_exec_t,s0)
+/usr/libexec/rhsm-facts-service  --  gen_context(system_u:object_r:rhsmcertd_exec_t,s0)
+/usr/libexec/rhsm-service  --  gen_context(system_u:object_r:rhsmcertd_exec_t,s0)
 
 /var/lib/rhsm(/.*)?	gen_context(system_u:object_r:rhsmcertd_var_lib_t,s0)
 


### PR DESCRIPTION
Confine rhsm service and rhsm-facts service as rhsmcertd_t
    
Rhsm service and rhsm-fact service run as unconfined_t. Use existing
rhsmcertd_t policy to confine rhsm service and rhsm-facts service as
rhsmcertd_t. Label binary files, which execute systemd daemon.
    
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1846081
