### PR TITLE
Add default fc specifications for patterns in /opt

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -174,6 +174,12 @@ ifdef(`distro_debian',`
 /opt				gen_context(system_u:object_r:usr_t,s0)
 /opt/.*				gen_context(system_u:object_r:usr_t,s0)
 
+/opt/(.*/)?etc		-d 	gen_context(system_u:object_r:etc_t,s0)
+/opt/(.*/)?etc/.*		gen_context(system_u:object_r:etc_t,s0)
+
+/opt/(.*/)?var		-d	gen_context(system_u:object_r:var_t,s0)
+/opt/(.*/)?var/.*		gen_context(system_u:object_r:var_t,s0)
+
 /opt/(.*/)?var/lib(/.*)?	gen_context(system_u:object_r:var_lib_t,s0)
 
 #


### PR DESCRIPTION
Patterns for /etc and /var subtrees inside the /opt tree were added.

Resolves: rhbz#2081059