### PR TITLE
Allow gst-plugin-scanner read virtual memory sysctls

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -473,6 +473,8 @@ userdom_delete_user_home_content_files(xdm_t)
 userdom_signull_unpriv_users(xdm_t)
 userdom_dontaudit_read_admin_home_lnk_files(xdm_t)
 
+kernel_read_vm_sysctls(xdm_t)
+
 # Allow gdm to run gdm-binary
 can_exec(xdm_t, xdm_exec_t)
 can_exec(xdm_t, xsession_exec_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1637622555.643:375): avc:  denied  { open } for  pid=27016 comm="gst-plugin-scan" path="/proc/sys/vm/mmap_min_addr" dev="proc" ino=32789 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_vm_t:s0 tclass=file permissive=0

Resolves: rhbz#2025808