### PR TITLE
Add the io_uring class

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -1101,3 +1101,9 @@ class lockdown
     integrity
     confidentiality
 }
+
+class io_uring
+{
+    override_creds
+    sqpoll
+}

--- a/policy/flask/flask_documentation.md
+++ b/policy/flask/flask_documentation.md
@@ -1916,8 +1916,10 @@ Used to manage access while attaching BPF programs to tracepoints, perf profilin
 
 ---
 
+## class io\_uring
 
+Used to control the ability to use special io\_uring features by the process. See also [the original kernel commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=740b03414b20e7f1879cd99aae27d8c401bbcbf9) for more details.
 
+**override_creds** - Allow *source* to override its credentials to *target*.
 
-
-
+**sqpoll** - Allow *source* to create an io\_uring kernel polling thread. *target* is always equal to *source*.

--- a/policy/flask/security_classes
+++ b/policy/flask/security_classes
@@ -205,4 +205,6 @@ class perf_event
 
 class lockdown
 
+class io_uring
+
 # FLASK

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -254,6 +254,10 @@ optional_policy(`
 # is handled in the interface as typeattribute cannot
 # be used on an attribute.
 
+# allow special io_uring features
+allow unconfined_domain_type domain:io_uring override_creds;
+allow unconfined_domain_type self:io_uring sqpoll;
+
 # Use bpf tools
 allow unconfined_domain_type domain:bpf { map_create map_read map_write prog_load prog_run };
 


### PR DESCRIPTION
This adds the new io_uring class used to control the ability to use
special io_uring features by processes.

Initially allow general usage to unconfined domains. Further rules can
be granted to individual domains as needed (such io_uring usage should
be very rare).

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>