### PR TITLE
Allow alsactl set group Process ID of a process

### DIFF
--- a/policy/modules/contrib/alsa.te
+++ b/policy/modules/contrib/alsa.te
@@ -43,7 +43,7 @@ systemd_unit_file(alsa_unit_file_t)
 
 allow alsa_t self:capability { dac_read_search  setgid setuid ipc_owner sys_nice };
 dontaudit alsa_t self:capability { sys_tty_config sys_admin };
-allow alsa_t self:process { getsched setsched signal_perms };
+allow alsa_t self:process { getsched setpgid setsched signal_perms };
 allow alsa_t self:sem create_sem_perms;
 allow alsa_t self:shm create_shm_perms;
 allow alsa_t self:unix_stream_socket { accept listen };


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1624169904.74:1152): avc:  denied  { setpgid } for  pid=115535 comm="alsactl" scontext=system_u:system_r:alsa_t:s0 tcontext=system_u:system_r:alsa_t:s0 tclass=process permissive=0

Resolves: rhbz#1974051