### PR TITLE
Allow rpmdb create directory in /usr/lib/sysimage

### DIFF
--- a/policy/modules/contrib/rpm.te
+++ b/policy/modules/contrib/rpm.te
@@ -265,6 +265,7 @@ allow rpmdb_t rpmdb_tmp_t:file map;
 
 manage_dirs_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
 manage_files_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
+files_usr_filetrans(rpmdb_t, rpm_var_lib_t, dir)
 files_var_lib_filetrans(rpmdb_t, rpm_var_lib_t, dir)
 
 manage_dirs_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)


### PR DESCRIPTION
With the 5f69c12c67d (Support /usr/lib/sysimage/rpm as the rpmdb path)
commit, the policy supports relocation of the rpmdb path to
/usr/lib/sysimage/rpm. The rpm-rebuilddb command needs to have a file
transition defined for the new path, too, which also needs to be without
a directory name as the new directory is created as
/usr/lib/sysimage/rpmrebuilddb.PID.

Resolves: rhbz#2061141