### PR TITLE
Allow pcp_domain execute its private memfd: objects

### DIFF
--- a/policy/modules/contrib/pcp.te
+++ b/policy/modules/contrib/pcp.te
@@ -82,6 +82,7 @@ files_tmp_filetrans(pcp_domain, pcp_tmp_t, { dir file sock_file })
 manage_dirs_pattern(pcp_domain, pcp_tmpfs_t, pcp_tmpfs_t)
 manage_files_pattern(pcp_domain, pcp_tmpfs_t, pcp_tmpfs_t)
 fs_tmpfs_filetrans(pcp_domain, pcp_tmpfs_t, { dir file })
+can_exec(pcp_domain, pcp_tmpfs_t)
 
 dev_read_urand(pcp_domain)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=SYSCALL msg=audit(05/20/22 08:51:14.880:2331328) : arch=x86_64 syscall=mmap success=no exit=EACCES a0=0x0 a1=0x1000 a2=0x5 a3=0x1 items=0 ppid=2067954 pid=2067963 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=python3 exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:pcp_pmcd_t:s0 key=(null)
type=AVC msg=audit(05/20/22 08:51:14.880:2331328) : avc:  denied  { execute } for  pid=2067963 comm=python3 path=/memfd:libffi (deleted) dev="tmpfs" ino=13527843 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:pcp_tmpfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2090711