### PR TITLE
Sanlock lvm

### DIFF
--- a/policy/modules/contrib/sanlock.te
+++ b/policy/modules/contrib/sanlock.te
@@ -139,6 +139,12 @@ tunable_policy(`sanlock_enable_home_dirs',`
 ')
 
 optional_policy(`
+	lvm_domtrans(sanlock_t)
+	lvm_sigkill(sanlock_t)
+	lvm_signal(sanlock_t)
+')
+
+optional_policy(`
     rhcs_domtrans_fenced(sanlock_t)
 ')
 

--- a/policy/modules/contrib/sanlock.te
+++ b/policy/modules/contrib/sanlock.te
@@ -139,11 +139,6 @@ tunable_policy(`sanlock_enable_home_dirs',`
 ')
 
 optional_policy(`
-	lvm_domtrans(sanlock_t)
-	lvm_sigkill(sanlock_t)
-')
-
-optional_policy(`
     rhcs_domtrans_fenced(sanlock_t)
 ')
 

--- a/policy/modules/system/lvm.fc
+++ b/policy/modules/system/lvm.fc
@@ -118,6 +118,7 @@ ifdef(`distro_gentoo',`
 /usr/sbin/lvmdiskscan		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmetad		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmiopversion		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+/usr/sbin/lvmlockctl		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmsadc		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmsar		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /usr/sbin/lvmpolld      --  gen_context(system_u:object_r:lvm_exec_t,s0)

--- a/policy/modules/system/lvm.fc
+++ b/policy/modules/system/lvm.fc
@@ -53,7 +53,6 @@ ifdef(`distro_gentoo',`
 /sbin/lvmdiskscan	--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmetad		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmiopversion	--	gen_context(system_u:object_r:lvm_exec_t,s0)
-/sbin/lvmlockctl	--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmsadc		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmsar		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 /sbin/lvmpolld      --  gen_context(system_u:object_r:lvm_exec_t,s0)

--- a/policy/modules/system/lvm.if
+++ b/policy/modules/system/lvm.if
@@ -319,6 +319,42 @@ interface(`lvm_signull',`
 
 ########################################
 ## <summary>
+##	Send lvm the kill signal.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`lvm_sigkill',`
+	gen_require(`
+		type lvm_t;
+	')
+
+	allow $1 lvm_t:process sigkill;
+')
+
+########################################
+## <summary>
+##	Send lvm a generic signal.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`lvm_signal',`
+	gen_require(`
+		type lvm_t;
+	')
+
+	allow $1 lvm_t:process signal;
+')
+
+########################################
+## <summary>
 ##	Send a message to lvm over the 
 ##	datagram socket.
 ## </summary>

--- a/policy/modules/system/lvm.if
+++ b/policy/modules/system/lvm.if
@@ -319,24 +319,6 @@ interface(`lvm_signull',`
 
 ########################################
 ## <summary>
-##	Send lvm the kill signal.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`lvm_sigkill',`
-	gen_require(`
-		type lvm_t;
-	')
-
-	allow $1 lvm_t:process sigkill;
-')
-
-########################################
-## <summary>
 ##	Send a message to lvm over the 
 ##	datagram socket.
 ## </summary>


### PR DESCRIPTION
    Support sanlock VG automated recovery on storage access loss

    When a node fails to renew an LV lock, watchdog resets the machine
    unless the LV was deactivated manually. Lvmlockctl since v2.03.12 has
    the lvmlockctl_kill_command option in lvm.conf, giving the administrator
    the way to run a custom script to automate the process of deactivating
    LVs and running lvmlockctl drop.

    This selinux-policy update brings the following changes:
    - lvmlockctl is labeled with the lvm_exec_t type
    - sanlock-helper is allowed domain transition to lvm_t
    - sanlock-helper is allowed sigkill and signal to lvm_t
    - the lvm_sigkill() and lvm_signal() interfaces were added

    Resolves: rhbz#1985000