### PR TITLE
Update rhcd policy for executing additional commands 3

### DIFF
--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -177,6 +177,9 @@ optional_policy(`
 	rpm_domtrans(rhcd_t)
 	rpm_manage_cache(rhcd_t)
 	rpm_manage_db(rhcd_t)
+	rpm_sigkill(rhcd_t)
+	rpm_signull(rhcd_t)
+	rpm_stream_connect(rhcd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/rpm.if
+++ b/policy/modules/contrib/rpm.if
@@ -177,6 +177,24 @@ interface(`rpm_dontaudit_exec',`
 
 ########################################
 ## <summary>
+##	Send a kill signal to rpm.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rpm_sigkill',`
+	gen_require(`
+		type rpm_t;
+	')
+
+	allow $1 rpm_t:process sigkill;
+')
+
+########################################
+## <summary>
 ##	Send a null signal to rpm.
 ## </summary>
 ## <param name="domain">
@@ -380,6 +398,24 @@ interface(`rpm_script_dbus_chat',`
 
 	allow $1 rpm_script_t:dbus send_msg;
 	allow rpm_script_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
+##	Connect to rpm unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rpm_stream_connect',`
+	gen_require(`
+		type rpm_t;
+	')
+
+	allow $1 rpm_t:unix_stream_socket connectto;
 ')
 
 ########################################


### PR DESCRIPTION
The policy now contains enhanced support for the following interprocess communication:

rpm connectto, rpm signull, rpm sigkill

Resolves: rhbz#2119351