### PR TITLE
Allow dnsmasq watch /etc/dnsmasq.d directories

### DIFF
--- a/policy/modules/contrib/dnsmasq.te
+++ b/policy/modules/contrib/dnsmasq.te
@@ -52,6 +52,7 @@ allow dnsmasq_t self:rawip_socket create_socket_perms;
 
 read_files_pattern(dnsmasq_t, dnsmasq_etc_t, dnsmasq_etc_t)
 list_dirs_pattern(dnsmasq_t, dnsmasq_etc_t, dnsmasq_etc_t)
+watch_dirs_pattern(dnsmasq_t, dnsmasq_etc_t, dnsmasq_etc_t)
 
 manage_files_pattern(dnsmasq_t, dnsmasq_lease_t, dnsmasq_lease_t)
 files_var_lib_filetrans(dnsmasq_t, dnsmasq_lease_t, file)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(12/07/2021 09:38:48.124:320) : proctitle=/usr/sbin/dnsmasq
type=PATH msg=audit(12/07/2021 09:38:48.124:320) : item=0 name=/etc/dnsmasq.d inode=29360448 dev=fd:01 mode=dir,755 ouid=root ogid=dnsmasq rdev=00:00 obj=system_u:object_r:dnsmasq_etc_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(12/07/2021 09:38:48.124:320) : cwd=/
type=SYSCALL msg=audit(12/07/2021 09:38:48.124:320) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0x8 a1=0x5586fa914c70 a2=0x88 a3=0x0 items=1 ppid=1 pid=5720 auid=unset uid=dnsmasq gid=dnsmasq euid=dnsmasq suid=dnsmasq fsuid=dnsmasq egid=dnsmasq sgid=dnsmasq fsgid=dnsmasq tty=(none) ses=unset comm=dnsmasq exe=/usr/sbin/dnsmasq subj=system_u:system_r:dnsmasq_t:s0 key=(null)
type=AVC msg=audit(12/07/2021 09:38:48.124:320) : avc:  denied  { watch } for  pid=5720 comm=dnsmasq path=/etc/dnsmasq.d dev="vda1" ino=29360448 scontext=system_u:system_r:dnsmasq_t:s0 tcontext=system_u:object_r:dnsmasq_etc_t:s0 tclass=dir permissive=0

Resolves: rhbz#2029866