### PR TITLE
Allow virtlogd_t read process state of user domains

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -855,6 +855,10 @@ optional_policy(`
     systemd_dbus_chat_logind(virtlogd_t)
 ')
 
+optional_policy(`
+	userdom_read_all_users_state(virtlogd_t)
+')
+
 ########################################
 #
 # virtual domains common policy


### PR DESCRIPTION
The virtlogd process reads /proc/PID/stat file to get the startup time
of the process connecting to it via a UNIX socket.
This is needed for polkit checks to get the
(PID, process start time) pair since PIDs can be reused.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(02/04/2020 03:05:47.764:347) : proctitle=/usr/sbin/virtlogd
type=PATH msg=audit(02/04/2020 03:05:47.764:347) : item=0 name=/proc/6084/stat inode=37875 dev=00:04 mode=file,444 ouid=root ogid=root rdev=00:00 obj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(02/04/2020 03:05:47.764:347) : cwd=/
type=SYSCALL msg=audit(02/04/2020 03:05:47.764:347) : arch=x86_64 syscall=openat success=yes exit=11 a0=0xffffff9c a1=0x55be8c3bb840 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=5612 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=virtlogd exe=/usr/sbin/virtlogd subj=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(02/04/2020 03:05:47.764:347) : avc:  denied  { open } for  pid=5612 comm=virtlogd path=/proc/6084/stat dev="proc" ino=37875 scontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1
type=AVC msg=audit(02/04/2020 03:05:47.764:347) : avc:  denied  { read } for  pid=5612 comm=virtlogd name=stat dev="proc" ino=37875 scontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1
type=AVC msg=audit(02/04/2020 03:05:47.764:347) : avc:  denied  { search } for  pid=5612 comm=virtlogd name=6084 dev="proc" ino=37864 scontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dir permissive=1

Resolves: rhbz#1797899