### PR TITLE
Allow PID 1 and dbus-broker IPC with a systemd user session

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -236,6 +236,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	userdom_rw_stream(system_dbusd_t)
+')
+
+optional_policy(`
 	virt_list_sandbox_dirs(system_dbusd_t)
 ')
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -872,6 +872,7 @@ optional_policy(`
 
 optional_policy(`
 	userdom_exec_user_bin_files(init_t)
+	userdom_rw_stream(init_t)
 ')
 
 ########################################


### PR DESCRIPTION
systemd-stdio-bridge is invoked using systemd-run to connect to a user
bus from a privileged context:
systemd-run -M.host -PGq --wait -pUser=user1 -pPAMName=login systemd-stdio-bridge -punix:path=${XDG_RUNTIME_DIR}/bus

The commands sequence is as follows:
1. dnf invokes rpm
2. a scriptlet is called from rpm
3. the scriptlet calls /usr/lib/systemd/systemd-update-helper
4. systemd-update-helper calls systemctl --user <uid>@ ...
5. in the systemctl binary, sd-bus invokes systemd-run
6. which invokes systemd-stdio-bridge as the user
7. systemctl communicates with the user manager over the bridge

Refer to this commit for more information:
https://github.com/systemd/systemd/pull/17967/commits/1b630835dff

Addresses the following AVC denials:
----
type=AVC msg=audit(11/15/2021 08:56:59.167:1097) : avc:  denied  { read write } for  pid=458 comm=dbus-broker path=socket:[37803] dev="sockfs" ino=37803 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1
----
type=AVC msg=audit(11/15/2021 08:56:59.168:1098) : avc:  denied  { read write } for  pid=1 comm=systemd path=socket:[37803] dev="sockfs" ino=37803 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1
----
type=PROCTITLE msg=audit(11/15/2021 08:56:59.184:1100) : proctitle=(o-bridge)
type=SYSCALL msg=audit(11/15/2021 08:56:59.184:1100) : arch=x86_64 syscall=ioctl success=no exit=ENOTTY(Inappropriate ioctl for device) a0=0x0 a1=TCGETS a2=0x7ffca74d78a0 a3=0x0 items=0 ppid=1 pid=6580 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(o-bridge) exe=/usr/lib/systemd/systemd subj=system_u:system_r:init_t:s0 key=(null)
type=AVC msg=audit(11/15/2021 08:56:59.184:1100) : avc:  denied  { ioctl } for  pid=6580 comm=(o-bridge) path=socket:[37803] dev="sockfs" ino=37803 ioctlcmd=TCGETS scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1
----

Resolves: rhbz#2023332