### PR TITLE
Update kernel_read_unix_sysctls() for sysctl_net_unix_t handling

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -2011,7 +2011,7 @@ interface(`kernel_read_unix_sysctls',`
 	')
 
 	read_files_pattern($1, { proc_t sysctl_t sysctl_net_t }, sysctl_net_unix_t)
-	list_dirs_pattern($1, { proc_t sysctl_t }, sysctl_net_t)
+	list_dirs_pattern($1, { proc_t sysctl_t sysctl_net_t }, sysctl_net_unix_t)
 ')
 
 ########################################


### PR DESCRIPTION
The sysctl_net_unix_t type is assigned to the /proc/sys/net/unix
directory and all files in it. With this commit, the
kernel_read_unix_sysctls() interface changes to allow reading the
directory.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(06/15/2022 08:47:54.924:172) : proctitle=/sbin/sysctl -a
type=AVC msg=audit(06/15/2022 08:47:54.924:172) : avc:  denied  { read } for  pid=3549 comm=sysctl name=unix dev="proc" ino=11516 scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:sysctl_net_unix_t:s0 tclass=dir permissive=1
type=SYSCALL msg=audit(06/15/2022 08:47:54.924:172) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x555bc8abc8c0 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=0 ppid=3548 pid=3549 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sysctl exe=/usr/sbin/sysctl subj=system_u:system_r:insights_client_t:s0 key=(null)