### PR TITLE
Allow postfix_mailqueue create and use unix dgram sockets

### DIFF
--- a/policy/modules/contrib/munin.te
+++ b/policy/modules/contrib/munin.te
@@ -281,6 +281,7 @@ allow mail_munin_plugin_t self:capability { dac_read_search  };
 
 allow mail_munin_plugin_t self:tcp_socket create_stream_socket_perms;
 allow mail_munin_plugin_t self:netlink_route_socket r_netlink_socket_perms;
+allow mail_munin_plugin_t self:unix_dgram_socket create_socket_perms;
 allow mail_munin_plugin_t self:udp_socket create_socket_perms;
 
 rw_files_pattern(mail_munin_plugin_t, munin_var_lib_t, munin_var_lib_t)


### PR DESCRIPTION
Addresses the following AVC denials:
type=AVC msg=audit(1586540404.372:2836): avc:  denied  { create } for  pid=19863 comm="postconf" scontext=system_u:system_r:mail_munin_plugin_t:s0 tcontext=system_u:system_r:mail_munin_plugin_t:s0 tclass=unix_dgram_socket permissive=1 type=AVC msg=audit(1586540404.379:2837): avc:  denied  { ioctl } for  pid=19863 comm="postconf" path="socket:[158244]" dev="sockfs" ino=158244 ioctlcmd=0x8910 scontext=system_u:system_r:mail_munin_plugin_t:s0 tcontext=system_u:system_r:mail_munin_plugin_t:s0 tclass=unix_dgram_socket permissive=1

Resolves: rhbz#1823088