### PR TITLE
Allow sss daemons read/write unnamed pipes of cloud-init

### DIFF
--- a/policy/modules/contrib/cloudform.if
+++ b/policy/modules/contrib/cloudform.if
@@ -41,6 +41,24 @@ interface(`cloudform_init_domtrans',`
 	domtrans_pattern($1, cloud_init_exec_t, cloud_init_t)
 ')
 
+########################################
+## <summary>
+##	Read and write unnamed cloud-init pipes.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`cloudform_rw_pipes',`
+	gen_require(`
+		type cloud_init_t;
+	')
+
+	allow $1 cloud_init_t:fifo_file rw_fifo_file_perms;
+')
+
 ######################################
 ## <summary>
 ##	Execute mongod in the caller domain.

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -186,6 +186,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cloudform_rw_pipes(sssd_t)
+')
+
+optional_policy(`
 	dbus_system_bus_client(sssd_t)
 	dbus_connect_system_bus(sssd_t)
 ')


### PR DESCRIPTION
The cloudform_rw_pipes() interface was added.

Addresses the following AVC denials:
[   10.779755] fedora audit[812]: AVC avc:  denied  { read } for  pid=812 comm="sss_cache" path="pipe:[18908]" dev="pipefs" ino=18908 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:cloud_init_t:s0 tclass=fifo_file permissive=0
[   10.779916] fedora audit[812]: AVC avc:  denied  { write } for  pid=812 comm="sss_cache" path="pipe:[18909]" dev="pipefs" ino=18909 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:cloud_init_t:s0 tclass=fifo_file permissive=0

Resolves: rhbz#2073265