### PR TITLE
Update rhcd policy for executing additional commands 5

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -207,6 +207,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cron_system_entry(insights_client_t, insights_client_exec_t)
+')
+
+optional_policy(`
 	dbus_system_bus_client(insights_client_t)
 ')
 

--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -28,9 +28,9 @@ files_pid_file(rhcd_var_run_t)
 #
 # rhcd local policy
 #
-allow rhcd_t self:capability { dac_override fowner sys_admin sys_rawio sys_resource};
+allow rhcd_t self:capability { audit_write dac_override fowner sys_admin sys_rawio sys_resource};
 allow rhcd_t self:fifo_file rw_fifo_file_perms;
-allow rhcd_t self:netlink_audit_socket create_socket_perms;
+allow rhcd_t self:netlink_audit_socket { create_socket_perms nlmsg_relay };
 allow rhcd_t self:netlink_generic_socket create_socket_perms;
 allow rhcd_t self:netlink_route_socket create_netlink_socket_perms;
 allow rhcd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
@@ -112,6 +112,7 @@ miscfiles_read_localization(rhcd_t)
 selinux_get_enforce_mode(rhcd_t)
 
 seutil_read_config(rhcd_t)
+seutil_read_file_contexts(rhcd_t)
 
 storage_raw_read_fixed_disk(rhcd_t)
 storage_raw_read_removable_device(rhcd_t)


### PR DESCRIPTION
The policy now contains enhanced support for the following interprocess communication:

audit, read selinux file_context files

Resolves: rhbz#2119351