### PR TITLE
Allow dirsrv read configfs files and directories

### DIFF
--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -125,11 +125,14 @@ corenet_sendrecv_all_client_packets(dirsrv_t)
 dev_read_sysfs(dirsrv_t)
 dev_read_urand(dirsrv_t)
 
+files_dontaudit_getattr_all_dirs(dirsrv_t)
 files_read_usr_symlinks(dirsrv_t)
 
 fs_getattr_all_fs(dirsrv_t)
 fs_list_cgroup_dirs(dirsrv_t)
 fs_read_cgroup_files(dirsrv_t)
+fs_read_configfs_dirs(dirsrv_t)
+fs_read_configfs_files(dirsrv_t)
 
 auth_use_pam(dirsrv_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1637164039.585:21999): avc:  denied  { getattr } for  pid=1398 comm="ns-slapd" path="/sys/kernel/config" dev="configfs" ino=13369 scontext=system_u:system_r:dirsrv_t:s0 tcontext=system_u:object_r:configfs_t:s0 tclass=dir permissive=0