### PR TITLE
Allow httpd named transitions in tmpfs directories

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -886,6 +886,10 @@ tunable_policy(`httpd_use_fusefs',`
 	fs_manage_fusefs_symlinks(httpd_t)
 ')
 
+tunable_policy(`httpd_use_opencryptoki',`
+	allow httpd_t self:capability fowner;
+')
+
 tunable_policy(`httpd_setrlimit',`
 	allow httpd_t self:process setrlimit;
 	allow httpd_t self:capability sys_resource;
@@ -930,6 +934,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# type transitions with a filename not allowed inside conditionals
+	pkcs_tmpfs_named_filetrans(httpd_t)
+
     tunable_policy(`httpd_use_opencryptoki',`
         pkcs_use_opencryptoki(httpd_t)
     ')

--- a/policy/modules/contrib/pkcs.if
+++ b/policy/modules/contrib/pkcs.if
@@ -132,12 +132,11 @@ interface(`pkcs_tmpfs_named_filetrans',`
 		type pkcs_slotd_tmpfs_t;
 	')
 
-	allow $1 pkcs_slotd_tmpfs_t:file map;
-
-	manage_files_pattern($1, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
 	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ccatok")
 	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.ep11tok")
 	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.lite")
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.stats_0")
+	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.stats_48")
 	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.swtok")
 	fs_tmpfs_filetrans($1, pkcs_slotd_tmpfs_t, file, "var.lib.opencryptoki.tpm.root")
 ')
@@ -155,10 +154,12 @@ interface(`pkcs_tmpfs_named_filetrans',`
 interface(`pkcs_use_opencryptoki',`
 	gen_require(`
         type pkcs_slotd_t;
+        type pkcs_slotd_tmpfs_t;
 	')
 
     allow $1 self:capability fsetid;
     allow pkcs_slotd_t $1:process signull;
+    allow $1 pkcs_slotd_tmpfs_t:file { create_file_perms mmap_rw_file_perms };
 
     kernel_search_proc($1)
     ps_process_pattern(pkcs_slotd_t, $1)


### PR DESCRIPTION
A part of this commit are also rules to manage pkcs_slotd_tmpfs_t type files.

Addresses AVC denials like these:

type=PROCTITLE msg=audit(12/02/2021 15:49:36.552:674) : proctitle=/usr/sbin/httpd -DFOREGROUND
type=PATH msg=audit(12/02/2021 15:49:36.552:674) : item=0 name=/dev/shm/var.lib.opencryptoki.swtok inode=64710 dev=00:16 mode=file,660 ouid=apache ogid=pkcs11 rdev=00:00 obj=unconfined_u:object_r:pkcs_slotd_tmpfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(12/02/2021 15:49:36.552:674) : cwd=/
type=SYSCALL msg=audit(12/02/2021 15:49:36.552:674) : arch=x86_64 syscall=openat success=yes exit=19 a0=0xffffff9c a1=0x7ffeb38e2e60 a2=O_RDWR|O_NOFOLLOW|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=21325 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=httpd exe=/usr/sbin/httpd subj=system_u:system_r:httpd_t:s0 key=(null)
type=AVC msg=audit(12/02/2021 15:49:36.552:674) : avc:  denied  { open } for  pid=21325 comm=httpd path=/dev/shm/var.lib.opencryptoki.swtok dev="tmpfs" ino=64710 scontext=system_u:system_r:httpd_t:s0 tcontext=unconfined_u:object_r:pkcs_slotd_tmpfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(12/02/2021 15:49:36.552:674) : avc:  denied  { read write } for  pid=21325 comm=httpd name=var.lib.opencryptoki.swtok dev="tmpfs" ino=64710 scontext=system_u:system_r:httpd_t:s0 tcontext=unconfined_u:object_r:pkcs_slotd_tmpfs_t:s0 tclass=file permissive=1

Resolves: rhbz#2028637