### PR TITLE
Label /run/NetworkManager/no-stub-resolv.conf net_conf_t

### DIFF
--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -41,6 +41,7 @@ ifdef(`distro_redhat',`
 /var/run/systemd/resolve/stub-resolv\.conf  gen_context(system_u:object_r:net_conf_t,s0)
 ')
 /var/run/NetworkManager/resolv\.conf.*   --  gen_context(system_u:object_r:net_conf_t,s0)
+/var/run/NetworkManager/no-stub-resolv\.conf   --  gen_context(system_u:object_r:net_conf_t,s0)
 
 /var/run/cloud-init(/.*)?     gen_context(system_u:object_r:net_conf_t,s0)
 

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1177,6 +1177,7 @@ interface(`sysnet_filetrans_named_content',`
 	init_pid_filetrans($1, net_conf_t, dir, "network")
 
 	optional_policy(`
+		networkmanager_pid_filetrans($1, net_conf_t, file, "no-stub-resolv.conf")
 		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf")
 		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
 	')


### PR DESCRIPTION
After removing systemd-resolved, /etc/resolv.conf was repointed to ../run/NetworkManager/no-stub-resolv.conf, with label NetworkManager_var_run_t, which leads to denied access for some processes like chronyd or unbound-anchor.

type=AVC msg=audit(1654344580.610:499): avc:  denied  { read } for  pid=11027 comm="unbound-anchor" name="no-stub-resolv.conf" dev="tmpfs" ino=2078 scontext=system_u:system_r:named_t:s0 tcontext=system_u:object_r:NetworkManager_var_run_t:s0 tclass=file permissive=0

Resolves: bz#2091275