### PR TITLE
Allow winbind-rpcd read and write its key ring

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1167,6 +1167,7 @@ optional_policy(`
 #
 
 allow winbind_rpcd_t self:capability { setgid setuid };
+allow winbind_rpcd_t self:key { read write };
 allow winbind_rpcd_t self:netlink_route_socket create_netlink_socket_perms;
 allow winbind_rpcd_t self:unix_dgram_socket { create_socket_perms sendto };
 allow winbind_rpcd_t self:unix_stream_socket connectto;


### PR DESCRIPTION
Addresses the following AVC denials:
type=AVC msg=audit(1663577560.480:3619): avc:  denied  { write } for  pid=109517 comm="samba-dcerpcd" scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:winbind_rpcd_t:s0 tclass=key permissive=1 type=AVC msg=audit(1663577560.480:3620): avc:  denied  { read } for  pid=109517 comm="samba-dcerpcd" scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:winbind_rpcd_t:s0 tclass=key permissive=1

Resolves: rhbz#2127854