### PR TITLE
Allow rabbitmq to access its private memfd: objects 

### DIFF
--- a/policy/modules/contrib/rabbitmq.te
+++ b/policy/modules/contrib/rabbitmq.te
@@ -35,6 +35,9 @@ files_tmp_file(rabbitmq_tmp_t)
 type rabbitmq_conf_t;
 files_config_file(rabbitmq_conf_t)
 
+type rabbitmq_tmpfs_t;
+files_tmpfs_file(rabbitmq_tmpfs_t)
+
 ######################################
 #
 # Rabbitmq local policy
@@ -73,6 +76,10 @@ files_tmp_filetrans(rabbitmq_t, rabbitmq_tmp_t, { file dir })
 manage_dirs_pattern(rabbitmq_t, rabbitmq_conf_t, rabbitmq_conf_t)
 manage_files_pattern(rabbitmq_t, rabbitmq_conf_t, rabbitmq_conf_t)
 files_etc_filetrans(rabbitmq_t, rabbitmq_conf_t, dir)
+
+manage_files_pattern(rabbitmq_t, rabbitmq_tmpfs_t, rabbitmq_tmpfs_t)
+fs_tmpfs_filetrans(rabbitmq_t, rabbitmq_tmpfs_t, file)
+can_exec(rabbitmq_t, rabbitmq_tmpfs_t)
 
 kernel_dgram_send(rabbitmq_t)
 


### PR DESCRIPTION
... to address the following AVC denials.

type=AVC msg=audit(1654743891.344:4500): avc:  denied  { write } for  pid=47118 comm="beam.smp" name="memfd:vmem" dev="tmpfs" ino=3077 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(1654743891.344:4501): avc:  denied  { read execute } for  pid=47118 comm="beam.smp" path=2F6D656D66643A766D656D202864656C6574656429 dev="tmpfs" ino=3077 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1

Resolves: rhbz#2056565