### PR TITLE
Network manager new policies

### DIFF
--- a/policy/modules/contrib/networkmanager.fc
+++ b/policy/modules/contrib/networkmanager.fc
@@ -3,7 +3,7 @@
 /etc/NetworkManager(/.*)?	gen_context(system_u:object_r:NetworkManager_etc_t,s0)
 /etc/NetworkManager/NetworkManager\.conf	gen_context(system_u:object_r:NetworkManager_etc_rw_t,s0)
 /etc/NetworkManager/system-connections(/.*)?	gen_context(system_u:object_r:NetworkManager_etc_rw_t,s0)
-/etc/NetworkManager/dispatcher\.d(/.*)?	gen_context(system_u:object_r:NetworkManager_initrc_exec_t,s0)
+/etc/NetworkManager/dispatcher\.d(/.*)?	gen_context(system_u:object_r:NetworkManager_dispatcher_script_t,s0)
 
 /etc/dhcp/manager-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
 /etc/dhcp/wireless-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
@@ -13,11 +13,11 @@
 /etc/wicd/wireless-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
 /etc/wicd/wired-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
 
-/usr/lib/NetworkManager/dispatcher\.d(/.*)? gen_context(system_u:object_r:NetworkManager_initrc_exec_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d(/.*)? gen_context(system_u:object_r:NetworkManager_dispatcher_script_t,s0)
 /usr/lib/systemd/system/NetworkManager.* --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
 /usr/lib/systemd/system/nm-cloud-setup\.(service|timer) --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
 
-/usr/libexec/nm-dispatcher.* --	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
+/usr/libexec/nm-dispatcher --	gen_context(system_u:object_r:NetworkManager_dispatcher_exec_t,s0)
 
 /usr/bin/NetworkManager	--	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
 /usr/bin/wpa_cli	--	gen_context(system_u:object_r:wpa_cli_exec_t,s0)
@@ -26,7 +26,7 @@
 
 /usr/sbin/NetworkManager	--	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
 /usr/sbin/wpa_supplicant	--	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
-/usr/sbin/NetworkManagerDispatcher --	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
+/usr/sbin/NetworkManagerDispatcher --	gen_context(system_u:object_r:NetworkManager_dispatcher_exec_t,s0)
 /usr/sbin/nm-system-settings	--	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
 /usr/bin/teamd          --  gen_context(system_u:object_r:NetworkManager_exec_t,s0)
 /usr/sbin/wicd 			--	gen_context(system_u:object_r:NetworkManager_exec_t,s0)

--- a/policy/modules/contrib/networkmanager.fc
+++ b/policy/modules/contrib/networkmanager.fc
@@ -18,6 +18,7 @@
 /usr/lib/systemd/system/nm-cloud-setup\.(service|timer) --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
 
 /usr/libexec/nm-dispatcher --	gen_context(system_u:object_r:NetworkManager_dispatcher_exec_t,s0)
+/usr/libexec/nm-priv-helper  -- gen_context(system_u:object_r:NetworkManager_priv_helper_exec_t,s0)
 
 /usr/bin/NetworkManager	--	gen_context(system_u:object_r:NetworkManager_exec_t,s0)
 /usr/bin/wpa_cli	--	gen_context(system_u:object_r:wpa_cli_exec_t,s0)

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -39,6 +39,10 @@ type NetworkManager_dispatcher_exec_t;
 type NetworkManager_dispatcher_script_t;
 files_type(NetworkManager_dispatcher_script_t)
 
+type NetworkManager_priv_helper_t;
+type NetworkManager_priv_helper_exec_t;
+init_nnp_daemon_domain(NetworkManager_priv_helper_t, NetworkManager_priv_helper_exec_t)
+
 type wpa_cli_t;
 type wpa_cli_exec_t;
 init_system_domain(wpa_cli_t, wpa_cli_exec_t)
@@ -524,6 +528,25 @@ optional_policy(`
 
 optional_policy(`
 	logging_send_syslog_msg(NetworkManager_dispatcher_t)
+')
+
+########################################
+#
+# NetworkManager-priv_helper local policy
+#
+
+allow NetworkManager_priv_helper_t self:capability dac_override;
+
+allow NetworkManager_priv_helper_t self:unix_dgram_socket { create_socket_perms sendto };
+
+kernel_dgram_send(NetworkManager_priv_helper_t)
+
+optional_policy(`
+        dbus_system_domain(NetworkManager_priv_helper_t, NetworkManager_priv_helper_exec_t)
+')
+
+optional_policy(`
+        openvswitch_stream_connect(NetworkManager_priv_helper_t)
 ')
 
 ########################################

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -33,6 +33,12 @@ files_type(NetworkManager_var_lib_t)
 type NetworkManager_var_run_t;
 files_pid_file(NetworkManager_var_run_t)
 
+type NetworkManager_dispatcher_t;
+type NetworkManager_dispatcher_exec_t;
+
+type NetworkManager_dispatcher_script_t;
+files_type(NetworkManager_dispatcher_script_t)
+
 type wpa_cli_t;
 type wpa_cli_exec_t;
 init_system_domain(wpa_cli_t, wpa_cli_exec_t)
@@ -500,6 +506,24 @@ optional_policy(`
 
 tunable_policy(`use_ecryptfs_home_dirs',`
 	fs_manage_ecryptfs_files(NetworkManager_t)
+')
+
+########################################
+#
+# NetworkManager-dispatcher local policy
+#
+
+allow NetworkManager_dispatcher_t self:unix_dgram_socket { create_socket_perms sendto };
+
+list_dirs_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, NetworkManager_dispatcher_script_t)
+read_files_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, NetworkManager_dispatcher_script_t)
+
+optional_policy(`
+	dbus_system_domain(NetworkManager_dispatcher_t, NetworkManager_dispatcher_exec_t)
+')
+
+optional_policy(`
+	logging_send_syslog_msg(NetworkManager_dispatcher_t)
 ')
 
 ########################################


### PR DESCRIPTION
Commit 1:

### Label NetworkManager-dispatcher service with separate context

NetworkManager-dispatcher run with same context as
NetworkManager. Label NetworkManager-dispatcher service
with separate context as NetworkManager_dispatcher_t.
Nm-dispatcher need communicate on D-Bus, work with unix
sockets and need executes scripts, which will be label
as NetworkManager_dispatcher_script_t.  Also need to send
logging messages to log.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1989070

Commit 2:

### Label new utility of NetworkManager nm-priv-helper
    
Label new nm-priv-helper utility of NetworkManager as
NetworkManager_priv_helper_t. Nm-priv-helper need communicate on
D-Bus, work unix sockets and transfer file decriptor
via D-Bus to NetworkManager. Enable nm-priv-helper
pass the file descriptor from the socket via
CAP_OVERRIDE capability.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1986076
