### PR TITLE
Allow confined sysadmin to use tool vipw and vigr

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -433,7 +433,7 @@ optional_policy(`
 # Password admin local policy
 #
 
-allow sysadm_passwd_t self:capability { chown dac_read_search  fsetid setuid setgid sys_resource };
+allow sysadm_passwd_t self:capability { chown dac_override dac_read_search  fsetid setuid setgid sys_resource };
 allow sysadm_passwd_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
 allow sysadm_passwd_t self:process { setrlimit setfscreate };
 allow sysadm_passwd_t self:fd use;
@@ -478,6 +478,7 @@ term_getattr_all_ptys(sysadm_passwd_t)
 auth_manage_passwd(sysadm_passwd_t)
 auth_manage_shadow(sysadm_passwd_t)
 auth_relabel_shadow(sysadm_passwd_t)
+auth_relabelto_passwd_files(sysadm_passwd_t)
 auth_etc_filetrans_shadow(sysadm_passwd_t)
 auth_use_nsswitch(sysadm_passwd_t)
 

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -501,12 +501,18 @@ init_dontaudit_rw_utmp(sysadm_passwd_t)
 logging_send_syslog_msg(sysadm_passwd_t)
 
 userdom_use_unpriv_users_fds(sysadm_passwd_t)
+userdom_dontaudit_manage_admin_dir(sysadm_passwd_t)
+userdom_dontaudit_manage_admin_files(sysadm_passwd_t)
 # user generally runs this from their home directory, so do not audit a search
 # on user home dir
 userdom_dontaudit_search_user_home_content(sysadm_passwd_t)
 
 optional_policy(`
 	nscd_run(sysadm_passwd_t, sysadm_passwd_roles)
+')
+
+optional_policy(`
+	sssd_domtrans(sysadm_passwd_t)
 ')
 
 ########################################

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -851,6 +851,26 @@ interface(`auth_relabel_shadow',`
 
 #######################################
 ## <summary>
+##	Relabel to the
+##	password file type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_relabelto_passwd_files',`
+	gen_require(`
+		type passwd_file_t;
+	')
+
+	files_search_etc($1)
+	allow $1 passwd_file_t:file relabelto;
+')
+
+#######################################
+## <summary>
 ##	Append to the login failure log.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
**Commit 1:**
Allow confined sysadmin to use vipw and vigr, which edits passwd,
shadow, group, gshadow.. Dontaudit manage files and dir labeled
with admin_home_t. Also vipw need to use sss_cache tool.
Allow domain transition from sysadm_passwd_t to sssd_exec_t.

**Commit 2:**
Vigr mechanism of editing group and passwd
files work on principle of recreating the current
file with new changes. Due to this mechanism is
need to again relabel file with selinux label.
Creating interface allowing relabel to the passwd_file_t
type. Allow relabeling for sysadm_passwd_t domain.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2049018