### PR TITLE
Update insights-client policy for additional commands execution 4

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -111,6 +111,7 @@ auth_read_passwd(insights_client_t)
 
 corecmd_exec_all_executables(insights_client_t)
 corenet_tcp_bind_generic_node(insights_client_t)
+corenet_tcp_connect_generic_port(insights_client_t)
 corenet_tcp_connect_http_port(insights_client_t)
 corenet_udp_bind_generic_node(insights_client_t)
 
@@ -176,7 +177,15 @@ optional_policy(`
 ')
 
 optional_policy(`
+	bind_domtrans_ndc(insights_client_t)
+')
+
+optional_policy(`
 	bootloader_exec(insights_client_t)
+')
+
+optional_policy(`
+	certmonger_dbus_chat(insights_client_t)
 ')
 
 optional_policy(`
@@ -292,6 +301,7 @@ optional_policy(`
 
 optional_policy(`
 	samba_manage_var_files(insights_client_t)
+	samba_manage_var_sock_files(insights_client_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The policy now contains enhanced support for the following commands
and services:

bind, certmonger, samba

Resolves: rhbz#2119507