### PR TITLE
Allow systemd-coredump read and write usermodehelper state

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1055,6 +1055,8 @@ manage_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_cor
 mmap_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_coredump_var_lib_t)
 init_var_lib_filetrans(systemd_coredump_t, systemd_coredump_var_lib_t, dir, "coredump")
 
+kernel_rw_usermodehelper_state(systemd_coredump_t)
+
 dev_write_kmsg(systemd_coredump_t)
 
 # To read info about the crashed process from /proc


### PR DESCRIPTION
When systemd (PID1) crashes, it freezes and systemd services cannot be
started, so coredump handling with systemd-coredump will not work
either. As frozen systemd does not collect zombies any longer, it looks
reasonable to avoid spawning further processes as much as possible.

Therefore systemd-coredump will write "|/bin/false" to the
kernel.core_pattern kernel tunable when it detects that it was PID 1
that had crashed to disable coredumping.

Resolves: rhbz#1982961