### PR TITLE
Allow vmtools_unconfined_t domain transition to rpm_script_t

### DIFF
--- a/policy/modules/contrib/vmtools.te
+++ b/policy/modules/contrib/vmtools.te
@@ -131,6 +131,10 @@ optional_policy(`
     corecmd_shell_domtrans(vmtools_t, vmtools_unconfined_t)
 
 	optional_policy(`
+		rpm_transition_script(vmtools_unconfined_t, system_r)
+	')
+
+	optional_policy(`
 		unconfined_domain(vmtools_unconfined_t)
 	')
 ')


### PR DESCRIPTION
VMware allow option to installing packages outside
the VMware guest through vmtools_unconfined file.
So vmtools_unconfined_t need allow domain transition·
for installing rpm packages.Allow  process transition·
from vmtools_unconfined_t domain to rpm_script_t domain.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1872245