### PR TITLE
Allow fedora-third party manage gpg keys

### DIFF
--- a/policy/modules/contrib/fedoratp.te
+++ b/policy/modules/contrib/fedoratp.te
@@ -20,6 +20,7 @@ corenet_tcp_connect_http_port(fedoratp_t)
 files_manage_system_conf_files(fedoratp_t)
 files_manage_generic_tmp_dirs(fedoratp_t)
 files_manage_generic_tmp_files(fedoratp_t)
+files_manage_var_lib_dirs(fedoratp_t)
 files_manage_var_lib_files(fedoratp_t)
 
 sysnet_dns_name_resolve(fedoratp_t)
@@ -34,6 +35,7 @@ optional_policy(`
 	delete_sock_files_pattern(fedoratp_t, tmp_t, gpg_agent_tmp_t)
 	manage_dirs_pattern(fedoratp_t, gpg_agent_tmp_t, gpg_agent_tmp_t)
 	manage_files_pattern(fedoratp_t, gpg_agent_tmp_t, gpg_agent_tmp_t)
+	manage_files_pattern(gpg_t, tmp_t, tmp_t)
 
 	files_watch_generic_tmp_dirs(gpg_t)
 	files_watch_generic_tmp_dirs(gpg_agent_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7933,6 +7933,24 @@ interface(`files_manage_var_lib_symlinks',`
 
 ########################################
 ## <summary>
+##	Manage generic directories in /var/lib.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_manage_var_lib_dirs',`
+	gen_require(`
+		type var_lib_t;
+	')
+
+	manage_dirs_pattern($1, var_lib_t, var_lib_t)
+')
+
+########################################
+## <summary>
 ##	Watch generic directories in /var/lib.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Resolves: rhbz#2001837