### PR TITLE
Allow winbind-rpcd write to winbind pid files

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1176,6 +1176,7 @@ allow winbind_rpcd_t winbind_rpcd_exec_t:file execute_no_trans;
 
 read_files_pattern(winbind_rpcd_t, samba_etc_t, samba_etc_t)
 
+write_files_pattern(winbind_rpcd_t, winbind_var_run_t, winbind_var_run_t)
 write_sock_files_pattern(winbind_rpcd_t, winbind_var_run_t, winbind_var_run_t)
 
 manage_files_pattern(winbind_rpcd_t, winbind_rpcd_var_run_t, winbind_rpcd_var_run_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1658286623.868:2435): avc:  denied  { write } for  pid=6219 comm="samba-dcerpcd" name="samba-dcerpcd.pid" dev="tmpfs" ino=1643 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:winbind_var_run_t:s0 tclass=file permissive=1