### PR TITLE
Label /etc/NetworkMamanger/VPN as NetworkManager_var_lib_t

### DIFF
--- a/policy/modules/contrib/networkmanager.fc
+++ b/policy/modules/contrib/networkmanager.fc
@@ -51,6 +51,7 @@
 
 /var/lib/wicd(/.*)?			gen_context(system_u:object_r:NetworkManager_var_lib_t,s0)
 /var/lib/NetworkManager(/.*)?		gen_context(system_u:object_r:NetworkManager_var_lib_t,s0)
+/etc/NetworkManager/VPN(/.*)?		gen_context(system_u:object_r:NetworkManager_var_lib_t,s0)
 
 /var/log/wicd.*				--	gen_context(system_u:object_r:NetworkManager_log_t,s0)
 


### PR DESCRIPTION
This is a legacy location for VPN .name files. Despite it's in /etc, it's actually not configuration. It should be treated the same as the non-legacy location, /usr/lib/NetworkManager/VPN.

Fixes the following denial, when, in presence of legacy VPN plugins, the location ends up labelled as NetworkManager_etc_t:

type=AVC msg=audit(1668185091.944:558): avc:  denied  { watch } for  pid=1095 comm="gmain" path="/etc/NetworkManager/VPN" dev="vda3" ino=277093 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=unconfined_u:object_r:NetworkManager_etc_t:s0 tclass=dir permissive=0