### PR TITLE
Allow sssd domtrans to pkcs_slotd_t

### DIFF
--- a/policy/modules/contrib/pkcs.if
+++ b/policy/modules/contrib/pkcs.if
@@ -118,6 +118,25 @@ interface(`pkcs_getattr_exec_files',`
 
 ########################################
 ## <summary>
+##	Transition to pkcs_slotd
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pkcs_domtrans',`
+	gen_require(`
+		type pkcs_slotd_t, pkcs_slotd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, pkcs_slotd_exec_t, pkcs_slotd_t)
+')
+
+########################################
+## <summary>
 ##	Create specific objects in the tmpfs directories
 ##	with a private type.
 ## </summary>

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -221,6 +221,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	pkcs_domtrans(sssd_t)
     pkcs_read_lock(sssd_t)
 ')
 


### PR DESCRIPTION
When sssd is configured to use smart cards login, any authentication
(e.g. sudo) will raise this AVC meaning smart card login was prevented
from working:

type=AVC msg=audit(1620803381.118:24793): avc:  denied  { getattr } for  pid=667312 comm="p11_child" path="/usr/sbin/pkcsslotd" dev="dm-1" ino=1581455 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:object_r:pkcs_slotd_exec_t:s0 tclass=file permissive=0

Sudo uses pam to authenticate a user. In pam stack, there is the sssd
pam module which talks through some IPC to sssd's p11_child.
This sssd's p11_child loads through p11-kit every pkcs11 module
installed in the system, which includes the opencryptoki pkcs11 module.
Opencryptoki pkcs11 module talks through some IPC to pkcsslotd daemon,
handling the communication with HW devices or soft tokens.

The pkcs_domtrans() interface was added.

Resolves: rhbz#1959705