### PR TITLE
Add erofs as a SELinux capable file system

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -29,6 +29,7 @@ typealias fs_t alias inotifyfs_t;
 # Requires that a security xattr handler exist for the filesystem.
 fs_use_xattr btrfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr encfs gen_context(system_u:object_r:fs_t,s0);
+fs_use_xattr erofs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr ext2 gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr ext3 gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr ext4 gen_context(system_u:object_r:fs_t,s0);


### PR DESCRIPTION
Can SELinuxProject/refpolicy@a885f70d50fe39c6cdc57d71ca54c02c0315a349 please be backported to fix [rhbz#2012463](https://bugzilla.redhat.com/2012463)?

This error affects all supported Fedora branches.  I can send a PR for `f33` and `f34` branches as well if this will be applied.