### PR TITLE
Allow chronyd send a message to sosreport over the datagram socket

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -175,6 +175,10 @@ optional_policy(`
     rolekit_dgram_send(chronyd_t)
 ')
 
+optional_policy(`
+	sosreport_dgram_send(chronyd_t)
+')
+
 ########################################
 #
 # Local policy

--- a/policy/modules/contrib/sosreport.if
+++ b/policy/modules/contrib/sosreport.if
@@ -166,3 +166,21 @@ interface(`sosreport_dbus_chat',`
         allow $1 sosreport_t:dbus send_msg;
         allow sosreport_t $1:dbus send_msg;
 ')
+
+########################################
+## <summary>
+##	Send a message to sosreport over the datagram socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sosreport_dgram_send',`
+	gen_require(`
+		type sosreport_t;
+	')
+
+	allow $1 sosreport_t:unix_dgram_socket sendto;
+')


### PR DESCRIPTION
The sosreport_dgram_send() interface was added.