### PR TITLE
Dontaudit pkcsslotd sys_admin capability

### DIFF
--- a/policy/modules/contrib/pkcs.te
+++ b/policy/modules/contrib/pkcs.te
@@ -46,6 +46,7 @@ systemd_unit_file(pkcs_slotd_unit_file_t)
 #
 
 allow pkcs_slotd_t self:capability { fsetid kill chown };
+dontaudit pkcs_slotd_t self:capability sys_admin;
 allow pkcs_slotd_t self:fifo_file rw_fifo_file_perms;
 allow pkcs_slotd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow pkcs_slotd_t self:sem create_sem_perms;


### PR DESCRIPTION
The sys_admin capability is requested when the
udev_monitor_set_receive_buffer_size() function used in socket_server.c
in pkcsslotd calls socketcall(), but is is not actually needed so it can
safely be denied.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(11/10/2021 06:08:52.730:525) : proctitle=/usr/sbin/pkcsslotd
type=SOCKETCALL msg=audit(11/10/2021 06:08:52.730:525) : nargs=5 a0=0x9 a1=0x1 a2=0x1a a3=0x3fff6b7dfc0 a4=10
type=SYSCALL msg=audit(11/10/2021 06:08:52.730:525) : arch=s390x syscall=socketcall(setsockopt) success=yes exit=0 a0=setsockopt a1=0x3fff6b7def0 a2=0x1a a3=0x3fff6b7dfc0 items=0 ppid=1 pid=48791 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pkcsslotd exe=/usr/sbin/pkcsslotd subj=system_u:system_r:pkcs_slotd_t:s0 key=(null)
type=AVC msg=audit(11/10/2021 06:08:52.730:525) : avc:  denied  { sys_admin } for  pid=48791 comm=pkcsslotd capability=sys_admin  scontext=system_u:system_r:pkcs_slotd_t:s0 tcontext=system_u:system_r:pkcs_slotd_t:s0 tclass=capability permissive=0

Resolves: rhbz#2021887