### PR TITLE
Update chronyd_pid_filetrans() to allow create dirs

### DIFF
--- a/policy/modules/contrib/chronyd.if
+++ b/policy/modules/contrib/chronyd.if
@@ -252,6 +252,7 @@ interface(`chronyd_pid_filetrans',`
                 type chronyd_var_run_t;
         ')
 
+	create_dirs_pattern($1, chronyd_var_run_t, chronyd_var_run_t)
         files_pid_filetrans($1, chronyd_var_run_t, dir, "chrony-dhcp")
 ')
 


### PR DESCRIPTION
The chronyd_pid_filetrans() interface was updated so that the caller
domain is now allowed to create the /run/chrony-dhcp directory.

Resolves: rhbz#2035117