### PR TITLE
Allow xdm_t nnp_transition to login_userdomain

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -750,6 +750,7 @@ userdom_manage_user_tmp_dirs(xdm_t)
 userdom_manage_user_tmp_files(xdm_t)
 userdom_manage_user_tmp_sockets(xdm_t)
 userdom_manage_tmp_role(system_r, xdm_t)
+userdom_nnp_transition_login_userdomain(xdm_t)
 
 #userdom_home_manager(xdm_t)
 tunable_policy(`xdm_write_home',`


### PR DESCRIPTION
Addresses the following AVC denial:
audit[4505]: AVC avc:  denied  { nnp_transition } for  pid=4505 comm="gdm-session-wor" scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=process2 permissive=0