### PR TITLE
Allow usbmuxd get attributes of tmpfs_t filesystems

### DIFF
--- a/policy/modules/contrib/usbmuxd.te
+++ b/policy/modules/contrib/usbmuxd.te
@@ -52,6 +52,7 @@ dev_read_urand(usbmuxd_t)
 dev_rw_generic_usb_dev(usbmuxd_t)
 
 fs_getattr_cgroup(usbmuxd_t)
+fs_getattr_tmpfs(usbmuxd_t)
 fs_getattr_xattr_fs(usbmuxd_t)
 
 auth_use_nsswitch(usbmuxd_t)


### PR DESCRIPTION
Resolves: rhbz#1954380