### PR TITLE
Allow ksmctl create hardware state information files

### DIFF
--- a/policy/modules/contrib/ksmtuned.te
+++ b/policy/modules/contrib/ksmtuned.te
@@ -91,5 +91,6 @@ tunable_policy(`ksmtuned_use_cifs',`
 #
 # Local policy for ksm
 #
+dev_create_sysfs_files(ksm_t)
 dev_rw_sysfs(ksm_t)
 


### PR DESCRIPTION
Addresses the following AVC denials:
type=PROCTITLE msg=audit(03/06/2022 14:23:34.678:235) : proctitle=/usr/libexec/ksmctl start
type=PATH msg=audit(03/06/2022 14:23:34.678:235) : item=1 name=/sys/kernel/mm/ksm/run inode=5435 dev=00:17 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(03/06/2022 14:23:34.678:235) : item=0 name=/sys/kernel/mm/ksm/ inode=5432 dev=00:17 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(03/06/2022 14:23:34.678:235) : arch=x86_64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0x558a0ea3603f a2=O_WRONLY|O_CREAT|O_TRUNC a3=0x1b6 items=2 ppid=1 pid=1153 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ksmctl exe=/usr/libexec/ksmctl subj=system_u:system_r:ksm_t:s0 key=(null)
type=AVC msg=audit(03/06/2022 14:23:34.678:235) : avc:  denied  { create } for  pid=1153 comm=ksmctl name=run scontext=system_u:system_r:ksm_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(03/06/2022 14:23:34.678:235) : avc:  denied  { add_name } for  pid=1153 comm=ksmctl name=run scontext=system_u:system_r:ksm_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1
type=AVC msg=audit(03/06/2022 14:23:34.678:235) : avc:  denied  { write } for  pid=1153 comm=ksmctl name=ksm dev="sysfs" ino=5432 scontext=system_u:system_r:ksm_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1

Resolves: rhbz#2091417