### PR TITLE
Add the userdom_prog_run_bpf_userdomain() interface

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -110,6 +110,8 @@ userdom_exec_admin_home_files(sysadm_t)
 userdom_manage_admin_files(sysadm_t)
 userdom_manage_admin_dirs(sysadm_t)
 
+userdom_prog_run_bpf_userdomain(sysadm_t)
+
 corenet_ib_access_unlabeled_pkeys(sysadm_t)
 corenet_ib_manage_subnet_unlabeled_endports(sysadm_t)
 corenet_tcp_bind_all_rpc_ports(sysadm_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -6808,3 +6808,21 @@ template(`userdom_security_admin_template',`
 		samhain_run($1, $2)
 	')
 ')
+#
+########################################
+## <summary>
+##	Allow caller domain to run bpftool on userdomain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_prog_run_bpf_userdomain',`
+	gen_require(`
+		attribute userdomain;
+	')
+
+	allow $1 userdomain:bpf { map_create map_read map_write prog_load prog_run };
+')


### PR DESCRIPTION
The userdom_prog_run_bpf_userdomain() interface was added
to allow the caller domain to run bpftool on the userdomain attribute.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(08/02/2022 11:36:12.251:13079) : proctitle=perf record -o /dev/null echo test
type=SYSCALL msg=audit(08/02/2022 11:36:12.251:13079) : arch=x86_64 syscall=bpf success=no exit=EACCES(Permission denied) a0=BPF_PROG_GET_FD_BY_ID a1=0x7ffda3e17100 a2=0x90 a3=0x55bd94ea10a0 items=0 ppid=291258 pid=291259 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=141 comm=perf exe=/usr/bin/perf subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(08/02/2022 11:36:12.251:13079) : avc:  denied  { prog_run } for  pid=291259 comm=perf scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=bpf permissive=0