### PR TITLE
Allow init map its private tmp files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -209,6 +209,7 @@ manage_dirs_pattern(init_t, init_tmp_t, init_tmp_t)
 manage_lnk_files_pattern(init_t, init_tmp_t, init_tmp_t)
 manage_sock_files_pattern(init_t, init_tmp_t, init_tmp_t)
 files_tmp_filetrans(init_t, init_tmp_t, { file sock_file })
+allow init_t init_tmp_t:file map;
 
 manage_dirs_pattern(init_t, init_var_lib_t, init_var_lib_t)
 manage_files_pattern(init_t, init_var_lib_t, init_var_lib_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(11/24/2021 01:50:26.378:167) : avc:  denied  { map } for  pid=1414 comm=cpupower-gui-he path=/var/tmp/ffi6reIpN (deleted) dev="nvme0n1p3" ino=88707980 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:init_tmp_t:s0 tclass=file permissive=0

Resolves: rhbz#2026228