### PR TITLE
Allow system_dbusd ioctl kernel with a unix stream sockets

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -94,6 +94,7 @@ manage_files_pattern(system_dbusd_t, system_dbusd_var_run_t, system_dbusd_var_ru
 manage_sock_files_pattern(system_dbusd_t, system_dbusd_var_run_t, system_dbusd_var_run_t)
 files_pid_filetrans(system_dbusd_t, system_dbusd_var_run_t, { file dir })
 
+kernel_ioctl_stream_sockets(system_dbusd_t)
 kernel_read_system_state(system_dbusd_t)
 kernel_read_kernel_sysctls(system_dbusd_t)
 kernel_stream_connect(system_dbusd_t)

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -3738,6 +3738,25 @@ interface(`kernel_rw_stream_socket_perms',`
     allow $1 kernel_t:fd use;
 ')
 
+#######################################
+## <summary>
+##  Allow the specified domain to ioctl a
+##  kernel with a unix domain stream sockets.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`kernel_ioctl_stream_sockets',`
+    gen_require(`
+        type init_t;
+    ')
+
+    allow $1 kernel_t:unix_stream_socket { getopt ioctl };
+')
+
 ########################################
 ## <summary>
 ##	Make the specified type usable for regular entries in proc


### PR DESCRIPTION
Systemd creates and starts to listen on the socket before
SELinux policy is loaded and it inherits the kernel secid as its label.

Allow system_dbusd ioctl kernel with a unix stream sockets
Create interface to allow the specified domain to ioctl a kernel with a unix domain stream sockets.

Fix: bz#2085392