### PR TITLE
Allow nm-dispatcher console plugin manage etc files

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -595,8 +595,7 @@ dev_rw_wireless(NetworkManager_dispatcher_tlp_t)
 
 domain_read_all_domains_state(NetworkManager_dispatcher_dnssec_t)
 
-files_create_etc_files(NetworkManager_dispatcher_console_t)
-files_rw_etc_files(NetworkManager_dispatcher_console_t)
+files_manage_etc_files(NetworkManager_dispatcher_console_t)
 
 init_status(NetworkManager_dispatcher_cloud_t)
 init_status(NetworkManager_dispatcher_ddclient_t)


### PR DESCRIPTION
The permissions is required to create and remove files in /etc/issue.d.

Resolves: rhbz#2080043