### PR TITLE
Allow cockpit_ws_t get attributes of fs_t filesystems

### DIFF
--- a/policy/modules/contrib/cockpit.te
+++ b/policy/modules/contrib/cockpit.te
@@ -82,6 +82,7 @@ auth_use_nsswitch(cockpit_ws_t)
 
 corecmd_exec_bin(cockpit_ws_t)
 
+fs_getattr_xattr_fs(cockpit_ws_t)
 fs_read_efivarfs_files(cockpit_ws_t)
 
 init_read_state(cockpit_ws_t)


### PR DESCRIPTION
This permission is required by systemctl executed in the cockpit-ws
caller domain.

Resolves: rhbz#1979182