### PR TITLE
Rip out some distro_redhat stuff

### DIFF
--- a/policy/modules.conf
+++ b/policy/modules.conf
@@ -2960,6 +2960,8 @@ fwupd = module
 #
 lttng-tools = module
 
+container = module
+
 # Layer: contrib
 # Module: rkt
 #

--- a/policy/modules/contrib/mozilla.if
+++ b/policy/modules/contrib/mozilla.if
@@ -51,12 +51,6 @@ interface(`mozilla_role',`
 	mozilla_run_plugin(mozilla_t, $1)
 	mozilla_dbus_chat($2)
 
-	userdom_manage_tmp_role($1, mozilla_t)
-
-	optional_policy(`
-		nsplugin_role($1, mozilla_t)
-	')
-
 	optional_policy(`
 		pulseaudio_role($1, mozilla_t)
 		pulseaudio_filetrans_admin_home_content(mozilla_t)
@@ -586,7 +580,6 @@ interface(`mozilla_filetrans_home_content',`
 	userdom_user_home_dir_filetrans($1, mozilla_home_t, dir, ".galeon")
 	userdom_user_home_dir_filetrans($1, mozilla_home_t, dir, ".java")
 	userdom_user_home_dir_filetrans($1, mozilla_home_t, dir, ".mozilla")
-	userdom_user_home_dir_filetrans($1, mozilla_home_t, dir, ".thunderbird")
 	userdom_user_home_dir_filetrans($1, mozilla_home_t, dir, ".netscape")
 	userdom_user_home_dir_filetrans($1, mozilla_home_t, dir, ".phoenix")
 	userdom_user_home_dir_filetrans($1, mozilla_home_t, dir, ".adobe")

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -353,98 +353,88 @@ optional_policy(`
 	xserver_run(staff_t, staff_r)
 ')
 
-ifndef(`distro_redhat',`
-	optional_policy(`
-		auth_role(staff_r, staff_t)
-	')
+optional_policy(`
+	auth_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		cdrecord_role(staff_r, staff_t)
-	')
+optional_policy(`
+	cdrecord_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		cron_role(staff_r, staff)
-	')
+optional_policy(`
+	cron_role(staff_r, staff)
+')
 
-	optional_policy(`
-		dbus_role_template(staff, staff_r, staff_t)
-	')
+optional_policy(`
+	evolution_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		evolution_role(staff_r, staff_t)
-	')
+optional_policy(`
+	games_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		games_role(staff_r, staff_t)
-	')
+optional_policy(`
+	gpg_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		gpg_role(staff_r, staff_t)
-	')
+optional_policy(`
+	java_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		java_role(staff_r, staff_t)
-	')
+optional_policy(`
+	lockdev_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		lockdev_role(staff_r, staff_t)
-	')
+optional_policy(`
+	lpd_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		lpd_role(staff_r, staff_t)
-	')
+optional_policy(`
+	mozilla_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		mozilla_role(staff_r, staff_t)
-	')
+optional_policy(`
+	mplayer_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		mplayer_role(staff_r, staff_t)
-	')
+optional_policy(`
+	pyzor_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		pyzor_role(staff_r, staff_t)
-	')
+optional_policy(`
+	razor_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		razor_role(staff_r, staff_t)
-	')
+optional_policy(`
+	rssh_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		rssh_role(staff_r, staff_t)
-	')
+optional_policy(`
+	spamassassin_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		spamassassin_role(staff_r, staff_t)
-	')
+optional_policy(`
+	systemd_systemctl_entrypoint(staff_t)
+')
 
-	optional_policy(`
-		systemd_systemctl_entrypoint(staff_t)
-	')
+optional_policy(`
+	thunderbird_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		thunderbird_role(staff_r, staff_t)
-	')
+optional_policy(`
+	tvtime_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		tvtime_role(staff_r, staff_t)
-	')
+optional_policy(`
+	uml_role(staff_r, staff_t)
+')
 
-	optional_policy(`
-		uml_role(staff_r, staff_t)
-	')
+optional_policy(`
+	userhelper_role_template(staff, staff_r, staff_t)
+')
 
-	optional_policy(`
-		userhelper_role_template(staff, staff_r, staff_t)
-	')
-
-	optional_policy(`
-		vmware_role(staff_r, staff_t)
-	')
-
-	optional_policy(`
-		wireshark_role(staff_r, staff_t)
-	')
+optional_policy(`
+	vmware_role(staff_r, staff_t)
 ')
 
 tunable_policy(`selinuxuser_execmod',`

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -163,132 +163,114 @@ optional_policy(`
 	vlock_run(user_t, user_r)
 ')
 
-ifndef(`distro_redhat',`
-	optional_policy(`
-		auth_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		bluetooth_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		cdrecord_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		cron_role(user_r, user)
-	')
-
-	optional_policy(`
-		dbus_role_template(user, user_r, user_t)
-
-		optional_policy(`
-			gnome_role_template(user, user_r, user_t)
-		')
-	')
-
-	optional_policy(`
-		evolution_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		games_role(user_r, user_t)
-	')
-
-	optional_policy(`
-       		gnome_filetrans_fontconfig_home_content(user_t)
-	')
-
-	optional_policy(`
-		gpg_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		hadoop_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		irc_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		java_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		lockdev_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		lpd_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		mozilla_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		mplayer_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		postgresql_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		pyzor_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		razor_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		rssh_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		spamassassin_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		ssh_role_template(user, user_r, user_t)
-	')
-
-	optional_policy(`
-		systemd_systemctl_entrypoint(user_t)
-	')
-
-
-	optional_policy(`
-		thunderbird_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		tvtime_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		uml_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		userhelper_role_template(user, user_r, user_t)
-	')
-
-	optional_policy(`
-		vmware_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		wireshark_role(user_r, user_t)
-	')
-
-	optional_policy(`
-		xserver_run(user_t, user_r)
-	')
+optional_policy(`
+	auth_role(user_r, user_t)
 ')
+
+optional_policy(`
+	bluetooth_role(user_r, user_t)
+')
+
+optional_policy(`
+	cdrecord_role(user_r, user_t)
+')
+
+optional_policy(`
+	cron_role(user_r, user)
+')
+
+optional_policy(`
+	evolution_role(user_r, user_t)
+')
+
+optional_policy(`
+	games_role(user_r, user_t)
+')
+
+optional_policy(`
+	gnome_filetrans_fontconfig_home_content(user_t)
+')
+
+optional_policy(`
+	gpg_role(user_r, user_t)
+')
+
+optional_policy(`
+	hadoop_role(user_r, user_t)
+')
+
+optional_policy(`
+	java_role(user_r, user_t)
+')
+
+optional_policy(`
+	lockdev_role(user_r, user_t)
+')
+
+optional_policy(`
+	lpd_role(user_r, user_t)
+')
+
+optional_policy(`
+	mozilla_role(user_r, user_t)
+')
+
+optional_policy(`
+	mplayer_role(user_r, user_t)
+')
+
+optional_policy(`
+	postgresql_role(user_r, user_t)
+')
+
+optional_policy(`
+	pyzor_role(user_r, user_t)
+')
+
+optional_policy(`
+	razor_role(user_r, user_t)
+')
+
+optional_policy(`
+	rssh_role(user_r, user_t)
+')
+
+optional_policy(`
+	spamassassin_role(user_r, user_t)
+')
+
+optional_policy(`
+	systemd_systemctl_entrypoint(user_t)
+')
+
+optional_policy(`
+	thunderbird_role(user_r, user_t)
+')
+
+optional_policy(`
+	tvtime_role(user_r, user_t)
+')
+
+optional_policy(`
+	uml_role(user_r, user_t)
+')
+
+optional_policy(`
+	userhelper_role_template(user, user_r, user_t)
+')
+
+optional_policy(`
+	vmware_role(user_r, user_t)
+')
+
+optional_policy(`
+	wireshark_role(user_r, user_t)
+')
+
+optional_policy(`
+	xserver_run(user_t, user_r)
+')
+
 
 optional_policy(`
     vmtools_run_helper(user_t, user_r)


### PR DESCRIPTION
This is defined in Fedora, and leads to breakage of various sorts.  For instance, `~/.thunderbird` and `~/.mozilla` aren’t properly labeled, and `sudo systemctl poweroff` breaks.