### PR TITLE
Fix file context pattern for /var/target

### DIFF
--- a/policy/modules/contrib/targetd.fc
+++ b/policy/modules/contrib/targetd.fc
@@ -8,7 +8,7 @@
 /usr/lib/systemd/system/targetd.*	--	gen_context(system_u:object_r:targetd_unit_file_t,s0)
 /usr/lib/systemd/system/targetclid.*	--	gen_context(system_u:object_r:targetclid_unit_file_t,s0)
 
-/var/target/(.*)?			gen_context(system_u:object_r:targetd_var_t,s0)
+/var/target(/.*)?			gen_context(system_u:object_r:targetd_var_t,s0)
 
 /var/run/targetclid\.pid	--	gen_context(system_u:object_r:targetclid_var_run_t,s0)
 /var/run/targetclid\.sock	-s	gen_context(system_u:object_r:targetclid_var_run_t,s0)


### PR DESCRIPTION
In the 34e3bbcc8b6 ("Label /var/target with targetd_var_t") commit,
there was /var/target/(.*)? pattern used instead of the correct
/var/target(/.*)?

Resolves: rhbz#2020169