### PR TITLE
Support hitless reloads feature in haproxy

### DIFF
--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -634,7 +634,7 @@ allow haproxy_t self:capability { chown fowner setgid setuid sys_chroot sys_reso
 allow haproxy_t self:capability2 block_suspend;
 allow haproxy_t self:process { fork setrlimit signal_perms };
 allow haproxy_t self:fifo_file rw_fifo_file_perms;
-allow haproxy_t self:unix_stream_socket create_stream_socket_perms;
+allow haproxy_t self:unix_stream_socket { create_stream_socket_perms connectto };
 allow haproxy_t self:tcp_socket create_stream_socket_perms;
 allow haproxy_t self: udp_socket create_socket_perms;
 


### PR DESCRIPTION
HAProxy has long had a feature for "hitless reloads" [1] that prevents
established connections from being dropped due to a reload. It can be
achieved with updating the configuration file with adding the option
'expose-fd listeners':

    stats socket /var/run/haproxy.sock mode 600 expose-fd listeners level user

[1] https://www.haproxy.com/blog/hitless-reloads-with-haproxy-howto/

Resolves: rhbz#1997182