### PR TITLE
Allow virt_domain map vhost devices

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -969,6 +969,7 @@ dev_rw_infiniband_dev(virt_domain)
 dev_rw_dri(virt_domain)
 dev_rw_tpm(virt_domain)
 dev_rw_xserver_misc(virt_domain)
+dev_map_vhost(virt_domain)
 
 domain_use_interactive_fds(virt_domain)
 

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5964,6 +5964,24 @@ interface(`dev_rw_inherited_vhost',`
 
 ########################################
 ## <summary>
+##	Allow map the vhost devices
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_map_vhost',`
+	gen_require(`
+		type device_t, vhost_device_t;
+	')
+
+	allow $1 vhost_device_t:chr_file map;
+')
+
+########################################
+## <summary>
 ##	Read and write VMWare devices.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The dev_map_vhost() interface was added.

This commit addresses the following AVC denial:

type=PROCTITLE msg=audit(12/26/2021 22:21:14.465:1513) : proctitle=/usr/libexec/qemu-kvm -name guest=r9,debug-threads=on -S -object {"qom-type":"secret","id":"masterKey0","format":"raw","file":"/
type=AVC msg=audit(12/26/2021 22:21:14.465:1513) : avc:  denied  { map } for  pid=31328 comm=CPU 0/KVM path=/dev/vhost-vdpa-0 dev="devtmpfs" ino=876 scontext=system_u:system_r:svirt_t:s0:c135,c969 tcontext=system_u:object_r:vhost_device_t:s0 tclass=chr_file permissive=0
type=SYSCALL msg=audit(12/26/2021 22:21:14.465:1513) : arch=x86_64 syscall=mmap success=no exit=EACCES(Permission denied) a0=0x0 a1=0x1000 a2=PROT_WRITE a3=MAP_SHARED items=0 ppid=1 pid=31328 auid=unset uid=unknown(107) gid=unknown(107) euid=unknown(107) suid=unknown(107) fsuid=unknown(107) egid=unknown(107) sgid=unknown(107) fsgid=unknown(107) tty=(none) ses=unset comm=CPU 0/KVM exe=/usr/libexec/qemu-kvm subj=system_u:system_r:svirt_t:s0:c135,c969 key=(null)

Resolves: rhbz#2035702