### PR TITLE
Allow domtrans to sssd_t and role access to sssd 

### DIFF
--- a/policy/modules/contrib/rpm.te
+++ b/policy/modules/contrib/rpm.te
@@ -489,6 +489,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_run_sssd(rpm_script_t, rpm_script_roles)
+')
+
+optional_policy(`
 	tzdata_domtrans(rpm_t)
 	tzdata_run(rpm_script_t, rpm_script_roles)
 ')

--- a/policy/modules/contrib/sssd.if
+++ b/policy/modules/contrib/sssd.if
@@ -429,6 +429,33 @@ interface(`sssd_dontaudit_stream_connect',`
 
 ########################################
 ## <summary>
+##      Execute sssd in the sssd domain, and
+##      allow the specified role the sssd domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed to transition.
+##      </summary>
+## </param>
+## <param name="role">
+##      <summary>
+##      Role allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`sssd_run_sssd',`
+        gen_require(`
+                type sssd_t;
+                attribute_role sssd_roles;
+        ')
+
+        sssd_domtrans($1)
+        roleattribute $2 sssd_roles;
+')
+
+########################################
+## <summary>
 ##	Connect to sssd over a unix stream socket in /var/run.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -5,6 +5,8 @@ policy_module(sssd, 1.2.0)
 # Declarations
 #
 
+attribute_role sssd_roles;
+
 ## <desc>
 ##	<p>
 ##	Allow sssd read, view, and write access to kernel keys with kernel_t type
@@ -22,6 +24,7 @@ gen_tunable(sssd_connect_all_unreserved_ports, false)
 type sssd_t;
 type sssd_exec_t;
 init_daemon_domain(sssd_t, sssd_exec_t)
+role sssd_roles types sssd_t;
 
 type sssd_initrc_exec_t;
 init_script_file(sssd_initrc_exec_t)


### PR DESCRIPTION
**Commit 1**

 Creating interface sssd_run_sssd()

This interface allow execute sssd in the
sssd domain, and allow the specified role
the sssd domain.

**Commit 2**

 Allow domtrans to sssd_t and role access to sssd

After previous fix in bugzilla arise a SELinux
error with role. Processes running under
unconfined_r do not have access to sssd_t.
Allow domain transition from rpm_script_t to
sssd_t and allow the rpm_script_roles in the
sssd domain.


Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2022690