### PR TITLE
Allow rotatelogs read httpd_log_t symlinks

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -1668,6 +1668,8 @@ optional_policy(`
 allow httpd_rotatelogs_t self:capability { dac_read_search  };
 
 manage_files_pattern(httpd_rotatelogs_t, httpd_log_t, httpd_log_t)
+read_lnk_files_pattern(httpd_rotatelogs_t, httpd_log_t, httpd_log_t)
+allow httpd_rotatelogs_t httpd_config_t:dir search_dir_perms;
 
 kernel_read_kernel_sysctls(httpd_rotatelogs_t)
 kernel_dontaudit_list_proc(httpd_rotatelogs_t)


### PR DESCRIPTION
This permission is required when rotatelogs is used in apache httpd configuration for handling logs and the /etc/httpd/logs path is used where the last directory is a symlink to ../../var/log/httpd:

CustomLog "|/usr/sbin/rotatelogs /etc/httpd/logs/www.example.com 3600" combined

Resolves: rhbz#2030633