### PR TITLE
Update ica_filetrans_named_content() with create_file_perms

### DIFF
--- a/policy/modules/contrib/ica.if
+++ b/policy/modules/contrib/ica.if
@@ -53,5 +53,6 @@ interface(`ica_filetrans_named_content',`
 		type ica_tmpfs_t;
 	')
 
+	allow $1 ica_tmpfs_t:file create_file_perms;
 	fs_tmpfs_filetrans($1, ica_tmpfs_t, file, "icastats_0")
 ')


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1630066723.697:140): avc:  denied  { create } for  pid=890 comm="sshd" name="icastats_0" scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:ica_tmpfs_t:s0 tclass=file permissive=0

Resolves: rhbz#1976180