### PR TITLE
Allow keepalived_unconfined_script_t dbus chat with init

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -144,6 +144,8 @@ optional_policy(`
 	allow keepalived_t keepalived_unconfined_script_exec_t:dir read_file_perms;
 	allow keepalived_t keepalived_unconfined_script_exec_t:file ioctl;
 
+	init_dbus_chat(keepalived_unconfined_script_t)
+
 	optional_policy(`
 		unconfined_domain(keepalived_unconfined_script_t)
 	')


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(1608050898.891:2527): pid=754 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.224 spid=1 tpid=70402 scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:keepalived_unconfined_script_t:s0 tclass=dbus permissive=0  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'UID="dbus" AUID="unset" SAUID="dbus"