### PR TITLE
Allow keepalived read the contents of the sysfs filesystem

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -81,6 +81,7 @@ corenet_tcp_connect_squid_port(keepalived_t)
 domain_read_all_domains_state(keepalived_t)
 domain_getattr_all_domains(keepalived_t)
 
+dev_read_sysfs(keepalived_t)
 dev_read_urand(keepalived_t)
 
 files_dontaudit_mounton_rootfs(keepalived_var_run_t)


### PR DESCRIPTION
Addresses the following AVC denial which is triggered on the keepalived
service start when it tries to read /sys/devices/system/cpu:

type=PROCTITLE msg=audit(06/17/2022 08:19:59.448:341) : proctitle=/usr/sbin/keepalived --dont-fork -D
type=PATH msg=audit(06/17/2022 08:19:59.448:341) : item=0 name=/sys/devices/system/cpu inode=39 dev=00:16 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(06/17/2022 08:19:59.448:341) : arch=x86_64 syscall=openat success=yes exit=12 a0=AT_FDCWD a1=0x7ff4be2afc3f a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=4449 pid=4451 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=keepalived exe=/usr/sbin/keepalived subj=system_u:system_r:keepalived_t:s0 key=(null)
type=AVC msg=audit(06/17/2022 08:19:59.448:341) : avc:  denied  { read } for  pid=4451 comm=keepalived name=cpu dev="sysfs" ino=39 scontext=system_u:system_r:keepalived_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1

Resolves: rhbz#2098130