### PR TITLE
Allow timedatex dbus chat with xdm

### DIFF
--- a/policy/modules/contrib/timedatex.te
+++ b/policy/modules/contrib/timedatex.te
@@ -57,6 +57,10 @@ optional_policy(`
     init_dbus_chat(timedatex_t)
 
     policykit_dbus_chat(timedatex_t)
+
+	optional_policy(`
+		xserver_dbus_chat_xdm(timedatex_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(1642064568.655:164): pid=942 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_call interface=org.freedesktop.timedate1 member=SetTimezone dest=:1.201 spid=6469 tpid=6505 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:timedatex_t:s0 tclass=dbus permissive=0  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'^]UID="dbus" AUID="unset" SAUID="dbus"

Resolves: rhbz#2040214