### PR TITLE
Change domain_kernel_load_modules boolean to true

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -26,7 +26,7 @@ gen_tunable(fips_mode, true)
 ## </p>
 ## </desc>
 #
-gen_tunable(domain_kernel_load_modules, false)
+gen_tunable(domain_kernel_load_modules, true)
 
 ## <desc>
 ## <p>


### PR DESCRIPTION
The default value of the domain_kernel_load_modules boolean has changed to true as it seems to be legitimate that every domain can call a syscall, e. g. socket(), which can trigger loading a kernel module required for completing the syscall.

Administrators still have the option to turn this boolean off and use individual rules to allow the permission only to domains which are required in their environment. Rules for particular domains remain in the policy sources.

Example audited denial:

type=PROCTITLE msg=audit(09/05/2022 04:58:16.271:287) : proctitle=/usr/sbin/rpc.statd
type=AVC msg=audit(09/05/2022 04:58:16.271:287) : avc:  denied  { module_request } for  pid=38630 comm=rpc.statd kmod="net-pf-10" scontext=system_u:system_r:rpcd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0
type=SYSCALL msg=audit(09/05/2022 04:58:16.271:287) : arch=s390x syscall=socketcall(socket) success=no exit=EAFNOSUPPORT(Address family not supported by protocol) a0=socket a1=0x3ffc84fe878 a2=0x6 a3=0xa items=0 ppid=38627 pid=38630 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc.statd exe=/usr/sbin/rpc.statd subj=system_u:system_r:rpcd_t:s0 key=(null)