### PR TITLE
Allow rhsmcertd get attributes of tmpfs_t filesystems

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -101,6 +101,7 @@ files_create_boot_flag(rhsmcertd_t)
 files_dontaudit_write_all_mountpoints(rhsmcertd_t)
 
 fs_dontaudit_write_configfs_dirs(rhsmcertd_t)
+fs_getattr_tmpfs(rhsmcertd_t)
 fs_read_xenfs_files(rhsmcertd_t)
 
 auth_map_passwd(rhsmcertd_t)


### PR DESCRIPTION
Resolves: rhbz#2015820