### PR TITLE
Allow login_userdomain write to session_dbusd tmp socket files

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -414,6 +414,7 @@ optional_policy(`
 
 optional_policy(`
 	dbus_create_session_tmp_sock_files(login_userdomain)
+	dbus_write_session_tmp_sock_files(login_userdomain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/17/2022 18:06:43.240:4086) : proctitle=/usr/lib/systemd/systemd --user
type=PATH msg=audit(01/17/2022 18:06:43.240:4086) : item=0 name=/proc/self/fd/27 inode=15 dev=00:34 mode=socket,666 ouid=user31979 ogid=user31979 rdev=00:00 obj=staff_u:object_r:session_dbusd_tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(01/17/2022 18:06:43.240:4086) : cwd=/
type=SYSCALL msg=audit(01/17/2022 18:06:43.240:4086) : arch=x86_64 syscall=utimensat success=no exit=EACCES(Permission denied) a0=0xffffff9c a1=0x7ffd627865d0 a2=0x0 a3=0x0 items=1 ppid=1 pid=97102 auid=user31979 uid=user31979 gid=user31979 euid=user31979 suid=user31979 fsuid=user31979 egid=user31979 sgid=user31979 fsgid=user31979 tty=(none) ses=19 comm=systemd exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(01/17/2022 18:06:43.240:4086) : avc:  denied  { write } for  pid=97102 comm=systemd name=bus dev="tmpfs" ino=15 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:session_dbusd_tmp_t:s0 tclass=sock_file permissive=0
