### PR TITLE
Allow exim watch generic certificate directories

### DIFF
--- a/policy/modules/contrib/exim.te
+++ b/policy/modules/contrib/exim.te
@@ -154,6 +154,7 @@ auth_domtrans_chk_passwd(exim_t)
 logging_send_syslog_msg(exim_t)
 
 miscfiles_read_generic_certs(exim_t)
+miscfiles_watch_generic_cert_dirs(exim_t)
 
 userdom_dontaudit_search_user_home_dirs(exim_t)
 

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -165,6 +165,25 @@ interface(`miscfiles_manage_generic_cert_dirs',`
 
 ########################################
 ## <summary>
+##	Watch generic SSL certificate dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`miscfiles_watch_generic_cert_dirs',`
+	gen_require(`
+		type cert_t;
+	')
+
+	allow $1 cert_t:dir watch_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Allow process to relabel cert_t
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(03/30/2022 08:32:06.235:262) : proctitle=/usr/sbin/exim -bd -q1h
type=PATH msg=audit(03/30/2022 08:32:06.235:262) : item=0 name=/etc/pki/tls inode=15714 dev=00:1f mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cert_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(03/30/2022 08:32:06.235:262) : cwd=/var/spool/exim
type=SYSCALL msg=audit(03/30/2022 08:32:06.235:262) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0xb a1=0x55bf60367b64 a2=0x80000ec8 a3=0x55bf5e5bd2a0 items=1 ppid=1 pid=804 auid=unset uid=exim gid=exim euid=exim suid=exim fsuid=exim egid=exim sgid=exim fsgid=exim tty=(none) ses=unset comm=exim exe=/usr/sbin/exim subj=system_u:system_r:exim_t:s0 key=(null)
type=AVC msg=audit(03/30/2022 08:32:06.235:262) : avc:  denied  { watch } for  pid=804 comm=exim path=/etc/pki/tls dev="vda2" ino=15714 scontext=system_u:system_r:exim_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=0