### PR TITLE
Allow nscd watch system db files in /var/db

### DIFF
--- a/policy/modules/contrib/nscd.te
+++ b/policy/modules/contrib/nscd.te
@@ -112,8 +112,8 @@ files_read_generic_tmp_symlinks(nscd_t)
 files_read_etc_runtime_files(nscd_t)
 files_watch_etc_dirs(nscd_t)
 files_watch_etc_files(nscd_t)
-
 files_map_system_db_files(nscd_t)
+files_watch_system_db_files(nscd_t)
 
 logging_send_audit_msgs(nscd_t)
 logging_send_syslog_msg(nscd_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -5835,6 +5835,24 @@ interface(`files_manage_system_db_files',`
 
 ######################################
 ## <summary>
+##	Watch manageable system db files in /var/db.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_system_db_files',`
+	gen_require(`
+		type system_db_t;
+	')
+
+	allow $1 system_db_t:file watch_file_perms;
+')
+
+######################################
+## <summary>
 ##  Map manageable system db files in /var/lib.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Addresses similar AVC denials:

type=PROCTITLE msg=audit(1627921351.462:3040): proctitle="/usr/sbin/nscd"
type=PATH msg=audit(1627921351.462:3040): item=0 name="/var/db/passwd.db" inode=68436716 dev=fd:00 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:system_db_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1627921351.462:3040): cwd="/"
type=SYSCALL msg=audit(1627921351.462:3040): arch=c000003e syscall=254 success=no exit=-13 a0=3 a1=7f0d6f7f11c8 a2=c08 a3=4000 items=1 ppid=1 pid=1163600 auid=4294967295 uid=28 gid=28 euid=28 suid=28 fsuid=28 egid=28 sgid=28 fsgid=28 tty=(none) ses=4294967295 comm="nscd" exe="/usr/sbin/nscd" subj=system_u:system_r:nscd_t:s0 key=(null)
type=AVC msg=audit(1627921351.462:3040): avc:  denied  { watch } for  pid=1163600 comm="nscd" path="/var/db/passwd.db" dev="dm-0" ino=68436716 scontext=system_u:system_r:nscd_t:s0 tcontext=system_u:object_r:system_db_t:s0 tclass=file permissive=0

Resolves: rhbz#1989416