### PR TITLE
Allow cups-pdf connect to the system log service

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -653,6 +653,8 @@ kernel_read_system_state(cups_pdf_t)
 
 auth_use_nsswitch(cups_pdf_t)
 
+logging_send_syslog_msg(cups_pdf_t)
+
 userdom_manage_user_home_content_dirs(cups_pdf_t)
 userdom_manage_user_home_content_files(cups_pdf_t)
 userdom_filetrans_home_content(cups_pdf_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(11/21/2022 17:48:24.290:9344) : proctitle=cups-pdf:/ 5 user970 testprint 1 finishings=3 number-up=1 print-color-mode=color job-uuid=urn:uuid:f804635e-848e-36d0-6d00-768e3
type=PATH msg=audit(11/21/2022 17:48:24.290:9344) : item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=39 dev=00:18 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SOCKADDR msg=audit(11/21/2022 17:48:24.290:9344) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DynamicUser }
type=SYSCALL msg=audit(11/21/2022 17:48:24.290:9344) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0xa a1=0x7fff3eb91940 a2=0x2d a3=0x0 items=1 ppid=175794 pid=178998 auid=unset uid=root gid=lp euid=root suid=root fsuid=root egid=lp sgid=lp fsgid=lp tty=(none) ses=unset comm=cups-pdf exe=/usr/lib/cups/backend/cups-pdf subj=system_u:system_r:cups_pdf_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(11/21/2022 17:48:24.290:9344) : avc:  denied  { connectto } for  pid=178998 comm=cups-pdf path=/run/systemd/userdb/io.systemd.DynamicUser scontext=system_u:system_r:cups_pdf_t:s0-s0:c0.c1023 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0