### PR TITLE
Allow systemd watch and watch_reads console devices

### DIFF
--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -408,6 +408,42 @@ interface(`term_create_console_dev',`
 
 ########################################
 ## <summary>
+##	Watch the console device (/dev/console).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`term_watch_console_dev',`
+	gen_require(`
+		type console_device_t;
+	')
+
+	allow $1 console_device_t:chr_file watch_chr_file_perms;
+')
+
+########################################
+## <summary>
+##	Watch_reads the console device (/dev/console).
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`term_watch_reads_console_dev',`
+	gen_require(`
+		type console_device_t;
+	')
+
+	allow $1 console_device_t:chr_file watch_reads_chr_file_perms;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of a pty filesystem
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -373,6 +373,8 @@ term_use_usb_ttys(init_t)
 term_use_all_ptys(init_t)
 term_setattr_all_ptys(init_t)
 term_use_virtio_console(init_t)
+term_watch_console_dev(init_t)
+term_watch_reads_console_dev(init_t)
 term_watch_unallocated_ttys(init_t)
 term_watch_reads_unallocated_ttys(init_t)
 


### PR DESCRIPTION
This permission is required for a service with "StandardInput=tty".
This means that standard input of the command which starts the service
is connected to a tty (/dev/console by default).

An example service is kbdrate to adjust typematic delay and rate:
https://wiki.archlinux.org/title/Linux_console/Keyboard_configuration#Systemd_service

The following interfaces were added:
- term_watch_console_dev
- term_watch_reads_console_dev

Resolves: rhbz#2001219