### PR TITLE
Allow samba-dcerpcd work with sssd

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1216,6 +1216,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_read_public_files(winbind_rpcd_t)
+	sssd_stream_connect(winbind_rpcd_t)
+')
+
+optional_policy(`
 	sysnet_read_config(winbind_rpcd_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denials:

type=AVC msg=audit(1655206265.325:3211): avc:  denied  { open } for  pid=33521 comm="samba-dcerpcd" path="/var/lib/sss/mc/initgroups" dev="vda3" ino=25205857 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=file permissive=1
type=AVC msg=audit(1655206265.325:3214): avc:  denied  { connectto } for  pid=33521 comm="samba-dcerpcd" path="/var/lib/sss/pipes/nss" scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:sssd_t:s0 tclass=unix_stream_socket permissive=1
type=AVC msg=audit(1655206265.325:3214): avc:  denied  { write } for  pid=33521 comm="samba-dcerpcd" name="nss" dev="vda3" ino=17045861 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=sock_file permissive=1

Resolves: rhbz#2096825