### PR TITLE
Revert "Label /etc/cockpit/ws-certs.d with cert_t"

### DIFF
--- a/policy/modules/system/miscfiles.fc
+++ b/policy/modules/system/miscfiles.fc
@@ -9,7 +9,6 @@ ifdef(`distro_gentoo',`
 # /etc
 #
 /etc/avahi/etc/localtime --	gen_context(system_u:object_r:locale_t,s0)
-/etc/cockpit/ws-certs\.d(/.*)?	gen_context(system_u:object_r:cert_t,s0)
 /etc/docker/certs\.d(/.*)?          gen_context(system_u:object_r:cert_t,s0)
 /etc/httpd/alias(/.*)?	        gen_context(system_u:object_r:cert_t,s0)
 /etc/localtime		-l	gen_context(system_u:object_r:locale_t,s0)


### PR DESCRIPTION
This reverts commit 0ac09c6d3b987d034e759936b92565831405e395.

Unfortunately duplicate file context entries cannot co-exist
even in modules installed with a different priority.