### PR TITLE
Label /var/cache/insights with insights_client_cache_t

### DIFF
--- a/policy/modules/contrib/insights_client.fc
+++ b/policy/modules/contrib/insights_client.fc
@@ -9,6 +9,8 @@
 /usr/bin/insights-client				--	gen_context(system_u:object_r:insights_client_exec_t,s0)
 /usr/bin/redhat-access-insights				--	gen_context(system_u:object_r:insights_client_exec_t,s0)
 
+/var/cache/insights(/.*)?		gen_context(system_u:object_r:insights_client_cache_t,s0)
+
 /var/lib/insights(/.*)?		gen_context(system_u:object_r:insights_client_var_lib_t,s0)
 
 /var/log/insights-client(/.*)?					gen_context(system_u:object_r:insights_client_var_log_t,s0)

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -21,6 +21,9 @@ files_config_file(insights_client_etc_rw_t)
 type insights_client_tmp_t;
 files_tmp_file(insights_client_tmp_t)
 
+type insights_client_cache_t;
+files_type(insights_client_cache_t)
+
 type insights_client_var_lib_t;
 files_type(insights_client_var_lib_t)
 
@@ -45,6 +48,8 @@ filetrans_pattern(insights_client_t, insights_client_etc_t, insights_client_etc_
 manage_dirs_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 manage_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file })
+
+manage_files_pattern(insights_client_t, insights_client_cache_t, insights_client_cache_t)
 
 manage_dirs_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
 manage_files_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)


### PR DESCRIPTION
The insights_client_t domain can now also manage files with
the insights_client_cache_t type.

Resolves: rhbz#2062136