### PR TITLE
Allow systemd-socket-proxyd get filesystems attributes

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -920,6 +920,7 @@ allow systemd_socket_proxyd_t self:tcp_socket accept;
 kernel_read_system_state(systemd_socket_proxyd_t)
 
 auth_use_nsswitch(systemd_socket_proxyd_t)
+fs_getattr_xattr_fs(systemd_socket_proxyd_t)
 sysnet_dns_name_resolve(systemd_socket_proxyd_t)
 
 tunable_policy(`systemd_socket_proxyd_bind_any',`


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(10/21/2022 14:24:54.098:975) : proctitle=/usr/lib/systemd/systemd-socket-proxyd 127.0.0.1:23
type=SYSCALL msg=audit(10/21/2022 14:24:54.098:975) : arch=x86_64 syscall=fstatfs success=yes exit=0 a0=0x4 a1=0x7ffca2f96ae0 a2=0x280100 a3=0x0 items=0 ppid=1 pid=48955 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-socket- exe=/usr/lib/systemd/systemd-socket-proxyd subj=system_u:system_r:systemd_socket_proxyd_t:s0 key=(null)
type=AVC msg=audit(10/21/2022 14:24:54.098:975) : avc:  denied  { getattr } for  pid=48955 comm=systemd-socket- name=/ dev="vda1" ino=128 scontext=system_u:system_r:systemd_socket_proxyd_t: