### PR TITLE
Label ports 10161-10162 tcp/udp with snmp

### DIFF
--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -340,7 +340,7 @@ network_port(sip, tcp,5060,s0, udp,5060,s0, tcp,5061,s0, udp,5061,s0)
 network_port(sixxsconfig, tcp,3874,s0, udp,3874,s0)
 network_port(smbd, tcp,137-139,s0, tcp,445,s0)
 network_port(smtp, tcp,25,s0, tcp,465,s0, tcp,587,s0)
-network_port(snmp, tcp,161-162,s0, udp,161-162,s0, tcp,199,s0, tcp, 1161, s0)
+network_port(snmp, tcp,161-162,s0, udp,161-162,s0, tcp,199,s0, tcp,1161,s0, tcp,10161-10162,s0, udp,10161-10162,s0,)
 network_port(smntubootstrap, tcp,2613,s0, udp,2613,s0)
 network_port(socks) # no defined portcon
 network_port(soundd, tcp,8000,s0, tcp,9433,s0, tcp, 16001, s0)


### PR DESCRIPTION
Simple Network Management Protocol over TLS and DTLS uses 10161-10162 ports. https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=snmp

Resolves: bz#2133221