### PR TITLE
Allow pmdalinux read files on an nfsd filesystem

### DIFF
--- a/policy/modules/contrib/pcp.te
+++ b/policy/modules/contrib/pcp.te
@@ -146,6 +146,7 @@ fs_getattr_all_fs(pcp_pmcd_t)
 fs_getattr_all_dirs(pcp_pmcd_t)
 fs_list_cgroup_dirs(pcp_pmcd_t)
 fs_read_cgroup_files(pcp_pmcd_t)
+fs_read_nfsd_files(pcp_pmcd_t)
 
 init_read_utmp(pcp_pmcd_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1659885488.520:327): avc:  denied  { search } for  pid=1394 comm="pmdalinux" name="/" dev="nfsd" ino=1 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:nfsd_fs_t:s0 tclass=dir permissive=1

Resolves: rhbz#2116153