### PR TITLE
Add bgpd sys_chroot capability

### DIFF
--- a/policy/modules/contrib/zebra.te
+++ b/policy/modules/contrib/zebra.te
@@ -40,7 +40,7 @@ files_pid_file(zebra_var_run_t)
 # Local policy
 #
 
-allow zebra_t self:capability { setgid setuid net_admin net_raw };
+allow zebra_t self:capability { setgid setuid sys_chroot net_admin net_raw };
 dontaudit zebra_t self:capability sys_tty_config;
 allow zebra_t self:process { signal_perms getcap setcap };
 allow zebra_t self:file rw_file_perms;


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(09/23/2022 13:39:42.856:6958) : proctitle=/usr/sbin/bgpd -R
type=PATH msg=audit(09/23/2022 13:39:42.856:6958) : item=0 name=/var/empty/bgpd inode=644194 dev=00:1e mode=dir,711 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:var_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(09/23/2022 13:39:42.856:6958) : arch=x86_64 syscall=chroot success=no exit=EPERM(Operation not permitted) a0=0x55af72eb04e7 a1=0x7f06fcd615b3 a2=0x0 a3=0x7f06fcd46ac0 items=1 ppid=115054 pid=115055 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=bgpd exe=/usr/sbin/bgpd subj=system_u:system_r:zebra_t:s0 key=(null)
type=AVC msg=audit(09/23/2022 13:39:42.856:6958) : avc:  denied  { sys_chroot } for  pid=115055 comm=bgpd capability=sys_chroot  scontext=system_u:system_r:zebra_t:s0 tcontext=system_u:system_r:zebra_t:s0 tclass=capability permissive=0