### PR TITLE
Revert "Dontaudit domain the fowner capability"

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -130,11 +130,6 @@ allow domain self:fifo_file rw_fifo_file_perms;
 allow domain self:sem create_sem_perms;
 allow domain self:shm create_shm_perms;
 
-# This is a temporary rule to work around a problem in kernel/xfs
-# triggering a false fowner capability AVC
-# https://bugzilla.redhat.com/show_bug.cgi?id=1933437
-dontaudit domain self:capability fowner;
-
 kernel_getattr_proc(domain)
 kernel_read_proc_symlinks(domain)
 kernel_read_crypto_sysctls(domain)


### PR DESCRIPTION
This reverts selinux-policy commit bca021fb2bdd since the kernel xfs
problem seems to be fixed with the eba0549bc7d1 ("xfs: don't generate
selinux audit messages for capability testing") commit.

Resolves: rhbz#1933437