### PR TITLE
Allow gnome at-spi processes create and use stream sockets

### DIFF
--- a/policy/modules/contrib/gnome.te
+++ b/policy/modules/contrib/gnome.te
@@ -293,6 +293,8 @@ userdom_use_inherited_user_terminals(gnomedomain)
 # at-spi local policy
 #
 
+allow gnome_atspi_t self:tcp_socket create_stream_socket_perms;
+
 files_map_read_etc_files(gnome_atspi_t)
 fs_getattr_cgroup(gnome_atspi_t)
 fs_getattr_tmpfs(gnome_atspi_t)


### PR DESCRIPTION
While X window connections usually communicate over a local socket,
with xdmcp in place (e. g. using Xephyr) tcp socket is needed.

Resolves: rhbz#2004885