### PR TITLE
Make postfix_postdrop_exec_t type an MTA executable file

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -62,7 +62,6 @@ postfix_server_domain_template(pipe)
 
 postfix_user_domain_template(postdrop)
 mta_mailserver_user_agent(postfix_postdrop_t)
-mta_agent_executable(postfix_postdrop_t)
 
 postfix_user_domain_template(postqueue)
 mta_mailserver_user_agent(postfix_postqueue_t)

--- a/policy/modules/contrib/svnserve.te
+++ b/policy/modules/contrib/svnserve.te
@@ -94,6 +94,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	postfix_domtrans_postdrop(svnserve_t)
+')
+
+optional_policy(`
     sasl_connect(svnserve_t)
 ')
 


### PR DESCRIPTION
Previously, it was postfix_postdrop_t which was assigned to the
mta_exec_type attribute which is incorrect. Since this commit it rather
is postfix_postdrop_exec_t instead of postfix_postdrop_t.
This change makes it aligned with other mta types like sendmail_exec_t,
while postfix_postdrop_t remains in the mta_user_agent attribute.

Resolves: rhbz#2004843