### PR TITLE
Allow svnserve send mail from the system

### DIFF
--- a/policy/modules/contrib/svnserve.te
+++ b/policy/modules/contrib/svnserve.te
@@ -90,6 +90,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mta_send_mail(svnserve_t)
+')
+
+optional_policy(`
     sasl_connect(svnserve_t)
 ')
 


### PR DESCRIPTION
The mta_send_mail() interface call for svnserve_t was added to allow
permissions to execute mta_exec_type attribute which currently is:
- courier_exec_t
- exim_exec_t
- postfix_postdrop_t
- sendmail_exec_t

Resolves: rhbz#2004843