### PR TITLE
Allow systemd-hostnamed dbus chat with init scripts

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -903,6 +903,10 @@ optional_policy(`
         dbus_system_bus_client(systemd_hostnamed_t)
         dbus_connect_system_bus(systemd_hostnamed_t)
 	dbus_watch_pid_dir_path(systemd_hostnamed_t)
+
+	optional_policy(`
+		init_dbus_chat_script(systemd_hostnamed_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(1659032710.225:59): pid=1684 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.23 spid=2281 tpid=2280 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:system_r:initrc_t:s0 tclass=dbus permissive=0  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'UID="dbus" AUID="unset" SAUID="dbus"

Resolves: rhbz#2111632