### PR TITLE
Allow dhcpcd set its resource limits

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -64,7 +64,7 @@ allow dhcpc_t self:capability { dac_read_search fsetid net_admin net_raw net_bin
 dontaudit dhcpc_t self:capability sys_admin;
 # for access("/etc/bashrc", X_OK) on Red Hat
 dontaudit dhcpc_t self:capability { dac_read_search sys_module };
-allow dhcpc_t self:process { getsched setsched getcap setcap setfscreate signal_perms };
+allow dhcpc_t self:process { getsched setsched getcap setcap setfscreate setrlimit signal_perms };
 allow dhcpc_t self:cap_userns { net_bind_service };
 
 allow dhcpc_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
Changing limits serves as an additional protection, preventing usage of
file handles an preventing further forking. Always changed to zero or
minimal amount required to work, reducing it always below system defaults.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(09/13/2021 09:36:08.570:200) : proctitle=dhcpcd: [master] [ip4] [ip6]
type=SYSCALL msg=audit(09/13/2021 09:36:08.570:200) : arch=x86_64 syscall=prlimit64 success=no exit=EACCES(Permission denied) a0=0x0 a1=0x6 a2=0x7ffc8d76a990 a3=0x0 items=0 ppid=1 pid=1438 auid=unset uid=dhcpcd gid=dhcpcd euid=dhcpcd suid=dhcpcd fsuid=dhcpcd egid=dhcpcd sgid=dhcpcd fsgid=dhcpcd tty=(none) ses=unset comm=dhcpcd exe=/usr/sbin/dhcpcd subj=system_u:system_r:dhcpc_t:s0 key=(null)
type=AVC msg=audit(09/13/2021 09:36:08.570:200) : avc:  denied  { setrlimit } for  pid=1438 comm=dhcpcd scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:system_r:dhcpc_t:s0 tclass=process permissive=0

Resolves: rhbz#1948324