### PR TITLE
Allow sblim-sfcbd connect to sblim-reposd stream

### DIFF
--- a/policy/modules/contrib/sblim.te
+++ b/policy/modules/contrib/sblim.te
@@ -155,6 +155,8 @@ dontaudit sblim_sfcbd_t self:cap_userns sys_ptrace;
 allow sblim_sfcbd_t self:process signal;
 allow sblim_sfcbd_t self:unix_stream_socket connectto;
 
+allow sblim_sfcbd_t sblim_reposd_t:unix_stream_socket connectto;
+
 manage_dirs_pattern(sblim_sfcbd_t, sblim_sfcb_tmpfs_t, sblim_sfcb_tmpfs_t)
 manage_files_pattern(sblim_sfcbd_t, sblim_sfcb_tmpfs_t, sblim_sfcb_tmpfs_t)
 fs_tmpfs_filetrans(sblim_sfcbd_t, sblim_sfcb_tmpfs_t, { dir file })


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(04/19/2022 03:55:06.660:427) : proctitle=/usr/sbin/sfcbd
type=SYSCALL msg=audit(04/19/2022 03:55:06.660:427) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x8b a1=0x7f7be6cd4fd0 a2=0x6e a3=0x0 items=0 ppid=10445 pid=10598 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sfcbd exe=/usr/sbin/sfcbd subj=system_u:system_r:sblim_sfcbd_t:s0 key=(null)
type=AVC msg=audit(04/19/2022 03:55:06.660:427) : avc:  denied  { connectto } for  pid=10598 comm=sfcbd path=/run/gather/.repos-socket scontext=system_u:system_r:sblim_sfcbd_t:s0 tcontext=system_u:system_r:sblim_reposd_t:s0 tclass=unix_stream_socket permissive=1

Resolves: rhbz#2075810