### PR TITLE
Add policy for boothd

### DIFF
--- a/policy/modules/contrib/boothd.fc
+++ b/policy/modules/contrib/boothd.fc
@@ -1,0 +1,11 @@
+/etc/booth(/.*)?				gen_context(system_u:object_r:boothd_etc_t,s0)
+
+/usr/sbin/boothd			--	gen_context(system_u:object_r:boothd_exec_t,s0)
+/usr/sbin/booth-keygen			--	gen_context(system_u:object_r:boothd_exec_t,s0)
+
+/usr/lib/systemd/system/booth@\.service			--	gen_context(system_u:object_r:boothd_unit_file_t,s0)
+/usr/lib/systemd/system/booth-arbitrator\.service	--      gen_context(system_u:object_r:boothd_unit_file_t,s0)
+
+/var/run/booth(/.*)?				gen_context(system_u:object_r:boothd_var_run_t,s0)
+
+/var/lib/booth(/.*)?				gen_context(system_u:object_r:boothd_var_lib_t,s0)

--- a/policy/modules/contrib/boothd.if
+++ b/policy/modules/contrib/boothd.if
@@ -1,0 +1,39 @@
+## <summary>policy for boothd</summary>
+
+########################################
+## <summary>
+##	Execute boothd_exec_t in the boothd domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`boothd_domtrans',`
+	gen_require(`
+		type boothd_t, boothd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, boothd_exec_t, boothd_t)
+')
+
+######################################
+## <summary>
+##	Execute boothd in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`boothd_exec',`
+	gen_require(`
+		type boothd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, boothd_exec_t)
+')

--- a/policy/modules/contrib/boothd.te
+++ b/policy/modules/contrib/boothd.te
@@ -1,0 +1,81 @@
+policy_module(boothd, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type boothd_t;
+type boothd_exec_t;
+init_daemon_domain(boothd_t, boothd_exec_t)
+
+type boothd_etc_t;
+files_config_file(boothd_etc_t)
+
+type boothd_unit_file_t;
+systemd_unit_file(boothd_unit_file_t)
+
+type boothd_var_run_t;
+files_pid_file(boothd_var_run_t)
+
+type boothd_var_lib_t;
+files_type(boothd_var_lib_t)
+
+########################################
+#
+# boothd local policy
+#
+allow boothd_t self:fifo_file rw_fifo_file_perms;
+allow boothd_t self:capability { chown dac_override dac_read_search net_admin setgid setuid sys_nice sys_resource };
+allow boothd_t self:netlink_route_socket create_netlink_socket_perms;
+allow boothd_t self:process { setsched setrlimit };
+allow boothd_t self:tcp_socket create_stream_socket_perms;
+allow boothd_t self:udp_socket create_socket_perms;
+allow boothd_t self:unix_dgram_socket create_socket_perms;
+allow boothd_t self:unix_stream_socket create_stream_socket_perms;
+
+read_files_pattern(boothd_t, boothd_etc_t, boothd_etc_t)
+
+manage_dirs_pattern(boothd_t, boothd_var_run_t, boothd_var_run_t)
+manage_files_pattern(boothd_t, boothd_var_run_t, boothd_var_run_t)
+files_pid_filetrans(boothd_t, boothd_var_run_t, { dir file} )
+
+manage_dirs_pattern(boothd_t, boothd_var_lib_t, boothd_var_lib_t)
+
+kernel_dgram_send(boothd_t)
+
+corecmd_exec_bin(boothd_t)
+corecmd_exec_shell(boothd_t)
+
+corenet_tcp_bind_boothd_port(boothd_t)
+corenet_udp_bind_boothd_port(boothd_t)
+corenet_tcp_bind_generic_node(boothd_t)
+corenet_udp_bind_generic_node(boothd_t)
+corenet_tcp_connect_boothd_port(boothd_t)
+
+domain_use_interactive_fds(boothd_t)
+
+files_read_etc_files(boothd_t)
+
+optional_policy(`
+	auth_read_passwd(boothd_t)
+')
+
+optional_policy(`
+	logging_create_devlog_dev(boothd_t)
+	logging_read_syslog_pid(boothd_t)
+')
+
+optional_policy(`
+	miscfiles_read_localization(boothd_t)
+')
+
+optional_policy(`
+	rhcs_read_log_cluster(boothd_t)
+	rhcs_rw_cluster_tmpfs(boothd_t)
+	rhcs_stream_connect_cluster(boothd_t)
+')
+
+optional_policy(`
+	sysnet_read_config(boothd_t)
+')

--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -126,6 +126,7 @@ network_port(bfd_multi, tcp,4784,s0, udp,4784,s0)
 network_port(bgp, tcp,179,s0, udp,179,s0, tcp,2605,s0, udp,2605,s0)
 network_port(boinc, tcp,31416,s0)
 network_port(boinc_client, tcp,1043,s0, udp,1034,s0)
+network_port(boothd, tcp,9929,s0, udp,9929,s0)
 network_port(brlp, tcp,4101,s0)
 network_port(biff) # no defined portcon
 network_port(certmaster, tcp,51235,s0)


### PR DESCRIPTION
Boothd - The Booth Cluster Ticket Manager, manages tickets which authorizes one of the cluster sites located in geographically dispersed distances to run certain resources. It is designed to be extend Pacemaker to support geographically distributed clustering.

bz#2128833