### PR TITLE
Allow postfix_domain read dovecot certificates

### DIFF
--- a/policy/modules/contrib/dovecot.if
+++ b/policy/modules/contrib/dovecot.if
@@ -219,3 +219,23 @@ interface(`dovecot_admin',`
 
 	admin_pattern($1, dovecot_passwd_t)
 ')
+
+########################################
+## <summary>
+##	Read dovecot SSL certificates
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dovecot_read_certs',`
+	gen_require(`
+		type dovecot_cert_t;
+	')
+
+	miscfiles_search_generic_cert_dirs($1)
+	read_files_pattern($1, dovecot_cert_t, dovecot_cert_t)
+	read_lnk_files_pattern($1, dovecot_cert_t, dovecot_cert_t)
+')

--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -842,6 +842,10 @@ miscfiles_read_generic_certs(postfix_domain)
 userdom_dontaudit_use_unpriv_user_fds(postfix_domain)
 
 optional_policy(`
+	dovecot_read_certs(postfix_domain)
+')
+
+optional_policy(`
 	mysql_stream_connect(postfix_domain)
     mysql_rw_db_sockets(postfix_domain)
 ')

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -288,6 +288,25 @@ interface(`miscfiles_manage_cert_files',`
 
 ########################################
 ## <summary>
+##	Search generic SSL certificates dirs
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`miscfiles_search_generic_cert_dirs',`
+	gen_require(`
+		type cert_t;
+	')
+
+	files_search_etc($1)
+	allow $1 cert_t:dir search_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Read fonts.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This permission is required when postfix is configured to use dovecot's
certificates.

The dovecot_read_certs() and miscfiles_search_generic_cert_dirs()
interfaces were created.

Resolves: rhbz#2043599