### PR TITLE
Allow services execute systemd-notify

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1959,6 +1959,7 @@ allow initrc_domain systemprocess:process transition;
 optional_policy(`
 	systemd_getattr_unit_dirs(daemon)
 	systemd_getattr_unit_dirs(systemprocess)
+	systemd_exec_notify(daemon)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -998,6 +998,24 @@ interface(`systemd_timedated_manage_lib_dirs',`
 
 ########################################
 ## <summary>
+##	Execute systemd-notify in the caller domain
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`systemd_exec_notify',`
+	gen_require(`
+		type systemd_notify_exec_t;
+	')
+
+	can_exec($1, systemd_notify_exec_t)
+')
+
+########################################
+## <summary>
 ##	Execute a domain transition to run systemd_notify.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -35,6 +35,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_exec_notify(unconfined_service_t)
+')
+
+optional_policy(`
 	virt_transition_svirt(unconfined_service_t, system_r)
 ')
 


### PR DESCRIPTION
With the ea76c5e8b58 ("Allow some domains use sd_notify()") commit,
daemon and unconfined_service_t were allowed permissions necessary
to use the sd_notify() API. This commit allows the same callers
the permissions to execute systemd-notify in the caller domain.

Aug 02 13:10:18 hostname audit[956]: AVC avc:  denied  { execute_no_trans } for  pid=956 comm="launch-xenstore" path="/usr/bin/systemd-notify" dev="sda4" ino=4200844 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:systemd_notify_exec_t:s0 tclass=file permissive=1