### PR TITLE
Change /run/user/[0-9]+ to /run/user/%{USERID} for proper labeling

### DIFF
--- a/policy/modules/contrib/dbus.fc
+++ b/policy/modules/contrib/dbus.fc
@@ -28,7 +28,8 @@ ifdef(`distro_gentoo',`
 
 /var/run/dbus(/.*)?		gen_context(system_u:object_r:system_dbusd_var_run_t,s0)
 
-/var/run/user/[0-9]+/dbus(/.*)? 	gen_context(system_u:object_r:session_dbusd_tmp_t,s0)
+/var/run/user/%{USERID}/bus	-s	gen_context(system_u:object_r:session_dbusd_tmp_t,s0)
+/var/run/user/%{USERID}/dbus-1(/.*)? 	gen_context(system_u:object_r:session_dbusd_tmp_t,s0)
 
 ifdef(`distro_redhat',`
 /var/named/chroot/var/run/dbus(/.*)?	gen_context(system_u:object_r:system_dbusd_var_run_t,s0)

--- a/policy/modules/contrib/gnome.fc
+++ b/policy/modules/contrib/gnome.fc
@@ -22,9 +22,9 @@ HOME_DIR/\.local/share/keyrings(/.*)?	gen_context(system_u:object_r:gkeyringd_gn
 HOME_DIR/\.Xdefaults		gen_context(system_u:object_r:config_home_t,s0)
 HOME_DIR/\.xine(/.*)?		gen_context(system_u:object_r:config_home_t,s0)
 
-/var/run/user/[^/]*/\.orc(/.*)?		gen_context(system_u:object_r:gstreamer_home_t,s0)
-/var/run/user/[^/]*/dconf(/.*)?	gen_context(system_u:object_r:config_home_t,s0)
-/var/run/user/[^/]*/keyring.*	gen_context(system_u:object_r:gkeyringd_tmp_t,s0)
+/var/run/user/%{USERID}/\.orc(/.*)?		gen_context(system_u:object_r:gstreamer_home_t,s0)
+/var/run/user/%{USERID}/dconf(/.*)?	gen_context(system_u:object_r:config_home_t,s0)
+/var/run/user/%{USERID}/keyring.*	gen_context(system_u:object_r:gkeyringd_tmp_t,s0)
 
 /root/\.cache(/.*)?	gen_context(system_u:object_r:cache_home_t,s0)
 /root/\.color/icc(/.*)?	gen_context(system_u:object_r:icc_data_home_t,s0)

--- a/policy/modules/kernel/filesystem.fc
+++ b/policy/modules/kernel/filesystem.fc
@@ -14,8 +14,8 @@ HOME_DIR/\.Private(/.*)?	gen_context(system_u:object_r:ecryptfs_t,s0)
 /usr/lib/udev/devices/hugepages/.*	<<none>>
 /usr/lib/udev/devices/shm	-d	gen_context(system_u:object_r:tmpfs_t,s0)
 /usr/lib/udev/devices/shm/.*	<<none>>
-/var/run/user/[^/]*/gvfs		-d	gen_context(system_u:object_r:fusefs_t,s0)
-/var/run/user/[^/]*/gvfs/.*	<<none>>
+/var/run/user/%{USERID}/gvfs		-d	gen_context(system_u:object_r:fusefs_t,s0)
+/var/run/user/%{USERID}/gvfs/.*	<<none>>
 
 # for systemd systems:
 #

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -273,6 +273,7 @@ dev_setattr_sound_dev(systemd_logind_t)
 dev_setattr_video_dev(systemd_logind_t)
 dev_write_kmsg(systemd_logind_t)
 
+domain_obj_id_change_exemption(systemd_logind_t)
 domain_read_all_domains_state(systemd_logind_t)
 domain_signal_all_domains(systemd_logind_t)
 domain_signull_all_domains(systemd_logind_t)

--- a/policy/modules/system/userdomain.fc
+++ b/policy/modules/system/userdomain.fc
@@ -28,10 +28,11 @@ HOME_DIR/tmp			-d	gen_context(system_u:object_r:user_tmp_t,s0)
 /tmp/\.X11-unix(/.*)?		gen_context(system_u:object_r:user_tmp_t,s0)
 /tmp/\.ICE-unix(/.*)?		gen_context(system_u:object_r:user_tmp_t,s0)
 
-
-
-/var/run/user(/.*)?	gen_context(system_u:object_r:user_tmp_t,s0)
+/var/run/user	-d	gen_context(system_u:object_r:user_tmp_t,s0)
+/var/run/user/[^/]+	-d	gen_context(system_u:object_r:user_tmp_t,s0)
+/var/run/user/[^/]+/.+		<<none>>
+/var/run/user/%{USERID}	-d	gen_context(system_u:object_r:user_tmp_t,s0)
+/var/run/user/%{USERID}/.+	<<none>>
 
 /tmp/hsperfdata_root        gen_context(system_u:object_r:user_tmp_t,s0)
 /var/tmp/hsperfdata_root    gen_context(system_u:object_r:user_tmp_t,s0)
-


### PR DESCRIPTION
In file context specification, the %{USERID} template can be used to
specify user id number. When genhomedircon is run subsequently, it
generates SELinux file context configuration entries for user home
directories and other user-related objects, which allows for proper
labeling the user part of SELinux context, too.

Additionally, systemd-logind was made exempt from the constraint
preventing changing the user identity in object contexts:

constrain dir_file_class_set { create relabelto relabelfrom }
(
        u1 == u2
        or t1 == can_change_object_identity
);

Resolves: rhbz#1878094