### PR TITLE
Allow systemd services watch dbusd pid directory and its parents

### DIFF
--- a/policy/modules/contrib/dbus.if
+++ b/policy/modules/contrib/dbus.if
@@ -606,6 +606,27 @@ interface(`dbus_watch_pid_dirs',`
 
 ########################################
 ## <summary>
+##	Watch system dbusd pid directory and all its parents
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dbus_watch_pid_dir_path',`
+	gen_require(`
+		type system_dbusd_var_run_t;
+	')
+
+	files_watch_root_dirs($1)
+	files_watch_var_run_dirs($1)
+	files_search_pids($1)
+	allow $1 system_dbusd_var_run_t:dir watch_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Read and write system dbus tmp socket files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -458,6 +458,7 @@ getty_start_services(systemd_machined_t)
 optional_policy(`
 	dbus_connect_system_bus(systemd_machined_t)
 	dbus_system_bus_client(systemd_machined_t)
+	dbus_watch_pid_dir_path(systemd_machined_t)
 ')
 
 optional_policy(`
@@ -536,6 +537,7 @@ init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "net
 optional_policy(`
     dbus_system_bus_client(systemd_networkd_t)
     dbus_connect_system_bus(systemd_networkd_t)
+	dbus_watch_pid_dir_path(systemd_networkd_t)
     dbus_read_pid_files(systemd_networkd_t)
     dbus_read_pid_sock_files(systemd_networkd_t)
     systemd_dbus_chat_logind(systemd_networkd_t)
@@ -862,6 +864,7 @@ userdom_dbus_send_all_users(systemd_hostnamed_t)
 optional_policy(`
         dbus_system_bus_client(systemd_hostnamed_t)
         dbus_connect_system_bus(systemd_hostnamed_t)
+	dbus_watch_pid_dir_path(systemd_hostnamed_t)
 ')
 
 optional_policy(`
@@ -978,7 +981,7 @@ optional_policy(`
         dbus_system_bus_client(systemd_timedated_t)
         dbus_connect_system_bus(systemd_timedated_t)
         dbus_read_pid_sock_files(systemd_timedated_t)
-	dbus_watch_pid_dirs(systemd_timedated_t)
+	dbus_watch_pid_dir_path(systemd_timedated_t)
 	dbus_watch_pid_sock_files(systemd_timedated_t)
 ')
 
@@ -1168,8 +1171,8 @@ optional_policy(`
 	dbus_connect_system_bus(systemd_resolved_t)
     dbus_read_pid_files(systemd_resolved_t)
     dbus_read_pid_sock_files(systemd_resolved_t)
+	dbus_watch_pid_dir_path(systemd_resolved_t)
 	dbus_watch_pid_sock_files(systemd_resolved_t)
-	dbus_watch_pid_dirs(systemd_resolved_t)
     systemd_dbus_chat_logind(systemd_resolved_t)
 ')
 


### PR DESCRIPTION
The following services were allowed to watch /run/dbus and all its
parents:
- systemd-resolved
- systemd-networkd
- systemd-timesyncd and systemd-timedated

These permissions are required when the services start earlier than
dbus-broker manages to establish the socket communication, e. g. after

  $ systemctl disable NetworkManager && systemctl enable systemd-networkd

The dbus_watch_pid_dir_path() interface was added. The redundant
dbus_watch_pid_dirs() calls were removed.

Resolves: rhbz#2031668