### PR TITLE
Allow insights-client send null signal to rpm and system cronjob

### DIFF
--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -775,6 +775,24 @@ interface(`cron_anacron_domtrans_system_job',`
 
 ########################################
 ## <summary>
+##	Send a null signal to cron system job.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cron_signull_system_job',`
+	gen_require(`
+		type system_cronjob_t;
+	')
+
+	allow $1 system_cronjob_t:process signull;
+')
+
+########################################
+## <summary>
 ##	Inherit and use a file descriptor
 ##	from system cron jobs.
 ## </summary>

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -206,6 +206,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cron_signull_system_job(insights_client_t)
 	cron_system_entry(insights_client_t, insights_client_exec_t)
 ')
 
@@ -311,6 +312,7 @@ optional_policy(`
 	rpm_manage_cache(insights_client_t)
 	rpm_hawkey_named_filetrans(insights_client_t)
 	rpm_read_db(insights_client_t)
+	rpm_signull(insights_client_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The cron_signull_system_job() interface was added.

Resolves: rhbz#2132230