### PR TITLE
Allow admin userdomains use socketpair()

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -58,7 +58,7 @@ template(`sudo_role_template',`
 	allow $1_sudo_t $3:file read_file_perms;;
 	allow $1_sudo_t $3:key search;
 
-	allow $1_sudo_t $1_t:unix_stream_socket connectto;
+	allow $1_sudo_t $1_t:unix_stream_socket { connectto read write };
 
 	# Enter this derived domain from the user domain
 	domtrans_pattern($3, sudo_exec_t, $1_sudo_t)


### PR DESCRIPTION
In cockpit, the bridge uses socketpair() to communicate to subprocesses.
For executing administrative commands, "sudo cockpit-bridge" is spawned,
and the permissions to read and write from the socket are required.

Simplified reproducer:
$ python3 -c 'import socket, subprocess; r = socket.socketpair(); p = subprocess.Popen(["sudo", "whoami"], stdout=r[0]); print(p.wait()); print(r[1].recv(100))'

sudo succeeds, but recv() hangs as the data flow is blocked.

This commit addresses the following AVC denial:

type=PROCTITLE msg=audit(01/06/2022 03:07:28.526:5532) : proctitle=sudo whoami
type=EXECVE msg=audit(01/06/2022 03:07:28.526:5532) : argc=2 a0=sudo a1=whoami
type=SYSCALL msg=audit(01/06/2022 03:07:28.526:5532) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7f302b08c470 a1=0x7f302b106450 a2=0x7ffe20fef5b8 a3=0xffffffffffffff01 items=2 ppid=567183 pid=567184 auid=admin uid=admin gid=admin euid=root suid=root fsuid=root egid=admin sgid=admin fsgid=admin tty=pts1 ses=6 comm=sudo exe=/usr/bin/sudo subj=staff_u:staff_r:staff_sudo_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(01/06/2022 03:07:28.526:5532) : avc:  denied  { read write } for  pid=567184 comm=sudo path=socket:[690408] dev="sockfs" ino=690408 scontext=staff_u:staff_r:staff_sudo_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0

Resolves: rhbz#1814569