### PR TITLE
Allow systemd watch unallocated ttys

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -373,6 +373,7 @@ term_use_usb_ttys(init_t)
 term_use_all_ptys(init_t)
 term_setattr_all_ptys(init_t)
 term_use_virtio_console(init_t)
+term_watch_unallocated_ttys(init_t)
 term_watch_reads_unallocated_ttys(init_t)
 
 # Run init scripts.


### PR DESCRIPTION
With the 2d28a7a8e01a (Remove all redundant watch permissions for systemd)
commit, term_watch_unallocated_ttys(init_t) was mistakenly removed.

Resolves: rhbz#1991329