### PR TITLE
Allow httpd read network sysctls

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -597,6 +597,7 @@ manage_files_pattern(httpd_t, squirrelmail_spool_t, squirrelmail_spool_t)
 manage_lnk_files_pattern(httpd_t, squirrelmail_spool_t, squirrelmail_spool_t)
 
 kernel_read_kernel_sysctls(httpd_t)
+kernel_read_net_sysctls(httpd_t)
 # for modules that want to access /proc/meminfo
 kernel_read_system_state(httpd_t)
 kernel_read_network_state(httpd_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(09/05/2022 15:03:53.634:444) : proctitle=/usr/bin/caddy run --environ --resume
type=PATH msg=audit(09/05/2022 15:03:53.634:444) : item=0 name=/proc/sys/net/core/somaxconn inode=28391 dev=00:16 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_net_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(09/05/2022 15:03:53.634:444) : arch=x86_64 syscall=openat success=yes exit=8 a0=AT_FDCWD a1=0xc000098c80 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=1856 auid=unset uid=caddy gid=caddy euid=caddy suid=caddy fsuid=caddy egid=caddy sgid=caddy fsgid=caddy tty=(none) ses=unset comm=caddy exe=/usr/bin/caddy subj=system_u:system_r:httpd_t:s0 key=(null)
type=AVC msg=audit(09/05/2022 15:03:53.634:444) : avc:  denied  { open } for  pid=1856 comm=caddy path=/proc/sys/net/core/somaxconn dev="proc" ino=28391 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1
type=AVC msg=audit(09/05/2022 15:03:53.634:444) : avc:  denied  { read } for  pid=1856 comm=caddy name=somaxconn dev="proc" ino=28391 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1

Resolves: rhbz#2122886