### PR TITLE
Allow smbcontrol read the network state information

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -743,6 +743,8 @@ samba_read_config(smbcontrol_t)
 samba_search_var(smbcontrol_t)
 samba_read_winbind_pid(smbcontrol_t)
 
+kernel_read_network_state(smbcontrol_t)
+
 domain_use_interactive_fds(smbcontrol_t)
 
 dev_read_urand(smbcontrol_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(12/15/2021 14:56:51.308:2289) : proctitle=smbcontrol winbind ping
type=AVC msg=audit(12/15/2021 14:56:51.308:2289) : avc:  denied  { read } for  pid=39355 comm=smbcontrol name=unix dev="proc" ino=4026532055 scontext=unconfined_u:unconfined_r:smbcontrol_t:s0-s0:c0.c1023 tcontext=system_u:object_r:proc_net_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(12/15/2021 14:56:51.308:2289) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x7fffd5d76250 a1=R_OK a2=0x8 a3=0x562d2bf87764 items=0 ppid=36929 pid=39355 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=9 comm=smbcontrol exe=/usr/bin/smbcontrol subj=unconfined_u:unconfined_r:smbcontrol_t:s0-s0:c0.c1023 key=(null)

Resolves: rhbz#2038157