### PR TITLE
Allow systemd watch and watch_reads user ptys

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -419,6 +419,8 @@ userdom_nnp_transition_login_userdomain(init_t)
 userdom_noatsecure_login_userdomain(init_t)
 userdom_sigchld_login_userdomain(init_t)
 userdom_use_user_ptys(init_t)
+userdom_watch_user_ptys(init_t)
+userdom_watch_reads_user_ptys(init_t)
 
 allow init_t self:process setsched;
 

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -3988,6 +3988,42 @@ interface(`userdom_use_user_ptys',`
 
 ########################################
 ## <summary>
+##	Watch a user pty.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_watch_user_ptys',`
+	gen_require(`
+		type user_devpts_t;
+	')
+
+	allow $1 user_devpts_t:chr_file watch_chr_file_perms;
+')
+
+########################################
+## <summary>
+##	Watch_reads a user pty.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_watch_reads_user_ptys',`
+	gen_require(`
+		type user_devpts_t;
+	')
+
+	allow $1 user_devpts_t:chr_file watch_reads_chr_file_perms;
+')
+
+########################################
+## <summary>
 ##	Read and write a inherited user domain pty.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This permission is required for "systemd-run --shell" to work.

The following AVC denial was addressed:

type=PROCTITLE msg=audit(05/13/2022 10:57:19.765:435) : proctitle=(bash)
type=PATH msg=audit(05/13/2022 10:57:19.765:435) : item=0 name=/dev/pts/1 inode=4 dev=00:19 mode=character,620 ouid=root ogid=tty rdev=88:01 obj=unconfined_u:object_r:user_devpts_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/13/2022 10:57:19.765:435) : cwd=/
type=SYSCALL msg=audit(05/13/2022 10:57:19.765:435) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0x3 a1=0x55e39a4fe560 a2=0x18 a3=0x0 items=1 ppid=1 pid=1109 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(bash) exe=/usr/lib/systemd/systemd subj=system_u:system_r:init_t:s0 key=(null)
type=AVC msg=audit(05/13/2022 10:57:19.765:435) : avc:  denied  { watch watch_reads } for  pid=1109 comm=(bash) path=/dev/pts/1 dev="devpts" ino=4 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0

The following interfaces were added:
- userdom_watch_user_ptys
- userdom_watch_reads_user_ptys

Resolves: rhbz#1980241