### PR TITLE
Report warning on duplicate definition of interface

### DIFF
--- a/policy/support/loadable_module.spt
+++ b/policy/support/loadable_module.spt
@@ -60,7 +60,7 @@ define(`policy_m4_comment',`
 # template(name,rules)
 #
 define(`template',` dnl
-	ifdef(`$1',`refpolicyerr(`duplicate definition of $1(). Original definition on '$1.) define(`__if_error')',`define(`$1',__line__)') dnl
+	ifdef(`$1',`refpolicywarn(`duplicate definition of $1(). Original definition on '$1.) define(`__if_error')',`define(`$1',__file__:__line__)') dnl
 	`define(`$1',` dnl
 	pushdef(`policy_call_depth',incr(policy_call_depth)) dnl
 	policy_m4_comment(policy_call_depth,begin `$1'(dollarsstar)) dnl
@@ -77,7 +77,7 @@ define(`template',` dnl
 # interface(name,rules)
 #
 define(`interface',` dnl
-	ifdef(`$1',`refpolicyerr(`duplicate definition of $1(). Original definition on '$1.) define(`__if_error')',`define(`$1',__line__)') dnl
+	ifdef(`$1',`refpolicywarn(`duplicate definition of $1(). Original definition on '$1.) define(`__if_error')',`define(`$1',__file__:__line__)') dnl
 	`define(`$1',` dnl
 	pushdef(`policy_call_depth',incr(policy_call_depth)) dnl
 	policy_m4_comment(policy_call_depth,begin `$1'(dollarsstar)) dnl


### PR DESCRIPTION
Duplicate definition of interface or template should only be a warning,
since it does not block the compilation.
The warning should also specify which file contains the original
definition.

Old:
 ipa.if:284: Error: duplicate definition of
  ipa_cert_filetrans_named_content(). Original definition on 284.
New:
 ipa.if:284: Warning: duplicate definition of
  ipa_cert_filetrans_named_content(). Original definition on
  /usr/share/selinux/devel/include/contrib/ipa.if:284.

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>