### PR TITLE
Support sanlock VG automated recovery on storage access loss

### DIFF
--- a/policy/modules/contrib/sanlock.te
+++ b/policy/modules/contrib/sanlock.te
@@ -139,6 +139,11 @@ tunable_policy(`sanlock_enable_home_dirs',`
 ')
 
 optional_policy(`
+	lvm_domtrans(sanlock_t)
+	lvm_sigkill(sanlock_t)
+')
+
+optional_policy(`
     rhcs_domtrans_fenced(sanlock_t)
 ')
 

--- a/policy/modules/system/lvm.fc
+++ b/policy/modules/system/lvm.fc
@@ -53,6 +53,7 @@ ifdef(`distro_gentoo',`
 /sbin/lvmdiskscan	--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmetad		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmiopversion	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+/sbin/lvmlockctl	--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmsadc		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmsar		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmpolld      --  gen_context(system_u:object_r:lvm_exec_t,s0)

--- a/policy/modules/system/lvm.if
+++ b/policy/modules/system/lvm.if
@@ -319,6 +319,24 @@ interface(`lvm_signull',`
 
 ########################################
 ## <summary>
+##	Send lvm the kill signal.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`lvm_sigkill',`
+	gen_require(`
+		type lvm_t;
+	')
+
+	allow $1 lvm_t:process sigkill;
+')
+
+########################################
+## <summary>
 ##	Send a message to lvm over the 
 ##	datagram socket.
 ## </summary>


### PR DESCRIPTION
When a node fails to renew an LV lock, watchdog resets the machine
unless the LV was deactivated manually. Lvmlockctl since v2.03.12 has
the lvmlockctl_kill_command option in lvm.conf, giving the administrator
the way to run a custom script to automate the process of deactivating
LVs and running lvmlockctl drop.

This selinux-policy update brings the following changes:
- lvmlockctl is labeled with the lvm_exec_t type
- sanlockd is allowed domain transition to lvm_t
- sanlockd is allowed sigkill to lvm_t
- the lvm_sigkill() interface was added

Resolves: rhbz#1985000