### PR TITLE
Allow gnome at-spi processes get attributes of tmpfs filesystems

### DIFF
--- a/policy/modules/contrib/gnome.te
+++ b/policy/modules/contrib/gnome.te
@@ -295,6 +295,7 @@ userdom_use_inherited_user_terminals(gnomedomain)
 
 files_map_read_etc_files(gnome_atspi_t)
 fs_getattr_cgroup(gnome_atspi_t)
+fs_getattr_tmpfs(gnome_atspi_t)
 
 optional_policy(`
 	dbus_acquire_svc_system_dbusd(gnome_atspi_t)


### PR DESCRIPTION
Resolves: rhbz#2003451