### PR TITLE
Allow communication between at-spi and gdm processes

### DIFF
--- a/policy/modules/contrib/dbus.if
+++ b/policy/modules/contrib/dbus.if
@@ -607,7 +607,7 @@ interface(`dbus_watch_pid_dirs',`
 
 ########################################
 ## <summary>
-##	Read and write system dbus tmp files
+##	Read and write system dbus tmp socket files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -826,7 +826,24 @@ interface(`dbus_acquire_svc_system_dbusd',`
 	')
 
 	allow $1 system_dbusd_t:dbus acquire_svc;
+')
 
+########################################
+## <summary>
+##	Allow signal the system dbusd type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`dbus_signal',`
+	gen_require(`
+		type system_dbusd_t;
+	')
+
+	allow $1 system_dbusd_t:process signal;
 ')
 
 ########################################

--- a/policy/modules/contrib/gnome.te
+++ b/policy/modules/contrib/gnome.te
@@ -292,8 +292,11 @@ files_map_read_etc_files(gnome_atspi_t)
 fs_getattr_cgroup(gnome_atspi_t)
 
 optional_policy(`
+	dbus_acquire_svc_system_dbusd(gnome_atspi_t)
 	dbus_exec_system_dbusd(gnome_atspi_t)
 	dbus_rw_tmp_sock_files(gnome_atspi_t)
+	dbus_send_system_bus(gnome_atspi_t)
+	dbus_signal(gnome_atspi_t)
 	dbus_stream_connect_session_bus(gnome_atspi_t)
 	dbus_system_bus_client(gnome_atspi_t)
 ')
@@ -307,6 +310,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	xserver_dbus_chat_xdm(gnome_atspi_t)
 	xserver_search_xdm_lib(gnome_atspi_t)
 	xserver_read_inherited_xdm_lib_files(gnome_atspi_t)
 	xserver_read_xdm_lib_files(gnome_atspi_t)

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -786,6 +786,7 @@ userdom_filetrans_generic_home_content(xdm_t)
 
 optional_policy(`
     dbus_exec_system_dbusd(xdm_t)
+    dbus_rw_tmp_sock_files(xdm_t)
     dbus_stream_connect_session_bus(xdm_t)
     dbus_systemctl(xdm_t)
 ')


### PR DESCRIPTION
Allow gnome_atspi_t:
- attempts to send dbus messages to system dbusd type,
- send a message on the system dbus,
- signal the system dbusd type,
- send and receive messages from xdm over dbus.

Allow xdm_t read and write system dbus tmp socket files.

The dbus_signal() interface was added.

Resolves: rhbz#1949712