### PR TITLE
Allow stalld set scheduling policy of kernel threads

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -32,6 +32,7 @@ files_pid_filetrans(stalld_t, stalld_var_run_t, { dir file lnk_file })
 kernel_getsched(stalld_t)
 kernel_manage_debugfs(stalld_t)
 kernel_read_all_proc(stalld_t)
+kernel_setsched(stalld_t)
 
 dev_read_sysfs(stalld_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(06/28/2022 23:03:43.468:135) : proctitle=/usr/bin/stalld --systemd -p 1000000000 -r 20000 -d 3 -t 30 --foreground --pidfile /run/stalld.pid
type=AVC msg=audit(06/28/2022 23:03:43.468:135) : avc:  denied  { setsched } for  pid=8733 comm=stalld scontext=system_u:system_r:stalld_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=process permissive=0
type=SYSCALL msg=audit(06/28/2022 23:03:43.468:135) : arch=x86_64 syscall=sched_setattr success=no exit=EACCES(Permission denied) a0=0x19 a1=0x7ffff4238d00 a2=0x0 a3=0x55ae00632210 items=0 ppid=1 pid=8733 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stalld exe=/usr/bin/stalld subj=system_u:system_r:stalld_t:s0 key=(null)

Resolves: rhbz#2096776