### PR TITLE
Allow cups-lpd read network sysctls

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -562,6 +562,7 @@ read_sock_files_pattern(cupsd_lpd_t, cupsd_var_run_t, cupsd_var_run_t)
 stream_connect_pattern(cupsd_lpd_t, cupsd_var_run_t, cupsd_var_run_t, cupsd_t)
 
 kernel_read_kernel_sysctls(cupsd_lpd_t)
+kernel_read_net_sysctls(cupsd_lpd_t)
 kernel_read_system_state(cupsd_lpd_t)
 
 corenet_all_recvfrom_netlabel(cupsd_lpd_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(06/29/2022 20:27:06.595:8551) : avc:  denied  { search } for  pid=119379 comm=cups-lpd name=net dev="proc" ino=14928 scontext=system_u:system_r:cupsd_lpd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0