### PR TITLE
Allow fprintd install a sleep delay inhibitor

### DIFF
--- a/policy/modules/contrib/fprintd.te
+++ b/policy/modules/contrib/fprintd.te
@@ -78,6 +78,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_dbus_chat_logind(fprintd_t)
+	systemd_write_inhibit_pipes(fprintd_t)
+')
+
+optional_policy(`
 	udev_read_db(fprintd_t)
 ')
 


### PR DESCRIPTION
The following permissions were added:
- allow fprint to write inhibit systemd pipes
- a fprintd to chat with systemd_logind via dbus

Addresses the following AVC denials:

type=USER_AVC msg=audit(08/31/2021 11:03:09.110:360) : pid=665 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:fprintd_t:s0 tcontext=system_u:system_r:systemd_logind_t:s0 tclass=dbus permissive=1  exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'

type=PROCTITLE msg=audit(08/31/2021 11:03:09.113:361) : proctitle=/usr/libexec/fprintd
type=SYSCALL msg=audit(08/31/2021 11:03:09.113:361) : arch=x86_64 syscall=recvmsg success=yes exit=16 a0=0x5 a1=0x7f097199e860 a2=MSG_CMSG_CLOEXEC a3=0x7ffceb324080 items=0 ppid=1 pid=3286 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=gdbus exe=/usr/libexec/fprintd subj=system_u:system_r:fprintd_t:s0 key=(null)
type=AVC msg=audit(08/31/2021 11:03:09.113:361) : avc:  denied  { write } for  pid=3286 comm=gdbus path=/run/systemd/inhibit/9.ref dev="tmpfs" ino=1764 scontext=system_u:system_r:fprintd_t:s0 tcontext=system_u:object_r:systemd_logind_inhibit_var_run_t:s0 tclass=fifo_file permissive=1