### PR TITLE
Label /usr/libexec/vdsm/supervdsmd and vdsmd with virtd_exec_t

### DIFF
--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -94,10 +94,13 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/bin/vios-proxy-guest	--  gen_context(system_u:object_r:virtd_exec_t,s0)
 
 #support for vdsm
-/usr/share/vdsm/vdsm    --       gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/libexec/vdsm/supervdsmd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/libexec/vdsm/vdsmd    --       gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/share/vdsm/respawn    --       gen_context(system_u:object_r:virtd_exec_t,s0)
-/usr/share/vdsm/supervdsmServer    --       gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/share/vdsm/daemonAdapter       --  gen_context(system_u:object_r:virtd_exec_t,s0)
+# these paths are now obsolete
+/usr/share/vdsm/vdsm    --       gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/share/vdsm/supervdsmServer    --       gen_context(system_u:object_r:virtd_exec_t,s0)
 
 # support for nova-stack
 /usr/bin/nova-compute       --  gen_context(system_u:object_r:virtd_exec_t,s0)


### PR DESCRIPTION
The location of the supervdsmd and vdsmd daemons have changed,
the /usr/share/vdsm/vdsm and /usr/share/vdsm/supervdsmServer paths
used previously are now obsolete in file context specification.

Resolves: rhbz#2063871