### PR TITLE
Allow rabbitmq to use systemd notify

### DIFF
--- a/policy/modules/contrib/rabbitmq.te
+++ b/policy/modules/contrib/rabbitmq.te
@@ -81,6 +81,8 @@ manage_files_pattern(rabbitmq_t, rabbitmq_tmpfs_t, rabbitmq_tmpfs_t)
 fs_tmpfs_filetrans(rabbitmq_t, rabbitmq_tmpfs_t, file)
 can_exec(rabbitmq_t, rabbitmq_tmpfs_t)
 
+init_stream_connect(rabbitmq_t)
+
 kernel_dgram_send(rabbitmq_t)
 
 kernel_read_system_state(rabbitmq_t)


### PR DESCRIPTION
... to address the following denials additionally found.

type=AVC msg=audit(1654884684.383:4434): avc:  denied  { getattr } for  pid=40772 comm="10_dirty_io_sch" path="/run/systemd/notify" dev="tmpfs" ino=36 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=sock_file permissive=1
type=AVC msg=audit(1654884684.383:4435): avc:  denied  { read } for  pid=40772 comm="10_dirty_io_sch" name="notify" dev="tmpfs" ino=36 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=sock_file permissive=1

Resolves: rhbz#2056565