### PR TITLE
fix(devices.fc): Replace single quote in comment to solve parsing issues

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -245,7 +245,7 @@ ifdef(`distro_suse', `
 
 ifdef(`distro_debian',`
 # this is a static /dev dir "backup mount"
-# if you want to disable udev, you'll have to boot permissive and relabel!
+# if you want to disable udev, you will have to boot permissive and relabel!
 /dev/\.static		-d	gen_context(system_u:object_r:device_t,s0)
 /dev/\.static/dev	-d	gen_context(system_u:object_r:device_t,s0)
 /dev/\.static/dev/(.*)?		<<none>>


### PR DESCRIPTION
## General
When setting `DISTRO = debian` you may encounter issues regarding syntax errors when parsing `tmp/base.fc.tmp` as reported in #1285.

This approach just removes the single quote within the comment in the Debian related part in `devices.fc` to successfully run the make target `policy`:

```
ifdef(`distro_debian',`
# this is a static /dev dir "backup mount"
# if you want to disable udev, you'll have to boot permissive and relabel!
/dev/\.static           -d      gen_context(system_u:object_r:device_t,s0)
/dev/\.static/dev       -d      gen_context(system_u:object_r:device_t,s0)
/dev/\.static/dev/(.*)?         <<none>>
')
```
Fixes #1285