### PR TITLE
Allow stalld setsched and sys_nice

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -19,7 +19,8 @@ files_pid_file(stalld_var_run_t)
 #
 # stalld local policy
 #
-allow stalld_t self:process { fork };
+allow stalld_t self:capability sys_nice;
+allow stalld_t self:process { fork setsched };
 allow stalld_t self:fifo_file rw_fifo_file_perms;
 allow stalld_t self:unix_stream_socket create_stream_socket_perms;
 


### PR DESCRIPTION
The stalld service acts as a thread stall detector. The daemon monitors
kernel threads and detects when threads are stalled as a result of CPU
starvation. The stalled thread is in turn boosted by stalld by setting
the SCHED_DEADLINE policy. For that, the sched_setattr() syscall is used.

Addresses the following AVC denials:

type=PROCTITLE msg=audit(06/02/2022 13:14:16.703:474) : proctitle=/usr/bin/stalld --systemd -p 1000000000 -r 20000 -d 3 -t 30 --foreground --pidfile /run/stalld.pid
type=SYSCALL msg=audit(06/02/2022 13:14:16.703:474) : arch=x86_64 syscall=sched_setattr success=no exit=EPERM(Operation not permitted) a0=0x0 a1=0x7ffd07c5d0e0 a2=0x0 a3=0x0 items=0 ppid=1 pid=4890 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stalld exe=/usr/bin/stalld subj=system_u:system_r:stalld_t:s0 key=(null)
type=AVC msg=audit(06/02/2022 13:14:16.703:474) : avc:  denied  { sys_nice } for  pid=4890 comm=stalld capability=sys_nice  scontext=system_u:system_r:stalld_t:s0 tcontext=system_u:system_r:stalld_t:s0 tclass=capability permissive=0

type=PROCTITLE msg=audit(06/02/2022 13:22:21.992:620) : proctitle=/usr/bin/stalld --systemd -p 1000000000 -r 20000 -d 3 -t 30 --foreground --pidfile /run/stalld.pid
type=SYSCALL msg=audit(06/02/2022 13:22:21.992:620) : arch=x86_64 syscall=sched_setattr success=no exit=EACCES(Permission denied) a0=0x0 a1=0x7fff6e9d2890 a2=0x0 a3=0x0 items=0 ppid=1 pid=8595 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stalld
 exe=/usr/bin/stalld subj=system_u:system_r:stalld_t:s0 key=(null)
type=AVC msg=audit(06/02/2022 13:22:21.992:620) : avc:  denied  { setsched } for  pid=8595 comm=stalld scontext=system_u:system_r:stalld_t:s0 tcontext=system_u:system_r:stalld_t:s0 tclass=process permissive=0

Resolves: rhbz#2092864