### PR TITLE
Allow ctdbd nlmsg_read on netlink_tcpdiag_socket

### DIFF
--- a/policy/modules/contrib/ctdb.te
+++ b/policy/modules/contrib/ctdb.te
@@ -45,7 +45,7 @@ allow ctdbd_t self:packet_socket create_socket_perms;
 allow ctdbd_t self:tcp_socket create_stream_socket_perms;
 allow ctdbd_t self:udp_socket create_socket_perms;
 allow ctdbd_t self:rawip_socket create_socket_perms;
-allow ctdbd_t self:netlink_tcpdiag_socket create_socket_perms;
+allow ctdbd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 
 append_files_pattern(ctdbd_t, ctdbd_log_t, ctdbd_log_t)
 create_files_pattern(ctdbd_t, ctdbd_log_t, ctdbd_log_t)


### PR DESCRIPTION
When ctdbd shuts down, it calls ss to read tcp diagnostics
which triggers the nlmsg_read permission. This permission is a part
of the create_netlink_socket_perms pattern, not create_socket_perms.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(05/26/22 09:35:47.419:545) : proctitle=ss -tn state established src [192.168.122.82
type=SYSCALL msg=audit(05/26/22 09:35:47.419:545) : arch=x86_64 syscall=sendmsg success=no exit=EACCES(Permission denied) a0=0x3 a1=0x7fffb6884aa0 a2=0x0 a3=0x1 items=0 ppid=979561 pid=979563 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ss exe=/usr/sbin/ss subj=system_u:system_r:ctdbd_t:s0 key=(null)
type=AVC msg=audit(05/26/22 09:35:47.419:545) : avc:  denied  { nlmsg_read } for  pid=979563 comm=ss scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:system_r:ctdbd_t:s0 tclass=netlink_tcpdiag_socket permissive=0

Resolves: rhbz#2090800