### PR TITLE
Allow unconfined to run virtd bpf

### DIFF
--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -192,6 +192,25 @@ interface(`virt_domtrans_bridgehelper',`
 	domtrans_pattern($1, virt_bridgehelper_exec_t, virt_bridgehelper_t)
 ')
 
+########################################
+## <summary>
+##      Allow caller domain to run bpftool.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`virt_prog_run_bpf',`
+        gen_require(`
+                type virtd_t;
+        ')
+
+    allow $1 virtd_t:bpf { map_create map_read map_write prog_load prog_run };
+')
+
+
 #######################################
 ## <summary>
 ##	Connect to virt over a unix domain stream socket.

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -385,6 +385,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	virt_prog_run_bpf(unconfined_t)
 	virt_transition_svirt(unconfined_t, unconfined_r)
 	virt_transition_svirt_sandbox(unconfined_t, unconfined_r)
 	virt_sandbox_entrypoint(unconfined_t)


### PR DESCRIPTION
Create virtd interface to allow caller domain to run bpf.
Apply virt_prog_run_bpf interface in unconfined domain.

Fixed BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2033504