### PR TITLE
Revert "Allow x_userdomain to dbus_chat with timedatex."

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -1812,10 +1812,6 @@ optional_policy(`
 	thumb_nnp_domtrans(x_userdomain)
 ')
 
-optional_policy(`
-        timedatex_dbus_chat(x_userdomain)
-')
-
 tunable_policy(`selinuxuser_direct_dri_enabled',`
 	dev_rw_dri(dridomain)
 ',`


### PR DESCRIPTION
This reverts commit 56ac3f0ca28 which was made redundant with
50417020c0e (Allow timedatex_t domain dbus chat with both confined
and unconfined users) containing a superset of the existing rules.