### PR TITLE
Allow sbd the sys_ptrace capability

### DIFF
--- a/policy/modules/contrib/sbd.te
+++ b/policy/modules/contrib/sbd.te
@@ -22,7 +22,7 @@ userdom_user_tmpfs_file(sbd_tmpfs_t)
 #
 # sbd local policy
 #
-allow sbd_t self:capability { dac_read_search dac_override ipc_lock kill sys_boot sys_nice sys_admin};
+allow sbd_t self:capability { dac_read_search dac_override ipc_lock kill sys_boot sys_nice sys_ptrace sys_admin};
 allow sbd_t self:process { fork setsched signal_perms };
 allow sbd_t self:fifo_file rw_fifo_file_perms;
 allow sbd_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
The capability is required to scan open file descriptors to find out additional processes which also have them open.

The sbd binary implements both the daemon that watches message slots as well as the management tool for interacting with the block storage device(s).

To get a full cluster view, pcs invokes the sbd-cmdline-tool on other nodes through the pcsd instances running there which effects sbd transition to sbd_t although it is a command in this case, not a service.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(09/12/2022 15:00:59.857:4015) : proctitle=/usr/sbin/sbd query-watchdog type=PATH msg=audit(09/12/2022 15:00:59.857:4015) : item=0 name=/proc/851/fd/0 inode=21560 dev=00:05 mode=link,500 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:rpcbind_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/12/2022 15:00:59.857:4015) : arch=x86_64 syscall=readlink success=no exit=EACCES(Permission denied) a0=0x7ffd9edd46c0 a1=0x7ffd9edd44b0 a2=0xff a3=0x0 items=1 ppid=538646 pid=538650 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sbd exe=/usr/sbin/sbd subj=system_u:system_r:sbd_t:s0 key=(null) type=AVC msg=audit(09/12/2022 15:00:59.857:4015) : avc:  denied  { sys_ptrace } for  pid=538650 comm=sbd capability=sys_ptrace  scontext=system_u:system_r:sbd_t:s0 tcontext=system_u:system_r:sbd_t:s0 tclass=capability permissive=0

Resolves: rhbz#2124552