### PR TITLE
Label /dev/crypto/nx-gzip with accelerator_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -22,6 +22,7 @@
 /dev/controlD64		-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
 /dev/cachefiles		-c	gen_context(system_u:object_r:cachefiles_device_t,s0)
 /dev/crash		-c	gen_context(system_u:object_r:crash_device_t,mls_systemhigh)
+/dev/crypto/nx-gzip	-c	gen_context(system_u:object_r:accelerator_device_t,mls_systemhigh)
 /dev/dahdi/.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
 /dev/dlm.*		-c	gen_context(system_u:object_r:dlm_control_device_t,s0)
 /dev/dma_heap/.+	-c	gen_context(system_u:object_r:dma_device_t,s0)

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -83,6 +83,12 @@ type crypt_device_t;
 dev_node(crypt_device_t)
 
 #
+# Type for /dev/crypto/nx-gzip
+#
+type accelerator_device_t;
+dev_node(accelerator_device_t)
+
+#
 # dlm_misc_device_t is the type of /dev/misc/dlm.*
 #
 type dlm_control_device_t;


### PR DESCRIPTION
The crypto and compression algorithms in kernel are managed under the
crypto subsystem because both are algorithms that can be HW-accelerated,
so they benefit from sharing the same infrastructure.