### PR TITLE
Move the chown call into make-srpm.sh

### DIFF
--- a/.copr/make-srpm.sh
+++ b/.copr/make-srpm.sh
@@ -14,6 +14,10 @@ EXPANDER_URL=https://github.com/fedora-selinux/macro-expander
 
 rpm -q rpm-build git-core || dnf install -y rpm-build git-core
 
+# Ensure that the git directory is owned by us to appease Git's
+# anti-CVE-2022-24765 measures.
+chown $(id -u):$(id -g) "$dirname/.."
+
 base_head_id="$(git -C "$dirname/.." rev-parse HEAD)"
 base_short_head_id="${base_head_id:0:7}"
 base_date="$(TZ=UTC git show -s --format=%cd --date=format-local:%F_%T HEAD | tr -d :-)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - run: dnf install --nogpgcheck -y make git-core rpm-build 'dnf-command(builddep)'
       - uses: actions/checkout@v2
-      - run: chown $(id -u) .
       - run: make -C .copr srpm outdir="$PWD"
       - name: Store the SRPM as an artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This workaround for Git CVE-2022-24765 fix is also needed when
make-srpm.sh is run inside COPR, so move it there. It also makes a bit
more sense as that's [the only place] where the git operations happen.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>