### PR TITLE
Add support for samba-dcerpcd

### DIFF
--- a/policy/modules/contrib/samba.fc
+++ b/policy/modules/contrib/samba.fc
@@ -18,6 +18,9 @@
 /usr/lib/systemd/system/nmb.*   --      gen_context(system_u:object_r:samba_unit_file_t,s0)
 /usr/lib/systemd/system/winbind.*   --  gen_context(system_u:object_r:samba_unit_file_t,s0)
 
+/usr/libexec/samba/rpcd_lsad	--	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
+/usr/libexec/samba/samba-dcerpcd --	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
+
 /usr/bin/net			--	gen_context(system_u:object_r:samba_net_exec_t,s0)
 /usr/bin/ntlm_auth		--	gen_context(system_u:object_r:winbind_helper_exec_t,s0)
 /usr/bin/smbcontrol		--	gen_context(system_u:object_r:smbcontrol_exec_t,s0)

--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -1080,3 +1080,22 @@ interface(`samba_admin',`
 	admin_pattern($1, samba_unit_file_t)
 	allow $1 samba_unit_file_t:service all_service_perms;
 ')
+
+########################################
+## <summary>
+##	Execute winbind rpcd in the winbind_rpcd_t domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`samba_domtrans_winbind_rpcd',`
+	gen_require(`
+		type winbind_rpcd_t, winbind_rpcd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, winbind_rpcd_exec_t, winbind_rpcd_t)
+')

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -176,8 +176,16 @@ role system_r types winbind_helper_t;
 type winbind_helper_exec_t;
 domain_entry_file(winbind_helper_t, winbind_helper_exec_t)
 
+type winbind_rpcd_t;
+type winbind_rpcd_exec_t;
+application_domain(winbind_rpcd_t, winbind_rpcd_exec_t)
+role system_r types winbind_rpcd_t;
+
 type winbind_log_t;
 logging_log_file(winbind_log_t)
+
+type winbind_rpcd_var_run_t;
+files_pid_file(winbind_rpcd_var_run_t)
 
 type winbind_var_run_t;
 files_pid_file(winbind_var_run_t)
@@ -1150,6 +1158,45 @@ optional_policy(`
 	squid_append_log(winbind_helper_t)
 	squid_rw_stream_sockets(winbind_helper_t)
 ')
+
+########################################
+#
+# Winbind-rpcd local policy
+#
+
+allow winbind_rpcd_t self:capability { setgid setuid };
+allow winbind_rpcd_t self:netlink_route_socket create_netlink_socket_perms;
+allow winbind_rpcd_t self:unix_dgram_socket { create_socket_perms sendto };
+allow winbind_rpcd_t self:udp_socket create_socket_perms;
+
+allow winbind_rpcd_t winbind_rpcd_exec_t:file execute_no_trans;
+
+read_files_pattern(winbind_rpcd_t, samba_etc_t, samba_etc_t)
+
+manage_files_pattern(winbind_rpcd_t, winbind_rpcd_var_run_t, winbind_rpcd_var_run_t)
+files_pid_filetrans(winbind_rpcd_t, winbind_rpcd_var_run_t, { dir file })
+manage_dirs_pattern(winbind_rpcd_t, smbd_var_run_t, smbd_var_run_t)
+manage_sock_files_pattern(winbind_rpcd_t, smbd_var_run_t, smbd_var_run_t)
+
+manage_files_pattern(winbind_rpcd_t, samba_log_t, samba_log_t)
+
+manage_dirs_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
+manage_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
+manage_sock_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
+allow winbind_rpcd_t samba_var_t:file { map } ;
+
+corecmd_exec_bin(winbind_rpcd_t)
+
+optional_policy(`
+	auth_read_passwd_file(winbind_rpcd_t)
+')
+
+# interactions with smbd_t/winbind_t
+allow smbd_t winbind_rpcd_t:unix_stream_socket connectto;
+allow winbind_t winbind_rpcd_t:unix_stream_socket connectto;
+
+samba_domtrans_winbind_rpcd(smbd_t)
+samba_domtrans_winbind_rpcd(winbind_t)
 
 ########################################
 #


### PR DESCRIPTION
New samba-dcerpcd binary is shipped with samba-4.16 (refer to
https://www.samba.org/samba/history/samba-4.16.0.html) to break out
the DCERPC services from smbd. samba-dcerpcd can be invoked on demand
from smbd or "winbind --np-helper" to serve DCERPC over named pipes,
or in a standalone mode, started separately from smbd or winbind,
but this requires changes to system startup scripts.

This commit bring SELinux support for the breakout with a new
winbind_rpcd_t type.

Resolves: rhbz#2083511