### PR TITLE
Allow sa-update to get init status and start systemd files

### DIFF
--- a/policy/modules/contrib/spamassassin.fc
+++ b/policy/modules/contrib/spamassassin.fc
@@ -23,6 +23,10 @@ HOME_DIR/\.spamd(/.*)?		gen_context(system_u:object_r:spamc_home_t,s0)
 /usr/bin/mimedefang-multiplexor --	gen_context(system_u:object_r:spamd_exec_t,s0)
 /usr/libexec/mimedefang-wrapper --	gen_context(system_u:object_r:spamd_exec_t,s0)
 
+/usr/lib/systemd/system/spamassassin\.service	--	gen_context(system_u:object_r:spamd_unit_file_t,s0)
+/usr/lib/systemd/system/sa-update\.service	--	gen_context(system_u:object_r:spamd_update_unit_file_t,s0)
+/usr/lib/systemd/system/sa-update\.timer	--	gen_context(system_u:object_r:spamd_update_unit_file_t,s0)
+
 /usr/share/spamassassin/sa-update.cron  --  gen_context(system_u:object_r:spamd_update_exec_t,s0)
 
 /var/lib/spamassassin(/.*)?	gen_context(system_u:object_r:spamd_var_lib_t,s0)

--- a/policy/modules/contrib/spamassassin.if
+++ b/policy/modules/contrib/spamassassin.if
@@ -424,3 +424,27 @@ interface(`spamassassin_spamd_admin',`
 	files_list_pids($1)
 	admin_pattern($1, spamd_var_run_t)
 ')
+
+########################################
+## <summary>
+##	Execute spamassassin server in the spamassassin domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`spamassassin_systemctl',`
+	gen_require(`
+		type spamd_t;
+		type spamd_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+	systemd_read_fifo_file_passwd_run($1)
+	allow $1 spamd_unit_file_t:file read_file_perms;
+	allow $1 spamd_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, spamd_t)
+')

--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -59,6 +59,12 @@ files_type(spamd_var_lib_t)
 type spamd_var_run_t;
 files_pid_file(spamd_var_run_t)
 
+type spamd_update_unit_file_t;
+systemd_unit_file(spamd_update_unit_file_t)
+
+type spamd_unit_file_t;
+systemd_unit_file(spamd_unit_file_t)
+
 ifdef(`distro_redhat',`
 	# spamassassin client executable
 	type spamc_t;
@@ -625,8 +631,6 @@ kernel_read_system_state(spamd_update_t)
 
 can_exec(spamd_update_t, spamd_update_exec_t)
 
-can_exec(spamd_update_t, spamd_update_exec_t)
-
 # for updating rules
 corenet_tcp_connect_http_port(spamd_update_t)
 
@@ -638,16 +642,15 @@ dev_read_urand(spamd_update_t)
 domain_use_interactive_fds(spamd_update_t)
 domain_read_all_domains_state(spamd_update_t)
 
-auth_use_nsswitch(spamd_update_t)
-auth_dontaudit_read_shadow(spamd_update_t)
-
-mta_read_config(spamd_update_t)
-
-userdom_search_admin_dir(spamd_update_t)
-userdom_use_inherited_user_ptys(spamd_update_t)
+spamassassin_systemctl(spamd_update_t)
 
 optional_policy(`
 	antivirus_systemctl(spamd_update_t)
+')
+
+optional_policy(`
+	auth_use_nsswitch(spamd_update_t)
+	auth_dontaudit_read_shadow(spamd_update_t)
 ')
 
 optional_policy(`
@@ -659,12 +662,25 @@ optional_policy(`
 	gpg_manage_home_content(spamd_update_t)
 ')
 
+optional_policy(`
+	init_status(spamd_update_t)
+')
+
+optional_policy(`
+	mta_read_config(spamd_update_t)
+')
+
+optional_policy(`
+	systemd_exec_systemctl(spamd_update_t)
+')
+
+optional_policy(`
+	userdom_search_admin_dir(spamd_update_t)
+	userdom_use_inherited_user_ptys(spamd_update_t)
+')
+
 tunable_policy(`spamd_update_can_network',`
 	corenet_sendrecv_all_client_packets(spamd_update_t)
 	corenet_tcp_connect_all_ports(spamd_update_t)
 	corenet_tcp_sendrecv_all_ports(spamd_update_t)
-')
-
-optional_policy(`
-    systemd_exec_systemctl(spamd_update_t)
 ')


### PR DESCRIPTION
Allow sa-update, automate SpamAssassin rule updates, to
status init_t and start systemd_unit_file_t

Resolves: rhbz#1819017