### PR TITLE
Update tor_bind_all_unreserved_ports interface

### DIFF
--- a/policy/modules/contrib/tor.te
+++ b/policy/modules/contrib/tor.te
@@ -8,7 +8,7 @@ policy_module(tor, 1.9.0)
 ## <desc>
 ##	<p>
 ##	Determine whether tor can bind
-##	tcp sockets to all unreserved ports.
+##	tcp and udp sockets to all unreserved ports.
 ##	</p>
 ## </desc>
 gen_tunable(tor_bind_all_unreserved_ports, false)
@@ -131,6 +131,7 @@ logging_send_syslog_msg(tor_t)
 tunable_policy(`tor_bind_all_unreserved_ports',`
 	corenet_sendrecv_all_server_packets(tor_t)
 	corenet_tcp_bind_all_unreserved_ports(tor_t)
+	corenet_udp_bind_all_unreserved_ports(tor_t)
 ')
 
 tunable_policy(`tor_can_network_relay',`


### PR DESCRIPTION
When enabled boolean tor_bind_all_unreserved_ports,
allow tor bind UDP sockets to all ports > 1024.

Fix: bz#2089486