### PR TITLE
fix(system/init.fc): Fix section description

### DIFF
--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -30,7 +30,7 @@ ifdef(`distro_gentoo', `
 ')
 
 #
-# /sbin
+# /bin
 #
 /bin/systemd		--	gen_context(system_u:object_r:init_exec_t,s0)
 


### PR DESCRIPTION
Fixes the corresponding section description in `system/init.fc`.