### PR TITLE
Allow xdm watch user home directories

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -758,6 +758,7 @@ userdom_manage_user_tmp_sockets(xdm_t)
 userdom_manage_tmp_role(system_r, xdm_t)
 userdom_mounton_tmp_sockets(xdm_t)
 userdom_nnp_transition_login_userdomain(xdm_t)
+userdom_watch_user_home_dirs(xdm_t)
 
 #userdom_home_manager(xdm_t)
 tunable_policy(`xdm_write_home',`

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -2284,6 +2284,24 @@ interface(`userdom_create_user_home_dirs',`
 
 ########################################
 ## <summary>
+##	Watch user home directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_watch_user_home_dirs',`
+	gen_require(`
+		type user_home_dir_t;
+	')
+
+	allow $1 user_home_dir_t:dir watch_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Create user home directories.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1659565459.557:2171): avc:  denied  { watch } for  pid=129930 comm="gmain" path="/home/username" dev="dm-0" ino=1583 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_dir_t:s0 tclass=dir permissive=0

Resolves: rhbz#2115133