### PR TITLE
Allow system_cronjob_t domtrans to rpm_script_t

### DIFF
--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -544,6 +544,7 @@ ifdef(`distro_redhat',`
 
 	# via redirection of standard out.
 	optional_policy(`
+		rpm_domtrans_script(system_cronjob_t)
 		rpm_manage_log(system_cronjob_t)
 	')
 ')


### PR DESCRIPTION
This permission is required for rpm-like programs executed from system
cronjobs, e. g. /etc/crontab.

Resolves: rhbz#2118362