### PR TITLE
Allow systemd-modules-load write to /dev/kmsg and send mssg to syslogd

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1259,8 +1259,11 @@ corecmd_exec_bin(systemd_modules_load_t)
 corecmd_exec_shell(systemd_modules_load_t)
 
 dev_read_sysfs(systemd_modules_load_t)
+dev_write_kmsg(systemd_modules_load_t)
 
 init_read_pid_files(systemd_modules_load_t)
+
+logging_dgram_send(systemd_modules_load_t)
 
 files_map_kernel_modules(systemd_modules_load_t)
 files_read_kernel_modules(systemd_modules_load_t)


### PR DESCRIPTION
Allow systemd_modules_load_t, early boot service that loads kernel modules,
write to the kernel messages device and send a message to syslogd over a unix domain datagram socket.

Fix: bz#2088257