### PR TITLE
Allow pulseaudio create gnome content (~/.config)

### DIFF
--- a/policy/modules/contrib/pulseaudio.te
+++ b/policy/modules/contrib/pulseaudio.te
@@ -152,6 +152,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gnome_create_home_config_dirs(pulseaudio_t)
 	gnome_read_gkeyringd_state(pulseaudio_t)
 	gnome_signull_gkeyringd(pulseaudio_t)
 	gnome_manage_gstreamer_home_files(pulseaudio_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(10/03/2022 18:19:59.393:477) : proctitle=/usr/bin/pulseaudio --daemonize=no --log-target=journal type=PATH msg=audit(10/03/2022 18:19:59.393:477) : item=1 name=/home/username/.config nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(10/03/2022 18:19:59.393:477) : item=0 name=/home/username/ inode=25197786 dev=fd:02 mode=dir,700 ouid=username ogid=username rdev=00:00 obj=staff_u:object_r:user_home_dir_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/03/2022 18:19:59.393:477) : arch=x86_64 syscall=mkdir success=no exit=EACCES(Permission denied) a0=0x55db1dc2a420 a1=0700 a2=0xffffffff a3=0x0 items=2 ppid=6693 pid=6748 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=(none) ses=11 comm=pulseaudio exe=/usr/bin/pulseaudio subj=staff_u:staff_r:pulseaudio_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(10/03/2022 18:19:59.393:477) : avc:  denied  { create } for  pid=6748 comm=pulseaudio name=.config scontext=staff_u:staff_r:pulseaudio_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:config_home_t:s0 tclass=dir permissive=0

Resolves: rhbz#2124387