### PR TITLE
Allow firewalld drop capabilities

### DIFF
--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -35,8 +35,9 @@ systemd_unit_file(firewalld_unit_file_t)
 # Local policy
 #
 
-allow firewalld_t self:capability { dac_read_search net_admin net_raw };
+allow firewalld_t self:capability { net_admin net_raw setpcap };
 dontaudit firewalld_t self:capability { dac_override sys_tty_config };
+allow firewalld_t self:process setcap;
 allow firewalld_t self:fifo_file rw_fifo_file_perms;
 allow firewalld_t self:unix_stream_socket { accept listen };
 allow firewalld_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
With the 04a8b1ab7467 ("feat(firewalld): drop linux capabilities") commit,
firewalld attempts to drop capabilities to a minimal required set
(CAP_NET_ADMIN, CAP_NET_RAW). For that, the setpcap capability and
setcap process permissions are required.

Since the minimum set does not contain dac_read_search, this capability
was also removed from selinux policy.

Resolves: rhbz#1985494