### PR TITLE
Allow rhsmcertd execute gpg

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -133,6 +133,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gpg_exec(rhsmcertd_t)
+')
+
+optional_policy(`
 	hostname_exec(rhsmcertd_t)
 ')
 


### PR DESCRIPTION
When a repository configuration changes to "repo_gpgcheck=1",
the rhsmcertd worker executes gpg or gpgsm to perform a GPG signature
check on this repository's metadata.

Addresses the following AVC denial:

type=AVC msg=audit(1626266161.404:102781): avc:  denied  { execute } for  pid=635719 comm="rhsmcertd-worke" name="gpg" dev="sdc" ino=144374 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:gpg_exec_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(1626266161.404:102781): arch=x86_64 syscall=execve success=no exit=EACCES a0=557662993060 a1=7ffd40ed5870 a2=7ffd40edb500 a3=0 items=0 ppid=635718 pid=635719 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=rhsmcertd-worke exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)

Resolves: rhbz#1887572