### PR TITLE
systemd: allow sys_admin for gpt-generator

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1163,7 +1163,7 @@ systemd_read_efivarfs(systemd_hwdb_t)
 # systemd_gpt_generator domain
 #
 
-allow systemd_gpt_generator_t self:capability sys_rawio;
+allow systemd_gpt_generator_t self:capability { sys_admin sys_rawio };
 allow systemd_gpt_generator_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 dev_read_sysfs(systemd_gpt_generator_t)


### PR DESCRIPTION
In Fedora 37 it seems systemd-gpt-auto-generator needs sys_admin capability. 
Hopefully fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2141998

Signed-off-by: Quintin Hill <stuff@quintin.me.uk>