### PR TITLE
Add policy for rshim

### DIFF
--- a/policy/modules/contrib/rshim.fc
+++ b/policy/modules/contrib/rshim.fc
@@ -1,0 +1,3 @@
+/usr/sbin/rshim				--	gen_context(system_u:object_r:rshim_exec_t,s0)
+
+/usr/lib/systemd/system/rshim.*		--	gen_context(system_u:object_r:rshim_unit_file_t,s0)

--- a/policy/modules/contrib/rshim.if
+++ b/policy/modules/contrib/rshim.if
@@ -1,0 +1,39 @@
+## <summary>policy for rshim</summary>
+
+########################################
+## <summary>
+##	Execute rshim_exec_t in the rshim domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`rshim_domtrans',`
+	gen_require(`
+		type rshim_t, rshim_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, rshim_exec_t, rshim_t)
+')
+
+######################################
+## <summary>
+##	Execute rshim in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rshim_exec',`
+	gen_require(`
+		type rshim_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, rshim_exec_t)
+')

--- a/policy/modules/contrib/rshim.te
+++ b/policy/modules/contrib/rshim.te
@@ -1,0 +1,49 @@
+policy_module(rshim, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type rshim_t;
+type rshim_exec_t;
+init_daemon_domain(rshim_t, rshim_exec_t)
+
+type rshim_unit_file_t;
+systemd_unit_file(rshim_unit_file_t)
+
+permissive rshim_t;
+
+########################################
+#
+# rshim local policy
+#
+allow rshim_t self:fifo_file rw_fifo_file_perms;
+allow rshim_t self:netlink_kobject_uevent_socket { bind create getattr setopt };
+allow rshim_t self:process { fork };
+allow rshim_t self:system module_load;
+allow rshim_t self:unix_stream_socket create_stream_socket_perms;
+
+kernel_read_proc_files(rshim_t)
+
+corecmd_exec_shell(rshim_t)
+
+auth_read_passwd_file(rshim_t)
+
+dev_read_sysfs(rshim_t)
+
+domain_use_interactive_fds(rshim_t)
+
+files_read_etc_files(rshim_t)
+files_read_kernel_modules(rshim_t)
+
+logging_send_syslog_msg(rshim_t)
+
+miscfiles_read_localization(rshim_t)
+
+modutils_exec_kmod(rshim_t)
+modutils_getattr_module_deps(rshim_t)
+modutils_read_module_config(rshim_t)
+modutils_read_module_deps_files(rshim_t)
+
+udev_read_pid_files(rshim_t)


### PR DESCRIPTION
rshim is the user-space rshim driver for BlueField SoC. It provides ways to access the rshim resources on the BlueField target via USB or PCIe from external host machine.

Resolves: rhbz#2080439