### PR TITLE
Add bluetooth-related permissions into a tunable block

### DIFF
--- a/policy/modules/contrib/pads.te
+++ b/policy/modules/contrib/pads.te
@@ -30,7 +30,6 @@ allow pads_t self:packet_socket { map create_socket_perms };
 allow pads_t self:socket create_socket_perms;
 allow pads_t self:udp_socket create_socket_perms;
 allow pads_t self:unix_dgram_socket create_socket_perms;
-allow pads_t self:bluetooth_socket create_socket_perms;
 allow pads_t self:netlink_netfilter_socket create_socket_perms;
 
 allow pads_t pads_config_t:file manage_file_perms;
@@ -61,6 +60,10 @@ files_search_spool(pads_t)
 logging_send_syslog_msg(pads_t)
 
 sysnet_dns_name_resolve(pads_t)
+
+tunable_policy(`deny_bluetooth',`',`
+	allow pads_t self:bluetooth_socket create_socket_perms;
+')
 
 optional_policy(`
 	prelude_manage_spool(pads_t)

--- a/policy/modules/contrib/snort.te
+++ b/policy/modules/contrib/snort.te
@@ -32,7 +32,6 @@ files_pid_file(snort_var_run_t)
 allow snort_t self:capability { setgid setuid net_admin net_raw dac_read_search  };
 dontaudit snort_t self:capability sys_tty_config;
 allow snort_t self:process signal_perms;
-allow snort_t self:bluetooth_socket create_socket_perms;
 allow snort_t self:netlink_generic_socket create_socket_perms;
 allow snort_t self:netlink_route_socket create_netlink_socket_perms;
 allow snort_t self:netlink_netfilter_socket create_socket_perms;
@@ -106,6 +105,10 @@ sysnet_dns_name_resolve(snort_t)
 
 userdom_dontaudit_use_unpriv_user_fds(snort_t)
 userdom_dontaudit_search_user_home_dirs(snort_t)
+
+tunable_policy(`deny_bluetooth',`',`
+	allow snort_t self:bluetooth_socket create_socket_perms;
+')
 
 optional_policy(`
 	prelude_manage_spool(snort_t)


### PR DESCRIPTION
Since the 5a0561d7b6 ("Introduce deny_bluetooth boolean") commit,
all permissions for the bluetooth_socket class should be in a
tunable_policy block for the deny_bluetooth boolean. Two of the recent
commits for the pads_t and snort_t domains allowed the permissions
unconditionally, which is fixed now.