### PR TITLE
Allow ssh client read kerberos homedir config files

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -246,6 +246,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	kerberos_read_home_content(ssh_t)
 	kerberos_read_keytab(ssh_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=PATH msg=audit(22.8.2022 10:09:52.495:4019) : item=0 name=/home/user/.k5identity inode=15144919 dev=fd:03 mode=file,664 ouid=user ogid=user rdev=00:00 obj=staff_u:object_r:krb5_home_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(22.8.2022 10:09:52.495:4019) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x564acca009b0 a2=O_RDONLY a3=0x0 items=1 ppid=78842 pid=439750 auid=user uid=user gid=user euid=user suid=user fsuid=user egid=user sgid=user fsgid=user tty=pts12 ses=3 comm=ssh exe=/usr/bin/ssh subj=staff_u:staff_r:ssh_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(22.8.2022 10:09:52.495:4019) : avc:  denied  { open } for  pid=439750 comm=ssh path=/home/user/.k5identity dev="dm-3" ino=15144919 scontext=staff_u:staff_r:ssh_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:krb5_home_t:s0 tclass=file permissive=1