### PR TITLE
Allow fedora-third-party read the passwords file

### DIFF
--- a/policy/modules/contrib/fedoratp.te
+++ b/policy/modules/contrib/fedoratp.te
@@ -47,6 +47,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	auth_read_passwd_file(fedoratp_t)
+')
+
+optional_policy(`
 	dbus_system_bus_client(fedoratp_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(08/02/2022 09:24:46.037:10090) : proctitle=/usr/bin/python3 /usr/bin/fedora-third-party refresh
type=PATH msg=audit(08/02/2022 09:24:46.037:10090) : item=0 name=/etc/passwd inode=751489 dev=00:1e mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:passwd_file_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(08/02/2022 09:24:46.037:10090) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f9a8586cbfa a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=192574 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=fedora-third-pa exe=/usr/bin/python3.10 subj=system_u:system_r:fedoratp_t:s0 key=(null)
type=AVC msg=audit(08/02/2022 09:24:46.037:10090) : avc:  denied  { read } for  pid=192574 comm=fedora-third-pa name=passwd dev="nvme0n1p5" ino=751489 scontext=system_u:system_r:fedoratp_t:s0 tcontext=system_u:object_r:passwd_file_t:s0 tclass=file permissive=0