### PR TITLE
Confine targetcli

### DIFF
--- a/policy/modules/contrib/targetd.fc
+++ b/policy/modules/contrib/targetd.fc
@@ -1,5 +1,12 @@
-/etc/target(/.*)?		gen_context(system_u:object_r:targetd_etc_rw_t,s0)
+/etc/target(/.*)?			gen_context(system_u:object_r:targetd_etc_rw_t,s0)
+
+/root/\.targetcli(/.*)?			gen_context(system_u:object_r:targetclid_home_t,s0)
 
 /usr/bin/targetd		--	gen_context(system_u:object_r:targetd_exec_t,s0)
+/usr/bin/targetclid		--      gen_context(system_u:object_r:targetclid_exec_t,s0)
 
-/usr/lib/systemd/system/targetd.*		--	gen_context(system_u:object_r:targetd_unit_file_t,s0)
+/usr/lib/systemd/system/targetd.*	--	gen_context(system_u:object_r:targetd_unit_file_t,s0)
+/usr/lib/systemd/system/targetclid.*	--	gen_context(system_u:object_r:targetclid_unit_file_t,s0)
+
+/var/run/targetclid\.pid	--	gen_context(system_u:object_r:targetclid_var_run_t,s0)
+/var/run/targetclid\.sock	-s	gen_context(system_u:object_r:targetclid_var_run_t,s0)

--- a/policy/modules/contrib/targetd.te
+++ b/policy/modules/contrib/targetd.te
@@ -9,14 +9,27 @@ type targetd_t;
 type targetd_exec_t;
 init_daemon_domain(targetd_t, targetd_exec_t)
 
+type targetclid_t;
+type targetclid_exec_t;
+init_daemon_domain(targetclid_t, targetclid_exec_t)
+
 type targetd_etc_rw_t;
 files_type(targetd_etc_rw_t)
 
 type targetd_unit_file_t;
 systemd_unit_file(targetd_unit_file_t)
 
+type targetclid_unit_file_t;
+systemd_unit_file(targetclid_unit_file_t)
+
 type targetd_tmp_t;
 files_tmp_file(targetd_tmp_t)
+
+type targetclid_home_t;
+userdom_user_home_content(targetclid_home_t)
+
+type targetclid_var_run_t;
+files_pid_file(targetclid_var_run_t)
 
 ########################################
 #
@@ -83,27 +96,82 @@ storage_raw_read_removable_device(targetd_t)
 sysnet_read_config(targetd_t)
 
 optional_policy(`
-    gnome_read_generic_data_home_dirs(targetd_t)
+	gnome_read_generic_data_home_dirs(targetd_t)
 ')
 
 optional_policy(`
-    lvm_domtrans(targetd_t)
+	lvm_domtrans(targetd_t)
 ')
 
 optional_policy(`
-    modutils_read_module_config(targetd_t)
+	modutils_read_module_config(targetd_t)
 ')
 
 optional_policy(`
-    rpc_manage_nfs_state_data(targetd_t)
+	rpc_manage_nfs_state_data(targetd_t)
 ')
 
 optional_policy(`
-    rpm_dontaudit_read_db(targetd_t)
-    rpm_dontaudit_exec(targetd_t)
+	rpm_dontaudit_read_db(targetd_t)
+	rpm_dontaudit_exec(targetd_t)
 ')
 
 optional_policy(`
-   udev_read_pid_files(targetd_t)
+	udev_read_pid_files(targetd_t)
 ')
 
+########################################
+#
+# targetclid local policy
+#
+allow targetclid_t self:capability dac_override;
+allow targetclid_t self:fifo_file rw_fifo_file_perms;
+allow targetclid_t self:system module_load;
+allow targetclid_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_dirs_pattern(targetclid_t, targetclid_home_t, targetclid_home_t)
+manage_files_pattern(targetclid_t, targetclid_home_t, targetclid_home_t)
+userdom_admin_home_dir_filetrans(targetclid_t, targetclid_home_t, dir, ".targetcli")
+
+manage_files_pattern(targetclid_t, targetclid_var_run_t, targetclid_var_run_t)
+manage_sock_files_pattern(targetclid_t, targetclid_var_run_t, targetclid_var_run_t)
+files_pid_filetrans(targetclid_t, targetclid_var_run_t, { file sock_file })
+
+manage_dirs_pattern(targetclid_t, targetd_etc_rw_t, targetd_etc_rw_t)
+
+kernel_load_module(targetclid_t)
+kernel_read_all_proc(targetclid_t)
+
+corecmd_exec_bin(targetclid_t)
+
+dev_read_sysfs(targetclid_t)
+
+domain_use_interactive_fds(targetclid_t)
+
+files_getattr_all_dirs(targetclid_t)
+files_read_etc_files(targetclid_t)
+
+fs_manage_configfs_dirs(targetclid_t)
+fs_manage_configfs_files(targetclid_t)
+
+optional_policy(`
+	auth_read_passwd(targetclid_t)
+')
+
+optional_policy(`
+	dbus_system_bus_client(targetclid_t)
+')
+
+optional_policy(`
+	libs_exec_ldconfig(targetclid_t)
+')
+
+optional_policy(`
+	miscfiles_read_localization(targetclid_t)
+')
+
+optional_policy(`
+	modutils_exec_kmod(targetclid_t)
+	modutils_read_module_config(targetclid_t)
+	modutils_read_module_deps(targetclid_t)
+')


### PR DESCRIPTION
Create policy for targetcli,  a shell for viewing, editing, and
saving the configuration of the kernel's target subsystem, also known as LIO.
It enables the administrator to assign local storage resources
backed by either files, volumes, local SCSI devices, or ramdisk,
and export them to remote systems via network fabrics, such as FCoE.

Fix bz#2020169 2020167