### PR TITLE
Allow ctdb create cluster logs

### DIFF
--- a/policy/modules/contrib/ctdb.te
+++ b/policy/modules/contrib/ctdb.te
@@ -141,6 +141,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhcs_create_log_cluster(ctdbd_t)
+')
+
+optional_policy(`
     rpc_domtrans_rpcd(ctdbd_t)
     rpc_manage_nfs_state_data_dir(ctdbd_t)
     rpc_read_nfs_state_data(ctdbd_t)

--- a/policy/modules/contrib/rhcs.fc
+++ b/policy/modules/contrib/rhcs.fc
@@ -109,6 +109,7 @@
 /var/log/cluster/cpglockd\.log.*        --      gen_context(system_u:object_r:cluster_var_log_t,s0)
 /var/log/cluster/corosync\.log.*    --  gen_context(system_u:object_r:cluster_var_log_t,s0)
 /var/log/cluster/rgmanager\.log.*       --  gen_context(system_u:object_r:cluster_var_log_t,s0)
+/var/log/ctdb(/.*)?		gen_context(system_u:object_r:cluster_var_log_t,s0)
 /var/log/pacemaker\.log.*           --  gen_context(system_u:object_r:cluster_var_log_t,s0)
 /var/log/pacemaker(/.*)?     gen_context(system_u:object_r:cluster_var_log_t,s0)
 /var/log/pcsd(/.*)?     gen_context(system_u:object_r:cluster_var_log_t,s0)

--- a/policy/modules/contrib/rhcs.if
+++ b/policy/modules/contrib/rhcs.if
@@ -731,6 +731,25 @@ interface(`rhcs_read_log_cluster',`
 
 ######################################
 ## <summary>
+##	Allow the specified domain to create cluster log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rhcs_create_log_cluster',`
+	gen_require(`
+		type cluster_var_log_t;
+	')
+
+	logging_search_logs($1)
+	create_files_pattern($1, cluster_var_log_t, cluster_var_log_t)
+')
+
+######################################
+## <summary>
 ##  Setattr cluster log files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The rhcs_create_log_cluster() interface was created.
The /var/log/ctdb(/.*)? pattern was assigned the cluster_var_log_t type.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(1643796294.117:142): proctitle="/usr/sbin/ctdbd"
type=PATH msg=audit(1643796294.117:142): item=1 name="/var/log/ctdb/log.ctdb" inode=14472543 dev=fd:00 mode=0100640 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:cluster_var_log_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1643796294.117:142): item=0 name="/var/log/ctdb/" inode=14472542 dev=fd:00 mode=040751 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:cluster_var_log_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1643796294.117:142): cwd="/var/lib/pacemaker/cores"
type=SYSCALL msg=audit(1643796294.117:142): arch=c000003e syscall=257 success=yes exit=5 a0=ffffff9c a1=55d6d9935700 a2=441 a3=1a4 items=2 ppid=42823 pid=42952 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="ctdbd" exe="/usr/sbin/ctdbd" subj=system_u:system_r:ctdbd_t:s0 key=(null)
type=AVC msg=audit(1643796294.117:142): avc:  denied  { open } for  pid=42952 comm="ctdbd" path="/var/log/ctdb/log.ctdb" dev="dm-0" ino=14472543 scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:cluster_var_log_t:s0 tclass=file permissive=1
type=AVC msg=audit(1643796294.117:142): avc:  denied  { create } for  pid=42952 comm="ctdbd" name="log.ctdb" scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:cluster_var_log_t:s0 tclass=file permissive=1
type=AVC msg=audit(1643796294.117:142): avc:  denied  { add_name } for  pid=42952 comm="ctdbd" name="log.ctdb" scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:cluster_var_log_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1643796294.117:142): avc:  denied  { write } for  pid=42952 comm="ctdbd" name="ctdb" dev="dm-0" ino=14472542 scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:cluster_var_log_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1643796294.117:142): avc:  denied  { search } for  pid=42952 comm="ctdbd" name="ctdb" dev="dm-0" ino=14472542 scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:cluster_var_log_t:s0 tclass=dir permissive=1

Resolves: rhbz#2049481