### PR TITLE
Add basic policy for BinderFS

### DIFF
--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -59,6 +59,9 @@ genfscon binder /hwbinder gen_context(system_u:object_r:binder_device_t,s0)
 ## /dev/binderfs/vndbinder - IPC between vendor/vendor processes with AIDL interfaces
 genfscon binder /vndbinder gen_context(system_u:object_r:binder_device_t,s0)
 
+#
+# cardmgr_dev_t is type for PCMCIA manager devices
+#
 type cardmgr_dev_t;
 dev_node(cardmgr_dev_t)
 files_tmp_file(cardmgr_dev_t)

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -46,6 +46,19 @@ dev_node(apm_bios_t)
 type autofs_device_t;
 dev_node(autofs_device_t)
 
+#
+# Type for /dev/binderfs
+#
+type binder_device_t;
+dev_node(binder_device_t)
+# Default Android binder devices
+## /dev/binderfs/binder - IPC between framework/app processes with Android Interface Definition Language (AIDL) interfaces
+genfscon binder /binder gen_context(system_u:object_r:binder_device_t,s0)
+## /dev/binderfs/hwbinder - IPC between framework/vendor and vendor/vendor processes with HAL Interface Definition Language (HIDL) interfaces
+genfscon binder /hwbinder gen_context(system_u:object_r:binder_device_t,s0)
+## /dev/binderfs/vndbinder - IPC between vendor/vendor processes with AIDL interfaces
+genfscon binder /vndbinder gen_context(system_u:object_r:binder_device_t,s0)
+
 type cardmgr_dev_t;
 dev_node(cardmgr_dev_t)
 files_tmp_file(cardmgr_dev_t)

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -56,6 +56,13 @@ role system_r types kernel_t;
 sid kernel gen_context(system_u:system_r:kernel_t,mls_systemhigh)
 
 #
+# BinderFS
+#
+type binderfs_t;
+fs_type(binderfs_t)
+genfscon binder / gen_context(system_u:object_r:binderfs_t,s0)
+
+#
 # DebugFS
 #
 


### PR DESCRIPTION
Binder is available in Fedora kernels since 5.15, but needs a
basic policy for BinderFS.

This policy lays the groundwork for Waydroid (a containerized
Android runtime environment for regular Linux systems) to function.

Co-authored-by: @aleasto
Co-authored-by: @Conan-Kudo 