### PR TITLE
Allow rhsmcertd create rpm hawkey logs with correct label

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -169,6 +169,7 @@ optional_policy(`
     rpm_read_cache(rhsmcertd_t)
     rpm_manage_cache(rhsmcertd_t)
     rpm_dbus_chat(rhsmcertd_t)
+	rpm_hawkey_named_filetrans(rhsmcertd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(04/07/21 18:18:42.827:918) : proctitle=/usr/libexec/platform-python /usr/libexec/rhsmcertd-worker
type=PATH msg=audit(04/07/21 18:18:42.827:918) : item=1 name=/var/log/hawkey.log inode=73 dev=fd:03 mode=file,600 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:rpm_log_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0^]OUID="root" OGID="root"
type=PATH msg=audit(04/07/21 18:18:42.827:918) : item=0 name=/var/log/ inode=2 dev=fd:03 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:var_log_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0^]OUID="root" OGID="root"
type=CWD msg=audit(04/07/21 18:18:42.827:918) : cwd=/
type=SYSCALL msg=audit(04/07/21 18:18:42.827:918) : arch=x86_64 syscall=openat success=yes exit=9 a0=AT_FDCWD a1=0x55fc374a6df0 a2=O_WRONLY|O_CREAT|O_APPEND a3=0x1b6 items=2 ppid=1431 pid=33456 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsmcertd-worke exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:rhsmcertd_t:s0 key=(null) SYSCALL=openat AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
type=AVC msg=audit(04/07/21 18:18:42.827:918) : avc:  denied  { create } for  pid=33456 comm=rhsmcertd-worke name=hawkey.log scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=1
type=AVC msg=audit(04/07/21 18:18:42.827:918) : avc:  denied  { add_name } for  pid=33456 comm=rhsmcertd-worke name=hawkey.log scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=dir permissive=1

Resolves: rhbz#1949871