### PR TITLE
Allow logrotate a domain transition to cluster administrative domain

### DIFF
--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -336,6 +336,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhcs_domtrans_cluster(logrotate_t)
+')
+
+optional_policy(`
 	samba_exec_log(logrotate_t)
 ')
 


### PR DESCRIPTION
In newer corosync versions, its logrotate script is shipped with
calling corosync-cfgtool to tell corosync to reopen all log files,
instead of using the copytruncate logrotate option.
A unix socket is used for communication, so corosync-cfgtool, called
from logrotate, needs the access to the socket, which is resolved as
a transition to the cluster_t domain.

Resolves: rhbz#2061277