### PR TITLE
Allow unconfined_t transition to mozilla_plugin_t with NoNewPrivileges

### DIFF
--- a/policy/modules/contrib/mozilla.if
+++ b/policy/modules/contrib/mozilla.if
@@ -273,6 +273,24 @@ interface(`mozilla_domtrans_plugin',`
 
 ########################################
 ## <summary>
+##	Allow caller to transition to mozilla_plugin_t with NoNewPrivileges
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`mozilla_nnp_domtrans_plugin',`
+	gen_require(`
+		type mozilla_plugin_t;
+	')
+
+	allow $1 mozilla_plugin_t:process2 nnp_transition;
+')
+
+########################################
+## <summary>
 ##	Execute mozilla_plugin in the mozilla_plugin domain, and
 ##	allow the specified role the mozilla_plugin domain.
 ## </summary>

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -337,6 +337,7 @@ optional_policy(`
 
 	tunable_policy(`unconfined_mozilla_plugin_transition', `
 			mozilla_domtrans_plugin(unconfined_t)
+			mozilla_nnp_domtrans_plugin(unconfined_t)
 	')
 ')
 


### PR DESCRIPTION
The mozilla_nnp_domtrans_plugin() interface was added.

Resolves: rhbz#2007418