### PR TITLE
Allow chrony-wait service start with DynamicUser=yes

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -40,6 +40,7 @@ type chronyc_t;
 type chronyc_exec_t;
 domain_type(chronyc_t, chronyc_exec_t)
 init_system_domain(chronyc_t, chronyc_exec_t)
+init_nnp_daemon_domain(chronyc_t)
 role chronyc_roles types chronyc_t;
 
 ########################################


### PR DESCRIPTION
When DynamicUser=yes is set in a service unit,
NoNewPrivileges=yes is set automatically, too.
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#NoNewPrivileges=

Resolves: rhbz#2008894