### PR TITLE
Remove slapd references to locations obsolete since 2008.

### DIFF
--- a/policy/modules/contrib/ldap.fc
+++ b/policy/modules/contrib/ldap.fc
@@ -13,11 +13,8 @@
 /usr/lib/slapd	--	gen_context(system_u:object_r:slapd_exec_t,s0)
 
 /var/lib/ldap(/.*)?	gen_context(system_u:object_r:slapd_db_t,s0)
-/var/lib/ldap/replog(/.*)?	gen_context(system_u:object_r:slapd_replog_t,s0)
 
 /var/lib/openldap-data(/.*)?	gen_context(system_u:object_r:slapd_db_t,s0)
-/var/lib/openldap-ldbm(/.*)?	gen_context(system_u:object_r:slapd_db_t,s0)
-/var/lib/openldap-slurpd(/.*)?	gen_context(system_u:object_r:slapd_db_t,s0)
 
 /var/lock/subsys/ldap	--	gen_context(system_u:object_r:slapd_lock_t,s0)
 /var/lock/subsys/slapd	--	gen_context(system_u:object_r:slapd_lock_t,s0)

--- a/policy/modules/contrib/ldap.if
+++ b/policy/modules/contrib/ldap.if
@@ -192,7 +192,7 @@ interface(`ldap_stream_connect',`
 #
 interface(`ldap_admin',`
 	gen_require(`
-		type slapd_t, slapd_tmp_t, slapd_replog_t;
+		type slapd_t, slapd_tmp_t;
 		type slapd_lock_t, slapd_etc_t, slapd_var_run_t;
 		type slapd_initrc_exec_t, slapd_log_t, slapd_cert_t;
 		type slapd_db_t, slapd_keytab_t;
@@ -212,12 +212,10 @@ interface(`ldap_admin',`
 	allow $2 system_r;
 
 	files_list_etc($1)
+	files_list_var_lib($1)
 	admin_pattern($1, { slapd_etc_t slapd_db_t slapd_cert_t slapd_keytab_t })
 
 	admin_pattern($1, slapd_lock_t)
-
-	files_list_var_lib($1)
-	admin_pattern($1, slapd_replog_t)
 
 	files_list_tmp($1)
 	admin_pattern($1, slapd_tmp_t)

--- a/policy/modules/contrib/ldap.te
+++ b/policy/modules/contrib/ldap.te
@@ -33,9 +33,6 @@ files_lock_file(slapd_lock_t)
 type slapd_log_t;
 logging_log_file(slapd_log_t)
 
-type slapd_replog_t;
-files_type(slapd_replog_t)
-
 type slapd_tmp_t;
 files_tmp_file(slapd_tmp_t)
 
@@ -76,10 +73,6 @@ files_lock_filetrans(slapd_t, slapd_lock_t, file)
 manage_dirs_pattern(slapd_t, slapd_log_t, slapd_log_t)
 manage_files_pattern(slapd_t, slapd_log_t, slapd_log_t)
 logging_log_filetrans(slapd_t, slapd_log_t, { file dir })
-
-manage_dirs_pattern(slapd_t, slapd_replog_t, slapd_replog_t)
-manage_files_pattern(slapd_t, slapd_replog_t, slapd_replog_t)
-manage_lnk_files_pattern(slapd_t, slapd_replog_t, slapd_replog_t)
 
 manage_dirs_pattern(slapd_t, slapd_tmp_t, slapd_tmp_t)
 manage_files_pattern(slapd_t, slapd_tmp_t, slapd_tmp_t)


### PR DESCRIPTION
Fixes https://github.com/fedora-selinux/selinux-policy/issues/808