### PR TITLE
Dontaudit domain map permission on directories

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -172,6 +172,9 @@ files_append_inherited_tmp_files(domain)
 files_mmap_usr_files(domain)
 files_read_all_base_ro_files(domain)
 files_dontaudit_getattr_kernel_symbol_table(domain)
+files_dontaudit_map_all_dirs(domain)
+
+fs_dontaudit_map_all_dirs(domain)
 
 # All executables should be able to search the directory they are in
 corecmd_search_bin(domain)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1854,6 +1854,25 @@ interface(`files_dontaudit_search_all_dirs',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to map
+##	file_type directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`files_dontaudit_map_all_dirs',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	dontaudit $1 file_type:dir map;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of all filesystems
 ##	with the type of a file.
 ## </summary>

--- a/policy/modules/kernel/files.te
+++ b/policy/modules/kernel/files.te
@@ -249,7 +249,8 @@ fs_associate_tmpfs(tmpfsfile)
 
 # Create/access any file in a labeled filesystem;
 allow files_unconfined_type file_type:{ file chr_file } ~{ execmod entrypoint };
-allow files_unconfined_type file_type:{ dir lnk_file sock_file fifo_file blk_file } *;
+allow files_unconfined_type file_type:dir ~map;
+allow files_unconfined_type file_type:{ lnk_file sock_file fifo_file blk_file } *;
 allow files_unconfined_type file_type:service *;
 
 # Mount/unmount any filesystem with the context= option.

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6540,6 +6540,25 @@ interface(`fs_dontaudit_getattr_all_dirs',`
 
 ########################################
 ## <summary>
+##	Dontaudit map of all directories
+##	with a filesystem type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_map_all_dirs',`
+	gen_require(`
+		attribute filesystem_type;
+	')
+
+	dontaudit $1 filesystem_type:dir map;
+')
+
+########################################
+## <summary>
 ##	Search all directories with a filesystem type.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -364,4 +364,5 @@ allow filesystem_unconfined_type filesystem_type:filesystem all_filesystem_perms
 # pseudo filesystem types that are applied to both the filesystem
 # and its files.
 allow filesystem_unconfined_type filesystem_type:{ file } ~entrypoint;
-allow filesystem_unconfined_type filesystem_type:{ dir lnk_file sock_file fifo_file chr_file blk_file } *;
+allow filesystem_unconfined_type filesystem_type:dir ~map;
+allow filesystem_unconfined_type filesystem_type:{ lnk_file sock_file fifo_file chr_file blk_file } *;

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -537,14 +537,17 @@ if( ! secure_mode_insmod ) {
 #
 
 allow kern_unconfined proc_type:{ file } ~entrypoint;
-allow kern_unconfined proc_type:{ dir lnk_file } *;
+allow kern_unconfined proc_type:dir ~map;
+allow kern_unconfined proc_type:lnk_file *;
 
 allow kern_unconfined sysctl_type:{ file } ~entrypoint;
-allow kern_unconfined sysctl_type:{ dir lnk_file } *;
+allow kern_unconfined sysctl_type:dir ~map;
+allow kern_unconfined sysctl_type:lnk_file *;
 
 allow kern_unconfined kernel_t:system *;
 
-allow kern_unconfined unlabeled_t:{ dir lnk_file sock_file fifo_file chr_file blk_file } *;
+allow kern_unconfined unlabeled_t:dir ~map;
+allow kern_unconfined unlabeled_t:{ lnk_file sock_file fifo_file chr_file blk_file } *;
 allow kern_unconfined unlabeled_t:file ~entrypoint;
 allow kern_unconfined unlabeled_t:filesystem *;
 allow kern_unconfined unlabeled_t:association *;

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -1715,7 +1715,6 @@ allow x_userdomain user_fonts_config_t:file read_file_perms;
 
 manage_dirs_pattern(x_userdomain, user_fonts_cache_t, user_fonts_cache_t)
 manage_files_pattern(x_userdomain, user_fonts_cache_t, user_fonts_cache_t)
-allow x_userdomain user_fonts_cache_t:dir map;
 
 stream_connect_pattern(x_userdomain, xserver_tmp_t, xserver_tmp_t, xserver_t)
 allow x_userdomain xserver_tmp_t:sock_file delete_sock_file_perms;

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -510,7 +510,7 @@ manage_sock_files_pattern(xdm_t, xdm_var_lib_t, xdm_var_lib_t)
 files_var_lib_filetrans(xdm_t, xdm_var_lib_t, { file dir })
 # Read machine-id
 files_read_var_lib_files(xdm_t)
-allow xdm_t xdm_var_lib_t:dir { map watch_dir_perms };
+allow xdm_t xdm_var_lib_t:dir watch_dir_perms;
 
 manage_dirs_pattern(xdm_t, xdm_var_run_t, xdm_var_run_t)
 manage_files_pattern(xdm_t, xdm_var_run_t, xdm_var_run_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1651700801.804:609): avc:  denied  { map } for  pid=5411 comm="stress-ng" path="/proc/10381" dev="proc" ino=67726 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dir permissive=0

which can be triggered by "stress-ng --all 8 --timeout 60s --metrics-brief --tz".

Resolves: rhbz#2081864