### PR TITLE
Label /usr/libexec/gdm-runtime-config with xdm_exec_t

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -121,6 +121,7 @@ HOME_DIR/\.dmrc.*	--	gen_context(system_u:object_r:xdm_home_t,s0)
 /usr/libexec/gsd-backlight-helper	--	gen_context(system_u:object_r:xserver_exec_t,s0)
 
 /usr/libexec/gdm-disable-wayland	--	gen_context(system_u:object_r:xdm_exec_t,s0)
+/usr/libexec/gdm-runtime-config		--	gen_context(system_u:object_r:xdm_exec_t,s0)
 
 /usr/lib/fontconfig/cache(/.*)?			gen_context(system_u:object_r:fonts_cache_t,s0)
 /usr/lib/qt-.*/etc/settings(/.*)? gen_context(system_u:object_r:xdm_var_run_t,s0)


### PR DESCRIPTION
GDM ships a udev rule that runs gdm-runtime-config in certain cases.
This command creates a file called /run/gdm/custom.conf.
Labeling the executable xdm_exec_t will result in a transition to xdm_t
and proper type of the /run/gdm directory if it needs to be created.