### PR TITLE
Allow syslogd_t domain relabel var_log_t files

### DIFF
--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -1348,6 +1348,25 @@ interface(`logging_write_generic_logs',`
 
 ########################################
 ## <summary>
+##	Relabel generic log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_relabel_generic_logs',`
+	gen_require(`
+		type var_log_t;
+	')
+
+	files_search_var($1)
+	relabel_files_pattern($1, var_log_t, var_log_t)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete symbolic
 ##	links in the /var/log directory.
 ## </summary>

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -667,6 +667,7 @@ init_use_fds(syslogd_t)
 # cjp: this doesnt make sense
 logging_send_syslog_msg(syslogd_t)
 logging_manage_all_logs(syslogd_t)
+logging_relabel_generic_logs(syslogd_t)
 logging_set_loginuid(syslogd_t)
 logging_watch_all_log_dirs_path(syslogd_t)
 


### PR DESCRIPTION
This actually applies to systemd-journald which has code to finalize a journal file in an asychronous thread. The journal-offline thread creates a temporary file and tries to atomically link it to a normal journal file name.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(04/14/2022 12:22:06.334:223) : proctitle=/usr/lib/systemd/systemd-journald type=PATH msg=audit(04/14/2022 12:22:06.334:223) : item=0 name=(null) inode=78269 dev=00:21 mode=file,640 ouid=root ogid=systemd-journal rdev=00:00 obj=system_u:object_r:var_log_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/14/2022 12:22:06.334:223) : arch=aarch64 syscall=fsetxattr success=yes exit=0 a0=0x1f a1=0xffff84000c39 a2=0xffff84000e70 a3=0x1f items=1 ppid=1 pid=450 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=journal-offline exe=/usr/lib/systemd/systemd-journald subj=system_u:system_r:syslogd_t:s0 key=(null) type=AVC msg=audit(04/14/2022 12:22:06.334:223) : avc:  denied  { relabelto } for  pid=450 comm=journal-offline name=.#system@a08e4b4e099d4330a74265f9d294fff5-00000000000010f4-0005dc9eec046b20.journal925dd1b0ca19822f dev="vda3" ino=78269 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=1 type=AVC msg=audit(04/14/2022 12:22:06.334:223) : avc:  denied  { relabelfrom } for  pid=450 comm=journal-offline name=.#system@a08e4b4e099d4330a74265f9d294fff5-00000000000010f4-0005dc9eec046b20.journal925dd1b0ca19822f dev="vda3" ino=78269 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=1

Resolves: rhbz#2075527