### PR TITLE
Allow sssd to set samba setting

### DIFF
--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -178,6 +178,25 @@ interface(`samba_domtrans_unconfined_net',`
 
 ########################################
 ## <summary>
+##	Execute samba net in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`samba_exec',`
+	gen_require(`
+		type samba_net_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, samba_net_exec_t)
+')
+
+########################################
+## <summary>
 ##	Execute samba net in the samba_net domain, and
 ##	allow the specified role the samba_net domain.
 ## </summary>
@@ -582,6 +601,25 @@ interface(`samba_manage_var_dirs',`
 	files_search_var_lib($1)
 	files_search_var_lib($1)
 	manage_dirs_pattern($1, samba_var_t, samba_var_t)
+')
+
+#####################################
+## <summary>
+##	Manage samba var sock files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`samba_manage_var_sock_files',`
+	gen_require(`
+		type samba_var_t;
+	')
+
+	files_search_pids($1)
+	manage_sock_files_pattern($1, samba_var_t, samba_var_t)
 ')
 
 ########################################

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -217,8 +217,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+    samba_exec(sssd_t)
     samba_manage_var_dirs(sssd_t)
     samba_manage_var_files(sssd_t)
+    samba_manage_var_sock_files(sssd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Sssd execute adcli and need set
samba Active Directory setting.
Allow sssd to set samba net AD
setting. Also creating needed
interfaces for this.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1855215