### PR TITLE
Allow rhsm-service execute its private memfd: objects

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -63,6 +63,7 @@ files_tmp_filetrans(rhsmcertd_t, rhsmcertd_tmp_t, { dir file })
 
 manage_files_pattern(rhsmcertd_t, rhsmcertd_tmpfs_t, rhsmcertd_tmpfs_t)
 fs_tmpfs_filetrans(rhsmcertd_t, rhsmcertd_tmpfs_t, file)
+can_exec(rhsmcertd_t, rhsmcertd_tmpfs_t)
 
 manage_dirs_pattern(rhsmcertd_t, rhsmcertd_var_lib_t, rhsmcertd_var_lib_t)
 manage_files_pattern(rhsmcertd_t, rhsmcertd_var_lib_t, rhsmcertd_var_lib_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/20/2022 13:24:35.553:330) : proctitle=/usr/libexec/platform-python /usr/libexec/rhsm-service
type=MMAP msg=audit(01/20/2022 13:24:35.553:330) : fd=9 flags=MAP_SHARED
type=SYSCALL msg=audit(01/20/2022 13:24:35.553:330) : arch=x86_64 syscall=mmap success=yes exit=139689074921472 a0=0x0 a1=0x1000 a2=PROT_READ|PROT_EXEC a3=MAP_SHARED items=0 ppid=1 pid=6833 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-service exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)
type=AVC msg=audit(01/20/2022 13:24:35.553:330) : avc:  denied  { execute } for  pid=6833 comm=rhsm-service path=/memfd:libffi (deleted) dev="tmpfs" ino=46376 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:rhsmcertd_tmpfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(01/20/2022 13:24:35.553:330) : avc:  denied  { map } for  pid=6833 comm=rhsm-service path=/memfd:libffi (deleted) dev="tmpfs" ino=46376 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:rhsmcertd_tmpfs_t:s0 tclass=file permissive=1

Resolves: rhbz#2029873