### PR TITLE
Allow pcp pmcd search tracefs and acct_data dirs

### DIFF
--- a/policy/modules/contrib/acct.if
+++ b/policy/modules/contrib/acct.if
@@ -62,6 +62,24 @@ interface(`acct_exec_data',`
 
 ########################################
 ## <summary>
+##      Search process accounting data.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`acct_search_data',`
+        gen_require(`
+                type acct_data_t;
+        ')
+
+        search_dirs_pattern($1, acct_data_t, acct_data_t)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete
 ##	process accounting data.
 ## </summary>

--- a/policy/modules/contrib/pcp.te
+++ b/policy/modules/contrib/pcp.te
@@ -146,6 +146,7 @@ fs_getattr_all_dirs(pcp_pmcd_t)
 fs_list_cgroup_dirs(pcp_pmcd_t)
 fs_read_cgroup_files(pcp_pmcd_t)
 fs_read_nfsd_files(pcp_pmcd_t)
+fs_search_tracefs_dirs(pcp_pmcd_t)
 
 init_read_utmp(pcp_pmcd_t)
 
@@ -158,6 +159,10 @@ storage_raw_read_fixed_disk(pcp_pmcd_t)
 
 userdom_read_user_tmp_files(pcp_pmcd_t)
 userdom_manage_unpriv_user_semaphores(pcp_pmcd_t)
+
+optional_policy(`
+	acct_search_data(pcp_pmcd_t)
+')
 
 optional_policy(`
 	cron_read_pid_files(pcp_pmcd_t)


### PR DESCRIPTION
Allow Performance Metrics Domain Agent (PMDA) search accesses on the directory /sys/kernel/tracing.
Addresses the following AVC denial:
type=AVC msg=audit(1642589553.515:244): avc:  denied  { search } for  pid=2039 comm="pmdakvm" name="/" dev="tracefs" ino=1 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:tracefs_t:s0 tclass=dir permissive=0
Resolves: bz#2041845

Allow pmdaproc search accesses on the directory /var/account.
Add interface to allow search process accounting data.
Addresses the following AVC denial:
type=AVC msg=audit(1642589553.499:243): avc:  denied  { search } for  pid=2036 comm="pmdaproc" name="account" dev="sdf1" ino=9175045 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:acct_data_t:s0 tclass=dir permissive=0
Resolves: bz#2041843