### PR TITLE
NetworkManager uses random file names

### DIFF
--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1140,9 +1140,9 @@ interface(`sysnet_filetrans_systemd_resolved',`
 	')
 
 	optional_policy(`
-		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf")
-		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
-		systemd_resolved_pid_filetrans($1, net_conf_t, { file lnk_file }, "stub-resolv.conf")
+		systemd_resolved_pid_filetrans($1, net_conf_t, file)
+		systemd_resolved_pid_filetrans($1, net_conf_t, file)
+		systemd_resolved_pid_filetrans($1, net_conf_t, { file lnk_file })
 	')
 ')
 


### PR DESCRIPTION
When writing to systemd-resolved’s configuration, NetworkManager creates
files with a random suffix, then renames the file to the final name.
This causes AVC denials, since the type_transition rules do not fire.
Fix this by removing the file name constraints.