### PR TITLE
Allow sandbox_xserver_t map sandbox_file_t

### DIFF
--- a/policy/modules/contrib/sandboxX.te
+++ b/policy/modules/contrib/sandboxX.te
@@ -48,12 +48,14 @@ tunable_policy(`deny_execmem',`',`
 ')
 
 allow sandbox_xserver_t self:fifo_file manage_fifo_file_perms;
+allow sandbox_xserver_t self:process setsched;
 allow sandbox_xserver_t self:shm create_shm_perms;
 allow sandbox_xserver_t self:tcp_socket create_stream_socket_perms;
 
 manage_dirs_pattern(sandbox_xserver_t, sandbox_file_t, sandbox_file_t)
 manage_files_pattern(sandbox_xserver_t, sandbox_file_t, sandbox_file_t)
 manage_sock_files_pattern(sandbox_xserver_t, sandbox_file_t, sandbox_file_t)
+allow sandbox_xserver_t sandbox_file_t:file map;
 allow sandbox_xserver_t sandbox_file_t:sock_file create_sock_file_perms;
 
 manage_dirs_pattern(sandbox_xserver_t, sandbox_xserver_tmpfs_t, sandbox_xserver_tmpfs_t)


### PR DESCRIPTION
Allow Xephyr with label sandbox_xserver_t to map sandbox_file_t files.
Allow sandbox_xserver_t to setsched.

Fixed Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1978020

Copr build: https://copr.fedorainfracloud.org/coprs/nknazeko/selinux-policy/build/3044040/