### PR TITLE
Allow rasdaemon sys_admin capability to verify the CAP_SYS_ADMIN of the soft_offline_page function implemented in the kernel

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -19,6 +19,7 @@ systemd_unit_file(rasdaemon_unit_file_t)
 #
 # rasdaemon local policy
 #
+allow rasdaemon_t self:capability sys_admin;
 allow rasdaemon_t self:fifo_file rw_fifo_file_perms;
 allow rasdaemon_t self:unix_stream_socket create_stream_socket_perms;
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4887,7 +4887,7 @@ template(`userdom_unpriv_usertype',`
 #
 template(`userdom_unpriv_type',`
     gen_require(`
-        attribute unpriv_userdomain, userdomain;
+        attribute userdomain;
     ')
     typeattribute $1  userdomain;
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4889,7 +4889,7 @@ template(`userdom_unpriv_type',`
     gen_require(`
         attribute userdomain;
     ')
-    typeattribute $1  userdomain;
+    typeattribute $1 userdomain;
 
     auth_use_nsswitch($1)
     ubac_constrained($1)


### PR DESCRIPTION
fix: https://github.com/fedora-selinux/selinux-policy/issues/860#issue-988223810
Allow rasdaemon sys_admin capability  to verify the CAP_SYS_ADMIN of the soft_offline_page function implemented in the kernel