### PR TITLE
Allow rhsmcertd to create cache file in /var/cache/cloud-what

### DIFF
--- a/policy/modules/contrib/rhsmcertd.fc
+++ b/policy/modules/contrib/rhsmcertd.fc
@@ -15,3 +15,5 @@
 /var/log/rhsm(/.*)?	gen_context(system_u:object_r:rhsmcertd_log_t,s0)
 
 /var/run/rhsm(/.*)?	gen_context(system_u:object_r:rhsmcertd_var_run_t,s0)
+
+/var/cache/cloud-what(/.*)? gen_context(system_u:object_r:cloud_what_var_cache_t,s0)

--- a/policy/modules/contrib/rhsmcertd.if
+++ b/policy/modules/contrib/rhsmcertd.if
@@ -195,6 +195,63 @@ interface(`rhsmcertd_manage_lib_dirs',`
 
 ########################################
 ## <summary>
+##	Read cloud-what cache files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cloud_what_read_cache_files',`
+	gen_require(`
+		type cloud_what_var_cache_t;
+	')
+
+	files_search_var($1)
+	read_files_pattern($1, cloud_what_var_cache_t, cloud_what_var_cache_t)
+')
+
+########################################
+## <summary>
+##	Manage cloud-what cache files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cloud_what_manage_cache_files',`
+	gen_require(`
+		type cloud_what_var_cache_t;
+	')
+
+	files_search_var($1)
+	manage_files_pattern($1, cloud_what_var_cache_t, cloud_what_var_cache_t)
+')
+
+########################################
+## <summary>
+##	Manage cloud-what cache directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cloud_what_manage_cache_dirs',`
+	gen_require(`
+		type cloud_what_var_cache_t;
+	')
+
+	files_search_var($1)
+	manage_dirs_pattern($1, cloud_what_var_cache_t, cloud_what_var_cache_t)
+')
+
+########################################
+## <summary>
 ##	Read rhsmcertd PID files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -30,6 +30,9 @@ files_pid_file(rhsmcertd_var_run_t)
 type rhsmcertd_config_t;
 files_config_file(rhsmcertd_config_t)
 
+type cloud_what_var_cache_t;
+files_type(cloud_what_var_cache_t)
+
 ########################################
 #
 # Local policy
@@ -61,6 +64,9 @@ manage_files_pattern(rhsmcertd_t, rhsmcertd_var_lib_t, rhsmcertd_var_lib_t)
 manage_dirs_pattern(rhsmcertd_t, rhsmcertd_var_run_t, rhsmcertd_var_run_t)
 manage_files_pattern(rhsmcertd_t, rhsmcertd_var_run_t, rhsmcertd_var_run_t)
 files_pid_filetrans(rhsmcertd_t, rhsmcertd_var_run_t, { file dir })
+
+manage_dirs_pattern(rhsmcertd_t, cloud_what_var_cache_t, cloud_what_var_cache_t)
+manage_files_pattern(rhsmcertd_t, cloud_what_var_cache_t, cloud_what_var_cache_t)
 
 kernel_read_network_state(rhsmcertd_t)
 kernel_read_net_sysctls(rhsmcertd_t)


### PR DESCRIPTION
* The `rhsmcertd` uses new python package cloud-what. This
  package tries to create cache file in `/var/cache/cloud-what`
* This commit create new label `cloud_what_var_cache_t` for this
  directory and it allows `rhsmcertd` service to manage files and
  directories in this cache directory.