### PR TITLE
Allow at-spi-launcher read and map xdm pid files

### DIFF
--- a/policy/modules/contrib/gnome.te
+++ b/policy/modules/contrib/gnome.te
@@ -83,6 +83,11 @@ type gnome_atspi_exec_t;
 init_daemon_domain(gnome_atspi_t, gnome_atspi_exec_t)
 role system_r types gnome_atspi_t;
 
+optional_policy(`
+	xserver_read_xdm_pid(gnome_atspi_t)
+	xserver_map_xdm_pid(gnome_atspi_t)
+')
+
 ##############################
 #
 # Local Policy


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(13.9.2021 12:52:01.322:203) : proctitle=/usr/libexec/at-spi-bus-launcher
type=PATH msg=audit(13.9.2021 12:52:01.322:203) : item=0 name=/run/gnome-initial-setup/.config/dconf/user inode=1360 dev=00:1a mode=file,644 ouid=gnome-initial-setup ogid=gnome-initial-setup rdev=00:00 obj=unconfined_u:object_r:xdm_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(13.9.2021 12:52:01.322:203) : cwd=/run/gnome-initial-setup
type=SYSCALL msg=audit(13.9.2021 12:52:01.322:203) : arch=x86_64 syscall=openat success=yes exit=4 a0=0xffffff9c a1=0x559b30a74400 a2=O_RDONLY a3=0x0 items=1 ppid=969 pid=970 auid=unset uid=gnome-initial-setup gid=gnome-initial-setup euid=gnome-initial-setup suid=gnome-initial-setup fsuid=gnome-initial-setup egid=gnome-initial-setup sgid=gnome-initial-setup fsgid=gnome-initial-setup tty=tty1 ses=unset comm=at-spi-bus-laun exe=/usr/libexec/at-spi-bus-launcher subj=system_u:system_r:gnome_atspi_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(13.9.2021 12:52:01.322:203) : avc:  denied  { open } for  pid=970 comm=at-spi-bus-laun path=/run/gnome-initial-setup/.config/dconf/user dev="tmpfs" ino=1360 scontext=system_u:system_r:gnome_atspi_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:xdm_var_run_t:s0 tclass=file permissive=1

Resolves: rhbz#1997310