### PR TITLE
Change dev_getattr_infiniband_dev() to use getattr_chr_files_pattern()

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2479,7 +2479,7 @@ interface(`dev_getattr_infiniband_dev',`
 		type device_t, infiniband_device_t;
 	')
 
-	getattr_files_pattern($1, device_t, infiniband_device_t)
+	getattr_chr_files_pattern($1, device_t, infiniband_device_t)
 ')
 
 ########################################


### PR DESCRIPTION
With commit 72995430f56 ("Allow arpwatch get attributes of
infiniband_device_t devices"), the dev_getattr_infiniband_dev()
interface was added, but it used getattr_files_pattern() instead
of getattr_chr_files_pattern() which is more proper as the device
files are char devices, not plain files.