### PR TITLE
Allow samba-dcerpcd use NSCD services over a unix stream socket

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1233,6 +1233,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	nscd_socket_use(winbind_rpcd_t)
+')
+
+optional_policy(`
 	sssd_read_public_files(winbind_rpcd_t)
 	sssd_stream_connect(winbind_rpcd_t)
 ')


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(08/26/2022 04:14:24.657:453) : proctitle=/usr/libexec/samba/samba-dcerpcd --libexec-rpcds --ready-signal-fd=23 --np-helper --debuglevel=0 type=PATH msg=audit(08/26/2022 04:14:24.657:453) : item=0 name=/var/run/nscd/socket inode=130894 dev=00:18 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:nscd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(08/26/2022 04:14:24.657:453) : saddr={ saddr_fam=local path=/var/run/nscd/socket } type=SYSCALL msg=audit(08/26/2022 04:14:24.657:453) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x4 a1=0x7ffccfc81970 a2=0x6e a3=0x6 items=1 ppid=1 pid=93859 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=samba-dcerpcd exe=/usr/libexec/samba/samba-dcerpcd subj=system_u:system_r:winbind_rpcd_t:s0 key=(null) type=AVC msg=audit(08/26/2022 04:14:24.657:453) : avc:  denied  { write } for  pid=93859 comm=samba-dcerpcd name=socket dev="tmpfs" ino=130894 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:nscd_var_run_t:s0 tclass=sock_file permissive=0

Resolves: rhbz#2121709