### PR TITLE
Allow insights-client rpm named file transitions

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -221,6 +221,7 @@ optional_policy(`
 optional_policy(`
 	rpm_domtrans(insights_client_t)
 	rpm_manage_cache(insights_client_t)
+	rpm_named_filetrans(insights_client_t)
 	rpm_read_db(insights_client_t)
 	rpm_setattr_db_files(insights_client_t)
 ')


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(08/01/2022 20:18:34.601:89) : proctitle=/usr/libexec/platform-python /usr/lib/python3.9/site-packages/insights_client/run.py --register
type=AVC msg=audit(08/01/2022 20:18:34.601:89) : avc:  denied  { create } for  pid=1040 comm=platform-python name=hawkey.log scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(08/01/2022 20:18:34.601:89) : arch=x86_64 syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x56173d6560e0 a2=O_WRONLY|O_CREAT|O_APPEND a3=0x1b6 items=1 ppid=892 pid=1040 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=platform-python exe=/usr/bin/python3.9 subj=system_u:system_r:insights_client_t:s0 key=(null)
type=PATH msg=audit(08/01/2022 20:18:34.601:89) : item=0 name=/var/log/hawkey.log inode=283322 dev=ca:04 mode=file,644 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:rpm_log_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: rhbz#2107363