### PR TITLE
Allow tcpdump read system state information in /proc

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -58,6 +58,7 @@ files_tmp_filetrans(netutils_t, netutils_tmp_t, { file dir })
 
 kernel_search_proc(netutils_t)
 kernel_read_all_sysctls(netutils_t)
+kernel_read_system_state(netutils_t)
 kernel_read_network_state(netutils_t)
 kernel_request_load_module(netutils_t)
 kernel_search_network_sysctl(traceroute_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(12.8.2021 17:32:41.672:1509) : proctitle=/usr/sbin/tcpdump -vvv -iradvd icmp6 and ip6[40] = 134 -w /tmp/radvd-tcp-dump-ipv6-ra.pcap
type=AVC msg=audit(12.8.2021 17:32:41.672:1509) : avc:  denied  { read } for  pid=62705 comm=tcpdump name=cmdline dev="proc" ino=4026531904 scontext=system_u:system_r:netutils_t:s0 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(12.8.2021 17:32:41.672:1509) : arch=ppc64le syscall=openat success=no exit=EACCES(Permission denied) a0=0xffffffffffffff9c a1=0x7fff81667370 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=62705 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tcpdump exe=/usr/sbin/tcpdump subj=system_u:system_r:netutils_t:s0 key=(null)
type=CWD msg=audit(12.8.2021 17:32:41.672:1509) : cwd=/
type=PATH msg=audit(12.8.2021 17:32:41.672:1509) : item=0 name=/proc/cmdline inode=4026531904 dev=00:15 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:proc_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: rhbz#1972577