### PR TITLE
Allow login_userdomain open/read/map system journal

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -410,6 +410,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	logging_mmap_journal(login_userdomain)
+	logging_read_syslog_pid(login_userdomain)
+')
+
+optional_policy(`
 	pkcs_tmpfs_named_filetrans(login_userdomain)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(27.10.2021 15:45:16.341:455) : proctitle=systemctl status user@1001
type=AVC msg=audit(27.10.2021 15:45:16.341:455) : avc:  denied  { read } for  pid=4764 comm=systemctl name=system.journal dev="tmpfs" ino=429 scontext=user_u:user_r:user_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=file permissive=1
type=AVC msg=audit(27.10.2021 15:45:16.341:455) : avc:  denied  { open } for  pid=4764 comm=systemctl path=/run/log/journal/edb15570307f47dd805feee9003d4e08/system.journal dev="tmpfs" ino=429 scontext=user_u:user_r:user_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(27.10.2021 15:45:16.341:455) : arch=x86_64 syscall=openat success=yes exit=6 a0=0xffffff9c a1=0x7fff96d6e1c0 a2=O_RDONLY|O_NONBLOCK|O_CLOEXEC a3=0x0 items=0 ppid=4739 pid=4764 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=pts1 ses=10 comm=systemctl exe=/usr/bin/systemctl subj=user_u:user_r:user_t:s0 key=(null)

Resolves: rhbz#2017838