### PR TITLE
Implement proper anon_inode support

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -545,6 +545,7 @@ kernel_request_load_module(virtd_t)
 kernel_search_debugfs(virtd_t)
 kernel_dontaudit_setsched(virtd_t)
 kernel_write_proc_files(virtd_t)
+kernel_io_uring_use(virtd_t)
 
 corecmd_exec_bin(virtd_t)
 corecmd_exec_shell(virtd_t)
@@ -912,6 +913,10 @@ kernel_read_device_sysctls(virt_domain)
 kernel_read_net_sysctls(virt_domain)
 kernel_read_network_state(virt_domain)
 kernel_ib_access_unlabeled_pkeys(virt_domain)
+kernel_io_uring_use(virt_domain)
+# qemu uses userfaultfd to implement live post-copy migration
+# https://wiki.qemu.org/Features/PostCopyLiveMigration
+kernel_userfaultfd_use(virt_domain)
 
 userdom_search_user_home_content(virt_domain)
 userdom_read_user_home_content_symlinks(virt_domain)

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -121,7 +121,6 @@ neverallow ~{ domain unlabeled_t } *:process *;
 # Rules applied to all domains
 #
 
-allow domain domain:anon_inode common_anon_inode_perms;
 # read /proc/(pid|self) entries
 allow domain self:dir { list_dir_perms watch_dir_perms };
 allow domain self:lnk_file { read_lnk_file_perms lock ioctl };
@@ -129,6 +128,9 @@ allow domain self:file rw_file_perms;
 allow domain self:fifo_file rw_fifo_file_perms;
 allow domain self:sem create_sem_perms;
 allow domain self:shm create_shm_perms;
+
+kernel_userfaultfd_domtrans(domain)
+kernel_io_uring_domtrans(domain)
 
 kernel_getattr_proc(domain)
 kernel_read_proc_symlinks(domain)
@@ -298,6 +300,8 @@ allow unconfined_domain_type domain:key *;
 allow unconfined_domain_type domain:perf_event rw_inherited_perf_event_perms;
 
 kernel_manage_perf_event(unconfined_domain_type)
+kernel_userfaultfd_use(unconfined_domain_type)
+kernel_io_uring_use(unconfined_domain_type)
 
 corenet_filetrans_all_named_dev(named_filetrans_domain)
 

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4503,3 +4503,113 @@ interface(`kernel_prog_run_bpf',`
 
     allow $1 kernel_t:bpf prog_run;
 ')
+
+########################################
+## <summary>
+##	Set up type transition for userfaultfd anon inodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to receive the type transition.
+##	</summary>
+## </param>
+#
+interface(`kernel_userfaultfd_domtrans',`
+	gen_require(`
+		type userfaultfd_t;
+	')
+	type_transition $1 self:anon_inode userfaultfd_t "[userfaultfd]";
+')
+
+########################################
+## <summary>
+##	Allow the domain to use the userfaultfd API via an inherited
+##	file descriptor.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_userfaultfd_use_inherited',`
+	gen_require(`
+		type userfaultfd_t;
+	')
+	allow $1 userfaultfd_t:anon_inode { getattr ioctl read };
+
+	# Work around a known bug; see:
+	# https://lore.kernel.org/selinux/20210624152515.1844133-1-omosnace@redhat.com/
+	allow $1 userfaultfd_t:anon_inode { write };
+')
+
+########################################
+## <summary>
+##	Allow the domain to use the userfaultfd API.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_userfaultfd_use',`
+	gen_require(`
+		type userfaultfd_t;
+	')
+	kernel_userfaultfd_use_inherited($1)
+	allow $1 userfaultfd_t:anon_inode create;
+')
+
+########################################
+## <summary>
+##	Set up type transition for io_uring anon inodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to receive the type transition.
+##	</summary>
+## </param>
+#
+interface(`kernel_io_uring_domtrans',`
+	gen_require(`
+		type io_uring_t;
+	')
+	type_transition $1 self:anon_inode io_uring_t "[io_uring]";
+')
+
+########################################
+## <summary>
+##	Allow the domain to use the io_uring API via an inherited file
+##	descriptor.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_io_uring_use_inherited',`
+	gen_require(`
+		type io_uring_t;
+	')
+	allow $1 io_uring_t:anon_inode { getattr read write map };
+')
+
+########################################
+## <summary>
+##	Allow the domain to use the io_uring API.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_io_uring_use',`
+	gen_require(`
+		type io_uring_t;
+	')
+	kernel_io_uring_use_inherited($1)
+	allow $1 io_uring_t:anon_inode create;
+')

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -234,6 +234,10 @@ sid file gen_context(system_u:object_r:unlabeled_t,s0)
 typealias unlabeled_t alias file_t;
 neverallow * unlabeled_t:file entrypoint;
 
+# anon_inode types
+type userfaultfd_t;
+type io_uring_t;
+
 # These initial sids are no longer used, and can be removed:
 sid any_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 sid file_labels		gen_context(system_u:object_r:unlabeled_t,s0)


### PR DESCRIPTION
Drop the existing allow-all workaround that simply allows all operations
on anon inodes and replace it with a better approach.

First, create individual types for each anon inode type (currently
userfaultfd and io_uring) and add transition rules for all domains so
that any anon inode they try to create gets the correct label.

Then create interfaces to allow common userfaultfd/io_uring usage to
individual domains.

Finally, grant the necessary permissions for known anon inode users in
the system policy (currently only libvirt) and to unconfined domains.

Note that the transition rules added in this commit require the policy
compiler to support self keyword in type transitions, which was
introduced in libsepol/checkpolicy version 3.4.