### PR TITLE
Add missing equivalence rules

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -9,14 +9,24 @@
 # example, but aliasing.
 # 
 /etc/init.d /etc/rc.d/init.d
+/usr/etc /etc
+/etc/systemd /usr/lib/systemd
 /lib32 /lib
 /lib64 /lib
 /run /var/run
 /run/lock /var/lock
 /usr/lib32 /usr/lib
 /usr/lib64 /usr/lib
+/usr/local/etc /etc
 /usr/local/lib32 /usr/lib
 /usr/local/lib64 /usr/lib
 /usr/local/lib /usr/lib
+/usr/local/include /usr/include
+/usr/local/bin /usr/bin
+/usr/local/src /usr/src
+/usr/local/sbin /usr/sbin
+/usr/local/share /usr/share
+/usr/local/libexec /usr/libexec
+/usr/local/games /usr/games
 /var/run/lock /var/lock
 /sbin /usr/sbin


### PR DESCRIPTION
I found this problem while adding SELinux support to Qubes OS and while
looking at upstream refpolicy.