### PR TITLE
Allow systemd-gpt-auto-generator to check for empty dirs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1112,6 +1112,11 @@ dev_read_sysfs(systemd_gpt_generator_t)
 dev_write_kmsg(systemd_gpt_generator_t)
 dev_read_rand(systemd_gpt_generator_t)
 
+files_list_boot(systemd_gpt_generator_t)
+files_list_home(systemd_gpt_generator_t)
+files_list_tmp(systemd_gpt_generator_t)
+files_list_usr(systemd_gpt_generator_t)
+files_list_var(systemd_gpt_generator_t)
 
 fstools_exec(systemd_gpt_generator_t)
 


### PR DESCRIPTION
systemd-gpt-auto-generator wants to check that certain subdirectories of / are empty before generating mount units for them this is not permitted by policy.

Addresses:
systemd-gpt-auto-generator[388]: Cannot check if "/home" is empty: Permission denied kernel: audit: type=1400 audit(1662118200.418:80): avc:  denied  { read } for  pid=388 comm="systemd-gpt-aut" name="home" dev="sda2" ino=3180 scontext=system_u:system_r:systemd_gpt_generator_t:s0 tcontext=system_u:object_r:home_root_t:s0 tclass=dir permissive=0 audit[388]: AVC avc:  denied  { read } for  pid=388 comm="systemd-gpt-aut" name="var" dev="sda2" ino=362569 scontext=system_u:system_r:systemd_gpt_generator_t:s0 tcontext=system_u:object_r:var_t:s0 tclass=dir permissive=0 systemd-gpt-auto-generator[388]: Cannot check if "/var" is empty: Permission denied

Resolves: rhbz#2123765