### PR TITLE
Ensure that `/run/systemd/*` are properly labeled

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3288,7 +3288,7 @@ interface(`init_filetrans_named_content',`
 		type initrc_var_run_t;
 		type machineid_t;
 		type initctl_t;
-        type systemd_unit_file_t;
+        	type systemd_unit_file_t;
 	')
 
 	files_pid_filetrans($1, initrc_var_run_t, file, "utmp")
@@ -3296,6 +3296,8 @@ interface(`init_filetrans_named_content',`
 	files_etc_filetrans($1, machineid_t, file, "machine-id" )
 	files_pid_filetrans($1, initctl_t, fifo_file, "fifo" )
 	init_pid_filetrans($1, systemd_unit_file_t, dir, "generator")
+	init_pid_filetrans($1, systemd_unit_file_t, dir, "generator.early")
+	init_pid_filetrans($1, systemd_unit_file_t, dir, "generator.late")
 	init_pid_filetrans($1, systemd_unit_file_t, dir, "system")
 ')
 


### PR DESCRIPTION
`/run/systemd/generator.{early,late}` were not covered by the type_transition rules.