### PR TITLE
Make NetworkManager_dispatcher_custom_t an unconfined domain

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -49,7 +49,6 @@ type NetworkManager_dispatcher_custom_t, networkmanager_dispatcher_plugin;
 role system_r types NetworkManager_dispatcher_custom_t;
 application_domain(NetworkManager_dispatcher_custom_t, NetworkManager_dispatcher_script_t)
 domtrans_pattern(NetworkManager_dispatcher_t, NetworkManager_dispatcher_script_t, NetworkManager_dispatcher_custom_t)
-permissive NetworkManager_dispatcher_custom_t;
 
 networkmanager_dispatcher_plugin_template(chronyc)
 networkmanager_dispatcher_plugin_template(cloud)
@@ -678,6 +677,10 @@ optional_policy(`
 optional_policy(`
 	tlp_manage_pid_files(NetworkManager_dispatcher_tlp_t)
 	tlp_filetrans_named_content(NetworkManager_dispatcher_tlp_t)
+')
+
+optional_policy(`
+	unconfined_domain(NetworkManager_dispatcher_custom_t)
 ')
 
 ########################################


### PR DESCRIPTION
Until now, the NetworkManager_dispatcher_custom_t type was
a permissive domain meaning all AVC denials were allowed, but audited.
Since this commit, no AVC denials will be reported.