### PR TITLE
Label /var/lib/plocate with locate_var_lib_t

### DIFF
--- a/policy/modules/contrib/slocate.fc
+++ b/policy/modules/contrib/slocate.fc
@@ -3,5 +3,6 @@
 /usr/bin/updatedb.*	--	gen_context(system_u:object_r:locate_exec_t,s0)
 
 /var/lib/[sm]locate(/.*)?	gen_context(system_u:object_r:locate_var_lib_t,s0)
+/var/lib/plocate(/.*)?		gen_context(system_u:object_r:locate_var_lib_t,s0)
 
 /var/run/mlocate\.daily\.lock	--	gen_context(system_u:object_r:locate_var_run_t,s0)


### PR DESCRIPTION
plocate is a new locate implementation to replace mlocate in the near
future. It uses /var/lib/plocate as the data directory so the directory
needs to have the correct label.