### PR TITLE
Allow few domains bpf capability

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -35,6 +35,7 @@ init_system_domain(traceroute_t, traceroute_exec_t)
 # Perform network administration operations and have raw access to the network.
 allow netutils_t self:capability { chown dac_read_search net_admin net_raw setuid setgid sys_chroot  setpcap };
 dontaudit netutils_t self:capability { sys_admin sys_tty_config };
+allow netutils_t self:capability2 bpf;
 allow netutils_t self:process { setcap signal_perms };
 allow netutils_t self:netlink_generic_socket create_socket_perms;
 allow netutils_t self:netlink_rdma_socket create_socket_perms;
@@ -214,6 +215,7 @@ optional_policy(`
 
 allow traceroute_t self:capability { net_admin net_raw setuid setgid };
 dontaudit traceroute_t self:capability { sys_admin };
+allow traceroute_t self:capability2 bpf;
 allow traceroute_t self:netlink_generic_socket create_socket_perms;
 allow traceroute_t self:netlink_rdma_socket create_socket_perms;
 allow traceroute_t self:rawip_socket create_socket_perms;

--- a/policy/modules/contrib/dhcp.te
+++ b/policy/modules/contrib/dhcp.te
@@ -39,6 +39,7 @@ files_pid_file(dhcpd_var_run_t)
 
 allow dhcpd_t self:capability { chown dac_read_search dac_override fowner sys_chroot net_raw kill setgid setuid setpcap sys_resource };
 dontaudit dhcpd_t self:capability { net_admin sys_admin sys_tty_config };
+allow dhcpd_t self:capability2 bpf;
 allow dhcpd_t self:process { getcap setcap signal_perms };
 allow dhcpd_t self:fifo_file rw_fifo_file_perms;
 allow dhcpd_t self:tcp_socket { accept listen };

--- a/policy/modules/contrib/fprintd.te
+++ b/policy/modules/contrib/fprintd.te
@@ -22,7 +22,7 @@ files_tmp_file(fprintd_tmp_t)
 #
 
 allow fprintd_t self:capability { sys_admin sys_nice };
-allow fprintd_t self:capability2 wake_alarm;
+allow fprintd_t self:capability2 { bpf wake_alarm };
 allow fprintd_t self:process { getsched setsched signal sigkill };
 allow fprintd_t self:fifo_file rw_fifo_file_perms;
 allow fprintd_t self:netlink_kobject_uevent_socket create_socket_perms;

--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -38,6 +38,7 @@ files_tmpfs_file(keepalived_tmpfs_t)
 #
 
 allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_admin sys_nice sys_ptrace };
+allow keepalived_t self:capability2 bpf;
 allow keepalived_t self:process { signal_perms getpgid setpgid setsched };
 allow keepalived_t self:icmp_socket create_socket_perms;
 allow keepalived_t self:netlink_socket create_socket_perms;

--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -27,6 +27,7 @@ systemd_mount_dir(lldpad_var_run_t)
 #
 allow lldpad_t self:capability { chown dac_override fowner fsetid kill net_admin net_raw setgid setuid sys_chroot sys_resource };
 dontaudit lldpad_t self:capability { sys_admin };
+allow lldpad_t self:capability2 bpf;
 allow lldpad_t self:shm create_shm_perms;
 allow lldpad_t self:fifo_file rw_fifo_file_perms;
 allow lldpad_t self:unix_stream_socket { accept connectto listen };

--- a/policy/modules/contrib/pcscd.te
+++ b/policy/modules/contrib/pcscd.te
@@ -23,7 +23,7 @@ init_daemon_run_dir(pcscd_var_run_t, "pcscd")
 
 allow pcscd_t self:capability {  dac_read_search fsetid };
 dontaudit pcscd_t self:capability { sys_admin };
-allow pcscd_t self:capability2 { wake_alarm };
+allow pcscd_t self:capability2 { bpf wake_alarm };
 allow pcscd_t self:cap_userns sys_ptrace;
 allow pcscd_t self:process { signal signull };
 dontaudit pcscd_t self:process setsched;

--- a/policy/modules/contrib/pkcs.te
+++ b/policy/modules/contrib/pkcs.te
@@ -47,6 +47,7 @@ systemd_unit_file(pkcs_slotd_unit_file_t)
 
 allow pkcs_slotd_t self:capability { fsetid kill chown };
 dontaudit pkcs_slotd_t self:capability sys_admin;
+allow pkcs_slotd_t self:capability2 bpf;
 allow pkcs_slotd_t self:fifo_file rw_fifo_file_perms;
 allow pkcs_slotd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow pkcs_slotd_t self:sem create_sem_perms;

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -427,7 +427,7 @@ optional_policy(`
 #
 
 allow xdm_t self:capability { setgid setuid sys_resource kill sys_tty_config mknod chown dac_read_search dac_override fowner fsetid ipc_owner sys_nice sys_rawio net_bind_service net_admin sys_ptrace };
-allow xdm_t self:capability2 { block_suspend };
+allow xdm_t self:capability2 { block_suspend bpf };
 allow xdm_t self:cap_userns { dac_override kill net_admin setpcap sys_admin sys_ptrace };
 dontaudit xdm_t self:capability sys_admin;
 dontaudit xdm_t self:capability2 wake_alarm;

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -82,6 +82,7 @@ files_type(ipsec_mgmt_devpts_t)
 
 allow ipsec_t self:capability { chown net_admin dac_read_search dac_override setpcap sys_admin sys_nice net_raw setuid setgid };
 dontaudit ipsec_t self:capability sys_tty_config;
+allow ipsec_t self:capability2 bpf;
 allow ipsec_t self:process { getcap setcap getsched signal signull setsched sigkill };
 allow ipsec_t self:tcp_socket create_stream_socket_perms;
 allow ipsec_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
Allow fprintd, ipsec, keepalived, lldpad, pcscd, xdm, pkcs_slotd_t, dhcpd, netutils and traceroute  bpf capability 

Resolves: rhbz#2134827
