### PR TITLE
Allow dirsrv_snmp_t to manage dirsrv_config_t & dirsrv_var_run_t files

### DIFF
--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -189,9 +189,9 @@ allow dirsrv_snmp_t self:fifo_file rw_fifo_file_perms;
 
 rw_files_pattern(dirsrv_snmp_t, dirsrv_tmpfs_t, dirsrv_tmpfs_t)
 
-read_files_pattern(dirsrv_snmp_t, dirsrv_var_run_t, dirsrv_var_run_t)
+manage_files_pattern(dirsrv_snmp_t, dirsrv_var_run_t, dirsrv_var_run_t)
 
-read_files_pattern(dirsrv_snmp_t, dirsrv_config_t, dirsrv_config_t)
+manage_files_pattern(dirsrv_snmp_t, dirsrv_config_t, dirsrv_config_t)
 
 manage_files_pattern(dirsrv_snmp_t, dirsrv_snmp_var_run_t, dirsrv_snmp_var_run_t)
 files_pid_filetrans(dirsrv_snmp_t, dirsrv_snmp_var_run_t, { file sock_file })


### PR DESCRIPTION
Allow LDAP-agent to manage files in directories /etc/dirsrv/ and /var/run/dirsrv.

Resolves: rhbz#2042515