### PR TITLE
Update rhcd policy for executing additional commands 4

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -1020,6 +1020,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	insights_client_write_tmp(httpd_t)
+')
+
+optional_policy(`
     ipa_read_lib(httpd_t)
     ipa_manage_pid_files(httpd_t)
 ')

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -147,6 +147,7 @@ files_getattr_all_file_type_fs(insights_client_t)
 files_getattr_all_pipes(insights_client_t)
 files_getattr_all_sockets(insights_client_t)
 files_manage_etc_symlinks(insights_client_t)
+files_map_read_etc_files(insights_client_t)
 files_read_non_security_files(insights_client_t)
 files_read_all_symlinks(insights_client_t)
 files_status_etc(insights_client_t)
@@ -223,6 +224,10 @@ optional_policy(`
 
 optional_policy(`
 	firewalld_dbus_chat(insights_client_t)
+')
+
+optional_policy(`
+	fwupd_dbus_chat(insights_client_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -30,6 +30,7 @@ files_pid_file(rhcd_var_run_t)
 #
 allow rhcd_t self:capability { dac_override fowner sys_admin sys_rawio sys_resource};
 allow rhcd_t self:fifo_file rw_fifo_file_perms;
+allow rhcd_t self:netlink_audit_socket create_socket_perms;
 allow rhcd_t self:netlink_generic_socket create_socket_perms;
 allow rhcd_t self:netlink_route_socket create_netlink_socket_perms;
 allow rhcd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
@@ -74,6 +75,7 @@ corecmd_exec_all_executables(rhcd_t)
 corecmd_watch_bin_dirs(rhcd_t)
 
 corenet_tcp_connect_http_port(rhcd_t)
+corenet_tcp_connect_unreserved_ports(rhcd_t)
 corenet_tcp_bind_generic_node(rhcd_t)
 
 dev_getattr_all(rhcd_t)
@@ -107,9 +109,12 @@ libs_exec_ldconfig(rhcd_t)
 miscfiles_read_generic_certs(rhcd_t)
 miscfiles_read_localization(rhcd_t)
 
+selinux_get_enforce_mode(rhcd_t)
+
 seutil_read_config(rhcd_t)
 
 storage_raw_read_fixed_disk(rhcd_t)
+storage_raw_read_removable_device(rhcd_t)
 
 sysnet_domtrans_ifconfig(rhcd_t)
 sysnet_read_config(rhcd_t)


### PR DESCRIPTION
The policy now contains enhanced support for the following interprocess communication:

audit, dconf, fwupd, httpd, read selinux context files, read storage devices

Resolves: rhbz#2119351