### PR TITLE
Allow abrt_domain read and write z90crypt device

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -679,4 +679,6 @@ optional_policy(`
 allow abrt_domain abrt_var_run_t:sock_file write_sock_file_perms;
 allow abrt_domain abrt_var_run_t:unix_stream_socket connectto;
 
+dev_rw_crypto(abrt_domain)
+
 files_read_etc_files(abrt_domain)


### PR DESCRIPTION
This permission is required on s390x systems with the Crypto Express
adapter card. The z90crypt device driver acts as the interface to the
PCI cryptography hardware and performs asynchronous encryption
operations (RSA) as used during the SSL handshake.

Addresses the following AVC denials:

time->Wed Jun  9 17:03:37 2021
type=PROCTITLE msg=audit(1623272617.670:20): proctitle=2F7573722F7362696E2F6162727464002D64002D73
type=PATH msg=audit(1623272617.670:20): item=0 name="/dev/z90crypt" inode=8497 dev=00:06 mode=020666 ouid=0 ogid=0 rdev=0a:3c obj=system_u:object_r:crypt_device_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1623272617.670:20): cwd="/"
type=SYSCALL msg=audit(1623272617.670:20): arch=80000016 syscall=288 success=no exit=-13 a0=ffffffffffffff9c a1=3ffb3faa61c a2=2 a3=0 items=1 ppid=1 pid=1252 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="abrtd" exe="/usr/sbin/abrtd" subj=system_u:system_r:abrt_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(1623272617.670:20): avc:  denied  { read write } for  pid=1252 comm="abrtd" name="z90crypt" dev="devtmpfs" ino=8497 scontext=system_u:system_r:abrt_t:s0-s0:c0.c1023 tcontext=system_u:object_r:crypt_device_t:s0 tclass=chr_file permissive=0

time->Wed Jun  9 17:03:37 2021
type=PROCTITLE msg=audit(1623272617.740:27): proctitle=2F7573722F62696E2F616272742D64756D702D6A6F75726E616C2D6F6F7073002D66787444
type=PATH msg=audit(1623272617.740:27): item=0 name="/dev/z90crypt" inode=8497 dev=00:06 mode=020666 ouid=0 ogid=0 rdev=0a:3c obj=system_u:object_r:crypt_device_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1623272617.740:27): cwd="/"
type=SYSCALL msg=audit(1623272617.740:27): arch=80000016 syscall=288 success=no exit=-13 a0=ffffffffffffff9c a1=3ff877aa61c a2=2 a3=0 items=1 ppid=1 pid=1285 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="abrt-dump-journ" exe="/usr/bin/abrt-dump-journal-oops" subj=system_u:system_r:abrt_dump_oops_t:s0 key=(null)
type=AVC msg=audit(1623272617.740:27): avc:  denied  { read write } for  pid=1285 comm="abrt-dump-journ" name="z90crypt" dev="devtmpfs" ino=8497 scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:object_r:crypt_device_t:s0 tclass=chr_file permissive=0