### PR TITLE
Allow postfix_domain to sendto unix dgram sockets.

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -790,6 +790,7 @@ allow postfix_domain self:fifo_file rw_fifo_file_perms;
 
 allow postfix_master_t postfix_domain:fifo_file { read write };
 allow postfix_master_t postfix_domain:process signal;
+allow postfix_domain postfix_master_t:unix_dgram_socket sendto;
 #https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=244456
 allow postfix_domain postfix_master_t:file read;
 allow postfix_domain postfix_etc_t:dir list_dir_perms;


### PR DESCRIPTION
Postfix from new version allow option to logging into file.
There is one process in postfix which handle it and other
postfix processes need communicate it through socket.
Allow postfix_domain sendto unix_dgram_socket to
postfix_master_t.

Bugzilla:https://bugzilla.redhat.com/show_bug.cgi?id=1920521