### PR TITLE
Allow xdm watch generic directories in /var/lib

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -639,6 +639,7 @@ files_watch_etc_files(xdm_t)
 files_watch_lib_dirs(xdm_t)
 files_watch_usr_dirs(xdm_t)
 files_watch_usr_files(xdm_t)
+files_watch_var_lib_dirs(xdm_t)
 files_watch_var_run_dirs(xdm_t)
 files_mounton_non_security(xdm_t)
 # Read /usr/share/terminfo/l/linux and /usr/share/icons/default/index.theme...


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(05/13/2021 11:58:56.107:530) : proctitle=/usr/bin/gnome-shell
type=PATH msg=audit(05/13/2021 11:58:56.107:530) : item=0 name=/var/lib/flatpak inode=27195052 dev=fd:02 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:var_lib_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/13/2021 11:58:56.107:530) : cwd=/var/lib/gdm
type=SYSCALL msg=audit(05/13/2021 11:58:56.107:530) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0x19 a1=0x55bfe134cc70 a2=0x1002fce a3=0x0 items=1 ppid=32043 pid=32126 auid=unset uid=gdm gid=gdm euid=gdm suid=gdm fsuid=gdm egid=gdm sgid=gdm fsgid=gdm tty=tty1 ses=unset comm=gnome-shell exe=/usr/bin/gnome-shell subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(05/13/2021 11:58:56.107:530) : avc:  denied  { watch } for  pid=32126 comm=gnome-shell path=/var/lib/flatpak dev="vda2" ino=27195052 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_lib_t:s0 tclass=dir permissive=0

Resolves: rhbz#1949790