### PR TITLE
Update insights-client policy for additional commands execution 5

### DIFF
--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -186,6 +186,7 @@ optional_policy(`
 optional_policy(`
 	insights_client_read_config(gpg_t)
 	insights_client_manage_lib_files(gpg_t)
+	insights_client_write_lib_sock_files(gpg_t)
 	insights_client_read_tmp(gpg_t)
 ')
 
@@ -340,6 +341,7 @@ optional_policy(`
 optional_policy(`
 	insights_client_manage_lib_dirs(gpg_agent_t)
 	insights_client_manage_lib_files(gpg_agent_t)
+	insights_client_manage_lib_sock_files(gpg_agent_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -247,6 +247,44 @@ interface(`insights_client_manage_lib_files',`
 
 ########################################
 ## <summary>
+##	Write to insights_client lib socket files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_write_lib_sock_files',`
+	gen_require(`
+		type insights_client_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	write_sock_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage insights_client lib socket files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_manage_lib_sock_files',`
+	gen_require(`
+		type insights_client_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_sock_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+')
+
+########################################
+## <summary>
 ##	Read insights_client temporary files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -46,6 +46,8 @@ logging_read_syslog_pid(journalctl_t)
 logging_mmap_journal(journalctl_t)
 logging_watch_journal_dir(journalctl_t)
 
+term_use_generic_ptys(journalctl_t)
+
 userdom_list_user_home_dirs(journalctl_t)
 userdom_read_user_home_content_files(journalctl_t)
 userdom_use_inherited_user_ptys(journalctl_t)


### PR DESCRIPTION
The policy now contains enhanced support for the following commands and services:

gpg, gpg-agent, journalctl

Resolves: rhbz#2119507