### PR TITLE
Allow mrtg send mails

### DIFF
--- a/policy/modules/contrib/mrtg.te
+++ b/policy/modules/contrib/mrtg.te
@@ -21,6 +21,9 @@ files_lock_file(mrtg_lock_t)
 type mrtg_log_t;
 logging_log_file(mrtg_log_t)
 
+type mrtg_tmp_t;
+files_tmp_file(mrtg_tmp_t);
+
 type mrtg_var_lib_t;
 files_type(mrtg_var_lib_t)
 
@@ -51,6 +54,9 @@ append_files_pattern(mrtg_t, mrtg_log_t, mrtg_log_t)
 create_files_pattern(mrtg_t, mrtg_log_t, mrtg_log_t)
 setattr_files_pattern(mrtg_t, mrtg_log_t, mrtg_log_t)
 logging_log_filetrans(mrtg_t, mrtg_log_t, { dir file })
+
+manage_files_pattern(mrtg_t, mrtg_tmp_t, mrtg_tmp_t)
+files_tmp_filetrans(mrtg_t, mrtg_tmp_t, file)
 
 manage_files_pattern(mrtg_t, mrtg_var_lib_t, mrtg_var_lib_t)
 manage_lnk_files_pattern(mrtg_t, mrtg_var_lib_t, mrtg_var_lib_t)
@@ -137,6 +143,10 @@ optional_policy(`
 
 optional_policy(`
 	quota_dontaudit_getattr_db(mrtg_t)
+')
+
+optional_policy(`
+	sendmail_domtrans(mrtg_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
When mrtg is configured to send mails through a pipe, a temporary file is open and then sendmail is executed.

Resolves: rhbz#2103675