### PR TITLE
Label /dev/wwan.+ with modem_manager_t

### DIFF
--- a/policy/modules/contrib/modemmanager.te
+++ b/policy/modules/contrib/modemmanager.te
@@ -82,3 +82,7 @@ optional_policy(`
 	udev_read_db(modemmanager_t)
 	udev_manage_pid_files(modemmanager_t)
 ')
+
+optional_policy(`
+	unconfined_stream_connect(modemmanager_t)
+')

--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -232,6 +232,8 @@ ifdef(`distro_suse', `
 /dev/vmbus/hv_vss		-c	gen_context(system_u:object_r:hypervvssd_device_t,s0)
 /dev/vmbus/hv_kvp		-c	gen_context(system_u:object_r:hypervkvp_device_t,s0)
 
+/dev/wwan.+		-c	gen_context(system_u:object_r:modem_device_t,s0)
+
 /dev/xen/blktap.*	-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/evtchn		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/gntdev		-c	gen_context(system_u:object_r:xen_device_t,s0)


### PR DESCRIPTION
The Qualcomm SDX55-based MBIM devices can have the device file name

/dev/wwan<WWAN_device_ID>p<unique_port_number><type>

where <type> is one of "at", "mbim", "qmi", "qcdm", "firehose".

There is no file transition defined.

Resolves: rhbz#1961571