### PR TITLE
Dontaudit dirsrv search filesystem sysctl directories

### DIFF
--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -106,6 +106,7 @@ list_dirs_pattern(dirsrv_t, dirsrv_share_t, dirsrv_share_t)
 kernel_read_network_state(dirsrv_t)
 kernel_read_system_state(dirsrv_t)
 kernel_read_kernel_sysctls(dirsrv_t)
+kernel_dontaudit_search_fs_sysctl(dirsrv_t)
 
 corecmd_search_bin(dirsrv_t)
 

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -2333,6 +2333,24 @@ interface(`kernel_rw_fs_sysctls',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to search filesystem sysctl directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`kernel_dontaudit_search_fs_sysctl',`
+	gen_require(`
+		type sysctl_fs_t;
+	')
+
+	dontaudit $1 sysctl_fs_t:dir search;
+')
+
+########################################
+## <summary>
 ##	Read IRQ sysctls.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The kernel_dontaudit_search_fs_sysctl() interface was added.