### PR TITLE
Allow rhsmcertd to read insights config files

### DIFF
--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -103,3 +103,23 @@ interface(`insights_client_filetrans_named_content',`
 
 	files_tmp_filetrans($1, insights_client_tmp_t, dir, "insights-client")
 ')
+
+########################################
+## <summary>
+##	Read insights_client config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_read_config',`
+	gen_require(`
+		type insights_client_etc_t, insights_client_etc_rw_t;
+	')
+
+	files_search_etc($1)
+	read_files_pattern($1, insights_client_etc_t, insights_client_etc_t)
+	read_files_pattern($1, insights_client_etc_rw_t, insights_client_etc_rw_t)
+')

--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -157,6 +157,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	insights_client_read_config(rhsmcertd_t)
+')
+
+optional_policy(`
 	kpatch_domtrans(rhsmcertd_t)
 	kpatch_read_lib_files(rhsmcertd_t)
 ')


### PR DESCRIPTION
Rhsmcertd obtains system information, including insights-client ID.

Add interface that allows domain to read insights_client config files.
Allow rhsmcertd to read insights_client config files.