### PR TITLE
Allow fetchmail search cgroup directories

### DIFF
--- a/policy/modules/contrib/fetchmail.te
+++ b/policy/modules/contrib/fetchmail.te
@@ -84,6 +84,7 @@ files_dontaudit_search_home(fetchmail_t)
 
 fs_getattr_all_fs(fetchmail_t)
 fs_search_auto_mountpoints(fetchmail_t)
+fs_search_cgroup_dirs(fetchmail_t)
 
 domain_use_interactive_fds(fetchmail_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(10/18/2021 12:38:06.862:575) : proctitle=/usr/bin/fetchmail -d 300 --fetchmailrc /etc/fetchmailrc.example
type=PATH msg=audit(10/18/2021 12:38:06.862:575) : item=0 name=/sys/fs/cgroup/cgroup.events nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/18/2021 12:38:06.862:575) : cwd=/
type=SYSCALL msg=audit(10/18/2021 12:38:06.862:575) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x7f80b39ed383 a1=F_OK a2=0x7f80b3cea890 a3=0x0 items=1 ppid=1 pid=4521 auid=unset uid=mail gid=mail euid=mail suid=mail fsuid=mail egid=mail sgid=mail fsgid=mail tty=(none) ses=unset comm=fetchmail exe=/usr/bin/fetchmail subj=system_u:system_r:fetchmail_t:s0 key=(null)
type=AVC msg=audit(10/18/2021 12:38:06.862:575) : avc:  denied  { search } for  pid=4521 comm=fetchmail name=/ dev="cgroup2" ino=1 scontext=system_u:system_r:fetchmail_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=dir permissive=0