### PR TITLE
Label more vdsm utils with virtd_exec_t

### DIFF
--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -93,12 +93,14 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 /usr/bin/vios-proxy-host	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/bin/vios-proxy-guest	--  gen_context(system_u:object_r:virtd_exec_t,s0)
 
-#support for vdsm
+# support for vdsm
+/usr/libexec/vdsm/daemonAdapter	--	gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/libexec/vdsm/respawn	--	gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/libexec/vdsm/supervdsmd	--	gen_context(system_u:object_r:virtd_exec_t,s0)
-/usr/libexec/vdsm/vdsmd    --       gen_context(system_u:object_r:virtd_exec_t,s0)
+/usr/libexec/vdsm/vdsmd		--	gen_context(system_u:object_r:virtd_exec_t,s0)
+# these paths are now obsolete
 /usr/share/vdsm/respawn    --       gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/share/vdsm/daemonAdapter       --  gen_context(system_u:object_r:virtd_exec_t,s0)
-# these paths are now obsolete
 /usr/share/vdsm/vdsm    --       gen_context(system_u:object_r:virtd_exec_t,s0)
 /usr/share/vdsm/supervdsmServer    --       gen_context(system_u:object_r:virtd_exec_t,s0)
 


### PR DESCRIPTION
This is a follow-up on the cbf9b2f25a6 ("Label
/usr/libexec/vdsm/supervdsmd and vdsmd with virtd_exec_t") commit.
The location of the vdsm daemons and utils have changed from
/usr/share/vdsm to /usr/libexec/vdsm, such a change needs to be backed
by an appropriate change in file context specification, too.

Resolves: rhbz#2063871