### PR TITLE
pidof executed by abrt can readlink /proc/*/exe

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -115,6 +115,7 @@ ifdef(`enable_mcs',`
 #
 
 allow abrt_t self:capability { chown dac_read_search dac_override fowner fsetid ipc_lock kill setgid setuid sys_nice sys_ptrace };
+allow abrt_t self:cap_userns sys_ptrace;
 dontaudit abrt_t self:capability { net_admin sys_rawio sys_ptrace };
 allow abrt_t self:process { setpgid sigkill signal signull setsched getsched };
 


### PR DESCRIPTION
At least one of the ABRT addons calls `pidof abrtd` which leads to { sys_ptrace } SELinux denials in cap_userns class.

In order to support the full functionality of ABRT and its addons, I believe that SELinux policy should allow this access.

Resolves: BZ#2071586