### PR TITLE
Fix koji repo URL pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,13 @@ jobs:
         with:
           name: srpm
           path: "*.src.rpm"
-      - run: dnf builddep --nogpgcheck --repofrompath 'koji,https://kojipkgs.fedoraproject.org/repos/$releasever/latest/$arch/' -y --srpm *.src.rpm
+      - run: |
+          if grep -q rawhide /etc/os-release; then
+            tag=rawhide
+          else
+            tag='f$releasever-build'
+          fi
+          dnf builddep --nogpgcheck --repofrompath "koji,https://kojipkgs.fedoraproject.org/repos/$tag/latest/\$arch/" -y --srpm *.src.rpm
       - run: rpmbuild --define "_topdir $PWD/rpmbuild" -rb *.src.rpm
       - name: Store binary RPMs as artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
For non-rawhide releases, 'f$releasever-build' tag name needs to be used
instead of '$releasever'.