### PR TITLE
Support using systemd-update-helper in rpm scriptlets

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -215,6 +215,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rpm_script_rw_stream_sockets(system_dbusd_t)
+')
+
+optional_policy(`
     snapper_read_inherited_pipe(system_dbusd_t)
 ')
 

--- a/policy/modules/contrib/rpm.if
+++ b/policy/modules/contrib/rpm.if
@@ -958,6 +958,7 @@ interface(`rpm_admin',`
 	rpm_run($1, $2)
 ')
 
+#######################################
 ## <summary>
 ##	Allow the specified domain to ioctl rpm_script_t
 ##	with a unix domain stream socket.
@@ -974,4 +975,23 @@ interface(`rpm_script_ioctl_stream_sockets',`
 	')
 
 	allow $1 rpm_script_t:unix_stream_socket ioctl;
+')
+
+#######################################
+## <summary>
+##	Allow the specified domain read and write to rpm_script_t
+##	over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`rpm_script_rw_stream_sockets',`
+	gen_require(`
+		type rpm_script_t;
+	')
+
+	allow $1 rpm_script_t:unix_stream_socket { read write };
 ')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -521,6 +521,7 @@ optional_policy(`
 optional_policy(`
 	rpm_read_db(init_t)
 	rpm_script_ioctl_stream_sockets(init_t)
+	rpm_script_rw_stream_sockets(init_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following AVC denials, dontaudited by default:
type=AVC msg=audit(07/08/2022 15:03:18.969:819) : avc:  denied  { read write } for  pid=1 comm=systemd path=socket:[47621] dev="sockfs" ino=47621 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:unconfined_r:rpm_script_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0

type=PROCTITLE msg=audit(07/08/2022 15:06:59.478:968) : proctitle=dbus-broker --log 4 --controller 9 --machine-id 31c23619ce0349e999f66291729cc4f6 --max-bytes 536870912 --max-fds 4096 --max-matc
type=SYSCALL msg=audit(07/08/2022 15:06:59.478:968) : arch=x86_64 syscall=recvmsg success=yes exit=720 a0=0x10 a1=0x7ffe701a5890 a2=MSG_DONTWAIT|MSG_CMSG_CLOEXEC a3=0xffffffff items=0 ppid=561 pid=567 auid=unset uid=dbus gid=dbus euid=dbus suid=dbus fsuid=dbus egid=dbus sgid=dbus fsgid=dbus tty=(none) ses=unset comm=dbus-broker exe=/usr/bin/dbus-broker subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(07/08/2022 15:06:59.478:968) : avc:  denied  { read write } for  pid=567 comm=dbus-broker path=socket:[51281] dev="sockfs" ino=51281 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:rpm_script_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0

The rpm_script_rw_stream_sockets() interface was added.

Resolves: rhbz#2100528