### PR TITLE
Allow nm-dispatcher read nm-dispatcher-script symlinks

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -529,6 +529,7 @@ allow NetworkManager_dispatcher_t self:unix_dgram_socket { create_socket_perms s
 
 list_dirs_pattern(NetworkManager_dispatcher_t, NetworkManager_t, NetworkManager_dispatcher_script_t)
 read_files_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, NetworkManager_dispatcher_script_t)
+read_lnk_files_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, NetworkManager_dispatcher_script_t)
 
 auth_read_passwd(NetworkManager_dispatcher_t)
 can_exec(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(02/11/2022 18:24:43.253:327) : proctitle=/usr/libexec/nm-dispatcher
type=PATH msg=audit(02/11/2022 18:24:43.253:327) : item=0 name=/usr/lib/NetworkManager/dispatcher.d/90-nm-cloud-setup.sh nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(02/11/2022 18:24:43.253:327) : cwd=/
type=SYSCALL msg=audit(02/11/2022 18:24:43.253:327) : arch=x86_64 syscall=stat success=no exit=EACCES(Permission denied) a0=0x560021c71530 a1=0x7ffd32b94050 a2=0x7ffd32b94050 a3=0x0 items=1 ppid=1 pid=5519 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=nm-dispatcher exe=/usr/libexec/nm-dispatcher subj=system_u:system_r:NetworkManager_dispatcher_t:s0 key=(null)
type=AVC msg=audit(02/11/2022 18:24:43.253:327) : avc:  denied  { read } for  pid=5519 comm=nm-dispatcher name=90-nm-cloud-setup.sh dev="vda2" ino=8503268 scontext=system_u:system_r:NetworkManager_dispatcher_t:s0 tcontext=system_u:object_r:NetworkManager_dispatcher_script_t:s0 tclass=lnk_file permissive=0