### PR TITLE
Add erofs as a SELinux capable file system

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -29,6 +29,7 @@ typealias fs_t alias inotifyfs_t;
 # Requires that a security xattr handler exist for the filesystem.
 fs_use_xattr btrfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr encfs gen_context(system_u:object_r:fs_t,s0);
+fs_use_xattr erofs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr ext2 gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr ext3 gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr ext4 gen_context(system_u:object_r:fs_t,s0);


### PR DESCRIPTION
EROFS supported the security xattr handler from Linux v4.19.
Add erofs to the filesystem policy now.

Reported-by: David Michael <fedora.dm0@gmail.com>
Signed-off-by: Gao Xiang <xiang@kernel.org>