### PR TITLE
Allow lldpd create and use tcp socket

### DIFF
--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -32,6 +32,7 @@ allow lldpad_t self:fifo_file rw_fifo_file_perms;
 allow lldpad_t self:unix_stream_socket { accept connectto listen };
 allow lldpad_t self:netlink_route_socket create_netlink_socket_perms;
 allow lldpad_t self:packet_socket create_socket_perms;
+allow lldpad_t self:tcp_socket create_socket_perms;
 allow lldpad_t self:udp_socket create_socket_perms;
 
 manage_files_pattern(lldpad_t, lldpad_tmpfs_t, lldpad_tmpfs_t)
@@ -53,6 +54,8 @@ kernel_request_load_module(lldpad_t)
 auth_read_passwd(lldpad_t)
 
 corecmd_exec_bin(lldpad_t)
+
+corenet_tcp_connect_agentx_port(lldpad_t)
 
 dev_read_sysfs(lldpad_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=1400 audit(1636686481.749:29971): avc:  denied  { create } for  pid=2731 comm="lldpd" scontext=system_u:system_r:lldpad_t:s0 tcontext=system_u:system_r:lldpad_t:s0 tclass=tcp_socket permissive=0

Resolves: rhbz#2028379