### PR TITLE
Allow xdm mounton user temporary socket files

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -753,6 +753,7 @@ userdom_manage_user_tmp_dirs(xdm_t)
 userdom_manage_user_tmp_files(xdm_t)
 userdom_manage_user_tmp_sockets(xdm_t)
 userdom_manage_tmp_role(system_r, xdm_t)
+userdom_mounton_tmp_sockets(xdm_t)
 userdom_nnp_transition_login_userdomain(xdm_t)
 
 #userdom_home_manager(xdm_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -462,6 +462,25 @@ interface(`userdom_mounton_tmp_dirs',`
 
 #######################################
 ## <summary>
+##	Mounton user temporary socket files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolebase/>
+#
+interface(`userdom_mounton_tmp_sockets',`
+	gen_require(`
+		type user_tmp_t;
+	')
+
+	allow $1 user_tmp_t:sock_file mounton;
+')
+
+#######################################
+## <summary>
 ##	Manage user temporary files
 ## </summary>
 ## <param name="role">


### PR DESCRIPTION
The userdom_mounton_tmp_sockets() interface was added.

Resolves: rhbz#2071259