### PR TITLE
Allow mdadm read iscsi pid files

### DIFF
--- a/policy/modules/contrib/iscsi.fc
+++ b/policy/modules/contrib/iscsi.fc
@@ -13,6 +13,7 @@
 
 /var/run/iscsid\.pid	--	gen_context(system_u:object_r:iscsi_var_run_t,s0)
 /var/run/iscsiuio\.pid	--	gen_context(system_u:object_r:iscsi_var_run_t,s0)
+/var/run/initiatorname\.iscsi	--	gen_context(system_u:object_r:iscsi_var_run_t,s0)
 
 /usr/lib/systemd/system/((iscsi)|(iscsid)|(iscsiuio))\.service	--	gen_context(system_u:object_r:iscsi_unit_file_t,s0)
 /usr/lib/systemd/system/((iscsid)|(iscsiuio))\.socket	--	gen_context(system_u:object_r:iscsi_unit_file_t,s0)

--- a/policy/modules/contrib/iscsi.if
+++ b/policy/modules/contrib/iscsi.if
@@ -208,3 +208,22 @@ interface(`iscsi_admin',`
 	files_search_tmp($1)
 	admin_pattern($1, iscsi_tmp_t)
 ')
+
+########################################
+## <summary>
+##	Read iscsi PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`iscsi_read_pid_files',`
+	gen_require(`
+		type iscsi_var_run_t;
+	')
+
+	allow $1 iscsi_var_run_t:file read_file_perms;
+	files_search_pids($1)
+')

--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -159,6 +159,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	iscsi_read_pid_files(mdadm_t)
+')
+
+optional_policy(`
     kdump_manage_kdumpctl_tmp_files(mdadm_t)
     kdump_rw_lock(mdadm_t)
 ')


### PR DESCRIPTION
The mdadm command needs to read /run/initiatorname.iscsi file which is
created by dracut-cmdline executed from initramfs. After loading SELinux
policy and switchroot, /run is relabeled, so no file transition needs to
be set, having the default file context entry should be enough.

The iscsi_read_pid_files() interface was added.

Addresses the following AVC denial:

type=AVC msg=audit(22.1.2021 18:23:19.833:17) : avc:  denied  { getattr } for  pid=972 comm=mdadm path=/run/initiatorname.iscsi dev="tmpfs" ino=12569 scontext=system_u:system_r:mdadm_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(22.1.2021 18:23:19.833:17) : arch=x86_64 syscall=stat success=no exit=EACCES(Operace zamítnuta) a0=0x55e616c2ce90 a1=0x7ffc88132660 a2=0x7ffc88132660 a3=0x100 items=0 ppid=1 pid=972 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=mdadm exe=/usr/sbin/mdadm subj=system_u:system_r:mdadm_t:s0 key=(null)