### PR TITLE
Allow domain transition to sssd_t and fix badly indented used interfaces

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -296,10 +296,10 @@ optional_policy(`
 
 optional_policy(`
 	sssd_domtrans(groupadd_t)
-    sssd_manage_lib_files(groupadd_t)
-    sssd_manage_public_files(groupadd_t)
-    sssd_read_pid_files(groupadd_t)
-    sssd_signal(groupadd_t)
+	sssd_manage_lib_files(groupadd_t)
+	sssd_manage_public_files(groupadd_t)
+	sssd_read_pid_files(groupadd_t)
+	sssd_signal(groupadd_t)
 ')
 
 optional_policy(`
@@ -661,10 +661,10 @@ optional_policy(`
 
 optional_policy(`
 	sssd_domtrans(useradd_t)
-    sssd_manage_lib_files(useradd_t)
-    sssd_manage_public_files(useradd_t)
-    sssd_read_pid_files(useradd_t)
-    sssd_signal(useradd_t)
+	sssd_manage_lib_files(useradd_t)
+	sssd_manage_public_files(useradd_t)
+	sssd_read_pid_files(useradd_t)
+	sssd_signal(useradd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -295,6 +295,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_domtrans(groupadd_t)
     sssd_manage_lib_files(groupadd_t)
     sssd_manage_public_files(groupadd_t)
     sssd_read_pid_files(groupadd_t)
@@ -659,6 +660,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_domtrans(useradd_t)
     sssd_manage_lib_files(useradd_t)
     sssd_manage_public_files(useradd_t)
     sssd_read_pid_files(useradd_t)

--- a/policy/modules/contrib/sssd.fc
+++ b/policy/modules/contrib/sssd.fc
@@ -3,6 +3,7 @@
 /etc/sssd(/.*)?			gen_context(system_u:object_r:sssd_conf_t,s0)
 
 /usr/sbin/sssd		--	gen_context(system_u:object_r:sssd_exec_t,s0)
+/usr/sbin/sss_cache	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_autofs	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_ifp	--	gen_context(system_u:object_r:sssd_exec_t,s0)
 /usr/libexec/sssd/sssd_nss	--	gen_context(system_u:object_r:sssd_exec_t,s0)


### PR DESCRIPTION
**Commit 1:**

Allow domain transition to sssd_t

When installing some rpm packages, new users or 
groups are added to the system using
the groupadd and useradd tools. Then the sss_cache 
file with the bin_t label is run and on this file 
groupadd and useradd want to setgid and this 
trigger SELinux denials. Label the sss_cache binary 
as sssd_exec_t and enabling the transition from 
groupadd_t and useradd_t to sssd_t. Sssd policy 
allowed setgid on this binary.
    
Bugzilla:https://bugzilla.redhat.com/show_bug.cgi?id=2022690

**Commit 2:**

Fix badly indented used interfaces

In policy is few badly indented used
iterfaces in optional blocks. Correction
of indentation of interface names.

