### PR TITLE
Update github actions to satisfy git 2.36 stricter rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - run: dnf install --nogpgcheck -y make git-core rpm-build 'dnf-command(builddep)'
       - uses: actions/checkout@v2
+      - run: chown $(id -u) .
       - run: make -C .copr srpm outdir="$PWD"
       - name: Store the SRPM as an artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
* With the fixes for CVE-2022-24765 that are common with versions of
   Git 2.30.4, 2.31.3, 2.32.2, 2.33.3, 2.34.3, and 2.35.3, Git has
   been taught not to recognise repositories owned by other users, in
   order to avoid getting affected by their config files and hooks.
   You can list the path to the safe/trusted repositories that may be
   owned by others on a multi-valued configuration variable
   `safe.directory` to override this behaviour, or use '*' to declare
   that you trust anything.
https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.36.0.txt

Addresses the following github actions error:
++ git -C ./.. rev-parse HEAD
fatal: unsafe repository ('/__w/selinux-policy/selinux-policy' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/selinux-policy/selinux-policy