### PR TITLE
Allow tlp dbus-chat with NetworkManager

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -88,6 +88,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	networkmanager_dbus_chat(tlp_t)
+')
+
+optional_policy(`
     sssd_read_public_files(tlp_t)
     sssd_stream_connect(tlp_t)
 ')


### PR DESCRIPTION
Addresses the following AVC denial:
type=USER_AVC msg=audit(05/11/21 09:11:56.868:303) : pid=1076 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:tlp_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=dbus permissive=0  exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'

Resolves: rhbz#2013439