### PR TITLE
Allow administrative users the bpf capability

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1640,6 +1640,8 @@ template(`userdom_admin_user_template',`
 	# $1_t local policy
 	#
 
+	allow $1_t self:capability2 bpf;
+
 	# Manipulate other users crontab.
 	allow $1_t self:passwd crontab;
 


### PR DESCRIPTION
The userdom_admin_user_template() template for creating an
administrative user was updated with the bpf capability so that
e. g. users in the sysadm_r role can run perf.
Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/12/2022 10:45:01.065:855) : proctitle=perf record -o /dev/null echo test
type=SYSCALL msg=audit(01/12/2022 10:45:01.065:855) : arch=x86_64 syscall=bpf success=no exit=ENOENT(No such file or directory) a0=BPF_PROG_GET_NEXT_ID a1=0x7fffd756dba0 a2=0x78 a3=0x3b items=0 ppid=9065 pid=9066 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=7 comm=perf exe=/usr/bin/perf subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(01/12/2022 10:45:01.065:855) : avc:  denied  { bpf } for  pid=9066 comm=perf capability=unknown-capability(39)  scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tclass=capability2 permissive=0