### PR TITLE
Allow unconfined_t transition to targetclid_home_t

### DIFF
--- a/policy/modules/contrib/targetd.if
+++ b/policy/modules/contrib/targetd.if
@@ -165,3 +165,20 @@ interface(`targetd_admin',`
 	')
 ')
 
+######################################
+## <summary>
+##  Transition to targetcli named content
+## </summary>
+## <param name="domain">
+##  <summary>
+##	Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`targetcli_filetrans_admin_home_content',`
+	gen_require(`
+		type targetclid_home_t;
+	')
+
+	userdom_admin_home_dir_filetrans($1, targetclid_home_t, dir, ".targetcli")
+')

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -637,6 +637,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	targetcli_filetrans_admin_home_content(sysadm_t)
+')
+
+optional_policy(`
 	tuned_dbus_chat(sysadm_t)
 ')
 

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -391,6 +391,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	targetcli_filetrans_admin_home_content(unconfined_t)
+')
+
+optional_policy(`
 	virt_prog_run_bpf(unconfined_t)
 	virt_transition_svirt(unconfined_t, unconfined_r)
 	virt_transition_svirt_sandbox(unconfined_t, unconfined_r)


### PR DESCRIPTION
If the targetcli command is executed before starting the targetclid service,
then the /root/.targetcli/ directory (and all files in it) is mislabeled.
The start of targetclid service in such situation then leads to SELinux denials.

Resolves: BZ#2106360