### PR TITLE
Allow kpropd read network sysctls

### DIFF
--- a/policy/modules/contrib/kerberos.te
+++ b/policy/modules/contrib/kerberos.te
@@ -369,6 +369,7 @@ files_tmp_filetrans(kpropd_t, krb5kdc_tmp_t, { file dir })
 
 kernel_read_system_state(kpropd_t)
 kernel_read_network_state(kpropd_t)
+kernel_read_net_sysctls(kpropd_t)
 
 can_exec(kpropd_t,kpropd_exec_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(06/23/2022 03:46:33.848:845) : proctitle=/usr/sbin/kpropd
type=PATH msg=audit(06/23/2022 03:46:33.848:845) : item=0 name=/proc/sys/net/ipv6/conf/all/disable_ipv6 inode=44028 dev=00:16 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_net_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(06/23/2022 03:46:33.848:845) : cwd=/
type=SYSCALL msg=audit(06/23/2022 03:46:33.848:845) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffc7e5b8550 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=13730 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=kpropd exe=/usr/sbin/kpropd subj=system_u:system_r:kpropd_t:s0 key=(null)
type=AVC msg=audit(06/23/2022 03:46:33.848:845) : avc:  denied  { read } for  pid=13730 comm=kpropd name=disable_ipv6 dev="proc" ino=44028 scontext=system_u:system_r:kpropd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=0