### PR TITLE
Allow systemd-machined stop generic service units

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -407,7 +407,7 @@ optional_policy(`
 #
 
 allow systemd_machined_t self:capability { dac_read_search dac_override setgid sys_admin sys_chroot sys_ptrace kill };
-allow systemd_machined_t systemd_unit_file_t:service { status start };
+allow systemd_machined_t systemd_unit_file_t:service { status start stop };
 allow systemd_machined_t self:unix_dgram_socket create_socket_perms;
 allow systemd_machined_t self:cap_userns { sys_chroot };
 


### PR DESCRIPTION
This permission is required when a "virsh destroy" command is run to
terminate a running domain.

Resolves: rhbz#1979522