### PR TITLE
Allow systemd-gpt-generator raw write to a fixed disk

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1176,7 +1176,7 @@ fstools_exec(systemd_gpt_generator_t)
 mls_file_read_to_clearance(systemd_gpt_generator_t)
 mls_file_write_to_clearance(systemd_gpt_generator_t)
 
-storage_raw_read_fixed_disk(systemd_gpt_generator_t)
+storage_raw_rw_fixed_disk(systemd_gpt_generator_t)
 storage_raw_read_removable_device(systemd_gpt_generator_t)
 
 allow systemd_gpt_generator_t systemd_gpt_generator_unit_file_t:file manage_file_perms;


### PR DESCRIPTION
Recent changes in systemd-gpt-auto-generator include replacing the loop_device_open() library call with loop_device_open_from_path() which tries to reopen the device node fd (using the /proc/self/fd/FD path) in read-write mode in order to use it for flock().

Resolves: rhbz#2134121