### PR TITLE
Allow ptp4l and chronyc respond to pmc

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -223,7 +223,7 @@ sysnet_read_config(chronyc_t)
 userdom_use_user_ptys(chronyc_t)
 userdom_use_inherited_user_ttys(chronyc_t)
 userdom_rw_stream(chronyc_t)
-userdom_dgram_send(chronyc_t)
+userdom_users_dgram_send(chronyc_t)
 
 optional_policy(`
     nscd_shm_use(chronyc_t)

--- a/policy/modules/contrib/linuxptp.te
+++ b/policy/modules/contrib/linuxptp.te
@@ -180,7 +180,7 @@ files_write_generic_pid_sockets(ptp4l_t)
 
 logging_send_syslog_msg(ptp4l_t)
 
-userdom_dgram_send(ptp4l_t)
+userdom_users_dgram_send(ptp4l_t)
 
 optional_policy(`
 	chronyd_rw_shm(ptp4l_t)


### PR DESCRIPTION
pmc is a command-line utility which implements a PTP management client
according to the IEEE standard 1588. It needs to exchange datagrams with
chronyc and ptp4l. While one side of the communication is allowed
generally, the other was allowed for the unpriv_userdomain attribute
only. With the 4b4eec49a55 ("Removed adding to attribute
unpriv_userdomain from userdom_unpriv_type template") commit, the
communication response was no longer allowed for unconfined_t.
This commit allows the communication for the userdomain attribute which
is a superset of unpriv_userdomain.

Resolves: rhbz#1991597