### PR TITLE
Update dnssec-trigger policy: setsched, module_request

### DIFF
--- a/policy/modules/contrib/dnssec.te
+++ b/policy/modules/contrib/dnssec.te
@@ -23,7 +23,7 @@ files_tmp_file(dnssec_trigger_tmp_t)
 # dnssec_trigger local policy
 #
 allow dnssec_trigger_t self:capability { net_admin linux_immutable sys_ptrace };
-allow dnssec_trigger_t self:process signal;
+allow dnssec_trigger_t self:process { setsched signal };
 allow dnssec_trigger_t self:fifo_file rw_fifo_file_perms;
 allow dnssec_trigger_t self:unix_stream_socket create_stream_socket_perms;
 allow dnssec_trigger_t self:tcp_socket create_stream_socket_perms;
@@ -41,7 +41,7 @@ files_tmp_filetrans(dnssec_trigger_t,dnssec_trigger_tmp_t,{ file dir })
 
 kernel_read_system_state(dnssec_trigger_t)
 kernel_read_network_state(dnssec_trigger_t)
-kernel_dontaudit_request_load_module(dnssec_trigger_t)
+kernel_request_load_module(dnssec_trigger_t)
 
 can_exec(dnssec_trigger_t, dnssec_trigger_exec_t)
 


### PR DESCRIPTION
Addresses the following AVC denials:

type=PROCTITLE msg=audit(09/21/2022 06:03:15.427:393) : proctitle=dnssec-trigger-control status type=SYSCALL msg=audit(09/21/2022 06:03:15.427:393) : arch=x86_64 syscall=setsockopt success=no exit=ENOENT(No such file or directory) a0=0x3 a1=tcp a2=TCP_ULP a3=0x7f2c308a0e8f items=0 ppid=948 pid=954 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=dnssec-trigger- exe=/usr/sbin/dnssec-trigger-control subj=system_u:system_r:dnssec_trigger_t:s0 key=(null) type=AVC msg=audit(09/21/2022 06:03:15.427:393) : avc:  denied  { module_request } for  pid=954 comm=dnssec-trigger- kmod="tcp-ulp-tls" scontext=system_u:system_r:dnssec_trigger_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0

type=PROCTITLE msg=audit(09/21/2022 06:03:15.430:394) : proctitle=/usr/bin/python3 -sE /usr/libexec/dnssec-trigger-script --setup
type=SYSCALL msg=audit(09/21/2022 06:03:15.430:394) : arch=x86_64 syscall=sched_setattr success=no exit=EACCES(Permission denied) a0=0x3b5 a1=0x562a63660c00 a2=0x0 a3=0x0 items=0 ppid=947 pid=949 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=dnssec-trigger- exe=/usr/bin/python3.10 subj=system_u:system_r:dnssec_trigger_t:s0 key=(null)
type=AVC msg=audit(09/21/2022 06:03:15.430:394) : avc:  denied  { setsched } for  pid=949 comm=dnssec-trigger- scontext=system_u:system_r:dnssec_trigger_t:s0 tcontext=system_u:system_r:dnssec_trigger_t:s0 tclass=process permissive=0