### PR TITLE
Allow sddm watch generic pid directories

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -638,6 +638,7 @@ files_watch_etc_dirs(xdm_t)
 files_watch_etc_files(xdm_t)
 files_watch_usr_dirs(xdm_t)
 files_watch_usr_files(xdm_t)
+files_watch_var_run_dirs(xdm_t)
 files_mounton_non_security(xdm_t)
 # Read /usr/share/terminfo/l/linux and /usr/share/icons/default/index.theme...
 files_read_usr_files(xdm_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(10/06/21 10:56:56.829:185) : proctitle=/usr/bin/sddm-greeter --socket /tmp/sddm-:0-pwkIiM --theme /usr/share/sddm/themes/01-breeze-fedora
type=PATH msg=audit(10/06/21 10:56:56.829:185) : item=0 name=/var/run inode=1 dev=00:1a mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/06/21 10:56:56.829:185) : cwd=/var/lib/sddm
type=SYSCALL msg=audit(10/06/21 10:56:56.829:185) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0x12 a1=0x7f87ef9bfe35 a2=0x100 a3=0x0 items=1 ppid=1592 pid=1612 auid=unset uid=sddm gid=sddm euid=sddm suid=sddm fsuid=sddm egid=sddm sgid=sddm fsgid=sddm tty=(none) ses=unset comm=sddm-greeter exe=/usr/bin/sddm-greeter subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(10/06/21 10:56:56.829:185) : avc:  denied  { watch } for  pid=1612 comm=sddm-greeter path=/run dev="tmpfs" ino=1 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=0

Resolves: rhbz#1997282