### PR TITLE
Add default file context for /run/gssproxy.default.sock

### DIFF
--- a/policy/modules/contrib/gssproxy.fc
+++ b/policy/modules/contrib/gssproxy.fc
@@ -5,4 +5,5 @@
 /var/lib/gssproxy(/.*)?		gen_context(system_u:object_r:gssproxy_var_lib_t,s0)
 
 /var/run/gssproxy\.pid		--	gen_context(system_u:object_r:gssproxy_var_run_t,s0)
+/var/run/gssproxy\.default\.sock	-s	gen_context(system_u:object_r:gssproxy_var_run_t,s0)
 /var/run/gssproxy\.sock		-s	gen_context(system_u:object_r:gssproxy_var_run_t,s0)


### PR DESCRIPTION
The default socket path changed from /var/lib/gsproxy to /run.