### PR TITLE
Allow systemd-resolved watch /run/systemd

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1143,6 +1143,8 @@ dev_read_sysfs(systemd_resolved_t)
 files_watch_root_dirs(systemd_resolved_t)
 files_watch_var_run_dirs(systemd_resolved_t)
 
+init_watch_pid_dir(systemd_resolved_t)
+
 sysnet_manage_config(systemd_resolved_t)
 sysnet_filetrans_systemd_resolved(systemd_resolved_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(08/11/2021 09:19:26.708:582) : proctitle=/usr/lib/systemd/systemd-resolved
type=PATH msg=audit(08/11/2021 09:19:26.708:582) : item=0 name=/run/systemd/ inode=2 dev=00:19 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(08/11/2021 09:19:26.708:582) : cwd=/
type=SYSCALL msg=audit(08/11/2021 09:19:26.708:582) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0x7 a1=0x7ff20e2c1f88 a2=0x40000100 a3=0xffffffcd items=1 ppid=1 pid=8003 auid=unset uid=systemd-resolve gid=systemd-resolve euid=systemd-resolve suid=systemd-resolve fsuid=systemd-resolve egid=systemd-resolve sgid=systemd-resolve fsgid=systemd-resolve tty=(none) ses=unset comm=systemd-resolve exe=/usr/lib/systemd/systemd-resolved subj=system_u:system_r:systemd_resolved_t:s0 key=(null)
type=AVC msg=audit(08/11/2021 09:19:26.708:582) : avc:  denied  { watch } for  pid=8003 comm=systemd-resolve path=/run/systemd dev="tmpfs" ino=2 scontext=system_u:system_r:systemd_resolved_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0