### PR TITLE
Allow chronyc read and write generic pty type

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -237,3 +237,7 @@ userdom_users_dgram_send(chronyc_t)
 optional_policy(`
     nscd_shm_use(chronyc_t)
 ')
+
+optional_policy(`
+	term_use_generic_ptys(chronyc_t)
+')


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(22.08.2022 11:35:41.535:261) : proctitle=/usr/bin/chronyc sources
type=EXECVE msg=audit(22.08.2022 11:35:41.535:261) : argc=2 a0=/usr/bin/chronyc a1=sources
type=SYSCALL msg=audit(22.08.2022 11:35:41.535:261) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7ffeb8105f8f a1=0x7ffeb81049e8 a2=0x7ffeb8104a00 a3=0x8 items=0 ppid=3294 pid=3295 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=chronyc exe=/usr/bin/chronyc subj=system_u:system_r:chronyc_t:s0 key=(null)
type=AVC msg=audit(22.08.2022 11:35:41.535:261) : avc:  denied  { read write } for  pid=3295 comm=chronyc path=/dev/pts/1 dev="devpts" ino=4 scontext=system_u:system_r:chronyc_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=chr_file permissive=0