### PR TITLE
Allow firewalld read the contents of the sysfs filesystem

### DIFF
--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -81,7 +81,7 @@ corecmd_exec_bin(firewalld_t)
 corecmd_exec_shell(firewalld_t)
 
 dev_read_urand(firewalld_t)
-dev_search_sysfs(firewalld_t)
+dev_read_sysfs(firewalld_t)
 
 domain_use_interactive_fds(firewalld_t)
 domain_obj_id_change_exemption(firewalld_t)


### PR DESCRIPTION
Addresses the following AVC denial which is triggered on the firewalld
service start when it tries to read /sys/devices/system/cpu/possible:

type=AVC msg=audit(1656139734.292:232): avc:  denied  { read } for  pid=1396 comm="firewalld" name="possible" dev="sysfs" ino=46 scontext=system_u:system_r:firewalld_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2101062