### PR TITLE
Do not allow login_userdomain use sd_notify()

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -400,8 +400,6 @@ files_watch_generic_tmp_dirs(login_userdomain)
 fs_create_cgroup_files(login_userdomain)
 fs_watch_cgroup_files(login_userdomain)
 
-init_use_notify(login_userdomain)
-
 libs_watch_lib_dirs(login_userdomain)
 
 miscfiles_watch_fonts_dirs(login_userdomain)


### PR DESCRIPTION
This commit partially reverts the ea76c5e8b586 ("Allow some domains use
sd_notify()") commit. While any systemd service should be allowed to
use sd_notify, which includes unconfined_service_t, login userdomains
should only talk to user service manager which runs in the respective
userdomain.