### PR TITLE
Label /var/tmp/insights-archive-.* with insights_client_tmp_t

### DIFF
--- a/policy/modules/contrib/insights_client.fc
+++ b/policy/modules/contrib/insights_client.fc
@@ -21,5 +21,6 @@
 
 /var/run/insights-client\.pid				--	gen_context(system_u:object_r:insights_client_var_run_t,s0)
 
+/var/tmp/insights-archive(/.*)?					gen_context(system_u:object_r:insights_client_tmp_t,s0)
 /var/tmp/insights-client(/.*)?					gen_context(system_u:object_r:insights_client_tmp_t,s0)
 

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -103,6 +103,7 @@ interface(`insights_client_filetrans_named_content',`
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "insights-client-egg-release")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "machine-id")
 
+	files_tmp_filetrans($1, insights_client_tmp_t, dir, "insights-archive")
 	files_tmp_filetrans($1, insights_client_tmp_t, dir, "insights-client")
 ')
 


### PR DESCRIPTION
The directory name varies and cannot be predicted, so this change
is not backed with a named transition.