### PR TITLE
Update the dhcp client local policy

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -60,7 +60,7 @@ ifdef(`distro_debian',`
 #
 # DHCP client local policy
 #
-allow dhcpc_t self:capability { dac_read_search  fsetid net_admin net_raw net_bind_service setpcap sys_nice sys_resource sys_tty_config };
+allow dhcpc_t self:capability { dac_read_search fsetid net_admin net_raw net_bind_service setgid setpcap setuid sys_chroot sys_nice sys_resource sys_tty_config };
 dontaudit dhcpc_t self:capability sys_admin;
 # for access("/etc/bashrc", X_OK) on Red Hat
 dontaudit dhcpc_t self:capability { dac_read_search sys_module };
@@ -75,6 +75,7 @@ allow dhcpc_t self:rawip_socket create_socket_perms;
 allow dhcpc_t self:netlink_generic_socket create_socket_perms;
 allow dhcpc_t self:netlink_route_socket { create_socket_perms nlmsg_read nlmsg_write };
 allow dhcpc_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow dhcpc_t self:unix_dgram_socket sendto;
 
 allow dhcpc_t dhcp_etc_t:dir list_dir_perms;
 read_lnk_files_pattern(dhcpc_t, dhcp_etc_t, dhcp_etc_t)
@@ -157,6 +158,7 @@ files_rw_inherited_tmp_file(dhcpc_t)
 files_dontaudit_rw_inherited_locks(dhcpc_t)
 
 fs_getattr_all_fs(dhcpc_t)
+fs_getattr_nsfs_files(dhcpc_t)
 fs_search_auto_mountpoints(dhcpc_t)
 
 term_dontaudit_use_all_ttys(dhcpc_t)


### PR DESCRIPTION
A new version of dhcpcd requires a few new permissions:
- the setgid, setuid, sys_chroot capabilities
- send a message to itself over a unix domain
- get an nsfs filesystem files attributes

Resolves: rhbz#1948324