### PR TITLE
Allow smbcontrol use additional socket types

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -718,6 +718,8 @@ allow smbcontrol_t self:capability2 block_suspend;
 allow smbcontrol_t self:process { signal signull };
 # internal communication is often done using fifo and unix sockets.
 allow smbcontrol_t self:fifo_file rw_file_perms;
+allow smbcontrol_t self:netlink_route_socket r_netlink_socket_perms;
+allow smbcontrol_t self:udp_socket create_socket_perms;
 allow smbcontrol_t self:unix_stream_socket create_stream_socket_perms;
 allow smbcontrol_t self:unix_dgram_socket create_socket_perms;
 


### PR DESCRIPTION
In order to set debug level, smbcontrol was allowed to;
- create and use udp socket
- create, use, and read netlink route sockets

AVC denials example:

type=PROCTITLE msg=audit(11/23/2021 08:19:05.790:553) : proctitle=smbcontrol all debug 100
type=SYSCALL msg=audit(11/23/2021 08:19:05.790:553) : arch=x86_64 syscall=socket success=no exit=EACCES(Permission denied) a0=netlink a1=SOCK_RAW a2=ip a3=0x7fbb520a88b8 items=0 ppid=1060 pid=2372 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=3 comm=smbcontrol exe=/usr/bin/smbcontrol subj=unconfined_u:unconfined_r:smbcontrol_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(11/23/2021 08:19:05.790:553) : avc:  denied  { create } for  pid=2372 comm=smbcontrol scontext=unconfined_u:unconfined_r:smbcontrol_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:smbcontrol_t:s0-s0:c0.c1023 tclass=netlink_route_socket permissive=0

Resolves: rhbz#2025931