### PR TITLE
Allow nmap create and use netlink generic socket

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -211,6 +211,7 @@ optional_policy(`
 
 allow traceroute_t self:capability { net_admin net_raw setuid setgid };
 dontaudit traceroute_t self:capability { sys_admin };
+allow traceroute_t self:netlink_generic_socket create_socket_perms;
 allow traceroute_t self:netlink_rdma_socket create_socket_perms;
 allow traceroute_t self:rawip_socket create_socket_perms;
 allow traceroute_t self:packet_socket { create_socket_perms map };


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(07/23/2021 03:45:29.661:442) : proctitle=nmap -sX 127.0.0.1
type=SYSCALL msg=audit(07/23/2021 03:45:29.661:442) : arch=x86_64 syscall=socket success=yes exit=5 a0=netlink a1=SOCK_RAW a2=chaos a3=0x556f1a539b70 items=0 ppid=4505 pid=7697 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=4 comm=nmap exe=/usr/bin/nmap subj=system_u:system_r:traceroute_t:s0 key=(null)
type=AVC msg=audit(07/23/2021 03:45:29.661:442) : avc:  denied  { create } for  pid=7697 comm=nmap scontext=system_u:system_r:traceroute_t:s0 tcontext=system_u:system_r:traceroute_t:s0 tclass=netlink_generic_socket permissive=1