### PR TITLE
Allow redis-sentinel execute a notification script

### DIFF
--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -97,6 +97,14 @@ tunable_policy(`redis_enable_notify',`
 
     corecmd_exec_bin(redis_t)
     corecmd_exec_shell(redis_t)
+
+	fs_getattr_tmpfs(redis_t)
+')
+
+optional_policy(`
+	tunable_policy(`redis_enable_notify',`
+		auth_read_passwd_file(redis_t)
+	')
 ')
 
 optional_policy(`
@@ -115,4 +123,10 @@ optional_policy(`
 optional_policy(`
     sssd_read_public_files(redis_t)
     sssd_search_lib(redis_t)
+')
+
+optional_policy(`
+	tunable_policy(`redis_enable_notify',`
+		systemd_userdbd_stream_connect(redis_t)
+	')
 ')

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2255,6 +2255,24 @@ interface(`auth_read_passwd',`
 
 ########################################
 ## <summary>
+##	Read the passwd passwords file (/etc/passwd) only
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_read_passwd_file',`
+	gen_require(`
+		type passwd_file_t;
+	')
+
+	allow $1 passwd_file_t:file read_file_perms;
+')
+
+########################################
+## <summary>
 ##	Mmap the passwd passwords file (/etc/passwd)
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The following permissions were added contionally when
the redis_enable_notify boolean is turned on:
- get the attributes of tmpfs directories
- read the passwords file
- connect to systemd-userdbd with a unix socket

One of the addressed AVC denials:

type=PROCTITLE msg=audit(10/15/2021 11:11:28.484:912) : proctitle=/bin/bash /var/lib/redis/notify.sh +monitor master mymaster 127.0.0.1 6379 quorum 2
type=PATH msg=audit(10/15/2021 11:11:28.484:912) : item=0 name=/run/systemd/userdb/ inode=37 dev=00:19 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/15/2021 11:11:28.484:912) : cwd=/tmp
type=SYSCALL msg=audit(10/15/2021 11:11:28.484:912) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=0xffffff9c a1=0x7fc42dd4c1bf a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=102459 pid=102466 auid=unset uid=redis gid=redis euid=redis suid=redis fsuid=redis egid=redis sgid=redis fsgid=redis tty=(none) ses=unset comm=notify.sh exe=/usr/bin/bash subj=system_u:system_r:redis_t:s0 key=(null)
type=AVC msg=audit(10/15/2021 11:11:28.484:912) : avc:  denied  { read } for  pid=102466 comm=notify.sh name=userdb dev="tmpfs" ino=37 scontext=system_u:system_r:redis_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=0