### PR TITLE
Add rhcd policy

### DIFF
--- a/policy/modules.conf
+++ b/policy/modules.conf
@@ -3078,3 +3078,10 @@ fedoratp = module
 # stalld
 #
 stalld = module
+
+# Layer: contrib
+# Module: rhcd
+#
+# rhcd
+#
+rhcd = module

--- a/policy/modules/contrib/rhcd.fc
+++ b/policy/modules/contrib/rhcd.fc
@@ -1,0 +1,5 @@
+/usr/sbin/rhcd			--	gen_context(system_u:object_r:rhcd_exec_t,s0)
+
+/usr/lib/systemd/system/rhcd.*	--	gen_context(system_u:object_r:rhcd_unit_file_t,s0)
+
+/var/run/rhc(/.*)?			gen_context(system_u:object_r:rhcd_var_run_t,s0)

--- a/policy/modules/contrib/rhcd.if
+++ b/policy/modules/contrib/rhcd.if
@@ -1,0 +1,39 @@
+## <summary>policy for rhcd</summary>
+
+########################################
+## <summary>
+##      Execute rhcd_exec_t in the rhcd domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##      Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`rhcd_domtrans',`
+        gen_require(`
+                type rhcd_t, rhcd_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        domtrans_pattern($1, rhcd_exec_t, rhcd_t)
+')
+
+######################################
+## <summary>
+##      Execute rhcd in the caller domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`rhcd_exec',`
+        gen_require(`
+                type rhcd_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        can_exec($1, rhcd_exec_t)
+')

--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -1,0 +1,37 @@
+policy_module(rhcd, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type rhcd_t;
+type rhcd_exec_t;
+init_daemon_domain(rhcd_t, rhcd_exec_t)
+
+type rhcd_unit_file_t;
+systemd_unit_file(rhcd_unit_file_t)
+
+type rhcd_var_run_t;
+files_pid_file(rhcd_var_run_t)
+
+permissive rhcd_t;
+
+########################################
+#
+# rhcd local policy
+#
+allow rhcd_t self:fifo_file rw_fifo_file_perms;
+allow rhcd_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_dirs_pattern(rhcd_t, rhcd_var_run_t, rhcd_var_run_t)
+files_pid_filetrans(rhcd_t, rhcd_var_run_t, { dir })
+
+dev_read_sysfs(rhcd_t)
+
+domain_use_interactive_fds(rhcd_t)
+
+files_read_etc_files(rhcd_t)
+
+miscfiles_read_generic_certs(rhcd_t)
+miscfiles_read_localization(rhcd_t)


### PR DESCRIPTION
Add policy for Red Hat connector (rhc), a tool that allows
RHEL hosts to connect to the Insights services.

Resolves: bz#1965013