### PR TITLE
Allow system cronjobs dbus chat with setroubleshoot

### DIFF
--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -674,6 +674,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	setroubleshoot_dbus_chat(system_cronjob_t)
+')
+
+optional_policy(`
     snapper_dbus_chat(system_cronjob_t)
 ')
 


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(10/10/2022 13:28:08.878:507) : pid=725 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.335 spid=35041 tpid=35039 scontext=system_u:system_r:setroubleshootd_t:s0 tcontext=system_u:system_r:system_cronjob_t:s0-s0:c0.c1023 tclass=dbus permissive=0  exe=/usr/bin/dbus-daemon sauid=dbus hostname=? addr=? terminal=?'

Resolves: rhbz#2125008