### PR TITLE
Allow fcoemon talk with unconfined user over unix domain datagram socket

### DIFF
--- a/policy/modules/contrib/fcoe.te
+++ b/policy/modules/contrib/fcoe.te
@@ -50,3 +50,7 @@ optional_policy(`
 optional_policy(`
     networkmanager_dgram_send(fcoemon_t)
 ')
+
+optional_policy(`
+	unconfined_dgram_send(fcoemon_t)
+')

--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -786,3 +786,20 @@ interface(`unconfined_exec_typebounds',`
 	typebounds unconfined_exec_t $1;
 ')
 
+########################################
+## <summary>
+##	Send a message to unconfined user over a unix domain datagram socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_dgram_send',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:unix_dgram_socket sendto;
+')


### PR DESCRIPTION
This issue starts to appear after unconfined_t was removed from the
unpriv_user_domain attribute with the 4b4eec49a55 ("Removed adding to
attribute unpriv_userdomain from userdom_unpriv_type template") commit.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(07/15/2021 07:52:50.625:282) : proctitle=/usr/sbin/fcoemon --syslog
type=SOCKADDR msg=audit(07/15/2021 07:52:50.625:282) : saddr={ saddr_fam=local path=fcm_clif/140736294511724 }
type=SYSCALL msg=audit(07/15/2021 07:52:50.625:282) : arch=ppc64le syscall=sendto success=no exit=EACCES(Permission denied) a0=0x5 a1=0x7fffc3693a78 a2=0x5 a3=0x0 items=0 ppid=1 pid=35341 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=fcoemon exe=/usr/sbin/fcoemon subj=system_u:system_r:fcoemon_t:s0 key=(null)
type=AVC msg=audit(07/15/2021 07:52:50.625:282) : avc:  denied  { sendto } for  pid=35341 comm=fcoemon path=fcm_clif/140736294511724 scontext=system_u:system_r:fcoemon_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#1978562