### PR TITLE
Allow sslh net_admin capability

### DIFF
--- a/policy/modules/contrib/sslh.te
+++ b/policy/modules/contrib/sslh.te
@@ -55,7 +55,7 @@ manage_files_pattern(sslh_t, sslh_var_run_t, sslh_var_run_t)
 
 logging_send_syslog_msg(sslh_t);
 
-allow sslh_t self:capability { setuid setgid };
+allow sslh_t self:capability { net_admin setuid setgid };
 allow sslh_t self:process { setcap getcap signal };
 
 allow sslh_t self:tcp_socket create_stream_socket_perms;


### PR DESCRIPTION
sslh is an application protocol (SSL/SSH) multiplexer.
It accepts connections on specified ports, and forwards them further,
based on tests performed on the first data packet sent by the remote
client.

When run in transparent proxy mode, sslh needs the CAP_NET_ADMIN
capability to set IP_TRANSPARENT on the socket.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(05/13/2022 20:04:47.514:792388) : proctitle=/usr/sbin/sslh -F/etc/sslh.cfg
type=SYSCALL msg=audit(05/13/2022 20:04:47.514:792388) : arch=x86_64 syscall=setsockopt success=no exit=EPERM(Operation not permitted) a0=0x3 a1=ip a2=IP_TRANSPARENT a3=0x7fff1bd843bc items=0 ppid=4078558 pid=4079955 auid=unset uid=sslh gid=sslh euid=sslh suid=sslh fsuid=sslh egid=sslh sgid=sslh fsgid=sslh tty=(none) ses=unset comm=sslh exe=/usr/sbin/sslh subj=system_u:system_r:sslh_t:s0 key=(null)
type=AVC msg=audit(05/13/2022 20:04:47.514:792388) : avc:  denied  { net_admin } for  pid=4079955 comm=sslh capability=net_admin  scontext=system_u:system_r:sslh_t:s0 tcontext=system_u:system_r:sslh_t:s0 tclass=capability permissive=0

Resolves: rhbz#1971170