### PR TITLE
Allow systemd-socket-proxyd get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -924,6 +924,7 @@ allow systemd_socket_proxyd_t self:tcp_socket accept;
 kernel_read_system_state(systemd_socket_proxyd_t)
 
 auth_use_nsswitch(systemd_socket_proxyd_t)
+fs_getattr_cgroup(systemd_socket_proxyd_t)
 fs_getattr_xattr_fs(systemd_socket_proxyd_t)
 sysnet_dns_name_resolve(systemd_socket_proxyd_t)
 


### PR DESCRIPTION
Resolves: rhbz#2141606