### PR TITLE
Allow cdcc mmap dcc-client-map files

### DIFF
--- a/policy/modules/contrib/dcc.te
+++ b/policy/modules/contrib/dcc.te
@@ -88,7 +88,7 @@ manage_dirs_pattern(cdcc_t, cdcc_tmp_t, cdcc_tmp_t)
 manage_files_pattern(cdcc_t, cdcc_tmp_t, cdcc_tmp_t)
 files_tmp_filetrans(cdcc_t, cdcc_tmp_t, { file dir })
 
-allow cdcc_t dcc_client_map_t:file rw_file_perms;
+allow cdcc_t dcc_client_map_t:file mmap_rw_file_perms;
 
 allow cdcc_t dcc_var_t:dir list_dir_perms;
 read_files_pattern(cdcc_t, dcc_var_t, dcc_var_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1669013119.191:10940): avc:  denied  { map } for  pid=613575 comm="cdcc" path="/var/lib/dcc/map" dev="dm-7" ino=10220 scontext=system_u:system_r:cdcc_t:s0 tcontext=system_u:object_r:dcc_client_map_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(1669013119.191:10940): arch=x86_64 syscall=mmap success=no exit=EACCES a0=0 a1=1e14 a2=3 a3=1 items=0 ppid=613567 pid=613575 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=cdcc exe=/usr/bin/cdcc subj=system_u:system_r:cdcc_t:s0 key=(null)

Resolves: rhbz#2144505