### PR TITLE
New policy for stalld

### DIFF
--- a/policy/modules/contrib/stalld.fc
+++ b/policy/modules/contrib/stalld.fc
@@ -1,0 +1,5 @@
+/usr/bin/stalld				--	gen_context(system_u:object_r:stalld_exec_t,s0)
+
+/usr/lib/systemd/system/stalld.*	--	gen_context(system_u:object_r:stalld_unit_file_t,s0)
+
+/var/run/stalld.pid			--	gen_context(system_u:object_r:stalld_var_run_t,s0)

--- a/policy/modules/contrib/stalld.if
+++ b/policy/modules/contrib/stalld.if
@@ -1,0 +1,97 @@
+
+## <summary>policy for stalld</summary>
+
+########################################
+## <summary>
+##      Execute stalld_exec_t in the stalld domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##      Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`stalld_domtrans',`
+        gen_require(`
+                type stalld_t, stalld_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        domtrans_pattern($1, stalld_exec_t, stalld_t)
+')
+
+######################################
+## <summary>
+##      Execute stalld in the caller domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`stalld_exec',`
+        gen_require(`
+                type stalld_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        can_exec($1, stalld_exec_t)
+')
+
+########################################
+## <summary>
+##      Read stalld PID files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`stalld_read_pid_files',`
+        gen_require(`
+                type stalld_var_run_t;
+        ')
+
+        files_search_pids($1)
+        read_files_pattern($1, stalld_var_run_t, stalld_var_run_t)
+')
+
+########################################
+## <summary>
+##      All of the rules required to administrate
+##      an stalld environment
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <param name="role">
+##      <summary>
+##      Role allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`stalld_admin',`
+        gen_require(`
+                type stalld_t;
+                type stalld_var_run_t;
+        ')
+
+        allow $1 stalld_t:process { signal_perms };
+        ps_process_pattern($1, stalld_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 stalld_t:process ptrace;
+    ')
+
+        files_search_pids($1)
+        admin_pattern($1, stalld_var_run_t)
+        optional_policy(`
+                systemd_passwd_agent_exec($1)
+                systemd_read_fifo_file_passwd_run($1)
+        ')
+')

--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -1,0 +1,43 @@
+policy_module(stalld, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type stalld_t;
+type stalld_exec_t;
+init_daemon_domain(stalld_t, stalld_exec_t)
+
+type stalld_unit_file_t;
+systemd_unit_file(stalld_unit_file_t)
+
+type stalld_var_run_t;
+files_pid_file(stalld_var_run_t)
+
+########################################
+#
+# stalld local policy
+#
+allow stalld_t self:process { fork };
+allow stalld_t self:fifo_file rw_fifo_file_perms;
+allow stalld_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_dirs_pattern(stalld_t, stalld_var_run_t, stalld_var_run_t)
+manage_files_pattern(stalld_t, stalld_var_run_t, stalld_var_run_t)
+manage_lnk_files_pattern(stalld_t, stalld_var_run_t, stalld_var_run_t)
+files_pid_filetrans(stalld_t, stalld_var_run_t, { dir file lnk_file })
+
+kernel_manage_debugfs(stalld_t)
+kernel_read_all_proc(stalld_t)
+
+dev_read_sysfs(stalld_t)
+
+domain_read_all_domains_state(stalld_t)
+domain_use_interactive_fds(stalld_t)
+
+files_read_etc_files(stalld_t)
+
+logging_send_syslog_msg(stalld_t)
+
+miscfiles_read_localization(stalld_t)


### PR DESCRIPTION
New policy for stalld, a daemon that monitors threads on a system running low latency applications.
It checks for job threads that have been on a run-queue without being scheduled onto a CPU for a specified threshold.

When it detects a stalled thread, stalld temporarily changes the scheduling policy to SCHED_DEADLINE
and assigns the thread a slice of CPU time to make forward progress.

Copr build: https://copr.fedorainfracloud.org/coprs/nknazeko/selinux-policy/
