### PR TITLE
Add ksm service to ksmtuned

### DIFF
--- a/policy/modules/contrib/ksmtuned.fc
+++ b/policy/modules/contrib/ksmtuned.fc
@@ -1,6 +1,9 @@
 /etc/rc\.d/init\.d/ksmtuned	--	gen_context(system_u:object_r:ksmtuned_initrc_exec_t,s0)
 
-/usr/lib/systemd/system/ksmtuned.*  --     gen_context(system_u:object_r:ksmtuned_unit_file_t,s0)
+/usr/lib/systemd/system/ksmtuned\.service	--	gen_context(system_u:object_r:ksmtuned_unit_file_t,s0)
+/usr/lib/systemd/system/ksm\.service		--	gen_context(system_u:object_r:ksm_unit_file_t,s0)
+
+/usr/libexec/ksmctl	--	gen_context(system_u:object_r:ksm_exec_t,s0)
 
 /usr/sbin/ksmtuned	--	gen_context(system_u:object_r:ksmtuned_exec_t,s0)
 

--- a/policy/modules/contrib/ksmtuned.te
+++ b/policy/modules/contrib/ksmtuned.te
@@ -23,8 +23,15 @@ type ksmtuned_t;
 type ksmtuned_exec_t;
 init_daemon_domain(ksmtuned_t, ksmtuned_exec_t)
 
+type ksm_t;
+type ksm_exec_t;
+init_daemon_domain(ksm_t, ksm_exec_t)
+
 type ksmtuned_unit_file_t;
 systemd_unit_file(ksmtuned_unit_file_t)
+
+type ksm_unit_file_t;
+systemd_unit_file(ksm_unit_file_t)
 
 type ksmtuned_initrc_exec_t;
 init_script_file(ksmtuned_initrc_exec_t)
@@ -79,3 +86,10 @@ tunable_policy(`ksmtuned_use_cifs',`
     fs_read_cifs_files(ksmtuned_t)
 	samba_read_share_files(ksmtuned_t)
 ')
+
+########################################
+#
+# Local policy for ksm
+#
+dev_rw_sysfs(ksm_t)
+


### PR DESCRIPTION
Add ksmctl and ksm.service - systemd service to start/stop
KSM (Kernel Samepage Merging) entirely.

Allow ksm to read/write sysfs files.

Fix BZ#2021131