### PR TITLE
Allow shorewall to access /var/lib/shorewall6-lite

### DIFF
--- a/policy/modules/contrib/shorewall.fc
+++ b/policy/modules/contrib/shorewall.fc
@@ -13,6 +13,7 @@
 /var/lib/shorewall(/.*)?	gen_context(system_u:object_r:shorewall_var_lib_t,s0)
 /var/lib/shorewall6(/.*)?	gen_context(system_u:object_r:shorewall_var_lib_t,s0)
 /var/lib/shorewall-lite(/.*)?	gen_context(system_u:object_r:shorewall_var_lib_t,s0)
+/var/lib/shorewall6-lite(/.*)?	gen_context(system_u:object_r:shorewall_var_lib_t,s0)
 
 /var/lock/subsys/shorewall	--	gen_context(system_u:object_r:shorewall_lock_t,s0)
 


### PR DESCRIPTION
This is required to operate the `shorewall6-lite` service.

AVC denials example:
```
type=AVC msg=audit(1637837574.772:19965): avc:  denied  { getattr } for  pid=1440315 comm="shorewall" path="/var/lib/shorewall6-lite/firewall.conf" dev="md125" ino=679 scontext=system_u:system_r:shorewall_t:s0 tcontext=unconfined_u:object_r:var_lib_t:s0 tclass=file permissive=0
type=AVC msg=audit(1637837574.791:19966): avc:  denied  { getattr } for  pid=1440315 comm="shorewall" path="/var/lib/shorewall6-lite/firewall" dev="md125" ino=590 scontext=system_u:system_r:shorewall_t:s0 tcontext=unconfined_u:object_r:var_lib_t:s0 tclass=file permissive=0
type=AVC msg=audit(1637837574.791:19967): avc:  denied  { getattr } for  pid=1440315 comm="shorewall" path="/var/lib/shorewall6-lite/firewall" dev="md125" ino=590 scontext=system_u:system_r:shorewall_t:s0 tcontext=unconfined_u:object_r:var_lib_t:s0 tclass=file permissive=0
```