### PR TITLE
Allow keepalived setsched and sys_nice

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -37,8 +37,8 @@ files_tmpfs_file(keepalived_tmpfs_t)
 # keepalived local policy
 #
 
-allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_admin sys_ptrace };
-allow keepalived_t self:process { signal_perms getpgid setpgid };
+allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_admin sys_nice sys_ptrace };
+allow keepalived_t self:process { signal_perms getpgid setpgid setsched };
 allow keepalived_t self:icmp_socket create_socket_perms;
 allow keepalived_t self:netlink_socket create_socket_perms;
 allow keepalived_t self:netlink_generic_socket create_socket_perms;


### PR DESCRIPTION
These permissions are particularly required on high load systems
when a keepalived child process may request to use more cpu resouces.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(04/12/22 05:56:21.085:38) : proctitle=/usr/sbin/keepalived -D
type=SYSCALL msg=audit(04/12/22 05:56:21.085:38) : arch=x86_64 syscall=sched_setscheduler success=no exit=EPERM(Operation not permitted) a0=0x41c a1=SCHED_RR|SCHED_RESET_ON_FORK a2=0x7fff2554107c a3=0x0 items=0 ppid=1051 pid=1052 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=keepalived exe=/usr/sbin/keepalived subj=system_u:system_r:keepalived_t:s0 key=(null)
type=AVC msg=audit(04/12/22 05:56:21.085:38) : avc:  denied  { setsched } for  pid=1052 comm=keepalived scontext=system_u:system_r:keepalived_t:s0 tcontext=system_u:system_r:keepalived_t:s0 tclass=process permissive=1
type=AVC msg=audit(04/12/22 05:56:21.085:38) : avc:  denied  { sys_nice } for  pid=1052 comm=keepalived capability=sys_nice  scontext=system_u:system_r:keepalived_t:s0 tcontext=system_u:system_r:keepalived_t:s0 tclass=capability permissive=1

Resolves: rhbz#2008033