### PR TITLE
    Allow userdomain named filetrans to pkcs_slotd_tmpfs_t domain and removing pkcs_tmpfs_filetrans interface and edit pkcs policy files

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -172,7 +172,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	pkcs_tmpfs_filetrans(certmonger_t)
+	pkcs_tmpfs_named_filetrans(certmonger_t)
 	pkcs_use_opencryptoki(certmonger_t)
 ')
 

--- a/policy/modules/contrib/pkcs.fc
+++ b/policy/modules/contrib/pkcs.fc
@@ -1,4 +1,4 @@
-/dev/shm/var\.lib\.opencryptoki.*	gen_context(system_u:object_r:pkcs_slotd_tmpfs_t,s0)
+/dev/shm/var\.lib\.opencryptoki.*  --	gen_context(system_u:object_r:pkcs_slotd_tmpfs_t,s0)
 
 /etc/rc\.d/init\.d/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_initrc_exec_t,s0)
 

--- a/policy/modules/contrib/pkcs.if
+++ b/policy/modules/contrib/pkcs.if
@@ -118,7 +118,7 @@ interface(`pkcs_getattr_exec_files',`
 
 ########################################
 ## <summary>
-##	Create and manage objects in the tmpfs directories
+##	Create specific objects in the tmpfs directories
 ##	with a private type.
 ## </summary>
 ## <param name="domain">
@@ -127,39 +127,19 @@ interface(`pkcs_getattr_exec_files',`
 ##	</summary>
 ## </param>
 #
-interface(`pkcs_tmpfs_filetrans',`
+interface(`pkcs_tmpfs_named_filetrans',`
 	gen_require(`
 		type pkcs_slotd_tmpfs_t;
 	')
+
 	allow $1 pkcs_slotd_tmpfs_t:file map;
 
 	manage_files_pattern($1, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
-	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, { file dir })
-
-	fs_manage_tmpfs_dirs($1)
-')
-
-########################################
-## <summary>
-##      Create specific objects in the tmpfs directories
-##      with a private type.
-## </summary>
-## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
-## </param>
-#
-interface(`pkcs_tmpfs_named_filetrans',`
-        gen_require(`
-                type pkcs_slotd_tmpfs_t;
-        ')
-
-        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ccatok")
-        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ep11tok")
-        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.lite")
-        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.swtok")
-        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.tpm.root")
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ccatok")
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ep11tok")
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.lite")
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.swtok")
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.tpm.root")
 ')
 
 ########################################

--- a/policy/modules/contrib/pkcs.if
+++ b/policy/modules/contrib/pkcs.if
@@ -141,6 +141,29 @@ interface(`pkcs_tmpfs_filetrans',`
 
 ########################################
 ## <summary>
+##      Create specific objects in the tmpfs directories
+##      with a private type.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`pkcs_tmpfs_named_filetrans',`
+        gen_require(`
+                type pkcs_slotd_tmpfs_t;
+        ')
+
+        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ccatok")
+        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ep11tok")
+        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.lite")
+        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.swtok")
+        fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.tpm.root")
+')
+
+########################################
+## <summary>
 ##	Use opencryptoki services
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -252,7 +252,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	pkcs_tmpfs_filetrans(ipsec_t)
+	pkcs_tmpfs_named_filetrans(ipsec_t)
 	pkcs_use_opencryptoki(ipsec_t)
 ')
 

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -410,6 +410,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+        pkcs_tmpfs_named_filetrans(login_userdomain)
+')
+
+optional_policy(`
 	systemd_login_watch_session_dirs(login_userdomain)
 ')
 

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -410,7 +410,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-        pkcs_tmpfs_named_filetrans(login_userdomain)
+	pkcs_tmpfs_named_filetrans(login_userdomain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
 **Commit1:** Allow login_userdomain named filetrans to pkcs_slotd_tmpfs_t domain

User can initialized token. But token which is
being initialized by user get a default context user_tmp_t.
Tokens need to have pkcs_slotd_tmpfs_t domain for proper
functionality with services like certmonger and etc.
Need to create named filetrans, due to SELinux conflicts
without specifying object.
Allow named filetrans from login_userdomain to pkcs_slotd_tmpfs_t.

List of all named tokens:https://github.com/opencryptoki/opencryptoki/blob/master/doc/system_resources
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2001599

**Commit 2:** Removing pkcs_tmpfs_filetrans interface and edit pkcs policy files

Removing pkcs_tmpfs_filetrans() interface, which is
replaced by pkcs_tmpfs_named_filetrans and add
additional rules to named interface like manage
pkcs_slotd_tmpfs_t files. Fix typo in pkcs.fc.