### PR TITLE
Allow some domains use sd_notify()

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3000,6 +3000,27 @@ interface(`init_rw_tcp_sockets',`
     allow $1 init_t:tcp_socket { read write getattr };
 ')
 
+#######################################
+## <summary>
+##	Use sd_notify
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_use_notify',`
+	gen_require(`
+		type init_t, init_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, init_var_run_t, init_var_run_t, init_t)
+	allow $1 init_var_run_t:sock_file read_sock_file_perms;
+	allow init_t $1:fifo_file write_fifo_file_perms;
+')
+
 ########################################
 ## <summary>
 ##	Get the system status information from init

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1955,6 +1955,7 @@ allow initrc_domain systemprocess:process transition;
 optional_policy(`
 	systemd_getattr_unit_dirs(daemon)
 	systemd_getattr_unit_dirs(systemprocess)
+	systemd_exec_notify(daemon)
 ')
 
 optional_policy(`

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1335,6 +1335,8 @@ ifdef(`distro_suse',`
 
 domain_dontaudit_use_interactive_fds(daemon)
 
+init_use_notify(daemon)
+
 userdom_dontaudit_list_admin_dir(daemon)
 userdom_dontaudit_search_user_tmp(daemon)
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -998,6 +998,24 @@ interface(`systemd_timedated_manage_lib_dirs',`
 
 ########################################
 ## <summary>
+##	Execute systemd-notify in the caller domain
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`systemd_exec_notify',`
+	gen_require(`
+		type systemd_notify_exec_t;
+	')
+
+	can_exec($1, systemd_notify_exec_t)
+')
+
+########################################
+## <summary>
 ##	Execute a domain transition to run systemd_notify.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -35,6 +35,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_exec_notify(unconfined_service_t)
+')
+
+optional_policy(`
 	virt_transition_svirt(unconfined_service_t, system_r)
 ')
 

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -20,6 +20,8 @@ role unconfined_r types unconfined_service_t;
 corecmd_bin_entry_type(unconfined_service_t)
 corecmd_shell_entry_type(unconfined_service_t)
 
+init_use_notify(unconfined_service_t)
+
 optional_policy(`
 	rpm_transition_script(unconfined_service_t, system_r)
 ')

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -400,6 +400,8 @@ files_watch_generic_tmp_dirs(login_userdomain)
 fs_create_cgroup_files(login_userdomain)
 fs_watch_cgroup_files(login_userdomain)
 
+init_use_notify(login_userdomain)
+
 libs_watch_lib_dirs(login_userdomain)
 
 miscfiles_watch_fonts_dirs(login_userdomain)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -400,8 +400,6 @@ files_watch_generic_tmp_dirs(login_userdomain)
 fs_create_cgroup_files(login_userdomain)
 fs_watch_cgroup_files(login_userdomain)
 
-init_use_notify(login_userdomain)
-
 libs_watch_lib_dirs(login_userdomain)
 
 miscfiles_watch_fonts_dirs(login_userdomain)


### PR DESCRIPTION
sd_notify() and a few similar systemd library functions may be called by
a service to notify the service manager about state changes. It can be
used to send arbitrary information. Most importantly, it can be used for
start-up completion notification.

With this commit, all types in the daemon and login_userdomain
attributes and unconfined_service_t can connect to init (PID 1) and
init can write back to the fifo_file created by the domain.

Resolves: rhbz#1903305