### PR TITLE
Allow rasdaemon sys_admin capability to verify the CAP_SYS_ADMIN of t…

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -19,6 +19,7 @@ systemd_unit_file(rasdaemon_unit_file_t)
 #
 # rasdaemon local policy
 #
+allow rasdaemon_t self:capability sys_admin;
 allow rasdaemon_t self:fifo_file rw_fifo_file_perms;
 allow rasdaemon_t self:unix_stream_socket create_stream_socket_perms;
 


### PR DESCRIPTION
fix: https://github.com/fedora-selinux/selinux-policy/issues/860#issue-988223810
Allow rasdaemon sys_admin capability to verify the CAP_SYS_ADMIN of the soft_offline_page function implemented in the kernel