### PR TITLE
Label abrt-action-generate-backtrace with abrt_handle_event_exec_t

### DIFF
--- a/policy/modules/contrib/abrt.fc
+++ b/policy/modules/contrib/abrt.fc
@@ -3,6 +3,7 @@
 
 /usr/lib/systemd/system/abrt.*	--	gen_context(system_u:object_r:abrt_unit_file_t,s0)
 
+/usr/bin/abrt-action-generate-backtrace	--	gen_context(system_u:object_r:abrt_handle_event_exec_t,s0)
 /usr/bin/abrt-dump-.* 	    --	gen_context(system_u:object_r:abrt_dump_oops_exec_t,s0)
 /usr/bin/abrt-uefioops-oops 	--	gen_context(system_u:object_r:abrt_dump_oops_exec_t,s0)
 /usr/bin/abrt-pyhook-helper 	--	gen_context(system_u:object_r:abrt_helper_exec_t,s0)


### PR DESCRIPTION
The abrt-action-generate-backtrace tool runs gdb(1) on a file named
coredump in the problem directory. gdb generates backtrace and other
diagnostic information about the state of the application at the moment
when coredump was generated, for that it needs the access to all
resources like devices.

Addresses the following AVC denial:
type=AVC msg=audit(1605076684.404:656): avc:  denied  { read } for  pid=6117 comm="gdb" name="renderD128" dev="devtmpfs" ino=3980 scontext=system_u:system_r:abrt_t:s0-s0:c0.c1023 tcontext=system_u:object_r:dri_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#1896648