### PR TITLE
Allow systemd read unlabeled symbolic links

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -2922,6 +2922,24 @@ interface(`kernel_dontaudit_getattr_unlabeled_blk_files',`
 
 ########################################
 ## <summary>
+##	Read unlabeled symbolic links.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_read_unlabeled_lnk_files',`
+	gen_require(`
+		type unlabeled_t;
+	')
+
+	allow $1 unlabeled_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Read and write unlabeled block device nodes.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -588,6 +588,7 @@ tunable_policy(`deny_bluetooth',`',`
 ')
 
 kernel_list_unlabeled(init_t)
+kernel_read_unlabeled_lnk_files(init_t)
 kernel_read_network_state(init_t)
 kernel_rw_all_sysctls(init_t)
 kernel_rw_security_state(init_t)


### PR DESCRIPTION
On a system boot systemd starts to launch services in the current target.
When it attempts to access a symbolic link which is critical for systemd
to continue and the symlink is unlabeled, the autorelabel target cannot
be reached to start relabeling and fix the unlabeled files.
This scenario applies to /etc/localtime when it was changed in SELinux
disabled mode.

Since this commit, systemd is allowed the read access to symbolic links
with the unlabeled_t type.

Resolves: rhbz#2021835