### PR TITLE
Allow sysadm user execute init scripts with a transition

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -89,6 +89,7 @@ init_halt(sysadm_t)
 init_undefined(sysadm_t)
 init_ioctl_stream_sockets(sysadm_t)
 init_prog_run_bpf(sysadm_t)
+init_domtrans_script(sysadm_t)
 
 logging_filetrans_named_content(sysadm_t)
 logging_map_audit_config(sysadm_t)


### PR DESCRIPTION
Addresses the following denial:
type=PROCTITLE msg=audit(01/20/2022 07:43:25.363:384) : proctitle=env -i PATH=/sbin:/usr/sbin:/bin:/usr/bin
type=PATH msg=audit(01/20/2022 07:43:25.363:384) : item=0 name=/etc/init.d/foo inode=2346349 dev=fd:01 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:initrc_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(01/20/2022 07:43:25.363:384) : cwd=/
type=SYSCALL msg=audit(01/20/2022 07:43:25.363:384) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x7ffd7cce359b a1=0x7ffd7cce1a28 a2=0x56368373db60 a3=0x0 items=1 ppid=5461 pid=5468 auid=sysadm-user uid=sysadm-user gid=sysadm-user euid=sysadm-user suid=sysadm-user fsuid=sysadm-user egid=sysadm-user sgid=sysadm-user fsgid=sysadm-user tty=pts1 ses=8 comm=env exe=/usr/bin/env subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null)
type=SELINUX_ERR msg=audit(01/20/2022 07:43:25.363:384) : op=security_compute_sid invalid_context=sysadm_u:system_r:sysadm_t:s0-s0:c0.c1023 scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:initrc_exec_t:s0 tclass=process

Resolves: rhbz#2039662