### PR TITLE
Allow NetworkManager dbus chat with fwupd

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -322,6 +322,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fwupd_dbus_chat(NetworkManager_t)
+')
+
+optional_policy(`
 	howl_signal(NetworkManager_t)
 ')
 


### PR DESCRIPTION
This permission is required since fwupd 1.6.3 when the "auto-connect"
option is not set. The service tries to connect to NetworkManager at
startup to ensure that the USB network interface is up so that it can
talk to the server BMC controller.

When the connection is not allowed, the daemon fails to start the redfish
plugin, which means that most of the updatable devices do not show up.

Resolves: rhbz#1993271