### PR TITLE
Allow systemd-timesyncd watch system dbus pid socket files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -970,6 +970,7 @@ optional_policy(`
         dbus_connect_system_bus(systemd_timedated_t)
         dbus_read_pid_sock_files(systemd_timedated_t)
 	dbus_watch_pid_dirs(systemd_timedated_t)
+	dbus_watch_pid_sock_files(systemd_timedated_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(11.8.2021 11:34:29.859:127) : proctitle=/usr/lib/systemd/systemd-timesyncd
type=PATH msg=audit(11.8.2021 11:34:29.859:127) : item=0 name=/run/dbus/system_bus_socket inode=1048 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:system_dbusd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(11.8.2021 11:34:29.859:127) : cwd=/
type=SYSCALL msg=audit(11.8.2021 11:34:29.859:127) : arch=x86_64 syscall=inotify_add_watch success=yes exit=4 a0=0xb a1=0x5611a5b939d0 a2=0x2000d84 a3=0x1000 items=1 ppid=1 pid=656 auid=unset uid=systemd-timesync gid=systemd-timesync euid=systemd-timesync suid=systemd-timesync fsuid=systemd-timesync egid=systemd-timesync sgid=systemd-timesync fsgid=systemd-timesync tty=(none) ses=unset comm=systemd-timesyn exe=/usr/lib/systemd/systemd-timesyncd subj=system_u:system_r:systemd_timedated_t:s0 key=(null)
type=AVC msg=audit(11.8.2021 11:34:29.859:127) : avc:  denied  { watch } for  pid=656 comm=systemd-timesyn path=/run/dbus/system_bus_socket dev="tmpfs" ino=1048 scontext=system_u:system_r:systemd_timedated_t:s0 tcontext=system_u:object_r:system_dbusd_var_run_t:s0 tclass=sock_file permissive=1