### PR TITLE
Allow stalld the getsched permission

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -29,6 +29,7 @@ manage_files_pattern(stalld_t, stalld_var_run_t, stalld_var_run_t)
 manage_lnk_files_pattern(stalld_t, stalld_var_run_t, stalld_var_run_t)
 files_pid_filetrans(stalld_t, stalld_var_run_t, { dir file lnk_file })
 
+kernel_getsched(stalld_t)
 kernel_manage_debugfs(stalld_t)
 kernel_read_all_proc(stalld_t)
 

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -144,6 +144,24 @@ interface(`kernel_dontaudit_setsched',`
 
 ########################################
 ## <summary>
+##	Get scheduling policy and attributes of kernel threads.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_getsched',`
+	gen_require(`
+		type kernel_t;
+	')
+
+	allow $1 kernel_t:process getsched;
+')
+
+########################################
+## <summary>
 ##	Send a SIGCHLD signal to kernel threads.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(06/13/2022 18:43:49.194:408) : proctitle=/usr/bin/stalld --systemd -p 1000000000 -r 20000 -d 3 -t 30 --foreground --pidfile /run/stalld.pid
type=AVC msg=audit(06/13/2022 18:43:49.194:408) : avc:  denied  { getsched } for  pid=3612 comm=stalld scontext=system_u:system_r:stalld_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=process permissive=0
type=SYSCALL msg=audit(06/13/2022 18:43:49.194:408) : arch=x86_64 syscall=sched_getattr success=no exit=EACCES(Permission denied) a0=0x19 a1=0x7fff1d0c42b0 a2=0x30 a3=0x0 items=0 ppid=1 pid=3612 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stalld exe=/usr/bin/stalld subj=system_u:system_r:stalld_t:s0 key=(null)

Resolves: rhbz#2096776