### PR TITLE
Allow winbind-rpcd use the terminal multiplexor

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1203,6 +1203,8 @@ corecmd_exec_bin(winbind_rpcd_t)
 
 corenet_tcp_connect_ipp_port(winbind_rpcd_t)
 
+term_use_ptmx(winbind_rpcd_t)
+
 optional_policy(`
 	auth_read_passwd(winbind_rpcd_t)
 ')


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(07/14/2022 07:07:43.161:380) : proctitle=/usr/libexec/samba/rpcd_lsad --configfile=/etc/samba/smb.conf --worker-group=3 --worker-index=0 --debuglevel=0 type=PATH msg=audit(07/14/2022 07:07:43.161:380) : item=0 name=/dev/ptmx inode=11387 dev=00:06 mode=character,666 ouid=root ogid=tty rdev=05:02 obj=system_u:object_r:ptmx_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/14/2022 07:07:43.161:380) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fb1d4cf2a46 a2=O_RDWR|O_NOCTTY a3=0x0 items=1 ppid=6326 pid=6336 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpcd_lsad exe=/usr/libexec/samba/rpcd_lsad subj=system_u:system_r:winbind_rpcd_t:s0 key=(null) type=AVC msg=audit(07/14/2022 07:07:43.161:380) : avc:  denied  { read write } for  pid=6336 comm=rpcd_lsad name=ptmx dev="devtmpfs" ino=11387 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:ptmx_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2107106