### PR TITLE
Add winbind-rpcd to samba_enable_home_dirs boolean

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -40,7 +40,7 @@ gen_tunable(samba_portmapper, false)
 
 ## <desc>
 ## <p>
-## Allow samba to share users home directories.
+## Allow samba and winbind-rpcd to share users home directories.
 ## </p>
 ## </desc>
 gen_tunable(samba_enable_home_dirs, false)
@@ -475,6 +475,7 @@ tunable_policy(`samba_domain_controller',`
 
 tunable_policy(`samba_enable_home_dirs',`
 	userdom_manage_user_home_content(smbd_t)
+	userdom_manage_user_home_content(winbind_rpcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Update samba_enable_home_dirs boolean to Allow winbind-rpcd to share users home directories.

SELinux denials appeared, when users configured home directory share in the smb.conf.

type=AVC msg=audit(1661934914.346:360): avc:  denied  { read } for  pid=4587 comm="samba-dcerpcd" path="/home/xx/Documents/xx" dev="dm-2" ino=21627745 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=dir permissive=0

Resolves: bz#2122904