### PR TITLE
Support using ICA crypto accelerator on s390x arch

### DIFF
--- a/policy/modules/contrib/apache.fc
+++ b/policy/modules/contrib/apache.fc
@@ -3,6 +3,8 @@ HOME_DIR/((www)|(web)|(public_html))/cgi-bin(/.+)? gen_context(system_u:object_r
 HOME_DIR/((www)|(web)|(public_html))(/.*)?/\.htaccess	--	gen_context(system_u:object_r:httpd_user_htaccess_t,s0)
 HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?	gen_context(system_u:object_r:httpd_user_ra_content_t,s0)
 
+/dev/shm/icastats_[0-9]+	--	gen_context(system_u:object_r:httpd_tmpfs_t,s0)
+
 /etc/apache(2)?(/.*)?			gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/apache-ssl(2)?(/.*)?		gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/cherokee(/.*)?			gen_context(system_u:object_r:httpd_config_t,s0)

--- a/policy/modules/contrib/apache.if
+++ b/policy/modules/contrib/apache.if
@@ -1967,3 +1967,43 @@ interface(`apache_ioctl_stream_sockets',`
 
     allow $1 httpd_t:unix_stream_socket ioctl;
 ')
+
+########################################
+## <summary>
+##	Create and manage files in the tmpfs directories
+##	with a private type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`apache_tmpfs_filetrans',`
+	gen_require(`
+		type httpd_tmpfs_t;
+	')
+
+	allow $1 httpd_tmpfs_t:file map;
+	manage_files_pattern($1, httpd_tmpfs_t, httpd_tmpfs_t)
+	fs_tmpfs_filetrans($1, httpd_tmpfs_t, file, "icastats_0")
+')
+
+########################################
+## <summary>
+##	Read, write, and map httpd tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`apache_rw_map_tmpfs_files',`
+	gen_require(`
+		type httpd_tmpfs_t;
+	')
+
+	fs_search_tmpfs($1)
+	mmap_rw_files_pattern($1, httpd_tmpfs_t, httpd_tmpfs_t)
+')

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -252,6 +252,10 @@ tunable_policy(`use_samba_home_dirs',`
 ')
 
 optional_policy(`
+	apache_rw_map_tmpfs_files(NetworkManager_t)
+')
+
+optional_policy(`
 	avahi_domtrans(NetworkManager_t)
 	avahi_kill(NetworkManager_t)
 	avahi_signal(NetworkManager_t)

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -178,6 +178,10 @@ tunable_policy(`sssd_connect_all_unreserved_ports',`
 ')
 
 optional_policy(`
+	apache_rw_map_tmpfs_files(sssd_t)
+')
+
+optional_policy(`
     bind_read_cache(sssd_t)
 ')
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -348,6 +348,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	apache_tmpfs_filetrans(sshd_t)
+')
+
+optional_policy(`
 	condor_rw_lib_files(sshd_t)
 	condor_rw_tcp_sockets_startd(sshd_t)
 	condor_rw_tcp_sockets_schedd(sshd_t)


### PR DESCRIPTION
When a system with mod_ssl and openssl is configured to use the ICA
crypto accelerator, the libica library, linked into the openssl-ibmca
engine, creates the /dev/shm/icastats_UIDNUM file to be used by other
services, refer to
https://github.com/opencryptoki/libica/blob/master/src/icastats_shared.c#L63
for the libica library details.

This commits defines a file context specification for /dev/shm/icastats_[0-9]+,
backed by a file transition for /dev/shm/icastats_0 when created by sshd,
and allows read permissions for sssd.

The apache_tmpfs_filetrans() and apache_read_map_tmpfs_files()
interfaces were added.

Resolves: rhbz#1976180