### PR TITLE
Do not allow staff user the unconfined role in secure_mode

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -82,6 +82,16 @@ ifndef(`enable_mls',`
 ')
 
 optional_policy(`
+	tunable_policy(`secure_mode',`',`
+		gen_require(`
+			bool secure_mode;
+		')
+
+		unconfined_role_change(staff_r)
+	')
+')
+
+optional_policy(`
 	abrt_read_cache(staff_t)
     abrt_map_cache(staff_t)
 ')
@@ -311,10 +321,6 @@ optional_policy(`
 
 optional_policy(`
 	userhelper_console_role_template(staff, staff_r, staff_t)
-')
-
-optional_policy(`
-	unconfined_role_change(staff_r)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The user in the staff_r role was allowed to switch to the unconfined
role regardless of the secure_mode boolean setting when specified as an
argument for the sudo command:

staff$ sudo -r unconfined_r -i
staff$ sudo -r unconfined_r id

This commit allows to change it only when secure_mode is off.

Resolves: rhbz#2022763