### PR TITLE
Allow xenstored change its hard resource limits

### DIFF
--- a/policy/modules/contrib/xen.te
+++ b/policy/modules/contrib/xen.te
@@ -423,6 +423,7 @@ optional_policy(`
 #
 
 allow xenstored_t self:capability { dac_read_search  ipc_lock sys_resource };
+allow xenstored_t self:process setrlimit;
 allow xenstored_t self:unix_stream_socket create_stream_socket_perms;
 allow xenstored_t self:unix_dgram_socket create_socket_perms;
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(09/23/2022 14:49:28.646:155) : proctitle=prlimit --nofile=1073741816 /usr/sbin/xenstored --pid-file /var/run/xen/xenstored.pid type=SYSCALL msg=audit(09/23/2022 14:49:28.646:155) : arch=x86_64 syscall=prlimit64 success=no exit=EACCES(Permission denied) a0=0x0 a1=0x7 a2=0x55fa676e15b0 a3=0x0 items=0 ppid=532 pid=536 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=prlimit exe=/usr/bin/prlimit subj=system_u:system_r:xenstored_t:s0 key=(null) type=AVC msg=audit(09/23/2022 14:49:28.646:155) : avc:  denied  { setrlimit } for  pid=536 comm=prlimit scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:system_r:xenstored_t:s0 tclass=process permissive=0

Resolves: rhbz#2125693