### PR TITLE
Allow networkmanager to signal unconfined process

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -532,6 +532,7 @@ optional_policy(`
 
 optional_policy(`
 	unconfined_dgram_send(NetworkManager_t)
+	unconfined_signal(NetworkManager_t)
 ')
 
 


### PR DESCRIPTION
Allow networkmanager to signal unconfined process

During kernel selftests, NetworkManager checks if teamd instance is started externally.
Teamd is a daemon to control a given team network device and runs in the caller domain - unconfined_t.

time->Fri Apr  8 11:01:16 2022
type=PROCTITLE msg=audit(1649430076.436:6807): proctitle=2F7573722F62696E2F7465616D64002D6B002D74006C6167
type=SYSCALL msg=audit(1649430076.436:6807): arch=c000003e syscall=62 success=no exit=-13 a0=1ad7f5 a1=f a2=0 a3=7fbf0f5d6ac0 items=0 ppid=13470 pid=1759420 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="teamd" exe="/usr/bin/teamd" subj=system_u:system_r:NetworkManager_t:s0 key=(null)
type=AVC msg=audit(1649430076.436:6807): avc:  denied  { signal } for  pid=1759420 comm="teamd" scontext=system_u:system_r:NetworkManager_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=process permissive=0

Allow NetworkManager_t to send generic signals to the unconfined domain.