### PR TITLE
Allow samba-bgqd to read a printer list

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1206,6 +1206,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cups_read_config(winbind_rpcd_t)
 	cups_stream_connect(winbind_rpcd_t)
 ')
 


### PR DESCRIPTION
Allow samba-bgqd, helper program performing asynchronous printing-related jobs,
to read /etc/printcap file, where are stored printer definitions.

Fix: bz#2118977