### PR TITLE
Allow tcpdump run as a systemd service

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -82,17 +82,19 @@ dev_write_usbmon_dev(netutils_t)
 dev_map_usbmon_dev(netutils_t)
 dev_rw_generic_usb_dev(netutils_t)
 
-fs_getattr_xattr_fs(netutils_t)
-
 domain_use_interactive_fds(netutils_t)
 
 files_read_etc_files(netutils_t)
 # for nscd
 files_dontaudit_search_var(netutils_t)
 
+fs_getattr_cgroup(netutils_t)
+fs_getattr_xattr_fs(netutils_t)
+
 init_use_fds(netutils_t)
 init_use_script_ptys(netutils_t)
 init_write_initrc_tmp_pipes(netutils_t)
+init_dontaudit_read_state(netutils_t)
 
 auth_use_nsswitch(netutils_t)
 


### PR DESCRIPTION
Allow tcpdump get attributes of cgroup filesystems.
Dontaudit tcpdump read the init process state.

Resolves: rhbz#1972577