### PR TITLE
Allow init watch and watch_reads user ttys

### DIFF
--- a/policy/modules/kernel/terminal.if
+++ b/policy/modules/kernel/terminal.if
@@ -1824,6 +1824,42 @@ interface(`term_dontaudit_use_all_user_ttys',`
 	term_dontaudit_use_all_ttys($1)
 ')
 
+########################################
+## <summary>
+##	Watch user tty device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`term_watch_user_ttys',`
+	gen_require(`
+		type user_tty_device_t;
+	')
+
+	allow $1 user_tty_device_t:chr_file watch_chr_file_perms;
+')
+
+########################################
+## <summary>
+##	Watch_reads user tty device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`term_watch_reads_user_ttys',`
+	gen_require(`
+		type user_tty_device_t;
+	')
+
+	allow $1 user_tty_device_t:chr_file watch_reads_chr_file_perms;
+')
+
 ####################################
 ## <summary>
 ##      Getattr on the virtio console.

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -377,6 +377,8 @@ term_watch_console_dev(init_t)
 term_watch_reads_console_dev(init_t)
 term_watch_unallocated_ttys(init_t)
 term_watch_reads_unallocated_ttys(init_t)
+term_watch_user_ttys(init_t)
+term_watch_reads_user_ttys(init_t)
 
 # Run init scripts.
 init_domtrans_script(init_t)


### PR DESCRIPTION
The term_watch_user_ttys() and term_watch_reads_user_ttys()
interfaces were added.

Resolves: rhbz#2058823