### PR TITLE
Allow fcoemon request the kernel to load a module

### DIFF
--- a/policy/modules/contrib/fcoe.te
+++ b/policy/modules/contrib/fcoe.te
@@ -34,6 +34,8 @@ manage_files_pattern(fcoemon_t, fcoemon_var_run_t, fcoemon_var_run_t)
 manage_sock_files_pattern(fcoemon_t, fcoemon_var_run_t, fcoemon_var_run_t)
 files_pid_filetrans(fcoemon_t, fcoemon_var_run_t, { dir file })
 
+kernel_request_load_module(fcoemon_t)
+
 dev_rw_sysfs(fcoemon_t)
 dev_create_sysfs_files(fcoemon_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1641434692.558:116): avc:  denied  { module_request } for  pid=2995 comm="fcoemon" kmod="8021q" scontext=system_u:system_r:fcoemon_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0
type=SYSCALL msg=audit(1641434692.558:116): arch=x86_64 syscall=ioctl success=no exit=ENOPKG a0=8 a1=8982 a2=7ffdd90301c0 a3=7fec871ae3e0 items=0 ppid=1 pid=2995 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=fcoemon exe=/usr/sbin/fcoemon subj=s

Resolves: rhbz#2034463