### PR TITLE
Allow dhclient manage pid files used by chronyd

### DIFF
--- a/policy/modules/contrib/chronyd.if
+++ b/policy/modules/contrib/chronyd.if
@@ -236,6 +236,25 @@ interface(`chronyd_manage_pid',`
 	manage_dirs_pattern($1, chronyd_var_run_t, chronyd_var_run_t)
 ')
 
+########################################
+## <summary>
+##	Manage pid files used by chronyd
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`chronyd_manage_pid_files',`
+	gen_require(`
+		type chronyd_var_run_t;
+	')
+
+	files_search_pids($1)
+	manage_files_pattern($1, chronyd_var_run_t, chronyd_var_run_t)
+')
+
 ######################################
 ## <summary>
 ##      Create objects in /var/run

--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -201,6 +201,7 @@ optional_policy(`
 	chronyd_systemctl(dhcpc_t)
 	chronyd_domtrans(dhcpc_t)
 	chronyd_domtrans_chronyc(dhcpc_t)
+	chronyd_manage_pid_files(dhcpc_t)
 	chronyd_pid_filetrans(dhcpc_t)
 	chronyd_read_keys(dhcpc_t)
 ')


### PR DESCRIPTION
The chronyd_manage_pid_files() interface was added.

Resolves: rhbz#2093709