### PR TITLE
Update insights-client policy (gpg, auditctl)

### DIFF
--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -182,6 +182,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	insights_client_read_config(gpg_t)
+	insights_client_read_tmp(gpg_t)
+')
+
+optional_policy(`
 	mozilla_read_user_home_files(gpg_t)
 	mozilla_write_user_home_files(gpg_t)
 ')

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -130,3 +130,41 @@ interface(`insights_client_read_config',`
 	read_files_pattern($1, insights_client_etc_t, insights_client_etc_t)
 	read_files_pattern($1, insights_client_etc_rw_t, insights_client_etc_rw_t)
 ')
+
+########################################
+## <summary>
+##	Read insights_client temporary files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_read_tmp',`
+	gen_require(`
+		type insights_client_tmp_t;
+	')
+
+	files_search_tmp($1)
+	read_files_pattern($1, insights_client_tmp_t, insights_client_tmp_t)
+')
+
+########################################
+## <summary>
+##	Write/append insights_client temporary files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_write_tmp',`
+	gen_require(`
+		type insights_client_tmp_t;
+	')
+
+	files_search_tmp($1)
+	write_files_pattern($1, insights_client_tmp_t, insights_client_tmp_t)
+')

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -149,6 +149,7 @@ miscfiles_read_localization(insights_client_t)
 
 selinux_compute_access_vector(insights_client_t)
 
+seutil_read_config(insights_client_t)
 seutil_read_module_store(insights_client_t)
 
 storage_raw_read_fixed_disk(insights_client_t)
@@ -207,6 +208,7 @@ optional_policy(`
 
 optional_policy(`
 	logging_domtrans_auditctl(insights_client_t)
+	logging_mmap_journal(insights_client_t)
 	logging_read_audit_config(insights_client_t)
 	logging_read_audit_log(insights_client_t)
 	logging_send_syslog_msg(insights_client_t)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -179,6 +179,10 @@ logging_set_audit_parameters(auditctl_t)
 logging_send_syslog_msg(auditctl_t)
 
 optional_policy(`
+	insights_client_write_tmp(auditctl_t)
+')
+
+optional_policy(`
 	rhcd_read_fifo_files(auditctl_t)
 ')
 


### PR DESCRIPTION
The insights_client_read_tmp() and insights_client_write_tmp()
interfaces were added.

Resolves: rhbz#2107363