### PR TITLE
Allow fedora-third-party manage 3rd party repos

### DIFF
--- a/policy/modules/contrib/fedoratp.te
+++ b/policy/modules/contrib/fedoratp.te
@@ -9,7 +9,7 @@ files_type(fedoratp_var_lib_t)
 
 manage_files_pattern(fedoratp_t, fedoratp_var_lib_t, fedoratp_var_lib_t)
 
-allow fedoratp_t self:capability sys_nice;
+allow fedoratp_t self:capability { dac_override sys_nice };
 allow fedoratp_t self:process setsched;
 allow fedoratp_t self:unix_dgram_socket create_socket_perms;
 
@@ -47,6 +47,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dbus_system_bus_client(fedoratp_t)
+')
+
+optional_policy(`
 	gnome_manage_cache_home_dir(fedoratp_t)
 	gnome_manage_generic_cache_files(fedoratp_t)
 	gnome_map_generic_cache_files(fedoratp_t)
@@ -62,4 +66,9 @@ optional_policy(`
 
 optional_policy(`
 	policykit_dbus_chat(fedoratp_t)
+')
+
+optional_policy(`
+	userdom_manage_admin_dirs(fedoratp_t)
+	userdom_manage_admin_files(fedoratp_t)
 ')


### PR DESCRIPTION
The fedora-third-party service was made a system dbus client and
was allowed to manage admin's home files and directories. As the
/root directory is read-only, the dac_override capability is needed, too:

ls -ld /root
dr-xr-x---. 1 root root 3610 Oct 21 17:31 /root

Resolves: rhbz#2017433