### PR TITLE
Allow blueman execute its private memfd: files

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -46,7 +46,7 @@ files_tmp_filetrans(blueman_t, blueman_tmp_t, { file dir })
 
 manage_files_pattern(blueman_t, blueman_tmpfs_t, blueman_tmpfs_t)
 fs_tmpfs_filetrans(blueman_t, blueman_tmpfs_t, file)
-allow blueman_t blueman_tmpfs_t:file map;
+can_exec(blueman_t, blueman_tmpfs_t)
 
 kernel_rw_net_sysctls(blueman_t)
 kernel_read_system_state(blueman_t)


### PR DESCRIPTION
This commit replaces single allow map permission, added by commit
f5125e8f5d7 ("Allow blueman map its private memfd: files"), with
can_exec() which is a superset.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(05/18/2022 19:15:09.524:6578) : proctitle=/usr/bin/python3 /usr/libexec/blueman-mechanism
type=MMAP msg=audit(05/18/2022 19:15:09.524:6578) : fd=8 flags=MAP_SHARED
type=SYSCALL msg=audit(05/18/2022 19:15:09.524:6578) : arch=x86_64 syscall=mmap success=no exit=EACCES(Permission denied) a0=0x0 a1=0x1000 a2=PROT_READ|PROT_EXEC a3=MAP_SHARED items=0 ppid=1 pid=91822 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=blueman-mechani exe=/usr/bin/python3.10 subj=system_u:system_r:blueman_t:s0 key=(null)
type=AVC msg=audit(05/18/2022 19:15:09.524:6578) : avc:  denied  { execute } for  pid=91822 comm=blueman-mechani path=/memfd:libffi (deleted) dev="tmpfs" ino=1043 scontext=system_u:system_r:blueman_t:s0 tcontext=system_u:object_r:blueman_tmpfs_t:s0 tclass=file permissive=0