### PR TITLE
Allow scripts to enter LUKS password

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -574,6 +574,8 @@ dev_write_sysfs_dirs(systemd_passwd_agent_t)
 
 term_read_console(systemd_passwd_agent_t)
 term_use_unallocated_ttys(systemd_passwd_agent_t)
+term_watch_unallocated_ttys(systemd_passwd_agent_t)
+term_watch_reads_unallocated_ttys(systemd_passwd_agent_t)
 
 init_create_pid_dirs(systemd_passwd_agent_t)
 init_rw_pipes(systemd_passwd_agent_t)


### PR DESCRIPTION
When a script is set to enter LUKS password at boot, it communicates with
systemd-tty-ask-password-agent. The agent requires the watch and
watch_reads permissions on unallocated terminal device nodes.

Addresses the following AVC denials:

audit: type=1400 audit(1630396253.336:96): avc:  denied  { watch watch_reads } for  pid=480 comm="systemd-tty-ask" path="/dev/tty1" dev="devtmpfs" ino=20 scontext=system_u:system_r:systemd_passwd_agent_t:s0 tcontext=system_u:object_r:tty_device_t:s0 tclass=chr_file permissive=0
audit: type=1300 audit(1630396253.336:96): arch=c000003e syscall=254 success=no exit=-13 a0=7 a1=7ffe9c946f23 a2=18 a3=564142057830 items=0 ppid=476 pid=480 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-tty-ask" exe="/usr/bin/systemd-tty-ask-password-agent" subj=system_u:system_r:systemd_passwd_agent_t:s0 key=(null)

Resolves: rhbz#1999526