### PR TITLE
filesystem.te: add genfscon rule for ntfs3 filesystem

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -276,6 +276,7 @@ genfscon hfsplus / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon msdos / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon ntfs-3g / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon ntfs / gen_context(system_u:object_r:dosfs_t,s0)
+genfscon ntfs3 / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon vfat / gen_context(system_u:object_r:dosfs_t,s0)
 genfscon exfat / gen_context(system_u:object_r:dosfs_t,s0)
 


### PR DESCRIPTION
Kernel 5.15 introduced a new NTFS filesystem driver. Add the same
genfscon rule for it as there is for other NTFS filesystems.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2029039
Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>