### PR TITLE
Allow blueman read/write its private memfd: objects

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -18,6 +18,9 @@ files_pid_file(blueman_var_run_t)
 type blueman_tmp_t;
 files_tmp_file(blueman_tmp_t)
 
+type blueman_tmpfs_t;
+files_tmpfs_file(blueman_tmpfs_t)
+
 ########################################
 #
 # Local policy
@@ -40,6 +43,9 @@ manage_dirs_pattern(blueman_t, blueman_tmp_t, blueman_tmp_t)
 manage_files_pattern(blueman_t, blueman_tmp_t, blueman_tmp_t)
 exec_files_pattern(blueman_t, blueman_tmp_t, blueman_tmp_t)
 files_tmp_filetrans(blueman_t, blueman_tmp_t, { file dir })
+
+manage_files_pattern(blueman_t, blueman_tmpfs_t, blueman_tmpfs_t)
+fs_tmpfs_filetrans(blueman_t, blueman_tmpfs_t, file)
 
 kernel_rw_net_sysctls(blueman_t)
 kernel_read_system_state(blueman_t)


### PR DESCRIPTION
The new blueman_tmpfs_t type was added, the blueman_t domain
can now manage blueman_tmpfs_t files, and there is a file transition
for files created in tmpfs_t directories.

Addresses the following AVC denial:

type=AVC msg=audit(1647531916.71:256): avc:  denied  { write } for  pid=1982 comm="blueman-mechani" path="/memfd:libffi (deleted)" dev="tmpfs" ino=10243 scontext=system_u:system_r:blueman_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2063483