### PR TITLE
Allow systemd-sleep get removable devices attributes

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1394,6 +1394,7 @@ fstools_rw_swap_files(systemd_sleep_t)
 
 # systemd-sleep needs to getattr swap partitions
 storage_getattr_fixed_disk_dev(systemd_sleep_t)
+storage_getattr_removable_dev(systemd_sleep_t)
 
 optional_policy(`
 	sysstat_domtrans(systemd_sleep_t)


### PR DESCRIPTION
This permission is required when a system is set up to use a swap
partition on a removable device.