### PR TITLE
filesystem: add fs_use_trans for ramfs

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -178,7 +178,7 @@ genfscon pstore / gen_context(system_u:object_r:pstore_t,s0)
 type ramfs_t;
 fs_type(ramfs_t)
 files_mountpoint(ramfs_t)
-genfscon ramfs / gen_context(system_u:object_r:ramfs_t,s0)
+fs_use_trans ramfs gen_context(system_u:object_r:ramfs_t,s0);
 
 type romfs_t;
 fs_type(romfs_t)


### PR DESCRIPTION
Enable extended attributes for inodes on ramfs filesystems, similar to
tmpfs filesystems.

For example systemd uses ramfs for service credentials[1], and xattr
support is needed for per service based labeling[2].

[1]: https://www.freedesktop.org/software/systemd/man/systemd-creds.html
[2]: https://github.com/systemd/systemd/pull/21158

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>