### PR TITLE
Allow amandad read network sysctls

### DIFF
--- a/policy/modules/contrib/amanda.te
+++ b/policy/modules/contrib/amanda.te
@@ -106,6 +106,7 @@ allow amanda_t amanda_tmpfs_t:file map;
 can_exec(amanda_t, { amanda_exec_t amanda_inetd_exec_t })
 
 kernel_read_kernel_sysctls(amanda_t)
+kernel_read_net_sysctls(amanda_t)
 kernel_read_system_state(amanda_t)
 kernel_read_network_state(amanda_t)
 kernel_dontaudit_getattr_unlabeled_files(amanda_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(05/18/2022 19:22:56.410:7703) : proctitle=/usr/sbin/amandad -auth=bsdtcp amdump amindexd amidxtaped
type=PATH msg=audit(05/18/2022 19:22:56.410:7703) : item=0 name=/proc/sys/net/ipv6/conf/all/disable_ipv6 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/18/2022 19:22:56.410:7703) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffcf33e0540 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=108386 auid=unset uid=amandabackup gid=disk euid=amandabackup suid=amandabackup fsuid=amandabackup egid=disk sgid=disk fsgid=disk tty=(none) ses=unset comm=amandad exe=/usr/lib64/amanda/amandad subj=system_u:system_r:amanda_t:s0 key=(null)
type=AVC msg=audit(05/18/2022 19:22:56.410:7703) : avc:  denied  { search } for  pid=108386 comm=amandad name=net dev="proc" ino=14920 scontext=system_u:system_r:amanda_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0