### PR TITLE
Allow rngd drop privileges via setuid/setgid/setcap

### DIFF
--- a/policy/modules/contrib/rngd.te
+++ b/policy/modules/contrib/rngd.te
@@ -30,8 +30,8 @@ files_pid_file(rngd_var_run_t)
 # Local policy
 #
 
-allow rngd_t self:capability { ipc_lock sys_admin };
-allow rngd_t self:process { setsched signal };
+allow rngd_t self:capability { ipc_lock setgid setuid sys_admin };
+allow rngd_t self:process { setcap setsched signal };
 allow rngd_t self:fifo_file rw_fifo_file_perms;
 allow rngd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow rngd_t self:unix_stream_socket { accept listen };


### PR DESCRIPTION
The rngd service starts as root to be able to access some resources
like /dev/hwrng, then it drops capabilities and changes ruid/euid/suid
and rgid/egid/sgid.

Resolves: rhbz#2058914