### PR TITLE
Update userdom_exec_user_tmp_files() with an entrypoint rule

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -556,6 +556,7 @@ interface(`userdom_exec_user_tmp_files',`
 		type user_tmp_t;
 	')
 
+	allow $1 user_tmp_t:file entrypoint;
 	exec_files_pattern($1, user_tmp_t, user_tmp_t)
 	dontaudit $1 user_tmp_t:sock_file execute;
 	files_search_tmp($1)


### PR DESCRIPTION
The userdom_exec_user_tmp_files() interface contains rules
to allow execution of user temporary files, but there were no rules
containing the executable type as entrypoint.

Resolves: rhbz#1966945