### PR TITLE
Allow tlp read its systemd unit

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -28,6 +28,8 @@ allow tlp_t self:udp_socket create_socket_perms;
 allow tlp_t self:unix_dgram_socket create_socket_perms;
 allow tlp_t self:netlink_generic_socket create_socket_perms;
 
+allow tlp_t tlp_unit_file_t:file read_file_perms;
+
 manage_dirs_pattern(tlp_t, tlp_var_run_t, tlp_var_run_t)
 manage_files_pattern(tlp_t, tlp_var_run_t, tlp_var_run_t)
 files_pid_filetrans(tlp_t, tlp_var_run_t, { dir file })


### PR DESCRIPTION
A tlp script executes systemctl to get status of the tlp service unit.

Resolves: rhbz#2013451