### PR TITLE
Allow tor get filesystem attributes

### DIFF
--- a/policy/modules/contrib/tor.te
+++ b/policy/modules/contrib/tor.te
@@ -124,6 +124,9 @@ domain_use_interactive_fds(tor_t)
 
 files_read_etc_runtime_files(tor_t)
 
+fs_getattr_cgroup(tor_t)
+fs_getattr_xattr_fs(tor_t)
+
 auth_use_nsswitch(tor_t)
 
 logging_send_syslog_msg(tor_t)


### PR DESCRIPTION
In particular, attributes of cgroup filesystems and generic filesystems with extended attributes.

Addresses the following AVC denials:

type=AVC msg=audit(1633585335.809:601): avc:  denied  { getattr } for  pid=1881 comm="tor" name="/" dev="cgroup2" ino=1 scontext=system_u:system_r:tor_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=filesystem permissive=1 type=AVC msg=audit(1633585335.809:602): avc:  denied  { getattr } for  pid=1881 comm="tor" name="/" dev="dm-0" ino=256 scontext=system_u:system_r:tor_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1

Resolves: rhbz#2012006