### PR TITLE
Allow userdomain read symlinks in /var/lib

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -387,6 +387,7 @@ tunable_policy(`deny_bluetooth',`',`
 dev_watch_generic_dirs(login_userdomain)
 
 files_map_var_lib_files(login_userdomain)
+files_read_var_lib_symlinks(login_userdomain)
 files_watch_etc_dirs(login_userdomain)
 files_watch_etc_files(login_userdomain)
 files_watch_system_conf_dirs(login_userdomain)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(02/15/22 11:39:56.020:247) : proctitle=/usr/bin/gnome-software --gapplication-service
type=PATH msg=audit(02/15/22 11:39:56.020:247) : item=0 name=/var/lib/flatpak/appstream/flathub/x86_64/active/appstream.xml.gz nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(02/15/22 11:39:56.020:247) : cwd=/home/user
type=SYSCALL msg=audit(02/15/22 11:39:56.020:247) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x7fb66c6f8da0 a1=F_OK a2=0x0 a3=0x20 items=1 ppid=1460 pid=2035 auid=user uid=user gid=user euid=user suid=user fsuid=user egid=user sgid=user fsgid=user tty=(none) ses=3 comm=pool-org.gnome. exe=/usr/bin/gnome-software subj=user_u:user_r:user_t:s0 key=(null)
type=AVC msg=audit(02/15/22 11:39:56.020:247) : avc:  denied  { read } for  pid=2035 comm=pool-org.gnome. name=active dev="vda2" ino=387091 scontext=user_u:user_r:user_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=lnk_file permissive=0