### PR TITLE
Allow unconfined domains read/write domain perf_events

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -288,6 +288,8 @@ allow unconfined_domain_type domain:lnk_file { read_lnk_file_perms ioctl lock };
 # act on all domains keys
 allow unconfined_domain_type domain:key *;
 
+allow unconfined_domain_type domain:perf_event rw_inherited_perf_event_perms;
+
 kernel_manage_perf_event(unconfined_domain_type)
 
 corenet_filetrans_all_named_dev(named_filetrans_domain)

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -79,8 +79,6 @@ kernel_rw_unlabeled_rawip_socket(unconfined_t)
 kernel_rw_unlabeled_smc_socket(unconfined_t)
 kernel_rw_unlabeled_vsock_socket(unconfined_t)
 
-domain_rw_perf_event_all_domains(unconfined_t)
-
 files_create_boot_flag(unconfined_t)
 files_create_default_dir(unconfined_t)
 files_root_filetrans_default(unconfined_t, dir)


### PR DESCRIPTION
Until now, the permissions to read and write perf_event file descriptors
from all domains was allowed to unconfined_t. This commit extends the
permissions to all unconfined domain types.

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/886