### PR TITLE
Allow systemd-gpt-auto-generator read udev pid files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1097,6 +1097,10 @@ systemd_unit_file_filetrans(systemd_gpt_generator_t, systemd_gpt_generator_unit_
 systemd_create_unit_file_dirs(systemd_gpt_generator_t)
 systemd_create_unit_file_lnk(systemd_gpt_generator_t)
 
+optional_policy(`
+	udev_read_pid_files(systemd_gpt_generator_t)
+')
+
 #######################################
 #
 # systemd_resolved domain


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(11.8.2021 13:30:43.108:107) : proctitle=/usr/lib/systemd/system-generators/systemd-gpt-auto-generator /run/systemd/generator /run/systemd/generator.early /run/systemd/g
type=SYSCALL msg=audit(11.8.2021 13:30:43.108:107) : arch=aarch64 syscall=openat success=no exit=EACCES(Permission denied) a0=0xffffffffffffff9c a1=0xffffc92fdc10 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=4522 pid=4530 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-gpt-aut exe=/usr/lib/systemd/system-generators/systemd-gpt-auto-generator subj=system_u:system_r:systemd_gpt_generator_t:s0 key=(null)
type=CWD msg=audit(11.8.2021 13:30:43.108:107) : cwd=/
type=PATH msg=audit(11.8.2021 13:30:43.108:107) : item=0 name=/run/udev/data/b252:1 inode=857 dev=00:1b mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:udev_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=AVC msg=audit(11.8.2021 13:30:43.108:107) : avc:  denied  { read } for  pid=4530 comm=systemd-gpt-aut name=b252:1 dev="tmpfs" ino=857 scontext=system_u:system_r:systemd_gpt_generator_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0

This access is required since systemd v249.