### PR TITLE
Update NetworkManager-dispatcher policy

### DIFF
--- a/policy/modules/contrib/cloudform.fc
+++ b/policy/modules/contrib/cloudform.fc
@@ -1,8 +1,5 @@
 /etc/rc\.d/init\.d/iwhd --      gen_context(system_u:object_r:iwhd_initrc_exec_t,s0)
 
-/etc/NetworkManager/dispatcher\.d/cloud-init-azure-hook	--	gen_context(system_u:object_r:cloud_init_exec_t,s0)
-/etc/NetworkManager/dispatcher\.d/hook-network-manager	--	gen_context(system_u:object_r:cloud_init_exec_t,s0)
-
 /usr/bin/cloud-init     --      gen_context(system_u:object_r:cloud_init_exec_t,s0)
 /usr/libexec/min-metadata-service     --      gen_context(system_u:object_r:cloud_init_exec_t,s0)
 /usr/libexec/min-cloud-agent    --  gen_context(system_u:object_r:cloud_init_exec_t,s0)

--- a/policy/modules/contrib/iscsi.if
+++ b/policy/modules/contrib/iscsi.if
@@ -227,3 +227,39 @@ interface(`iscsi_read_pid_files',`
 	allow $1 iscsi_var_run_t:file read_file_perms;
 	files_search_pids($1)
 ')
+
+########################################
+## <summary>
+##	Get iscsi service status
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`iscsi_service_status',`
+	gen_require(`
+		type iscsi_unit_file_t;
+	')
+
+	allow $1 iscsi_unit_file_t:service status;
+')
+
+########################################
+## <summary>
+##	Reload iscsi service
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`iscsi_service_reload',`
+	gen_require(`
+		type iscsi_unit_file_t;
+	')
+
+	allow $1 iscsi_unit_file_t:service reload;
+')

--- a/policy/modules/contrib/networkmanager.fc
+++ b/policy/modules/contrib/networkmanager.fc
@@ -4,6 +4,11 @@
 /etc/NetworkManager/NetworkManager\.conf	gen_context(system_u:object_r:NetworkManager_etc_rw_t,s0)
 /etc/NetworkManager/system-connections(/.*)?	gen_context(system_u:object_r:NetworkManager_etc_rw_t,s0)
 /etc/NetworkManager/dispatcher\.d(/.*)?	gen_context(system_u:object_r:NetworkManager_dispatcher_script_t,s0)
+/etc/NetworkManager/dispatcher\.d/11-dhclient	--	gen_context(system_u:object_r:NetworkManager_dispatcher_dhclient_script_t,s0)
+/etc/NetworkManager/dispatcher\.d/20-chrony-dhcp	--	gen_context(system_u:object_r:NetworkManager_dispatcher_chronyc_script_t,s0)
+/etc/NetworkManager/dispatcher\.d/20-chrony-onoffline	--	gen_context(system_u:object_r:NetworkManager_dispatcher_chronyc_script_t,s0)
+/etc/NetworkManager/dispatcher\.d/cloud-init-azure-hook	--	gen_context(system_u:object_r:NetworkManager_dispatcher_cloud_script_t,s0)
+/etc/NetworkManager/dispatcher\.d/hook-network-manager	--	gen_context(system_u:object_r:NetworkManager_dispatcher_cloud_script_t,s0)
 
 /etc/dhcp/manager-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
 /etc/dhcp/wireless-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
@@ -14,6 +19,14 @@
 /etc/wicd/wired-settings.conf -- gen_context(system_u:object_r:NetworkManager_var_lib_t, s0)
 
 /usr/lib/NetworkManager/dispatcher\.d(/.*)? gen_context(system_u:object_r:NetworkManager_dispatcher_script_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d/04-iscsi	--	gen_context(system_u:object_r:NetworkManager_dispatcher_iscsid_script_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d/11-dhclient	--	gen_context(system_u:object_r:NetworkManager_dispatcher_dhclient_script_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d/20-chrony-dhcp	--	gen_context(system_u:object_r:NetworkManager_dispatcher_chronyc_script_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d/20-chrony-onoffline	--	gen_context(system_u:object_r:NetworkManager_dispatcher_chronyc_script_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d/30-winbind	--	gen_context(system_u:object_r:NetworkManager_dispatcher_winbind_script_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d/90-nm-cloud-setup\.sh	--	gen_context(system_u:object_r:NetworkManager_dispatcher_cloud_script_t,s0)
+/usr/lib/NetworkManager/dispatcher\.d/no-wait\.d/90-nm-cloud-setup\.sh	--	gen_context(system_u:object_r:NetworkManager_dispatcher_cloud_script_t,s0)
+
 /usr/lib/systemd/system/NetworkManager.* --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
 /usr/lib/systemd/system/nm-cloud-setup\.(service|timer) --	gen_context(system_u:object_r:NetworkManager_unit_file_t,s0)
 

--- a/policy/modules/contrib/networkmanager.if
+++ b/policy/modules/contrib/networkmanager.if
@@ -659,3 +659,28 @@ interface(`networkmanager_filetrans_named_content',`
 	files_etc_filetrans($1, NetworkManager_var_lib_t, file, "wired-settings.conf")
 	logging_log_filetrans($1, NetworkManager_var_lib_t, file, "wpa_supplicant.log")
 ')
+#
+########################################
+## <summary>
+##	Create a set of derived types for various
+##	NetworkManager-dispatcher plugins
+## </summary>
+## <param name="prefix">
+##	<summary>
+##	The name to be used for deriving type names.
+##	</summary>
+## </param>
+#
+template(`networkmanager_dispatcher_plugin_template',`
+	gen_require(`
+		attribute networkmanager_dispatcher_plugin, networkmanager_dispatcher_script;
+		type NetworkManager_dispatcher_t;
+	')
+
+	type NetworkManager_dispatcher_$1_t, networkmanager_dispatcher_plugin;
+	type NetworkManager_dispatcher_$1_script_t, networkmanager_dispatcher_script;
+	application_domain(NetworkManager_dispatcher_$1_t, NetworkManager_dispatcher_$1_script_t)
+	role system_r types NetworkManager_dispatcher_$1_t;
+
+	domtrans_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_$1_script_t, NetworkManager_dispatcher_$1_t)
+')

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -5,6 +5,9 @@ policy_module(networkmanager, 1.15.3)
 # Declarations
 #
 
+attribute networkmanager_dispatcher_plugin;
+attribute networkmanager_dispatcher_script;
+
 type NetworkManager_t;
 type NetworkManager_exec_t;
 init_daemon_domain(NetworkManager_t, NetworkManager_exec_t)
@@ -35,9 +38,17 @@ files_pid_file(NetworkManager_var_run_t)
 
 type NetworkManager_dispatcher_t;
 type NetworkManager_dispatcher_exec_t;
+init_daemon_domain(NetworkManager_dispatcher_t, NetworkManager_dispatcher_exec_t)
+init_nnp_daemon_domain(NetworkManager_dispatcher_t, NetworkManager_dispatcher_exec_t)
 
-type NetworkManager_dispatcher_script_t;
+type NetworkManager_dispatcher_script_t, networkmanager_dispatcher_script;
 files_type(NetworkManager_dispatcher_script_t)
+
+networkmanager_dispatcher_plugin_template(chronyc)
+networkmanager_dispatcher_plugin_template(cloud)
+networkmanager_dispatcher_plugin_template(dhclient)
+networkmanager_dispatcher_plugin_template(iscsid)
+networkmanager_dispatcher_plugin_template(winbind)
 
 type NetworkManager_priv_helper_t;
 type NetworkManager_priv_helper_exec_t;
@@ -519,31 +530,55 @@ tunable_policy(`use_ecryptfs_home_dirs',`
 
 ########################################
 #
+# NetworkManager-cloud-setup local policy
+#
+
+########################################
+#
 # NetworkManager-dispatcher local policy
 #
 
 allow NetworkManager_dispatcher_t self:capability sys_nice;
 allow NetworkManager_dispatcher_t self:process setsched;
+allow NetworkManager_dispatcher_t self:netlink_route_socket { create_socket_perms nlmsg_read };
 allow NetworkManager_dispatcher_t self:udp_socket create_socket_perms;
 allow NetworkManager_dispatcher_t self:unix_dgram_socket { create_socket_perms sendto };
+allow NetworkManager_dispatcher_t NetworkManager_unit_file_t:file getattr;
+allow NetworkManager_dispatcher_cloud_t NetworkManager_unit_file_t:file getattr;
 
 list_dirs_pattern(NetworkManager_dispatcher_t, NetworkManager_t, NetworkManager_dispatcher_script_t)
-read_files_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, NetworkManager_dispatcher_script_t)
-read_lnk_files_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, NetworkManager_dispatcher_script_t)
+list_dirs_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, networkmanager_dispatcher_script)
+read_files_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, networkmanager_dispatcher_script)
+read_lnk_files_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, networkmanager_dispatcher_script)
+read_lnk_files_pattern(networkmanager_dispatcher_plugin, NetworkManager_dispatcher_script_t, networkmanager_dispatcher_script)
 
 auth_read_passwd(NetworkManager_dispatcher_t)
+auth_read_passwd(networkmanager_dispatcher_plugin)
+
 can_exec(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t)
+
 corecmd_exec_bin(NetworkManager_dispatcher_t)
+corecmd_exec_bin(networkmanager_dispatcher_plugin)
 corecmd_exec_shell(NetworkManager_dispatcher_t)
+corecmd_exec_shell(NetworkManager_dispatcher_chronyc_t)
+corecmd_exec_shell(NetworkManager_dispatcher_cloud_t)
+corecmd_exec_shell(NetworkManager_dispatcher_iscsid_t)
+corecmd_exec_shell(NetworkManager_dispatcher_winbind_t)
+
+dev_read_sysfs(NetworkManager_dispatcher_cloud_t)
+
+init_status(NetworkManager_dispatcher_cloud_t)
+init_ioctl_stream_sockets(networkmanager_dispatcher_plugin)
+init_stream_connect(networkmanager_dispatcher_plugin)
 
 optional_policy(`
-	chronyd_domtrans(NetworkManager_dispatcher_t)
-	chronyd_domtrans_chronyc(NetworkManager_dispatcher_t)
-	chronyd_pid_filetrans(NetworkManager_dispatcher_t)
+	chronyd_domtrans_chronyc(NetworkManager_dispatcher_chronyc_t)
+	chronyd_manage_pid(NetworkManager_dispatcher_chronyc_t)
+	chronyd_pid_filetrans(NetworkManager_dispatcher_chronyc_t)
 ')
 
 optional_policy(`
-	cloudform_init_domtrans(NetworkManager_dispatcher_t)
+	cloudform_init_domtrans(NetworkManager_dispatcher_cloud_t)
 ')
 
 optional_policy(`
@@ -552,12 +587,16 @@ optional_policy(`
 ')
 
 optional_policy(`
+	iscsi_service_reload(NetworkManager_dispatcher_iscsid_t)
+	iscsi_service_status(NetworkManager_dispatcher_iscsid_t)
+')
+
+optional_policy(`
 	logging_send_syslog_msg(NetworkManager_dispatcher_t)
 ')
 
 optional_policy(`
-	samba_domtrans_smbcontrol(NetworkManager_dispatcher_t)
-	samba_service_status(NetworkManager_dispatcher_t)
+	samba_service_status(NetworkManager_dispatcher_winbind_t)
 ')
 
 optional_policy(`
@@ -566,6 +605,9 @@ optional_policy(`
 
 optional_policy(`
 	systemd_exec_systemctl(NetworkManager_dispatcher_t)
+	systemd_exec_systemctl(NetworkManager_dispatcher_cloud_t)
+	systemd_exec_systemctl(NetworkManager_dispatcher_iscsid_t)
+	systemd_exec_systemctl(NetworkManager_dispatcher_winbind_t)
 ')
 
 ########################################


### PR DESCRIPTION
The NetworkManager-dispatcher policy was updated to allow for execution
of dispatcher scripts with a transition.

These scripts were assigned a different label:
- /usr/lib/NetworkManager/dispatcher\.d/04-iscsi
- /usr/lib/NetworkManager/dispatcher\.d/20-chrony-dhcp
- /usr/lib/NetworkManager/dispatcher\.d/20-chrony-onoffline