### PR TITLE
Allow domain use userfaultfd over all domains

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -121,7 +121,7 @@ neverallow ~{ domain unlabeled_t } *:process *;
 # Rules applied to all domains
 #
 
-allow domain self:anon_inode common_anon_inode_perms;
+allow domain domain:anon_inode common_anon_inode_perms;
 # read /proc/(pid|self) entries
 allow domain self:dir { list_dir_perms watch_dir_perms };
 allow domain self:lnk_file { read_lnk_file_perms lock ioctl };


### PR DESCRIPTION
Until now, all processes were allowed to use userfaultfd as well other
anon_inodes to get a file descriptor from the same domain.
Since this commit the permissions are allowed between different domains.