### PR TITLE
Allow sysadm_t dbus chat with realmd_t

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -250,6 +250,10 @@ optional_policy(`
         systemd_dbus_chat_localed(sysadm_t)
         systemd_hwdb_mmap_config(sysadm_t)
     ')
+
+	optional_policy(`
+		realmd_dbus_chat(sysadm_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
This permission is needed for "realm list" and similar commands.

Addresses the following AVC denial:

type=USER_AVC msg=audit(07/28/2021 11:02:36.395:184922) : pid=1787 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_call interface=org.freedesktop.DBus.Properties member=GetAll dest=:1.22238 spid=8937 tpid=8941 scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:realmd_t:s0 tclass=dbus  exe=/usr/bin/dbus-daemon sauid=dbus hostname=? addr=? terminal=?'

Resolves: rhbz#2000488