### PR TITLE
Allow systemd permissions needed for sandboxed services

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -187,6 +187,7 @@ allow init_t self:bpf { map_create map_read map_write prog_load prog_run };
 # setuid (from /sbin/shutdown)
 # sys_chroot (from /usr/bin/chroot): now provided by corecmd_chroot_exec_chroot()
 
+allow init_t self:file mounton;
 allow init_t self:fifo_file rw_fifo_file_perms;
 
 allow init_t self:service manage_service_perms;
@@ -544,6 +545,7 @@ optional_policy(`
 optional_policy(`
 	postfix_exec(init_t)
 	postfix_list_spool(init_t)
+	mta_getattr_spool(init_t)
 	mta_read_config(init_t)
 	mta_manage_aliases(init_t)
 ')


### PR DESCRIPTION
The permissions to mounton self and get mail spool files attributes
were added for init_t. Example service requiring it is accountsservice
which since v22 has more tightened sandboxing which includes mounting
into private namespaces and accessible paths.

Resolves: rhbz#2122059