### PR TITLE
Fix typo in comment

### DIFF
--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -89,7 +89,7 @@ logging_send_syslog_msg(redis_t)
 sysnet_dns_name_resolve(redis_t)
 
 tunable_policy(`redis_enable_notify',`
-	# allow httpd to connect to mail servers
+	# allow redis to connect to mail servers
 	corenet_tcp_connect_smtp_port(redis_t)
 	corenet_sendrecv_smtp_client_packets(redis_t)
 	corenet_tcp_connect_pop_port(redis_t)


### PR DESCRIPTION
Hello. I just want to fix small typo in redis policy file.