### PR TITLE
Allow pmie read network state information and network sysctls

### DIFF
--- a/policy/modules/contrib/pcp.te
+++ b/policy/modules/contrib/pcp.te
@@ -231,6 +231,8 @@ allow pcp_pmie_t pcp_pmcd_t:unix_stream_socket connectto;
 
 allow pcp_pmie_t pcp_pmcd_t:process signal;
 
+kernel_read_net_sysctls(pcp_pmie_t)
+kernel_read_network_state(pcp_pmie_t)
 kernel_read_system_state(pcp_pmie_t)
 kernel_dontaudit_request_load_module(pcp_pmie_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(08/02/2022 11:34:16.597:12831) : proctitle=/usr/bin/pmie -b -F -P -l /var/log/pcp/pmie/ip-172-31-24-64.us-east-2.compute.internal/pmie.log -c config.default
type=PATH msg=audit(08/02/2022 11:34:16.597:12831) : item=0 name=/proc/net/if_inet6 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(08/02/2022 11:34:16.597:12831) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x7f4aa35486d5 a1=F_OK a2=0x0 a3=0x8 items=1 ppid=1 pid=284086 auid=unset uid=pcp gid=pcp euid=pcp suid=pcp fsuid=pcp egid=pcp sgid=pcp fsgid=pcp tty=(none) ses=unset comm=pmie exe=/usr/bin/pmie subj=system_u:system_r:pcp_pmie_t:s0 key=(null)
type=AVC msg=audit(08/02/2022 11:34:16.597:12831) : avc:  denied  { read } for  pid=284086 comm=pmie name=net dev="proc" ino=4026531845 scontext=system_u:system_r:pcp_pmie_t:s0 tcontext=system_u:object_r:proc_net_t:s0 tclass=lnk_file permissive=0