### PR TITLE
Allow unbound connectto unix_stream_socket

### DIFF
--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -79,7 +79,7 @@ dontaudit named_t self:capability sys_tty_config;
 allow named_t self:capability2 block_suspend;
 allow named_t self:process { setsched getcap setcap setrlimit signal_perms };
 allow named_t self:fifo_file rw_fifo_file_perms;
-allow named_t self:unix_stream_socket { accept listen };
+allow named_t self:unix_stream_socket { accept connectto listen };
 allow named_t self:tcp_socket { accept listen };
 
 allow named_t dnssec_t:file read_file_perms;


### PR DESCRIPTION
Allow unbound connectto unix_stream_socket.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1905441