### PR TITLE
Allow targetclid read /var/target files

### DIFF
--- a/policy/modules/contrib/targetd.te
+++ b/policy/modules/contrib/targetd.te
@@ -51,9 +51,6 @@ manage_dirs_pattern(targetd_t, targetd_etc_rw_t, targetd_etc_rw_t)
 manage_files_pattern(targetd_t, targetd_etc_rw_t, targetd_etc_rw_t)
 files_etc_filetrans(targetd_t, targetd_etc_rw_t, { dir file })
 
-list_dirs_pattern(targetd_t, targetd_var_t, targetd_var_t)
-read_files_pattern(targetd_t, targetd_var_t, targetd_var_t)
-
 manage_dirs_pattern(targetd_t, targetd_tmp_t, targetd_tmp_t)
 manage_files_pattern(targetd_t, targetd_tmp_t, targetd_tmp_t)
 files_tmp_filetrans(targetd_t, targetd_tmp_t, { file dir })
@@ -138,6 +135,9 @@ allow targetclid_t self:unix_stream_socket create_stream_socket_perms;
 manage_dirs_pattern(targetclid_t, targetclid_home_t, targetclid_home_t)
 manage_files_pattern(targetclid_t, targetclid_home_t, targetclid_home_t)
 userdom_admin_home_dir_filetrans(targetclid_t, targetclid_home_t, dir, ".targetcli")
+
+list_dirs_pattern(targetclid_t, targetd_var_t, targetd_var_t)
+read_files_pattern(targetclid_t, targetd_var_t, targetd_var_t)
 
 manage_files_pattern(targetclid_t, targetclid_var_run_t, targetclid_var_run_t)
 manage_sock_files_pattern(targetclid_t, targetclid_var_run_t, targetclid_var_run_t)


### PR DESCRIPTION
With the 34e3bbcc8b6 ("Label /var/target with targetd_var_t") commit,
permissions were allowed to read files in /var/target for targetd_t
instead of targetclid_t. This commit allows it to targetclid_t instead.

Resolves: rhbz#2020169