### PR TITLE
Allow systemd-logind destroy unconfined user's IPC objects

### DIFF
--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -803,3 +803,39 @@ interface(`unconfined_dgram_send',`
 
 	allow $1 unconfined_t:unix_dgram_socket sendto;
 ')
+
+########################################
+## <summary>
+##	Destroy unconfined user's message queue entries.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_destroy_msgq',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:msgq destroy;
+')
+
+########################################
+## <summary>
+##	Destroy unconfined user's SysV shared memory segments.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_destroy_shm',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:shm destroy;
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -393,6 +393,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_destroy_msgq(systemd_logind_t)
+	unconfined_destroy_shm(systemd_logind_t)
+')
+
+optional_policy(`
 	rpm_dbus_chat(systemd_logind_t)
 ')
 


### PR DESCRIPTION
Systemd-logind was allowed to destroy an unconfined user's message queue
entries and SysV shared memory segments.

This permission is required when a login session is terminated on
a system with "RemoveIPC=yes" in /etc/systemd/logind.conf.

The unconfined_destroy_msgq() and unconfined_destroy_shm()
interfaces were added.

Resolves: rhbz#2014801