### PR TITLE
Allow system_mail-t read network sysctls

### DIFF
--- a/policy/modules/contrib/mta.te
+++ b/policy/modules/contrib/mta.te
@@ -188,7 +188,7 @@ allow system_mail_t mail_home_t:file manage_file_perms;
 
 read_files_pattern(system_mail_t, mailcontent_type, mailcontent_type)
 
-kernel_search_network_sysctl(system_mail_t)
+kernel_read_net_sysctls(system_mail_t)
 
 corecmd_exec_shell(system_mail_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1663932465.372:588): avc:  denied  { read } for  pid=122144 comm="sendmail" name="disable_ipv6" dev="proc" ino=2645630 scontext=system_u:system_r:system_mail_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=0

Resolves: rhbz#2129326