### PR TITLE
Allow init read/write inherited user fifo files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -414,7 +414,7 @@ userdom_manage_tmp_sockets(init_t)
 userdom_delete_user_tmp_files(init_t)
 userdom_delete_user_home_content_files(init_t)
 userdom_connectto_stream(init_t)
-
+userdom_rw_inherited_user_pipes(init_t)
 userdom_transition_login_userdomain(init_t)
 userdom_nnp_transition_login_userdomain(init_t)
 userdom_noatsecure_login_userdomain(init_t)


### PR DESCRIPTION
This commit backs the usage of "systemd-run --pipe" when standard input, output, and error of the transient service are inherited from the systemd-run command itself. The --pipe switch allows systemd-run to be used within shell pipelines.

Addresses the following AVC denials:

type=AVC msg=audit(09/21/2022 05:24:28.596:328) : avc:  denied  { write } for  pid=1 comm=systemd path=pipe:[16980] dev="pipefs" ino=16980 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=fifo_file permissive=0

type=AVC msg=audit(09/21/2022 05:34:12.088:422) : avc:  denied  { read } for  pid=1 comm=systemd path=pipe:[18554] dev="pipefs" ino=18554 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=fifo_file permissive=0

type=PROCTITLE msg=audit(09/21/2022 05:36:42.853:427) : proctitle=(grep) type=SYSCALL msg=audit(09/21/2022 05:36:42.853:427) : arch=x86_64 syscall=ioctl success=no exit=EACCES(Permission denied) a0=0x0 a1=TCGETS a2=0x7ffebe2ae1c0 a3=0x0 items=0 ppid=1 pid=1269 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(grep) exe=/usr/lib/systemd/systemd subj=system_u:system_r:init_t:s0 key=(null) type=AVC msg=audit(09/21/2022 05:36:42.853:427) : avc:  denied  { ioctl } for  pid=1269 comm=(grep) path=pipe:[18588] dev="pipefs" ino=18588 ioctlcmd=TCGETS scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=fifo_file permissive=0

Resolves: rhbz#2036829