### PR TITLE
Allow lldpad send to unconfined_t over a unix dgram socket

### DIFF
--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -84,5 +84,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+    unconfined_dgram_send(lldpad_t)
+')
+
+optional_policy(`
     virt_dgram_send(lldpad_t)
 ')


### PR DESCRIPTION
This permission is required for lldptool to manage the LLDP settings and
status of lldpad from cli.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(08/19/2021 15:11:30.855:315) : proctitle=/usr/sbin/lldpad -t
type=SOCKADDR msg=audit(08/19/2021 15:11:30.855:315) : saddr={ saddr_fam=local path=/com/intel/lldpad/5534 }
type=SYSCALL msg=audit(08/19/2021 15:11:30.855:315) : arch=x86_64 syscall=sendto success=no exit=EACCES(Permission denied) a0=0x3 a1=0x557868ce99c0 a2=0xc a3=0x0 items=0 ppid=1 pid=5518 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=lldpad exe=/usr/sbin/lldpad subj=system_u:system_r:lldpad_t:s0 key=(null)
type=AVC msg=audit(08/19/2021 15:11:30.855:315) : avc:  denied  { sendto } for  pid=5518 comm=lldpad path=/com/intel/lldpad/5534 scontext=system_u:system_r:lldpad_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_dgram_socket permissive=0