### PR TITLE
Label /var/run/machine-id as machineid_t

### DIFF
--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -73,6 +73,7 @@ ifdef(`distro_gentoo', `
 /var/lib/systemd(/.*)?	gen_context(system_u:object_r:init_var_lib_t,s0)
 /var/lib/private/systemd(/.*)?	gen_context(system_u:object_r:init_var_lib_t,s0)
 /var/run/initctl	-p	gen_context(system_u:object_r:initctl_t,s0)
+/var/run/machine-id	--	gen_context(system_u:object_r:machineid_t,s0)
 /var/run/systemd/initctl/fifo	-p	gen_context(system_u:object_r:initctl_t,s0)
 /var/run/utmp		--	gen_context(system_u:object_r:initrc_var_run_t,s0)
 /var/run/runlevel\.dir		gen_context(system_u:object_r:initrc_var_run_t,s0)


### PR DESCRIPTION
/run/machine-id is only created if /etc/machine-id failed to be created
for some reason, and it is then bind-mounted to /etc/machine-id. That
means that /etc/machine-id and /run/machine-id should have the same
selinux label.

Resolves: rhbz#2061680