### PR TITLE
Use files_tmpfs_file() for rhsmcertd_tmpfs_t

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -22,7 +22,7 @@ type rhsmcertd_tmp_t;
 files_tmp_file(rhsmcertd_tmp_t)
 
 type rhsmcertd_tmpfs_t;
-files_tmp_file(rhsmcertd_tmpfs_t)
+files_tmpfs_file(rhsmcertd_tmpfs_t)
 
 type rhsmcertd_var_lib_t;
 files_type(rhsmcertd_var_lib_t)


### PR DESCRIPTION
With the f3fcabd0de8 (Allow rhsm-service read/write its private memfd:
objects) commit, the rhsmcertd_tmpfs_t type was created with using
files_tmp_file() interface instead of files_tmpfs_file() which is the
proper one.