### PR TITLE
Label /var/run/ecblp0 pipe with cupsd_var_run_t

### DIFF
--- a/policy/modules/contrib/cups.fc
+++ b/policy/modules/contrib/cups.fc
@@ -70,7 +70,7 @@
 /var/ekpd(/.*)?			gen_context(system_u:object_r:cupsd_var_run_t,s0)
 /var/run/cups(/.*)?		gen_context(system_u:object_r:cupsd_var_run_t,mls_systemhigh)
 /var/run/hplip(/.*)		gen_context(system_u:object_r:cupsd_var_run_t,s0)
-/var/run/ecblp0		--	gen_context(system_u:object_r:cupsd_var_run_t,s0)
+/var/run/ecblp0		-p	gen_context(system_u:object_r:cupsd_var_run_t,s0)
 /var/run/hp.*\.pid	--	gen_context(system_u:object_r:cupsd_var_run_t,s0)
 /var/run/hp.*\.port	--	gen_context(system_u:object_r:cupsd_var_run_t,s0)
 /var/run/ptal-printd(/.*)?	gen_context(system_u:object_r:ptal_var_run_t,s0)


### PR DESCRIPTION
With the edce3e31ec2 (Label /var/run/ecblp0 as cupsd_var_run_t) commit,
default file context for /var/run/ecblp0 was defined for a plain file
instead of a named pipe which is actually used by epson drivers.

Resolves: rhbz#2061427