### PR TITLE
Allow fprintd read and write hardware state information

### DIFF
--- a/policy/modules/contrib/fprintd.te
+++ b/policy/modules/contrib/fprintd.te
@@ -40,7 +40,7 @@ kernel_read_system_state(fprintd_t)
 corecmd_exec_bin(fprintd_t)
 
 dev_list_usbfs(fprintd_t)
-dev_read_sysfs(fprintd_t)
+dev_rw_sysfs(fprintd_t)
 dev_read_urand(fprintd_t)
 dev_rw_generic_usb_dev(fprintd_t)
 


### PR DESCRIPTION
The persist and wakeup files in the /sys/bus/usb/devices/.*/power
directory are required to write to on systems with the fingerprint
reader.

Addresses the following AVC denial:

type=AVC msg=audit(1633462273.636:301): avc:  denied  { write } for  pid=2980 comm="fprintd" name="persist" dev="sysfs" ino=23698 scontext=system_u:system_r:fprintd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2010925