### PR TITLE
Allow firewalld the sys_module capability

### DIFF
--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -72,6 +72,7 @@ can_exec(firewalld_t, firewalld_var_run_t)
 kernel_read_network_state(firewalld_t)
 kernel_read_system_state(firewalld_t)
 kernel_rw_net_sysctls(firewalld_t)
+kernel_load_module(firewalld_t)
 kernel_request_load_module(firewalld_t)
 
 files_list_kernel_modules(firewalld_t)


### PR DESCRIPTION
This capability needs to be allowed when a service which requires
a kernel module loaded is added to the configuration:

firewall-cmd --add-service ftp

Resolves: rhbz#1999152