### PR TITLE
Make cupsd_lpd_t a daemon

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -53,7 +53,7 @@ files_type(cupsd_var_lib_t)
 
 type cupsd_lpd_t, cups_domain;
 type cupsd_lpd_exec_t;
-init_domain(cupsd_lpd_t, cupsd_lpd_exec_t)
+init_daemon_domain(cupsd_lpd_t, cupsd_lpd_exec_t)
 
 type cupsd_lpd_tmp_t;
 files_tmp_file(cupsd_lpd_tmp_t)


### PR DESCRIPTION
The init_domain() interface call for cupsd_lpd_t was replaced by
init_daemon_domain() as it seems to be more appropriate although they
have different content. cupsd-lpd is a daemon and has a systemd
service unit.

Resolves: rhbz#2020531