### PR TITLE
Allow sblim-gatherd the kill capability

### DIFF
--- a/policy/modules/contrib/sblim.te
+++ b/policy/modules/contrib/sblim.te
@@ -69,7 +69,7 @@ auth_read_passwd(sblim_domain)
 # Gatherd local policy
 #
 
-allow sblim_gatherd_t self:capability { dac_read_search  sys_nice sys_ptrace };
+allow sblim_gatherd_t self:capability { dac_read_search kill sys_nice sys_ptrace };
 allow sblim_gatherd_t self:process { setsched signal };
 allow sblim_gatherd_t self:fifo_file rw_fifo_file_perms;
 allow sblim_gatherd_t self:unix_stream_socket { accept listen };


### PR DESCRIPTION
The sblim-gather plugin for Operating System Metrics offers the
NumberOfUsers metric which executes "who -u | wc -l" as the value
source, refer to
/usr/share/doc/sblim-gather/metricOperatingSystem.readme

The who command calls read_utmp() which calls desirable_utmp_entry()
containing "kill (UT_PID (u), 0)" to check the existence of the login
process.

Resolves: rhbz#2082677