### PR TITLE
Allow chage domtrans to sssd

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -422,6 +422,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_domtrans(passwd_t)
     sssd_manage_lib_files(passwd_t)
     sssd_manage_public_files(passwd_t)
     sssd_read_pid_files(passwd_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(02/15/2022 16:04:12.036:1591) : proctitle=chage -d 0 user
type=PATH msg=audit(02/15/2022 16:04:12.036:1591) : item=0 name=/usr/sbin/sss_cache inode=8920535 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sssd_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(02/15/2022 16:04:12.036:1591) : cwd=/root
type=SYSCALL msg=audit(02/15/2022 16:04:12.036:1591) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x55a73e1a7250 a1=0x7ffeecce2690 a2=0x7ffeecce2688 a3=0x7f125fce4840 items=1 ppid=104530 pid=104533 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=127 comm=chage exe=/usr/bin/chage subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(02/15/2022 16:04:12.036:1591) : avc:  denied  { execute } for  pid=104533 comm=chage name=sss_cache dev="vda2" ino=8920535 scontext=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sssd_exec_t:s0 tclass=file permissive=0

Resolves: rhbz#2054718