### PR TITLE
Add stalld to modules.conf

### DIFF
--- a/policy/modules.conf
+++ b/policy/modules.conf
@@ -3071,3 +3071,10 @@ ica = module
 # fedoratp
 #
 fedoratp = module
+
+# Layer: contrib
+# Module: stalld
+#
+# stalld
+#
+stalld = module


### PR DESCRIPTION
The stalld module is a new policy module, but the reference was not
added to modules.conf.