### PR TITLE
Allow stalld get and set scheduling policy of all domains.

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -36,7 +36,9 @@ kernel_setsched(stalld_t)
 
 dev_read_sysfs(stalld_t)
 
+domain_getsched_all_domains(stalld_t)
 domain_read_all_domains_state(stalld_t)
+domain_setpriority_all_domains(stalld_t)
 domain_use_interactive_fds(stalld_t)
 
 files_read_etc_files(stalld_t)


### PR DESCRIPTION
Allow stalld get and set scheduling policy of all domains.

Stalld needs to have full access to sched_getattr() or sched_setattr()
to any type of "program" (daemon, kernel threads, user commands... etc),
which includes common process started from a commandline with unconfined_t type.

Fixed: bz#2105038