### PR TITLE
Update mount_manage_pid_files() to use manage_files_pattern

### DIFF
--- a/policy/modules/system/mount.if
+++ b/policy/modules/system/mount.if
@@ -154,8 +154,8 @@ interface(`mount_manage_pid_files',`
 		type mount_var_run_t;
 	')
 
-	allow $1 mount_var_run_t:file manage_file_perms;
 	files_search_pids($1)
+	manage_files_pattern($1, mount_var_run_t, mount_var_run_t)
 ')
 
 ########################################


### PR DESCRIPTION
Update the mount_manage_pid_files() interface to use the
manage_files_pattern pattern instead of manage_file_perms
object permissions set so that the domain allowed access
can write to the mount pid directories.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(09/01/2021 09:08:49.702:156) : proctitle=/bin/mount -t nfsd nfsd /proc/fs/nfsd
type=PATH msg=audit(09/01/2021 09:08:49.702:156) : item=0 name=/run/mount inode=394 dev=00:19 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:mount_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(09/01/2021 09:08:49.702:156) : cwd=/var/lib/nfs
type=SYSCALL msg=audit(09/01/2021 09:08:49.702:156) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x55f4e4f62550 a1=W_OK|R_OK a2=0x7ffdf1ce8c80 a3=0x0 items=1 ppid=1351 pid=1352 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=mount exe=/usr/bin/mount subj=system_u:system_r:nfsd_t:s0 key=(null)
type=AVC msg=audit(09/01/2021 09:08:49.702:156) : avc:  denied  { write } for  pid=1352 comm=mount name=mount dev="tmpfs" ino=394 scontext=system_u:system_r:nfsd_t:s0 tcontext=system_u:object_r:mount_var_run_t:s0 tclass=dir permissive=0