### PR TITLE
blueman-mechanism can read ~/.local/lib/python*/site-packages directory

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -93,7 +93,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	gnome_search_gconf(blueman_t)
+	gnome_search_gconf_data_dir(blueman_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
If the ~/.local/lib/python*/site-packages/ directory exists in root's home directory then the blueman-mechanism service tries to read that directory during its start.

The blueman-mechanism program is written in Python and I believe that Python is trying to find locally installed python modules.

In order to avoid these SELinux denials, SELinux policy should allow the access.

Resolves: BZ#2027044