### PR TITLE
Allow systemd-sysctl read the security state information

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1020,6 +1020,7 @@ allow systemd_sysctl_t self:unix_dgram_socket create_socket_perms;
 kernel_dgram_send(systemd_sysctl_t)
 kernel_request_load_module(systemd_sysctl_t)
 kernel_rw_all_sysctls(systemd_sysctl_t)
+kernel_read_security_state(systemd_sysctl_t)
 kernel_write_security_state(systemd_sysctl_t)
 
 files_read_system_conf_files(systemd_sysctl_t)


### PR DESCRIPTION
Addresses the following AVC denial:
Feb 19 14:19:22 audit[641]: AVC avc:  denied  { read } for  pid=641 comm="systemd-sysctl" name="suid_dumpable" dev="proc" ino=400 scontext=system_u:system_r:systemd_sysctl_t:s0 tcontext=system_u:object_r:proc_security_t:s0 tclass=file permissive=0
Feb 19 14:19:22 audit[641]: SYSCALL arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=7ffd162b13d0 a2=80102 a3=0 items=0 ppid=1 pid=641 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-sysctl" exe="/usr/lib/systemd/systemd-sysctl" subj=system_u:system_r:systemd_sysctl_t:s0 key=(null)
Feb 19 14:19:22 audit: PROCTITLE proctitle="/usr/lib/systemd/systemd-sysctl"

Resolves: rhbz#2056207