### PR TITLE
fix(sedoctool.py): Fix syntax warning: "is not" with a literal

### DIFF
--- a/support/sedoctool.py
+++ b/support/sedoctool.py
@@ -272,7 +272,7 @@ def format_html_desc(node):
 	desc_buf = ''
 	for desc in node.childNodes:
 		if desc.nodeName == "#text":
-			if desc.data is not '':
+			if desc.data != '':
 				if desc.parentNode.nodeName != "p":
 					desc_buf += "<p>" + desc.data + "</p>"
 				else:


### PR DESCRIPTION
## General
Running the make target `policy` throws a syntax warning on newer Py3 versions:
```
/home/vagrant/selinux-policy-targeted-fedora/selinux-policy/support/sedoctool.py:275: SyntaxWarning: "is not" with a literal. Did you mean "!="?
```

This PR fixes this warning when using Py3.8+ versions.