### PR TITLE
Dontaudit sfcbd sys_ptrace cap_userns

### DIFF
--- a/policy/modules/contrib/sblim.te
+++ b/policy/modules/contrib/sblim.te
@@ -151,6 +151,7 @@ miscfiles_read_certs(sblim_reposd_t)
 #
 
 allow sblim_sfcbd_t self:capability { sys_ptrace setgid setuid };
+dontaudit sblim_sfcbd_t self:cap_userns sys_ptrace;
 allow sblim_sfcbd_t self:process signal;
 allow sblim_sfcbd_t self:unix_stream_socket connectto;
 


### PR DESCRIPTION
sfcbd goes through all /proc/PID/exe links to check whether there's an
instance of sfcbd running already. For reading a file with its own type
sblim_sfcbd_t the sys_ptrace user namespace capability is not required.