### PR TITLE
Allow systemd-gpt-auto-generator create and use netlink_kobject_ueven…

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1096,6 +1096,7 @@ systemd_read_efivarfs(systemd_hwdb_t)
 #
 
 allow systemd_gpt_generator_t self:capability sys_rawio;
+allow systemd_gpt_generator_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 dev_read_sysfs(systemd_gpt_generator_t)
 dev_write_kmsg(systemd_gpt_generator_t)


### PR DESCRIPTION
…t_socket

Addresses the following AVC denial:
type=AVC msg=audit(1649951765.765:599): avc:  denied  { create } for  pid=35143 comm="systemd-gpt-aut" scontext=system_u:system_r:systemd_gpt_generator_t:s0 tcontext=system_u:system_r:systemd_gpt_generator_t:s0 tclass=netlink_kobject_uevent_socket permissive=0

Resolves: rhbz#2075589