### PR TITLE
Allow systemd-coredump read and write usermodehelper state

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1039,7 +1039,7 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # setgid setuid - to set own credentials to match the dumped process credentials
 # setpcap - to drop capabilities
 allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_ptrace };
-allow systemd_coredump_t self:cap_userns sys_ptrace;
+allow systemd_coredump_t self:cap_userns { dac_read_search dac_override sys_admin sys_ptrace };
 
 # To set its capability set
 allow systemd_coredump_t self:process setcap;
@@ -1065,6 +1065,8 @@ domain_read_all_domains_state(systemd_coredump_t)
 # (can be basically any file type)
 files_read_non_security_files(systemd_coredump_t)
 files_map_non_security_files(systemd_coredump_t)
+
+files_mounton_rootfs(systemd_coredump_t)
 
 fs_getattr_nsfs_files(systemd_coredump_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1054,6 +1054,8 @@ manage_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_cor
 mmap_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_coredump_var_lib_t)
 init_var_lib_filetrans(systemd_coredump_t, systemd_coredump_var_lib_t, dir, "coredump")
 
+kernel_rw_usermodehelper_state(systemd_coredump_t)
+
 dev_write_kmsg(systemd_coredump_t)
 
 # To read info about the crashed process from /proc


### PR DESCRIPTION
When systemd (PID1) crashes, it freezes and systemd services cannot be
started, so coredump handling with systemd-coredump will not work
either. As frozen systemd does not collect zombies any longer, it looks
reasonable to avoid spawning further processes as much as possible.

Therefore systemd-coredump will write "|/bin/false" to the
kernel.core_pattern kernel tunable when it detects that it was PID 1
that had crashed to disable coredumping.

Resolves: rhbz#1982961