### PR TITLE
Allow ipsec_t read/write tpm devices

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -180,6 +180,7 @@ corenet_rw_tun_tap_dev(ipsec_t)
 dev_read_sysfs(ipsec_t)
 dev_read_rand(ipsec_t)
 dev_read_urand(ipsec_t)
+dev_rw_tpm(ipsec_t)
 
 domain_use_interactive_fds(ipsec_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1652729361.214:334): avc:  denied  { getattr } for  pid=1642 comm="charon" path="/dev/tpmrm0" dev="devtmpfs" ino=135 scontext=system_u:system_r:ipsec_t:s0 tcontext=system_u:object_r:tpm_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2086926