### PR TITLE
Do not let system_cronjob_t create redhat-access-insights.log with va…

### DIFF
--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -577,10 +577,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-    cron_generic_log_filetrans_log_insights(system_cronjob_t)
-')
-
-optional_policy(`
     chronyd_run_chronyc(system_cronjob_t,system_r)
 ')
 


### PR DESCRIPTION
…r_log_t

Introduced with 4ea87fdd302 ("Allow system_cronjob_t to create
redhat-access-insights.log with var_log_t"), this commit needs to be
partially reverted because insights-client now have its own policy.
The cron_generic_log_filetrans_log_insights() interface has been kept
for compatibility reasons.