### PR TITLE
Rename samba_exec() to samba_exec_net()

### DIFF
--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -186,7 +186,7 @@ interface(`samba_domtrans_unconfined_net',`
 ##	</summary>
 ## </param>
 #
-interface(`samba_exec',`
+interface(`samba_exec_net',`
 	gen_require(`
 		type samba_net_exec_t;
 	')

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -217,7 +217,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-    samba_exec(sssd_t)
+    samba_exec_net(sssd_t)
     samba_manage_var_dirs(sssd_t)
     samba_manage_var_files(sssd_t)
     samba_manage_var_sock_files(sssd_t)


### PR DESCRIPTION
The samba_exec() interface was renamed to samba_exec_net() to match
existing convetions.