### PR TITLE
Allow tumblerd write to session_dbusd tmp socket files

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -146,6 +146,7 @@ optional_policy(`
 	dbus_stream_connect_session_bus(thumb_t)
 	dbus_chat_session_bus(thumb_t)
 	dbus_system_bus_client(thumb_t)
+	dbus_write_session_tmp_sock_files(thumb_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1642635456.954:3314): avc:  denied  { write } for  pid=104519 comm="tumblerd" name="bus" dev="tmpfs" ino=40 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:object_r:session_dbusd_tmp_t:s0 tclass=sock_file permissive=0

Resolves: rhbz#2042696