### PR TITLE
Allow auditd_t noatsecure for a transition to audisp_remote_t

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -194,7 +194,7 @@ allow auditd_t self:tcp_socket create_stream_socket_perms;
 allow auditd_t auditd_etc_t:dir list_dir_perms;
 allow auditd_t auditd_etc_t:file { read_file_perms map };
 
-allow auditd_t audisp_remote_t:process signal;
+allow auditd_t audisp_remote_t:process { noatsecure signal };
 
 manage_dirs_pattern(auditd_t, auditd_log_t, auditd_log_t)
 manage_files_pattern(auditd_t, auditd_log_t, auditd_log_t)


### PR DESCRIPTION
The following denial appears in journal (not in audit log):

[  854.289408] audit: type=1400 audit(1654584400.897:524): avc:  denied  { noatsecure } for  pid=10443 comm="auditd" scontext=system_u:system_r:auditd_t:s0 tcontext=system_u:system_r:audisp_remote_t:s0 tclass=process permissive=0

Resolves: rhbz#2081907