### PR TITLE
Allow postfix/smtp and postfix/virtual read kerberos key table

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -700,6 +700,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	kerberos_read_keytab(postfix_smtp_t)
+')
+
+optional_policy(`
 	milter_stream_connect_all(postfix_smtp_t)
 ')
 
@@ -775,6 +779,10 @@ mta_manage_spool(postfix_virtual_t)
 userdom_manage_user_home_dirs(postfix_virtual_t)
 userdom_manage_user_home_content(postfix_virtual_t)
 userdom_filetrans_home_content(postfix_virtual_t)
+
+optional_policy(`
+	kerberos_read_keytab(postfix_virtual_t)
+')
 
 ########################################
 #


### PR DESCRIPTION
This permission is required when postfix is configured to use virtual
mailboxes and stored data into postgresql database.

Resolves: rhbz#1983308