### PR TITLE
Allow systemd-hostnamed talk to init scripts over dbus

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -862,6 +862,7 @@ dev_read_sysfs(systemd_hostnamed_t)
 
 fs_read_xenfs_files(systemd_hostnamed_t)
 
+init_dbus_chat_script(systemd_hostnamed_t)
 init_delete_pid_dir_entry(systemd_hostnamed_t)
 init_status(systemd_hostnamed_t)
 init_stream_connect(systemd_hostnamed_t)


### PR DESCRIPTION
Addresses the following USER_AVC denial:
type=USER_AVC msg=audit(1659032710.225:59): pid=1684 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.23 spid=2281 tpid=2280 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:system_r:initrc_t:s0 tclass=dbus permissive=0  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'UID="dbus" AUID="unset" SAUID="dbus"

Resolves: rhbz#2111632