### PR TITLE
Allow systemd_hostnamed label /run/systemd/* as hostnamed_etc_t

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -851,6 +851,7 @@ allow systemd_hostnamed_t self:unix_dgram_socket create_socket_perms;
 manage_files_pattern(systemd_hostnamed_t, hostname_etc_t, hostname_etc_t)
 manage_lnk_files_pattern(systemd_hostnamed_t, hostname_etc_t, hostname_etc_t)
 files_etc_filetrans(systemd_hostnamed_t, hostname_etc_t, file)
+init_pid_filetrans(systemd_hostnamed_t, hostname_etc_t, file )
 
 kernel_dgram_send(systemd_hostnamed_t)
 kernel_read_xen_state(systemd_hostnamed_t)


### PR DESCRIPTION
Allow systemd_hostnamed_t to create dirs and files in /run/systemd/* with label hostnamed_etc_t
Names of these files and dirs include hashes.

Fix: bz#1976684