### PR TITLE
Allow systemd-io-bridge ioctl rpm_script_t

### DIFF
--- a/policy/modules/contrib/rpm.if
+++ b/policy/modules/contrib/rpm.if
@@ -957,3 +957,21 @@ interface(`rpm_admin',`
 
 	rpm_run($1, $2)
 ')
+
+## <summary>
+##	Allow the specified domain to ioctl rpm_script_t
+##	with a unix domain stream socket.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`rpm_script_ioctl_stream_sockets',`
+	gen_require(`
+		type rpm_script_t;
+	')
+
+	allow $1 rpm_script_t:unix_stream_socket ioctl;
+')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -516,6 +516,7 @@ optional_policy(`
 
 optional_policy(`
 	rpm_read_db(init_t)
+	rpm_script_ioctl_stream_sockets(init_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The permission to allow systemd-io-bridge ioctl rpm_script_t
with a unix domain stream socket was added to the policy.
It may be required when rpm packages are updated.

Addresses the following AVC denial:
type=AVC msg=audit(1637218398.533:2223): avc:  denied  { ioctl } for  pid=346362 comm="(o-bridge)" path="socket:[14969251]" dev="sockfs" ino=14969251 ioctlcmd=0x5401 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:unconfined_r:rpm_script_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

Resolves: rhbz#2024489