### PR TITLE
Add permissions to manage lnk_files into gnome_manage_home_config

### DIFF
--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -1398,7 +1398,8 @@ interface(`gnome_manage_home_config',`
 	')
 
 	manage_files_pattern($1, config_home_t, config_home_t)
-    allow $1 config_home_t:file map;
+	manage_lnk_files_pattern($1, config_home_t, config_home_t)
+	allow $1 config_home_t:file map;
 ')
 
 #######################################


### PR DESCRIPTION
The gnome_manage_home_config() interface contains manage_files_pattern()
call for config_home_t files only, but symlinks can be there, too.

Addresses the following AVC denial:
type=AVC msg=audit(1652884370.574:523): avc:  denied  { unlink } for  pid=45745 comm="systemd-user-ru" name="user" dev="tmpfs" ino=240 scontext=system_u:system_r:systemd_logind_t:s0 tcontext=unconfined_u:object_r:config_home_t:s0 tclass=lnk_file permissive=0

Resolves: rhbz#2088269