### PR TITLE
Allow hostapd bind UDP sockets to the dhcpd port

### DIFF
--- a/policy/modules/contrib/hostapd.te
+++ b/policy/modules/contrib/hostapd.te
@@ -37,6 +37,8 @@ kernel_read_system_state(hostapd_t)
 kernel_read_network_state(hostapd_t)
 kernel_request_load_module(hostapd_t)
 
+corenet_udp_bind_dhcpd_port(hostapd_t)
+
 dev_read_rand(hostapd_t)
 dev_read_urand(hostapd_t)
 dev_read_sysfs(hostapd_t)


### PR DESCRIPTION
Resolves: rhbz#1977676