### PR TITLE
Allow dlm_controld send a null signal to a cluster daemon

### DIFF
--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -374,6 +374,8 @@ optional_policy(`
 allow dlm_controld_t self:capability { dac_read_search net_admin sys_admin setgid sys_resource };
 allow dlm_controld_t self:netlink_kobject_uevent_socket create_socket_perms;
 
+allow dlm_controld_t cluster_t:process signull;
+
 files_pid_filetrans(dlm_controld_t, dlm_controld_var_run_t, dir)
 
 stream_connect_pattern(dlm_controld_t, fenced_var_run_t, fenced_var_run_t, fenced_t)


### PR DESCRIPTION
Resolves: rhbz#2095884