### PR TITLE
Allow systemd work with install_t unix stream sockets

### DIFF
--- a/policy/modules/contrib/anaconda.fc
+++ b/policy/modules/contrib/anaconda.fc
@@ -11,3 +11,5 @@
 /usr/bin/preupg.*   --  gen_context(system_u:object_r:preupgrade_exec_t,s0)
 /var/lib/preupgrade(/.*)?   gen_context(system_u:object_r:preupgrade_data_t,s0)
 /var/log/preupgrade(/.*)?   gen_context(system_u:object_r:preupgrade_data_t,s0)
+
+/var/run/ostree-booted	-s	gen_context(system_u:object_r:install_var_run_t,s0)

--- a/policy/modules/contrib/anaconda.if
+++ b/policy/modules/contrib/anaconda.if
@@ -130,3 +130,40 @@ interface(`anaconda_manage_lib_files_preupgrade',`
 	manage_lnk_files_pattern($1, preupgrade_data_t, preupgrade_data_t)
 	files_search_var_lib($1)
 ')
+
+########################################
+## <summary>
+##	Connect over a unix stream socket
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`anaconda_stream_connect',`
+	gen_require(`
+		type install_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, install_var_run_t, install_var_run_t, install_t)
+')
+
+########################################
+## <summary>
+##	Create and use a unix stream socket
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`anaconda_create_unix_stream_sockets',`
+	gen_require(`
+		type install_t;
+	')
+
+	allow $1 install_t:unix_stream_socket create_stream_socket_perms;
+')

--- a/policy/modules/contrib/anaconda.te
+++ b/policy/modules/contrib/anaconda.te
@@ -28,6 +28,9 @@ type install_exec_t;
 application_domain(install_t, install_exec_t)
 role install_roles types install_t;
 
+type install_var_run_t;
+files_pid_file(install_var_run_t)
+
 type preupgrade_t;
 type preupgrade_exec_t;
 application_domain(preupgrade_t, preupgrade_exec_t)
@@ -86,6 +89,9 @@ systemd_dbus_chat_localed(install_t)
 systemd_dbus_chat_logind(install_t)
 init_dbus_chat(install_t)
 init_nnp_daemon_domain(install_t)
+
+manage_sock_files_pattern(install_t, install_var_run_t, install_var_run_t)
+files_pid_filetrans(install_t, install_var_run_t, sock_file)
 
 tunable_policy(`deny_ptrace',`',`
 	domain_ptrace_all_domains(install_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -452,6 +452,11 @@ storage_raw_rw_fixed_disk(init_t)
 sysnet_read_dhcpc_state(init_t)
 
 optional_policy(`
+	anaconda_stream_connect(init_t)
+	anaconda_create_unix_stream_sockets(init_t)
+')
+
+optional_policy(`
     bootloader_domtrans(init_t)
 ')
 


### PR DESCRIPTION
The anaconda_stream_connect() and anaconda_create_unix_stream_sockets()
interfaces were added.

Resolves: rhbz#1976303