### PR TITLE
Allow syslogd read network sysctls

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -541,6 +541,7 @@ kernel_rw_stream_socket_perms(syslogd_t)
 kernel_read_system_state(syslogd_t)
 kernel_read_network_state(syslogd_t)
 kernel_read_kernel_sysctls(syslogd_t)
+kernel_read_net_sysctls(syslogd_t)
 kernel_read_netlink_audit_socket(syslogd_t)
 kernel_read_proc_symlinks(syslogd_t)
 # Allow access to /proc/kmsg for syslog-ng


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1669156432.404:191): avc:  denied  { read } for  pid=700 comm="rsyslogd" name="disable_ipv6" dev="proc" ino=19523 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=0

Resolves: rhbz#2145019