### PR TITLE
Allow rpc.gssd read network sysctls

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -369,7 +369,7 @@ kernel_read_system_state(gssd_t)
 kernel_read_network_state(gssd_t)
 kernel_read_network_state_symlinks(gssd_t)
 kernel_request_load_module(gssd_t)
-kernel_search_network_sysctl(gssd_t)
+kernel_read_net_sysctls(gssd_t)
 kernel_signal(gssd_t)
 
 corecmd_exec_bin(gssd_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1668606673.80:374): avc:  denied  { read } for  pid=1236 comm="rpc.gssd" name="disable_ipv6" dev="proc" ino=32004 scontext=system_u:system_r:gssd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=0

Resolves: rhbz#2143271