### PR TITLE
Allow systemd to delete fwupd var cache files

### DIFF
--- a/policy/modules/contrib/fwupd.if
+++ b/policy/modules/contrib/fwupd.if
@@ -78,6 +78,26 @@ interface(`fwupd_search_cache',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain to delete
+##	fwupd cache.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fwupd_delete_cache_files',`
+	gen_require(`
+		type fwupd_cache_t;
+	')
+
+	allow $1 fwupd_cache_t:dir rmdir;
+	delete_files_pattern($1, fwupd_cache_t, fwupd_cache_t)
+')
+
+########################################
+## <summary>
 ##	Read fwupd cache files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -462,6 +462,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+    fwupd_delete_cache_files(init_t)
+')
+
+optional_policy(`
     fprintd_exec(init_t)
     fprintd_mounton_var_lib(init_t)
 ')


### PR DESCRIPTION
Systemd can clean fwupd cache data via·
'systemctl clean --what=cache fwupd.service'.
Allow init_t domain deleting cache files·
with label fwupd_cache_t. Part of this fix is also
create new interface for this purpouses.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1759554