### PR TITLE
Modify systemd_hwdb_manage_config() for named transition

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2419,7 +2419,7 @@ interface(`systemd_hwdb_manage_config',`
 	manage_files_pattern($1, systemd_hwdb_etc_t, systemd_hwdb_etc_t)
 	mmap_files_pattern($1, systemd_hwdb_etc_t, systemd_hwdb_etc_t)
 	allow $1 systemd_hwdb_etc_t:file {relabelfrom relabelto};
-	files_etc_filetrans($1, systemd_hwdb_etc_t, file)
+	files_etc_filetrans($1, systemd_hwdb_etc_t, file, "hwdb.bin")
 ')
 
 ########################################

--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -199,7 +199,6 @@ sysnet_manage_config(udev_t)
 
 systemd_login_read_pid_files(udev_t)
 systemd_getattr_unit_files(udev_t)
-systemd_hwdb_manage_config(udev_t)
 systemd_domtrans_sysctl(udev_t)
 
 userdom_dontaudit_search_user_home_content(udev_t)


### PR DESCRIPTION
The systemd_hwdb_manage_config() interface has changed to contain
a named file transition to systemd_hwdb_etc_t only for the "hwdb.bin"
filename.

Until now, systemd_hwdb_manage_config() contained unnamed file
transition for files created in an etc_t labeled directories, which
resulted in incorrect labels for files in other part of the /etc tree.

Also note there is a files_filetrans_named_content() interface called for
the named_filetrans_domain attribute and some other domains which
contains only named file transitions.

Resolves: rhbz#2061725