### PR TITLE
Revert "update libs_filetrans_named_content() to have support for /us…

### DIFF
--- a/policy/modules/system/libraries.if
+++ b/policy/modules/system/libraries.if
@@ -607,12 +607,10 @@ interface(`files_lib_filetrans_shared_lib',`
 #
 interface(`libs_filetrans_named_content',`
 	gen_require(`
-        type lib_t;
 		type ld_so_cache_t;
 		type ldconfig_cache_t;
 	')
 
-    files_var_lib_filetrans($1,ldconfig_cache_t, dir, "debug")
 	files_var_filetrans($1, ldconfig_cache_t, dir, "ldconfig")
 	files_etc_filetrans($1, ld_so_cache_t, file, "ld.so.cache")
 	files_etc_filetrans($1, ld_so_cache_t, file, "ld.so.cache~")


### PR DESCRIPTION
…r/lib/debug directory"

This reverts commit bbe5ef3b83907f87c5ea8c3feb01c520af6969af.
The reason for this commit seems to be unclear: unlike the commit
message, there is no /usr/lib/debug reference in the content, but rather
/var/lib/debug, and there is no accompanying file context specification
for /var/lib/debug.
The lib_t declaration is also pointless.