### PR TITLE
Allow vlock search the contents of the /dev/pts directory

### DIFF
--- a/policy/modules/contrib/vlock.te
+++ b/policy/modules/contrib/vlock.te
@@ -40,5 +40,7 @@ init_dontaudit_rw_utmp(vlock_t)
 
 logging_send_syslog_msg(vlock_t)
 
+term_search_ptys(vlock_t)
+
 userdom_dontaudit_search_user_home_dirs(vlock_t)
 userdom_use_inherited_user_terminals(vlock_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(08/31/2022 09:28:27.751:867) : proctitle=vlock type=PATH msg=audit(08/31/2022 09:28:27.751:867) : item=0 name=/dev/pts/1 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/31/2022 09:28:27.751:867) : arch=x86_64 syscall=stat success=no exit=EACCES(Permission denied) a0=0x55b5ce6f0b60 a1=0x7ffdd6518320 a2=0x7ffdd6518320 a3=0x0 items=1 ppid=9040 pid=12550 auid=sysadm-user uid=sysadm-user gid=sysadm-user euid=sysadm-user suid=sysadm-user fsuid=sysadm-user egid=sysadm-user sgid=sysadm-user fsgid=sysadm-user tty=pts1 ses=17 comm=vlock exe=/usr/bin/vlock subj=sysadm_u:sysadm_r:vlock_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(08/31/2022 09:28:27.751:867) : avc:  denied  { search } for  pid=12550 comm=vlock name=/ dev="devpts" ino=1 scontext=sysadm_u:sysadm_r:vlock_t:s0-s0:c0.c1023 tcontext=system_u:object_r:devpts_t:s0 tclass=dir permissive=0

Resolves: rhbz#2122838