### PR TITLE
Set the abrt_handle_event boolean to on

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -29,7 +29,7 @@ gen_tunable(abrt_upload_watch_anon_write, true)
 ##	handle ABRT event scripts.
 ##	</p>
 ## </desc>
-gen_tunable(abrt_handle_event, false)
+gen_tunable(abrt_handle_event, true)
 
 attribute abrt_domain;
 


### PR DESCRIPTION
The default value of the abrt_handle_event boolean was now set to "on"
so that abrt is able to execute its event scripts in the
abrt_handle_event_t domain which is unconfined. Without having access
to most files on the filesystem, the event scripts cannot generate
backtrace or successfully run gdb, so that AVC denials like this are
audited:

type=AVC msg=audit(1659953265.634:396): avc:  denied  { read } for  pid=5965 comm="gdb" name="card0" dev="devtmpfs" ino=236 scontext=system_u:system_r:abrt_t:s0-s0:c0.c1023 tcontext=system_u:object_r:dri_device_t:s0 tclass=chr_file permissive=0

Administrators still have the option to turn this boolean off.

Resolves: rhbz#2116494