### PR TITLE
Allow cups-lpd read network sysctls

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -647,6 +647,7 @@ files_tmp_filetrans(cups_pdf_t, cups_pdf_tmp_t, { dir file })
 
 fs_search_auto_mountpoints(cups_pdf_t)
 
+kernel_read_net_sysctls(cups_pdf_t)
 kernel_read_system_state(cups_pdf_t)
 
 auth_use_nsswitch(cups_pdf_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(05/18/2022 19:31:33.481:8879) : proctitle=/usr/lib/cups/daemon/cups-lpd
type=PATH msg=audit(05/18/2022 19:31:33.481:8879) : item=0 name=/proc/sys/net/ipv6/conf/all/disable_ipv6 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/18/2022 19:31:33.481:8879) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fff5c8c3290 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=124314 auid=unset uid=lp gid=lp euid=lp suid=lp fsuid=lp egid=lp sgid=lp fsgid=lp tty=(none) ses=unset comm=cups-lpd exe=/usr/lib/cups/daemon/cups-lpd subj=system_u:system_r:cupsd_lpd_t:s0 key=(null)
type=AVC msg=audit(05/18/2022 19:31:33.481:8879) : avc:  denied  { search } for  pid=124314 comm=cups-lpd name=net dev="proc" ino=14920 scontext=system_u:system_r:cupsd_lpd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0