### PR TITLE
Set default file context for /sys/firmware/efi/efivars

### DIFF
--- a/policy/modules/kernel/filesystem.fc
+++ b/policy/modules/kernel/filesystem.fc
@@ -28,8 +28,8 @@ HOME_DIR/\.Private(/.*)?	gen_context(system_u:object_r:ecryptfs_t,s0)
 /sys/fs/pstore	-d	gen_context(system_u:object_r:pstore_t,s0)
 /sys/fs/pstore/.*	<<none>>
 
-/sys/firmware/efi	-d	gen_context(system_u:object_r:efivarfs_t,s0)
-/sys/firmware/efi/.*	<<none>>
+/sys/firmware/efi/efivars	-d	gen_context(system_u:object_r:efivarfs_t,s0)
+/sys/firmware/efi/efivars/.*	<<none>>
 
 /sys/kernel/tracing	-d	gen_context(system_u:object_r:tracefs_t,s0)
 /sys/kernel/tracing/.*	<<none>>


### PR DESCRIPTION
Set the default file context specification for /sys/firmware/efi/efivars
instead of /sys/firmware/efi since this is the way how the labels are
set by kernel, so the labels can possibly be changed by restorecon in
an incorrect way.

$ ls -ldZ /sys/firmware /sys/firmware/efi /sys/firmware/efi/efivars
drwxr-xr-x. 7 root root system_u:object_r:sysfs_t:s0    0 Jun 15 08:59 /sys/firmware
drwxr-xr-x. 5 root root system_u:object_r:sysfs_t:s0    0 Jun 15 08:59 /sys/firmware/efi
drwxr-xr-x. 2 root root system_u:object_r:efivarfs_t:s0 0 Jun 15 14:10 /sys/firmware/efi/efivars

$ restorecon -Rvn /sys/firmware/efi
Would relabel /sys/firmware/efi from system_u:object_r:sysfs_t:s0 to system_u:object_r:efivarfs_t:s0

Resolves: rhbz#1972372