### PR TITLE
Allow sshd read sysctl files

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -304,6 +304,7 @@ allow sshd_t sshd_keytab_t:file read_file_perms;
 kernel_search_key(sshd_t)
 kernel_link_key(sshd_t)
 kernel_read_net_sysctls(sshd_t)
+kernel_read_sysctl(sshd_t)
 
 files_search_all(sshd_t)
 files_create_home_dir(sshd_t)


### PR DESCRIPTION
This permissions is required when "nofile unlimited" is configured
in the system resources limits.

echo "testuser hard nofile unlimited" >> /etc/security/limits.d/testuser.conf

Resolves: rhbz#2036585