### PR TITLE
Allow xdm connect to unconfined_service_t over a unix stream socket

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -891,6 +891,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_server_stream_connectto(xdm_t)
+')
+
+optional_policy(`
     virt_filetrans_home_content(xdm_t)
 ')
 

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -212,6 +212,24 @@ interface(`unconfined_server_stream_connect',`
 
 ########################################
 ## <summary>
+##	Connect to unconfined_service_t with a unix socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_server_stream_connectto',`
+	gen_require(`
+		type unconfined_service_t;
+	')
+
+	allow $1 unconfined_service_t:unix_stream_socket connectto;
+')
+
+########################################
+## <summary>
 ##	Connect to unconfined_server with a unix socket.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The unconfined_server_stream_connectto() interface was added.

Addresses the following AVC denial:
type=AVC msg=audit(1629759956.74:220): avc:  denied  { connectto } for  pid=1300 comm="gnome-initial-s" path="/tmp/dbus-SJQtBR21nt" scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:unconfined_service_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

Resolves: rhbz#1943574