### PR TITLE
Allow system-dbusd execute gnome keyringd

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -195,6 +195,7 @@ optional_policy(`
 optional_policy(`
 	gnome_atspi_domtrans(system_dbusd_t)
 	gnome_exec_gconf(system_dbusd_t)
+	gnome_exec_keyringd(system_dbusd_t)
 	gnome_read_inherited_home_icc_data_files(system_dbusd_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(7.9.2021 14:11:37.443:253) : avc:  denied  { execute } for  pid=1461 comm=dbus-d
aemon name=gnome-keyring-daemon dev="vda2" ino=3316 scontext=system_u:system_r:system_dbusd_t:s0-s0
:c0.c1023 tcontext=system_u:object_r:gkeyringd_exec_t:s0 tclass=file permissive=1

Resolves: rhbz#2003778