### PR TITLE
Allow D-bus communication between avahi and sosreport

### DIFF
--- a/policy/modules/contrib/sosreport.te
+++ b/policy/modules/contrib/sosreport.te
@@ -187,6 +187,10 @@ optional_policy(`
 	dbus_system_bus_client(sosreport_t)
 
     optional_policy(`
+        avahi_dbus_chat(sosreport_t)
+    ')
+
+    optional_policy(`
         rpm_dbus_chat(sosreport_t)
     ')
 


### PR DESCRIPTION
Avahi_t need communicate with sosreport_t via D-bus.
Allow D-bus communication between avahi_t and
sosreport_t.

rhbz#1916397