### PR TITLE
Add numad the ipc_owner capability

### DIFF
--- a/policy/modules/contrib/numad.te
+++ b/policy/modules/contrib/numad.te
@@ -23,7 +23,7 @@ files_pid_file(numad_var_run_t)
 # numad local policy
 #
 
-allow numad_t self:capability { kill sys_nice sys_ptrace } ;
+allow numad_t self:capability { ipc_owner kill sys_nice sys_ptrace } ;
 allow numad_t self:fifo_file rw_fifo_file_perms;
 allow numad_t self:msgq create_msgq_perms;
 allow numad_t self:msg { send receive };


### PR DESCRIPTION
This permission is required when the cpu allocation in a vm definition contains <vcpu placement="auto" />
which means cpuset option will be configured by querying numad.

Addresses the following AVC denial:

type=AVC msg=audit(1637903670.950:2626): avc:  denied  { ipc_owner } for  pid=72952 comm="numad" capability=15  scontext=system_u:system_r:numad_t:s0-s0:c0.c1023 tcontext=system_u:system_r:numad_t:s0-s0:c0.c1023 tclass=capability permissive=0

Resolves: rhbz#2026968