### PR TITLE
Allow chronyd send and receive chronyd/ntp client packets

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -106,10 +106,12 @@ corenet_udp_sendrecv_generic_node(chronyd_t)
 corenet_udp_bind_generic_node(chronyd_t)
 
 corenet_sendrecv_ntp_server_packets(chronyd_t)
+corenet_sendrecv_ntp_client_packets(chronyd_t)
 corenet_udp_bind_ntp_port(chronyd_t)
 corenet_udp_sendrecv_ntp_port(chronyd_t)
 
 corenet_sendrecv_chronyd_server_packets(chronyd_t)
+corenet_sendrecv_chronyd_client_packets(chronyd_t)
 corenet_udp_bind_chronyd_port(chronyd_t)
 corenet_udp_sendrecv_chronyd_port(chronyd_t)
 


### PR DESCRIPTION
These permissions are required when packets tagging following
/usr/share/doc/nftables/examples/secmark.nft is enabled.

Addresses the following AVC denial:
type=AVC msg=audit(1661030515.019:1079): avc:  denied  { send } for  pid=973 comm="chronyd" saddr=10.224.122.55 src=51686 daddr=10.25.28.124 dest=123 netif=eth0 scontext=system_u:system_r:chronyd_t:s0 tcontext=system_u:object_r:ntp_client_packet_t:s0 tclass=packet permissive=0

Resolves: rhbz#2120016