### PR TITLE
Allow alsa bind mixer controls to led triggers

### DIFF
--- a/policy/modules/contrib/alsa.te
+++ b/policy/modules/contrib/alsa.te
@@ -82,11 +82,13 @@ corecmd_exec_bin(alsa_t)
 
 dev_getattr_fs(alsa_t)
 dev_read_sound(alsa_t)
-dev_read_sysfs(alsa_t)
+dev_rw_sysfs(alsa_t)
 dev_read_urand(alsa_t)
 dev_write_sound(alsa_t)
 
 files_search_var_lib(alsa_t)
+
+modutils_domtrans_kmod(alsa_t)
 
 term_dontaudit_use_console(alsa_t)
 term_dontaudit_use_generic_ptys(alsa_t)


### PR DESCRIPTION
Since v5.13, the kernel has support to bind certain alsa mixer controls
to LED triggers from userspace to control the mute-LEDS found on some
devices (typically embedded inside the keyboard's mute keys).

To allow that, alsa needs to be able to execute "modprobe snd_ctl_led"
and write to /sys/class/sound/ctl-led/speaker/ and .../mic.

Resolves: rhbz#1958210