### PR TITLE
Support new PING_CHECK health checker in keepalived

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -39,6 +39,7 @@ files_tmpfs_file(keepalived_tmpfs_t)
 
 allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_admin sys_ptrace };
 allow keepalived_t self:process { signal_perms getpgid setpgid };
+allow keepalived_t self:icmp_socket create_socket_perms;
 allow keepalived_t self:netlink_socket create_socket_perms;
 allow keepalived_t self:netlink_generic_socket create_socket_perms;
 allow keepalived_t self:netlink_netfilter_socket create_socket_perms;
@@ -61,7 +62,7 @@ kernel_read_network_state(keepalived_t)
 kernel_request_load_module(keepalived_t)
 kernel_rw_usermodehelper_state(keepalived_t)
 kernel_search_network_sysctl(keepalived_t)
-kernel_read_net_sysctls(keepalived_t)
+kernel_rw_net_sysctls(keepalived_t)
 
 auth_use_nsswitch(keepalived_t)
 


### PR DESCRIPTION
keepalived is now allowed to create and use icmp_socket.
keepalived is now allowed to modify /proc/sys/net/ipv4/ping_group_range;
for that, it was allowed to modify the content of sysctl network files
instead of only reading them.

Addresses the following AVC denials:

type=PROCTITLE msg=audit(10/05/2021 11:58:21.534:855) : proctitle=/usr/sbin/keepalived -D
type=SYSCALL msg=audit(10/05/2021 11:58:21.534:855) : arch=x86_64 syscall=socket success=yes exit=8 a0=inet a1=SOCK_DGRAM a2=icmp a3=0x1 items=0 ppid=7768 pid=7769 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=keepalived exe=/usr/sbin/keepalived subj=system_u:system_r:keepalived_t:s0 key=(null)
type=AVC msg=audit(10/05/2021 11:58:21.534:855) : avc:  denied  { create } for  pid=7769 comm=keepalived scontext=system_u:system_r:keepalived_t:s0 tcontext=system_u:system_r:keepalived_t:s0 tclass=icmp_socket permissive=1

type=PROCTITLE msg=audit(10/05/2021 11:55:10.973:851) : proctitle=/usr/sbin/keepalived -D
type=PATH msg=audit(10/05/2021 11:55:10.973:851) : item=0 name=/proc/sys/net/ipv4/ping_group_range inode=48051 dev=00:05 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_net_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/05/2021 11:55:10.973:851) : cwd=/etc/keepalived
type=SYSCALL msg=audit(10/05/2021 11:55:10.973:851) : arch=x86_64 syscall=openat success=yes exit=9 a0=0xffffff9c a1=0x560268bbf640 a2=O_RDWR a3=0x0 items=1 ppid=7686 pid=7687 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=keepalived exe=/usr/sbin/keepalived subj=system_u:system_r:keepalived_t:s0 key=(null)
type=AVC msg=audit(10/05/2021 11:55:10.973:851) : avc:  denied  { write } for  pid=7687 comm=keepalived name=ping_group_range dev="proc" ino=48051 scontext=system_u:system_r:keepalived_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1

Resolves: rhbz#2010873