### PR TITLE
Allow tmpreaper the sys_ptrace userns capability

### DIFF
--- a/policy/modules/contrib/tmpreaper.te
+++ b/policy/modules/contrib/tmpreaper.te
@@ -41,6 +41,7 @@ init_nnp_daemon_domain(tmpreaper_t)
 #
 
 allow tmpreaper_t self:capability { dac_read_search fowner sys_ptrace };
+allow tmpreaper_t self:cap_userns sys_ptrace;
 allow tmpreaper_t self:fifo_file rw_fifo_file_perms;
 
 kernel_list_unlabeled(tmpreaper_t)


### PR DESCRIPTION
The permission is required by the fuser command which is executed
by tmpwatch when it runs as a system cron job.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(03/10/2022 16:57:01.309:741) : proctitle=/usr/sbin/fuser -s . file
type=PATH msg=audit(03/10/2022 16:57:01.309:741) : item=0 name=/proc/983/maps inode=594520 dev=00:15 mode=file,444 ouid=uuidd ogid=uuidd rdev=00:00 obj=system_u:system_r:uuidd_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(03/10/2022 16:57:01.309:741) : cwd=/tmp/test
type=SYSCALL msg=audit(03/10/2022 16:57:01.309:741) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x562a62a3c6c0 a2=O_RDONLY a3=0x0 items=1 ppid=128041 pid=128042 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=fuser exe=/usr/sbin/fuser subj=system_u:system_r:tmpreaper_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(03/10/2022 16:57:01.309:741) : avc:  denied  { sys_ptrace } for  pid=128042 comm=fuser capability=sys_ptrace  scontext=system_u:system_r:tmpreaper_t:s0-s0:c0.c1023 tcontext=system_u:system_r:tmpreaper_t:s0-s0:c0.c1023 tclass=cap_userns permissive=0

Resolves: rhbz#2062823