### PR TITLE
Allow chronyd talk with unconfined user over unix domain dgram socket

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -179,6 +179,10 @@ optional_policy(`
 	sosreport_dgram_send(chronyd_t)
 ')
 
+optional_policy(`
+	unconfined_dgram_send(chronyd_t)
+')
+
 ########################################
 #
 # Local policy


### PR DESCRIPTION
This permission is required by applications which use the unix datagram
socket to communicate with chronyd directly, e.g. for monitoring
purposes. The other direction of communication is allowed by a rule for
unconfined_domain_type.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(03/17/2022 12:11:19.881:312) : proctitle=/usr/sbin/chronyd
type=PATH msg=audit(03/17/2022 12:11:19.881:312) : item=0 name=/run/chrony/chronyc.sock inode=39486 dev=00:18 mode=socket,777 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:chronyd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(03/17/2022 12:11:19.881:312) : cwd=/
type=SOCKADDR msg=audit(03/17/2022 12:11:19.881:312) : saddr={ saddr_fam=local path=/run/chrony/chronyc.sock }
type=SYSCALL msg=audit(03/17/2022 12:11:19.881:312) : arch=x86_64 syscall=sendmsg success=no exit=EACCES(Permission denied) a0=0x8 a1=0x7fffeef72f20 a2=0x0 a3=0x0 items=1 ppid=1 pid=680 auid=unset uid=chrony gid=chrony euid=chrony suid=chrony fsuid=chrony egid=chrony sgid=chrony fsgid=chrony tty=(none) ses=unset comm=chronyd exe=/usr/sbin/chronyd subj=system_u:system_r:chronyd_t:s0 key=(null)
type=AVC msg=audit(03/17/2022 12:11:19.881:312) : avc:  denied  { sendto } for  pid=680 comm=chronyd path=/run/chrony/chronyc.sock scontext=system_u:system_r:chronyd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#2065313