### PR TITLE
Label /etc/cockpit/ws-certs.d with cert_t

### DIFF
--- a/policy/modules/system/miscfiles.fc
+++ b/policy/modules/system/miscfiles.fc
@@ -9,6 +9,7 @@ ifdef(`distro_gentoo',`
 # /etc
 #
 /etc/avahi/etc/localtime --	gen_context(system_u:object_r:locale_t,s0)
+/etc/cockpit/ws-certs\.d(/.*)?	gen_context(system_u:object_r:cert_t,s0)
 /etc/docker/certs\.d(/.*)?          gen_context(system_u:object_r:cert_t,s0)
 /etc/httpd/alias(/.*)?	        gen_context(system_u:object_r:cert_t,s0)
 /etc/localtime		-l	gen_context(system_u:object_r:locale_t,s0)


### PR DESCRIPTION
Certmonger is not allowed to write into /etc/cockpit/ws-certs.d/ as
this directory currently has the default `etc_t` type, but certmonger
can only write into `cert_t` directories.

Based on the 6ec4881856e ("tls: Fix SELinux policy and documentation for
certmonger certificates") commit in cockpit.

Resolves: rhbz#1907473