### PR TITLE
Update rhcd policy for executing additional commands 2

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -175,6 +175,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhcd_dgram_send(chronyd_t)
+')
+
+optional_policy(`
     rolekit_dgram_send(chronyd_t)
 ')
 

--- a/policy/modules/contrib/rhcd.if
+++ b/policy/modules/contrib/rhcd.if
@@ -55,3 +55,39 @@ interface(`rhcd_read_fifo_files',`
 
 	allow $1 rhcd_t:fifo_file read_fifo_file_perms;
 ')
+
+######################################
+## <summary>
+##      Write/append rhcd fifo files
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`rhcd_write_fifo_files',`
+        gen_require(`
+                type rhcd_t;
+        ')
+
+	allow $1 rhcd_t:fifo_file write_fifo_file_perms;
+')
+
+######################################
+## <summary>
+##      Send a message to rhcd over a datagram socket.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`rhcd_dgram_send',`
+        gen_require(`
+                type rhcd_t;
+        ')
+
+	allow $1 rhcd_t:unix_dgram_socket sendto;
+')

--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -28,10 +28,12 @@ files_pid_file(rhcd_var_run_t)
 #
 # rhcd local policy
 #
-allow rhcd_t self:capability { sys_admin sys_rawio sys_resource};
+allow rhcd_t self:capability { dac_override fowner sys_admin sys_rawio sys_resource};
 allow rhcd_t self:fifo_file rw_fifo_file_perms;
 allow rhcd_t self:netlink_generic_socket create_socket_perms;
 allow rhcd_t self:netlink_route_socket create_netlink_socket_perms;
+allow rhcd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
+allow rhcd_t self:process setsched;
 allow rhcd_t self:tcp_socket create_stream_socket_perms;
 allow rhcd_t self:udp_socket create_socket_perms;
 allow rhcd_t self:unix_dgram_socket create_socket_perms;
@@ -104,6 +106,8 @@ libs_exec_ldconfig(rhcd_t)
 
 miscfiles_read_generic_certs(rhcd_t)
 miscfiles_read_localization(rhcd_t)
+
+seutil_read_config(rhcd_t)
 
 storage_raw_read_fixed_disk(rhcd_t)
 
@@ -185,7 +189,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_dbus_chat_logind(rhcd_t)
 	systemd_status_all_unit_files(rhcd_t)
+	systemd_write_inhibit_pipes(rhcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The policy now contains enhanced support for the following commands
and services:

chronyd, journalctl, systemd-logind, systemd-inhibit

Resolves: rhbz#2119351