### PR TITLE
Allow sanlock get attributes of filesystems with extended attributes

### DIFF
--- a/policy/modules/contrib/sanlock.te
+++ b/policy/modules/contrib/sanlock.te
@@ -96,6 +96,7 @@ domain_use_interactive_fds(sanlock_t)
 files_read_mnt_symlinks(sanlock_t)
 
 fs_getattr_cgroup(sanlock_t)
+fs_getattr_xattr_fs(sanlock_t)
 fs_rw_cephfs_files(sanlock_t)
 
 storage_raw_rw_fixed_disk(sanlock_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(01/28/2022 09:41:01.094:1832) : proctitle=/usr/sbin/sanlock daemon
type=AVC msg=audit(01/28/2022 09:41:01.094:1832) : avc:  denied  { getattr } for  pid=37165 comm=sanlock name=/ dev="dm-3" ino=128 scontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0
type=SYSCALL msg=audit(01/28/2022 09:41:01.094:1832) : arch=x86_64 syscall=statfs success=no exit=EACCES(Permission denied) a0=0x7fdade30b49d a1=0x7ffeeeb41a70 a2=0x49 a3=0x1000 items=0 ppid=1 pid=37165 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sanlock exe=/usr/sbin/sanlock subj=system_u:system_r:sanlock_t:s0-s0:c0.c1023 key=(null)

Resolves: rhbz#2047811