### PR TITLE
Label /usr/sbin/virtproxyd as virtd_exec_t

### DIFF
--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -45,6 +45,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/sbin/virtnetworkd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtnodedevd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtnwfilterd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/sbin/virtproxyd    --      gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtqemud	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtsecretd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/sbin/virtstoraged	--	gen_context(system_u:object_r:virtd_exec_t,s0)


### PR DESCRIPTION
The virtproxyd is server side daemon component of the
libvirt virtualization management system.As it is part
of libvirt, label it as virtd_exec_t.

Bugzilla:https://bugzilla.redhat.com/show_bug.cgi?id=1854332