### PR TITLE
Allow nm-dispatcher sendmail plugin get status of systemd services

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -675,6 +675,7 @@ optional_policy(`
 	systemd_stop_systemd_services(NetworkManager_dispatcher_ddclient_t)
 	systemd_status_systemd_services(NetworkManager_dispatcher_ddclient_t)
 	systemd_start_systemd_services(NetworkManager_dispatcher_sendmail_t)
+	systemd_status_systemd_services(NetworkManager_dispatcher_sendmail_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This plugin actually wants to get status just of the sendmail service.

Addresses the following AVC denial:
type=USER_AVC msg=audit(28.7.2022 13:38:34.836:247) : pid=1 uid=root auid=unset ses=unset subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=unset uid=root gid=root path=/usr/lib/systemd/system/sendmail.service cmdline="" function="reply_unit_path" scontext=system_u:system_r:NetworkManager_dispatcher_sendmail_t:s0 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=service permissive=0  exe=/usr/lib/systemd/systemd sauid=root hostname=? addr=? terminal=?'

Resolves: rhbz#2111834