### PR TITLE
Allow management of lnk_files if similar access to regular files

### DIFF
--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -159,6 +159,7 @@ interface(`logging_read_audit_log',`
 
 	files_search_var($1)
 	read_files_pattern($1, auditd_log_t, auditd_log_t)
+	read_lnk_files_pattern($1, auditd_log_t, auditd_log_t)
 	allow $1 auditd_log_t:dir list_dir_perms;
 ')
 
@@ -1136,6 +1137,7 @@ interface(`logging_read_all_logs',`
 	allow $1 logfile:dir list_dir_perms;
 	allow $1 logfile:file map;
 	read_files_pattern($1, logfile, logfile)
+	read_lnk_files_pattern($1, logfile, logfile)
 ')
 
 ########################################
@@ -1243,6 +1245,7 @@ interface(`logging_read_generic_logs',`
 	allow $1 var_log_t:dir list_dir_perms;
 	allow $1 var_log_t:file map;
 	read_files_pattern($1, var_log_t, var_log_t)
+	read_lnk_files_pattern($1, var_log_t, var_log_t)
 ')
 
 ########################################
@@ -1339,6 +1342,7 @@ interface(`logging_write_generic_logs',`
 	files_search_var($1)
 	allow $1 var_log_t:dir list_dir_perms;
 	write_files_pattern($1, var_log_t, var_log_t)
+	read_lnk_files_pattern($1, var_log_t, var_log_t)
 ')
 
 ########################################
@@ -1453,6 +1457,7 @@ interface(`logging_manage_generic_logs',`
 
 	files_search_var($1)
 	manage_files_pattern($1, var_log_t, var_log_t)
+	manage_lnk_files_pattern($1, var_log_t, var_log_t)
 ')
 
 ########################################


### PR DESCRIPTION
container-selinux has container_logreader_t which needs to be able
to read symbolic liks.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>