### PR TITLE
Allow sssd dbus chat with system cronjobs

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -192,6 +192,10 @@ optional_policy(`
 optional_policy(`
 	dbus_system_bus_client(sssd_t)
 	dbus_connect_system_bus(sssd_t)
+
+	optional_policy(`
+		cron_dbus_chat_system_job(sssd_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(10/11/2022 14:36:01.711:447) : pid=973 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.1467 spid=5736 tpid=7278 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:system_cronjob_t:s0-s0:c0.c1023 tclass=dbus permissive=0  exe=/usr/bin/dbus-daemon sauid=dbus hostname=? addr=? terminal=?'

Resolves: rhbz#2132922