### PR TITLE
Allow winbind_rpcd_t connect to self over a unix_stream_socket

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1168,6 +1168,7 @@ optional_policy(`
 allow winbind_rpcd_t self:capability { setgid setuid };
 allow winbind_rpcd_t self:netlink_route_socket create_netlink_socket_perms;
 allow winbind_rpcd_t self:unix_dgram_socket { create_socket_perms sendto };
+allow winbind_rpcd_t self:unix_stream_socket connectto;
 allow winbind_rpcd_t self:udp_socket create_socket_perms;
 
 allow winbind_rpcd_t winbind_rpcd_exec_t:file execute_no_trans;


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(06/13/2022 04:54:59.247:2004) : proctitle=/usr/libexec/samba/rpcd_classic --configfile=/etc/samba/smb.conf --worker-group=6 --worker-index=0 --debuglevel=10
type=AVC msg=audit(06/13/2022 04:54:59.247:2004) : avc:  denied  { connectto } for  pid=23402 comm=rpcd_classic path=/run/samba/ncalrpc/np/winreg scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:winbind_rpcd_t:s0 tclass=unix_stream_socket permissive=0
type=SYSCALL msg=audit(06/13/2022 04:54:59.247:2004) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x10 a1=0x5624dd0ca5d0 a2=0x6e a3=0x7fe7094db260 items=0 ppid=23239 pid=23402 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpcd_classic exe=/usr/libexec/samba/rpcd_classic subj=system_u:system_r:winbind_rpcd_t:s0 key=(null)

Resolves: rhbz#2096255