### PR TITLE
Allow lldpad send to kdump over a unix dgram socket

### DIFF
--- a/policy/modules/contrib/kdump.if
+++ b/policy/modules/contrib/kdump.if
@@ -341,3 +341,20 @@ interface(`kdump_manage_lib_files',`
 	manage_files_pattern($1, kdump_var_lib_t, kdump_var_lib_t)
 ')
 
+#######################################
+## <summary>
+##	Send to kdump over a unix dgram socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kdump_dgram_send',`
+	gen_require(`
+		type kdump_t;
+	')
+
+	allow $1 kdump_t:unix_dgram_socket sendto;
+')

--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -72,6 +72,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+    kdump_dgram_send(lldpad_t)
+')
+
+optional_policy(`
     networkmanager_dgram_send(lldpad_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(1625452049.961:55): proctitle=/usr/sbin/lldpad -t
type=SYSCALL msg=audit(1625452049.961:55): arch=c000003e syscall=44 success=no exit=-13 a0=3 a1=562bdbb615e0 a2=1a a3=0 items=0 ppid=1 pid=1170 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="lldpad" exe="/usr/sbin/lldpad" subj=system_u:system_r:lldpad_t:s0 key=(null)
type=AVC msg=audit(1625452049.961:55): avc:  denied  { sendto } for  pid=1170 comm="lldpad" path=002F636F6D2F696E74656C2F6C6C647061642F34383233 scontext=system_u:system_r:lldpad_t:s0 tcontext=system_u:system_r:kdumpctl_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#1979121