### PR TITLE
Allow fenced read kerberos key tables

### DIFF
--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -488,6 +488,8 @@ optional_policy(`
 		corenet_tcp_connect_ssh_port(fenced_t)
 		corenet_tcp_sendrecv_ssh_port(fenced_t)
 
+		kerberos_read_keytab(fenced_t)
+
 		ssh_exec(fenced_t)
 		ssh_read_user_home_files(fenced_t)
 	')


### PR DESCRIPTION
This permission is required when the fence_virtd service is
configured with "qemu+ssh" as a backend.
Note the fenced_can_ssh boolean needs to be turned on.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(05/26/2021 03:58:48.979:3486) : proctitle=ssh -T -e none -- localhost sh -c 'if 'nc' -q 2>&1 | grep "requires an argument" >/dev/null 2>&1; then ARG=-q0;else ARG=;fi;'nc'
type=PATH msg=audit(05/26/2021 03:58:48.979:3486) : item=0 name=/var/kerberos/krb5/user/0/client.keytab nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/26/2021 03:58:48.979:3486) : cwd=/
type=SYSCALL msg=audit(05/26/2021 03:58:48.979:3486) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=0xffffff9c a1=0x55e12b8db150 a2=O_RDONLY a3=0x0 items=1 ppid=65609 pid=65613 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ssh exe=/usr/bin/ssh subj=system_u:system_r:fenced_t:s0 key=(null)
type=AVC msg=audit(05/26/2021 03:58:48.979:3486) : avc:  denied  { search } for  pid=65613 comm=ssh name=krb5 dev="vda1" ino=3178255 scontext=system_u:system_r:fenced_t:s0 tcontext=system_u:object_r:krb5_keytab_t:s0 tclass=dir permissive=0