### PR TITLE
Allow sosreport dbus chat abrt systemd timedatex

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -350,6 +350,7 @@ optional_policy(`
 #')
 
 optional_policy(`
+	sosreport_dbus_chat(abrt_t)
 	sosreport_domtrans(abrt_t)
 	sosreport_read_tmp_files(abrt_t)
 	sosreport_delete_tmp_files(abrt_t)

--- a/policy/modules/contrib/sosreport.if
+++ b/policy/modules/contrib/sosreport.if
@@ -146,3 +146,23 @@ interface(`sosreport_signull',`
 	allow $1 sosreport_t:process signull;
 ')
 
+########################################
+## <summary>
+##      Send and receive messages from
+##      sosreport over dbus.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`sosreport_dbus_chat',`
+        gen_require(`
+                type sosreport_t;
+                class dbus send_msg;
+        ')
+
+        allow $1 sosreport_t:dbus send_msg;
+        allow sosreport_t $1:dbus send_msg;
+')

--- a/policy/modules/contrib/timedatex.te
+++ b/policy/modules/contrib/timedatex.te
@@ -64,6 +64,9 @@ optional_policy(`
 ')
 
 optional_policy(`
-    userdom_dbus_send_all_users(timedatex_t)
+    sosreport_dbus_chat(timedatex_t)
 ')
 
+optional_policy(`
+    userdom_dbus_send_all_users(timedatex_t)
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -542,6 +542,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+    sosreport_dbus_chat(systemd_networkd_t)
+')
+
+optional_policy(`
     udev_read_db(systemd_networkd_t)
 ')
 


### PR DESCRIPTION
Create sosreport dbus chat interface.

Allow abrt, systemd and timedatex to dbus chat sosreport