### PR TITLE
Allow radiusd connect to the radacct port

### DIFF
--- a/policy/modules/contrib/radius.te
+++ b/policy/modules/contrib/radius.te
@@ -111,6 +111,7 @@ corenet_udp_sendrecv_dhcpd_port(radiusd_t)
 
 corenet_tcp_connect_postgresql_port(radiusd_t)
 corenet_tcp_connect_http_port(radiusd_t)
+corenet_tcp_connect_radacct_port(radiusd_t)
 
 corenet_sendrecv_radacct_server_packets(radiusd_t)
 corenet_tcp_bind_radacct_port(radiusd_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/10/22 10:30:09.991:359) : proctitle=/usr/sbin/radiusd -d /etc/raddb
type=AVC msg=audit(01/10/22 10:30:09.991:359) : avc:  denied  { name_connect } for  pid=21784 comm=radiusd dest=1813 scontext=system_u:system_r:radiusd_t:s0 tcontext=system_u:object_r:radacct_port_t:s0 tclass=tcp_socket permissive=0
type=SYSCALL msg=audit(01/10/22 10:30:09.991:359) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x8 a1=0x7f71c6f22a50 a2=0x10 a3=0x7f71c6f22ad8 items=0 ppid=1 pid=21784 auid=unset uid=radiusd gid=radiusd euid=radiusd suid=radiusd fsuid=radiusd egid=radiusd sgid=radiusd fsgid=radiusd tty=(none) ses=unset comm=radiusd exe=/usr/sbin/radiusd subj=system_u:system_r:radiusd_t:s0 key=(null)

Resolves: rhbz#2038955