### PR TITLE
Allow useradd and groupadd the setgid capability

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -212,7 +212,7 @@ optional_policy(`
 # Groupadd local policy
 #
 
-allow groupadd_t self:capability { dac_read_search dac_override chown fowner kill setuid sys_resource audit_write };
+allow groupadd_t self:capability { dac_read_search dac_override chown fowner kill setgid setuid sys_resource audit_write };
 dontaudit groupadd_t self:capability { fsetid sys_tty_config };
 allow groupadd_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execheap execstack };
 allow groupadd_t self:process { setrlimit setfscreate };
@@ -513,7 +513,7 @@ optional_policy(`
 # Useradd local policy
 #
 
-allow useradd_t self:capability { dac_read_search dac_override chown kill fowner fsetid setuid sys_ptrace sys_resource sys_chroot };
+allow useradd_t self:capability { dac_read_search dac_override chown kill fowner fsetid setgid setuid sys_ptrace sys_resource sys_chroot };
 
 dontaudit useradd_t self:capability { net_admin sys_tty_config };
 dontaudit useradd_t self:cap_userns { sys_ptrace };


### PR DESCRIPTION
When an rpm package adds a new user or a group as a part of one of
the install scripts, sss_cache requires the setgid or setuid capability
for the setresuid(2) syscall.

Resolves: rhbz#2022690