### PR TITLE
Allow launch-xenstored read filesystem sysctls

### DIFF
--- a/policy/modules/contrib/xen.te
+++ b/policy/modules/contrib/xen.te
@@ -450,6 +450,8 @@ files_var_lib_filetrans(xenstored_t, xenstored_var_lib_t, { file dir sock_file }
 
 stream_connect_pattern(xenstored_t, evtchnd_var_run_t, evtchnd_var_run_t, evtchnd_t)
 
+kernel_read_fs_sysctls(xenstored_t)
+
 auth_use_nsswitch(xenstored_t)
 
 can_exec(xenstored_t, xenstored_exec_t)


### PR DESCRIPTION
Addresses the following AVC denial:
Aug 02 13:10:18 doppelganger.flyn.org audit[949]: AVC avc:  denied  { search } for  pid=949 comm="launch-xenstore" name="fs" dev="proc" ino=15591 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:sysctl_fs_t:s0 tclass=dir permissive=1

Resolves: rhbz#2114498