### PR TITLE
Allow ntlm_auth read the network state information

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1123,6 +1123,8 @@ allow winbind_t smbcontrol_t:unix_dgram_socket sendto;
 
 stream_connect_pattern(winbind_helper_t, winbind_var_run_t, winbind_var_run_t, winbind_t)
 
+kernel_read_network_state(winbind_helper_t)
+
 dev_read_urand(winbind_helper_t)
 
 term_list_ptys(winbind_helper_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(04/08/2022 11:23:01.059:975) : proctitle=/usr/bin/ntlm_auth --request-nt-key --username=nbusr --challenge=6869fc32773c4d14 --nt-response=3b5e9f56addbe9dcebd91d0da1672267
type=SYSCALL msg=audit(04/08/2022 11:23:01.059:975) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x7fff53b4d7e0 a1=R_OK a2=0x8 a3=0x1d items=1 ppid=25175 pid=25208 auid=unset uid=unknown(95) gid=unknown(95) euid=unknown(95) suid=unknown(95) fsuid=unknown(95) egid=unknown(95) sgid=unknown(95) fsgid=unknown(95) tty=(none) ses=unset comm=ntlm_auth exe=/usr/bin/ntlm_auth subj=system_u:system_r:winbind_helper_t:s0 key=(null)
type=PATH msg=audit(04/08/2022 11:23:01.059:975) : item=0 name=/proc/net/unix inode=4026532055 dev=00:05 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:proc_net_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=AVC msg=audit(04/08/2022 11:23:01.059:975) : avc:  denied  { read } for  pid=25208 comm=ntlm_auth name=unix dev="proc" ino=4026532055 scontext=system_u:system_r:winbind_helper_t:s0 tcontext=system_u:object_r:proc_net_t:s0 tclass=file permissive=0

Resolves: rhbz#2073349