### PR TITLE
Allow haproxy list the sysfs directories content

### DIFF
--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -661,6 +661,7 @@ corenet_tcp_connect_http_port(haproxy_t)
 corenet_tcp_connect_http_cache_port(haproxy_t)
 corenet_tcp_connect_rtp_media_port(haproxy_t)
 
+dev_list_sysfs(haproxy_t)
 dev_read_rand(haproxy_t)
 dev_read_urand(haproxy_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(07/28/2021 07:36:55.442:428) : proctitle=/usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -c -q
type=PATH msg=audit(07/28/2021 07:36:55.442:428) : item=0 name=/sys/devices/system/node inode=614 dev=00:16 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(07/28/2021 07:36:55.442:428) : cwd=/
type=SYSCALL msg=audit(07/28/2021 07:36:55.442:428) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=0xffffff9c a1=0x5591cb5eb5b4 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=14624 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=haproxy exe=/usr/sbin/haproxy subj=system_u:system_r:haproxy_t:s0 key=(null)
type=AVC msg=audit(07/28/2021 07:36:55.442:428) : avc:  denied  { read } for  pid=14624 comm=haproxy name=node dev="sysfs" ino=614 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=0