### PR TITLE
nut-upsd: kernel_read_system_state, fs_getattr_cgroup

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -51,10 +51,13 @@ allow nut_upsd_t nut_upsdrvctl_t:unix_stream_socket connectto;
 read_files_pattern(nut_upsd_t, nut_conf_t, nut_conf_t)
 
 kernel_read_kernel_sysctls(nut_upsd_t)
+kernel_read_system_state(nut_upsd_t)
 
 corenet_tcp_bind_ups_port(nut_upsd_t)
 corenet_tcp_bind_generic_port(nut_upsd_t)
 corenet_tcp_bind_all_nodes(nut_upsd_t)
+
+fs_getattr_cgroup(nut_upsd_t)
 
 optional_policy(`
 	unconfined_stream_connect(nut_upsd_t)


### PR DESCRIPTION
nut-upsd was allowed to read system state information in /proc and get attributes of cgroup filesystems.

Resolves: rhbz#2038580