### PR TITLE
Allow nm-dispatcher ddclient plugin load a kernel module

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -582,6 +582,8 @@ manage_files_pattern(NetworkManager_dispatcher_console_t, NetworkManager_dispatc
 
 read_files_pattern(NetworkManager_dispatcher_dnssec_t, NetworkManager_etc_t, NetworkManager_etc_rw_t)
 
+kernel_request_load_module(NetworkManager_dispatcher_ddclient_t)
+
 auth_read_passwd(networkmanager_dispatcher_plugin)
 
 corecmd_exec_bin(NetworkManager_dispatcher_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1662837398.503:514): avc:  denied  { module_request } for  pid=48108 comm="ip" kmod="netdev-vnet0" scontext=system_u:system_r:NetworkManager_dispatcher_ddclient_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=1

Resolves: rhbz#2125819