### PR TITLE
Allow nm-dispatcher winbind plugin read samba config files

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -649,6 +649,7 @@ optional_policy(`
 
 optional_policy(`
 	samba_domtrans_smbcontrol(NetworkManager_dispatcher_winbind_t)
+	samba_read_config(NetworkManager_dispatcher_winbind_t)
 	samba_service_status(NetworkManager_dispatcher_winbind_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:
Jul 12 15:01:02 hostname audit[140521]: AVC avc:  denied  { search } for  pid=140521 comm="testparm" name="samba" dev="dm-1" ino=1704052 scontext=system_u:system_r:NetworkManager_dispatcher_winbind_t:s0 tcontext=system_u:object_r:samba_etc_t:s0 tclass=dir permissive=0

Resolves: rhbz#2092808