### PR TITLE
Allow pppd create a file in the locks directory

### DIFF
--- a/policy/modules/contrib/ppp.te
+++ b/policy/modules/contrib/ppp.te
@@ -106,7 +106,7 @@ manage_files_pattern(pppd_t, pppd_etc_rw_t, pppd_etc_rw_t)
 filetrans_pattern(pppd_t, pppd_etc_t, pppd_etc_rw_t, file)
 
 manage_files_pattern(pppd_t, pppd_lock_t, pppd_lock_t)
-files_lock_filetrans(pppd_t, pppd_lock_t, dir)
+files_lock_filetrans(pppd_t, pppd_lock_t, { dir file })
 files_search_locks(pppd_t)
 
 manage_files_pattern(pppd_t, pppd_log_t, pppd_log_t)


### PR DESCRIPTION
So far, a rule for creating a private lock dir was defined in the
policy. Since this commit there is also a rule for a plain file.

Resolves: rhbz#2022902