### PR TITLE
Allow nm-dispatcher custom plugin dbus chat with nm

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -624,6 +624,7 @@ optional_policy(`
 	dbus_system_bus_client(NetworkManager_dispatcher_tlp_t)
 	networkmanager_dbus_chat(NetworkManager_dispatcher_tlp_t)
 	dbus_system_bus_client(NetworkManager_dispatcher_custom_t)
+	networkmanager_dbus_chat(NetworkManager_dispatcher_custom_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following USER_AVC denial:
Aug 10 07:46:39 host audit[679]: USER_AVC pid=679 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:NetworkManager_dispatcher_custom_t:s0 tclass=dbus permissive=0 exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=? terminal=?'

Resolves: rhbz#2117188