### PR TITLE
Allow kpropd get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/contrib/kerberos.te
+++ b/policy/modules/contrib/kerberos.te
@@ -385,6 +385,8 @@ dev_read_urand(kpropd_t)
 
 files_search_tmp(kpropd_t)
 
+fs_getattr_cgroup(kpropd_t)
+
 selinux_validate_context(kpropd_t)
 
 auth_use_nsswitch(kpropd_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/12/2022 17:58:09.626:7104) : proctitle=/usr/sbin/kpropd
type=PATH msg=audit(01/12/2022 17:58:09.626:7104) : item=0 name=/sys/fs/cgroup/ inode=1 dev=00:1b mode=dir,555 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(01/12/2022 17:58:09.626:7104) : arch=x86_64 syscall=statfs success=no exit=EACCES(Permission denied) a0=0x7f78a1e413ae a1=0x7ffd080f54c0 a2=0x7f78a2137260 a3=0x0 items=1 ppid=1 pid=132239 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=kpropd exe=/usr/sbin/kpropd subj=system_u:system_r:kpropd_t:s0 key=(null)
type=AVC msg=audit(01/12/2022 17:58:09.626:7104) : avc:  denied  { getattr } for  pid=132239 comm=kpropd name=/ dev="cgroup2" ino=1 scontext=system_u:system_r:kpropd_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=filesystem permissive=0