### PR TITLE
Allow qemu-kvm create and use netlink rdma sockets

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -357,6 +357,7 @@ files_mountpoint(container_ro_file_t)
 
 allow svirt_t self:process ptrace;
 
+allow svirt_t self:netlink_rdma_socket create_socket_perms;
 # it was a part of auth_use_nsswitch
 allow svirt_t self:netlink_route_socket r_netlink_socket_perms;
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(03/14/2022 22:06:18.065:740) : proctitle=/usr/libexec/qemu-kvm -name guest=test,debug-threads=on -S -object {"qom-type":"secret","id":"masterKey0","format":"raw","file":
type=SYSCALL msg=audit(03/14/2022 22:06:18.065:740) : arch=x86_64 syscall=socket success=yes exit=24 a0=netlink a1=SOCK_RAW a2=hmp a3=0x7f384033faa0 items=0 ppid=1 pid=34781 auid=unset uid=qemu gid=qemu euid=qemu suid=qemu fsuid=qemu egid=qemu sgid=qemu fsgid=qemu tty=(none) ses=unset comm=qemu-kvm exe=/usr/libexec/qemu-kvm subj=system_u:system_r:svirt_t:s0:c247,c409 key=(null)
type=AVC msg=audit(03/14/2022 22:06:18.065:740) : avc:  denied  { create } for  pid=34781 comm=qemu-kvm scontext=system_u:system_r:svirt_t:s0:c247,c409 tcontext=system_u:system_r:svirt_t:s0:c247,c409 tclass=netlink_rdma_socket permissive=1

Resolves: rhbz#2063612