### PR TITLE
Allow lldpd connect to snmpd with a unix domain stream socket

### DIFF
--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -83,6 +83,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	snmp_stream_connect(lldpad_t)
+')
+
+optional_policy(`
     sysnet_read_config(lldpad_t)
 ')
 


### PR DESCRIPTION
If the lldpd service is configured to enable the SNMP subagent
(using the -x option), the lldpd process tries to connect to snmpd's
agentx. By default, the /var/agentx/master socket file is used.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/03/22 06:21:57.359:417) : proctitle=/usr/sbin/lldpd -x
type=PATH msg=audit(01/03/22 06:21:57.359:417) : item=0 name=/var/agentx/master nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(01/03/22 06:21:57.359:417) : cwd=/
type=SOCKADDR msg=audit(01/03/22 06:21:57.359:417) : saddr={ saddr_fam=local path=/var/agentx/master }
type=SYSCALL msg=audit(01/03/22 06:21:57.359:417) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x6 a1=0x5586e8de9980 a2=0x6e a3=0x0 items=1 ppid=1 pid=12595 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=lldpd exe=/usr/sbin/lldpd subj=system_u:system_r:lldpad_t:s0 key=(null)
type=AVC msg=audit(01/03/22 06:21:57.359:417) : avc:  denied  { search } for  pid=12595 comm=lldpd name=agentx dev="vda1" ino=2034987 scontext=system_u:system_r:lldpad_t:s0 tcontext=system_u:object_r:snmpd_var_lib_t:s0 tclass=dir permissive=0

Resolves: rhbz#1991029