### PR TITLE
Allow targetclid read generic SSL certificates (fixed)

### DIFF
--- a/policy/modules/contrib/targetd.te
+++ b/policy/modules/contrib/targetd.te
@@ -110,10 +110,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	miscfiles_read_generic_certs(targetd_t)
-')
-
-optional_policy(`
 	modutils_read_module_config(targetd_t)
 ')
 
@@ -177,6 +173,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	miscfiles_read_generic_certs(targetclid_t)
 	miscfiles_read_localization(targetclid_t)
 ')
 


### PR DESCRIPTION
With the fd12b923287 ("Allow targetclid read generic SSL certificates")
commit, the permission to read generic SSL certificates was allowed to
the targetd_t domain. This commit allows it to targetclid_t instead.

Resolves: rhbz#2020169