### PR TITLE
Allow rhcd create rpm hawkey logs with correct label

### DIFF
--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -175,6 +175,7 @@ optional_policy(`
 
 optional_policy(`
 	rpm_domtrans(rhcd_t)
+	rpm_hawkey_named_filetrans(rhcd_t)
 	rpm_manage_cache(rhcd_t)
 	rpm_manage_db(rhcd_t)
 	rpm_sigkill(rhcd_t)


### PR DESCRIPTION
Resolves: rhbz#2119351