### PR TITLE
Allow nm-dispatcher custom plugin create and use unix dgram socket

### DIFF
--- a/policy/modules/contrib/ddclient.if
+++ b/policy/modules/contrib/ddclient.if
@@ -100,3 +100,21 @@ interface(`ddclient_admin',`
 	files_list_tmp($1)
 	admin_pattern($1, ddclient_tmp_t)
 ')
+
+########################################
+## <summary>
+##	Get the attributes of ddclient PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ddclient_getattr_pid_files',`
+	gen_require(`
+		type ddclient_var_run_t;
+	')
+
+	getattr_files_pattern($1, ddclient_var_run_t, ddclient_var_run_t)
+')

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -644,6 +644,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	samba_domtrans_smbcontrol(NetworkManager_dispatcher_winbind_t)
 	samba_service_status(NetworkManager_dispatcher_winbind_t)
 ')
 

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -562,6 +562,7 @@ allow NetworkManager_dispatcher_custom_t self:udp_socket create_socket_perms;
 allow NetworkManager_dispatcher_ddclient_t self:udp_socket create_socket_perms;
 allow NetworkManager_dispatcher_t self:unix_dgram_socket { create_socket_perms sendto };
 allow NetworkManager_dispatcher_ddclient_t self:unix_dgram_socket { create_socket_perms sendto };
+allow NetworkManager_dispatcher_custom_t self:unix_dgram_socket { create_socket_perms sendto };
 allow NetworkManager_dispatcher_t NetworkManager_unit_file_t:file getattr;
 allow NetworkManager_dispatcher_cloud_t NetworkManager_unit_file_t:file getattr;
 

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -627,6 +627,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ddclient_getattr_pid_files(NetworkManager_dispatcher_ddclient_t)
+')
+
+optional_policy(`
 	dnssec_trigger_domtrans(NetworkManager_dispatcher_dnssec_t)
 ')
 
@@ -665,6 +669,9 @@ optional_policy(`
 	systemd_exec_systemctl(NetworkManager_dispatcher_winbind_t)
 	systemd_exec_systemctl(NetworkManager_dispatcher_custom_t)
 	systemd_getattr_unit_files(NetworkManager_dispatcher_ddclient_t)
+	systemd_start_systemd_services(NetworkManager_dispatcher_ddclient_t)
+	systemd_stop_systemd_services(NetworkManager_dispatcher_ddclient_t)
+	systemd_status_systemd_services(NetworkManager_dispatcher_ddclient_t)
 	systemd_start_systemd_services(NetworkManager_dispatcher_sendmail_t)
 ')
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1442,6 +1442,42 @@ interface(`systemd_start_systemd_services',`
 	allow $1 systemd_unit_file_t:service start;
 ')
 
+########################################
+## <summary>
+##	Allow the specified domain to stop systemd services.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_stop_systemd_services',`
+	gen_require(`
+		type systemd_unit_file_t;
+	')
+
+	allow $1 systemd_unit_file_t:service stop;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to status systemd services.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_status_systemd_services',`
+	gen_require(`
+		type systemd_unit_file_t;
+	')
+
+	allow $1 systemd_unit_file_t:service status;
+')
+
 #######################################
 ## <summary>
 ##  Allow the specified domain to reload all systemd services.


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1654238161.81:4923): avc:  denied  { create } for  pid=696389 comm="logger" scontext=system_u:system_r:NetworkManager_dispatcher_custom_t:s0 tcontext=system_u:system_r:NetworkManager_dispatcher_custom_t:s0 tclass=unix_dgram_socket permissive=1

Resolves: rhbz#2093155