### PR TITLE
Allow sudodomain send a null signal to sshd processes

### DIFF
--- a/policy/modules/admin/sudo.te
+++ b/policy/modules/admin/sudo.te
@@ -129,6 +129,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ssh_signull(sudodomain)
+')
+
+optional_policy(`
     systemd_write_inherited_logind_sessions_pipes(sudodomain)
 ')
 


### PR DESCRIPTION
This denial appears when maxlogins is specified in PAM limits configuration:
type=PROCTITLE msg=audit(11/18/21 13:22:44.231:774) : proctitle=sudo -u staff echo
type=SYSCALL msg=audit(11/18/21 13:22:44.231:774) : arch=x86_64 syscall=kill success=no exit=EACCES(Permission denied) a0=0x1a2c a1=SIG0 a2=0x4 a3=0x7ffd93c089cf items=0 ppid=6747 pid=6748 auid=staff uid=root gid=staff euid=root suid=root fsuid=root egid=staff sgid=staff fsgid=staff tty=(none) ses=16 comm=sudo exe=/usr/bin/sudo subj=staff_u:staff_r:staff_sudo_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(11/18/21 13:22:44.231:774) : avc:  denied  { signull } for  pid=6748 comm=sudo scontext=staff_u:staff_r:staff_sudo_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=process permissive=0

Resolves: rhbz#1966945