### PR TITLE
Allow winbind-rpcd get attributes of device and pty filesystems

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1203,6 +1203,9 @@ corecmd_exec_bin(winbind_rpcd_t)
 
 corenet_tcp_connect_ipp_port(winbind_rpcd_t)
 
+dev_getattr_fs(winbind_rpcd_t)
+
+term_getattr_pty_fs(winbind_rpcd_t)
 term_use_ptmx(winbind_rpcd_t)
 
 optional_policy(`


### PR DESCRIPTION
Resolves: rhbz#2107106