### PR TITLE
Allow rhsm-service read/write its private memfd: objects

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -21,6 +21,9 @@ files_lock_file(rhsmcertd_lock_t)
 type rhsmcertd_tmp_t;
 files_tmp_file(rhsmcertd_tmp_t)
 
+type rhsmcertd_tmpfs_t;
+files_tmp_file(rhsmcertd_tmpfs_t)
+
 type rhsmcertd_var_lib_t;
 files_type(rhsmcertd_var_lib_t)
 
@@ -57,6 +60,9 @@ files_lock_filetrans(rhsmcertd_t, rhsmcertd_lock_t, file)
 manage_dirs_pattern(rhsmcertd_t, rhsmcertd_tmp_t, rhsmcertd_tmp_t)
 manage_files_pattern(rhsmcertd_t, rhsmcertd_tmp_t, rhsmcertd_tmp_t)
 files_tmp_filetrans(rhsmcertd_t, rhsmcertd_tmp_t, { dir file })
+
+manage_files_pattern(rhsmcertd_t, rhsmcertd_tmpfs_t, rhsmcertd_tmpfs_t)
+fs_tmpfs_filetrans(rhsmcertd_t, rhsmcertd_tmpfs_t, file)
 
 manage_dirs_pattern(rhsmcertd_t, rhsmcertd_var_lib_t, rhsmcertd_var_lib_t)
 manage_files_pattern(rhsmcertd_t, rhsmcertd_var_lib_t, rhsmcertd_var_lib_t)


### PR DESCRIPTION
The new rhsmcertd_tmpfs_t type was added, the rhsmcertd_t domain
can manage rhsmcertd_tmpfs_t files, and there is a file transition
for files created in tmpfs_t directories.

Addresses the following AVC denial:

avc:  denied  { write } for  pid=2447 comm="rhsm-service" name="memfd:libffi" dev="tmpfs" ino=41282 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2029873