### PR TITLE
Allow confined users to use kinit,klist and etc.

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -302,6 +302,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rpc_rw_gssd_keys(staff_t)
+')
+
+optional_policy(`
 	ssh_role_template(staff, staff_r, staff_t)
 ')
 

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -118,6 +118,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rpc_rw_gssd_keys(user_t)
+')
+
+optional_policy(`
 	rpm_dontaudit_dbus_chat(user_t)
 ')
 

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -578,6 +578,14 @@ tunable_policy(`selinuxuser_execstack',`
 optional_policy(`
 	fs_list_cgroup_dirs(confined_admindomain)
 ')
+
+optional_policy(`
+	kerberos_read_keytab(confined_admindomain)
+')
+
+optional_policy(`
+	rpc_rw_gssd_keys(confined_admindomain)
+')
 	
 optional_policy(`
 	ssh_rw_stream_sockets(confined_admindomain)


### PR DESCRIPTION
Confined users need to use kerberos authentication
 for NFS. Allow confined users to write gssd keys and
use tools like kinit, klist and kdestroy. Allow for
confined users like staff_t, admin types and user_t.
For admin types allow read kerberos keytab file via
adding interfaces kerberos_read_keytab() for
confined_admindomain attribute.
    
 Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2026598
