### PR TITLE
Label /var/run/user/%{USERID}/dbus with session_dbusd_tmp_t

### DIFF
--- a/policy/modules/contrib/dbus.fc
+++ b/policy/modules/contrib/dbus.fc
@@ -29,6 +29,7 @@ ifdef(`distro_gentoo',`
 /var/run/dbus(/.*)?		gen_context(system_u:object_r:system_dbusd_var_run_t,s0)
 
 /var/run/user/%{USERID}/bus	-s	gen_context(system_u:object_r:session_dbusd_tmp_t,s0)
+/var/run/user/%{USERID}/dbus(/.*)? 	gen_context(system_u:object_r:session_dbusd_tmp_t,s0)
 /var/run/user/%{USERID}/dbus-1(/.*)? 	gen_context(system_u:object_r:session_dbusd_tmp_t,s0)
 
 ifdef(`distro_redhat',`


### PR DESCRIPTION
With the 925e0fcfc37 ("Change /run/user/[0-9]+ to /run/user/%{USERID}
for proper labeling") commit, the updated regexp stopped to match
/var/run/user/%{USERID}/dbus by mistake.