### PR TITLE
Label /run/stratisd with stratisd_var_run_t

### DIFF
--- a/policy/modules/contrib/stratisd.fc
+++ b/policy/modules/contrib/stratisd.fc
@@ -1,5 +1,8 @@
 /usr/libexec/stratisd		--	gen_context(system_u:object_r:stratisd_exec_t,s0)
 
+/dev/stratis(/.*)?  gen_context(system_u:object_r:stratisd_data_t,s0)
+
 /stratis(/.*)?  gen_context(system_u:object_r:stratisd_data_t,s0)
 
 /var/run/stratisd.*		--	gen_context(system_u:object_r:stratisd_var_run_t,s0)
+/var/run/stratisd(/.*)?			gen_context(system_u:object_r:stratisd_var_run_t,s0)


### PR DESCRIPTION
So far, there was support in selinux-policy for Stratis devices in /stratis.
The stratis project accepted the suggestions from multiple groups to move
the devices to a root file system directory that already existed, such as /dev.
Apart from that, devices are now created in /run/stratisd, so the
/run/stratisd directory also needs to be labeled with stratisd_var_run_t.

Resolves: rhbz#2039974