### PR TITLE
Update samba-dcerpcd policy for kerberos usage 2

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1208,11 +1208,16 @@ optional_policy(`
 ')
 
 optional_policy(`
+	kerberos_read_keytab(winbind_rpcd_t)
 	kerberos_use(winbind_rpcd_t)
 ')
 
 optional_policy(`
 	logging_send_syslog_msg(winbind_rpcd_t)
+')
+
+optional_policy(`
+	miscfiles_read_generic_certs(winbind_rpcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
These additional permissions were added:
- read kerberos key tables
- read generic SSL certificates

Resolves: rhbz#2096521