### PR TITLE
Add the new 'cmd' permission to the 'io_uring' class

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -1100,4 +1100,5 @@ class io_uring
 {
     override_creds
     sqpoll
+    cmd
 }

--- a/policy/flask/flask_documentation.md
+++ b/policy/flask/flask_documentation.md
@@ -1923,3 +1923,5 @@ Used to control the ability to use special io\_uring features by the process. Se
 **override_creds** - Allow *source* to override its credentials to *target*.
 
 **sqpoll** - Allow *source* to create an io\_uring kernel polling thread. *target* is always equal to *source*.
+
+**cmd** - Allow *source* to pass commands to special file *target* (`IORING_OP_URING_CMD`). The semantics of the commands are defined by the kernel subsystem/module implementing the special file's operations and may be subject to other access checks. See also kernel commits [2a5840124009](https://git.kernel.org/torvalds/c/2a5840124009) and [f4d653dcaa4e](https://git.kernel.org/torvalds/c/f4d653dcaa4e).

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -255,6 +255,7 @@ optional_policy(`
 # allow special io_uring features
 allow unconfined_domain_type domain:io_uring override_creds;
 allow unconfined_domain_type self:io_uring sqpoll;
+files_io_uring_cmd_on_all_files(unconfined_domain_type)
 
 # Use bpf tools
 allow unconfined_domain_type domain:bpf { map_create map_read map_write prog_load prog_run };

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -10190,3 +10190,21 @@ interface(`files_dontaudit_mounton_modules_object',`
 
 	allow $1 modules_object_t:dir mounton;
 ')
+
+########################################
+## <summary>
+##	Allow the domain to use IORING_OP_URING_CMD on all files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_io_uring_cmd_on_all_files',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	allow $1 file_type:io_uring cmd;
+')


### PR DESCRIPTION
This permission has been added in kernel version 6.0, but is planned to be backported to 5.19 stable as well (since the IORING_OP_URING_CMD support was added in kernel 5.19).

Initially allow it for unconfined domains on all files. The usage of this type of io_uring command should be very rare (if any), so I don't expect any major disruption from this change.