### PR TITLE
Allow fedora-third-party create and use unix_dgram_socket

### DIFF
--- a/policy/modules/contrib/fedoratp.te
+++ b/policy/modules/contrib/fedoratp.te
@@ -9,6 +9,8 @@ files_type(fedoratp_var_lib_t)
 
 manage_files_pattern(fedoratp_t, fedoratp_var_lib_t, fedoratp_var_lib_t)
 
+allow fedoratp_t self:unix_dgram_socket create_socket_perms;
+
 corecmd_exec_bin(fedoratp_t)
 
 files_manage_system_conf_files(fedoratp_t)


### PR DESCRIPTION
Resolves: rhbz#2001837