### PR TITLE
policy/modules/contrib: Support /usr/lib/sysimage/rpm as the rpmdb path

### DIFF
--- a/policy/modules/contrib/rpm.fc
+++ b/policy/modules/contrib/rpm.fc
@@ -62,6 +62,9 @@ ifdef(`distro_redhat', `
 /var/lib/yum(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
 /var/lib/dnf(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
 
+# This is in /usr, but is expected to be variable content from a policy perspective (#2042149)
+/usr/lib/sysimage/rpm(/.*)?		gen_context(system_u:object_r:rpm_var_lib_t,s0)
+
 /var/log/dnf.log.*		--	gen_context(system_u:object_r:rpm_log_t,s0)
 /var/log/dnf.librepo.log.*	--	gen_context(system_u:object_r:rpm_log_t,s0)
 /var/log/dnf.rpm.log.*		--	gen_context(system_u:object_r:rpm_log_t,s0)


### PR DESCRIPTION
Reference: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr

Resolves: [rhbz#2042149](https://bugzilla.redhat.com/2042149)