### PR TITLE
Allow login_userdomain dbus chat with rhsmcertd

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -449,6 +449,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhsmcertd_dbus_chat(login_userdomain)
+')
+
+optional_policy(`
 	rpc_watch_exports(login_userdomain)
 ')
 


### PR DESCRIPTION
Addresses the following USER_AVC denial:
type=USER_AVC msg=audit(1662423125.839:301): pid=896 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_call interface=com.redhat.RHSM1.Config member=GetAll dest=:1.386 spid=4090 tpid=2540 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:system_r:rhsmcertd_t:s0 tclass=dbus permissive=0  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'

Resolves: rhbz#2124388