### PR TITLE
Allow cloud-init dbus chat with systemd-logind

### DIFF
--- a/policy/modules/contrib/cloudform.te
+++ b/policy/modules/contrib/cloudform.te
@@ -105,6 +105,7 @@ miscfiles_read_localization(cloud_init_t)
 selinux_validate_context(cloud_init_t)
 
 systemd_dbus_chat_hostnamed(cloud_init_t)
+systemd_dbus_chat_logind(cloud_init_t)
 systemd_dbus_chat_timedated(cloud_init_t)
 systemd_exec_systemctl(cloud_init_t)
 systemd_start_all_services(cloud_init_t)


### PR DESCRIPTION
When cloud-init executes a user data script to build a new image
template and there are commands using su or sudo, the process goes
through PAM stack for su/sudo which typically includes pam_systemd.
This PAM module calls systemd-logind to create a session for the user.
Then systemd-logind attempts to dbus send the results back to
cloud-init, but SELinux policy did not contain such permissions, which
resulted in 25 seconds delay:

Jan  1 08:00:00 hostname dbus[12345]: [system] Activating via systemd: service name='org.freedesktop.login1' unit='dbus-org.freedesktop.login1.service'
Jan  1 08:00:25 hostname dbus[12345]: [system] Failed to activate service 'org.freedesktop.login1': timed out

Addresses the following AVC denial:

type=USER_AVC msg=audit(1637751660.446:66): pid=652 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.19 spid=723 tpid=1434 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:cloud_init_t:s0 tclass=dbus permissive=0  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'UID="dbus" AUID="unset" SAUID="dbus"

Resolves: rhbz#2009769