### PR TITLE
Allow ipsec_t only read tpm devices

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5239,6 +5239,24 @@ interface(`dev_map_sysfs',`
 
 ########################################
 ## <summary>
+##	Read the TPM device.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_read_tpm',`
+	gen_require(`
+		type device_t, tpm_device_t;
+	')
+
+	read_chr_files_pattern($1, device_t, tpm_device_t)
+')
+
+########################################
+## <summary>
 ##	Read and write the TPM device.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -180,8 +180,8 @@ corenet_rw_tun_tap_dev(ipsec_t)
 
 dev_read_sysfs(ipsec_t)
 dev_read_rand(ipsec_t)
+dev_read_tpm(ipsec_t)
 dev_read_urand(ipsec_t)
-dev_rw_tpm(ipsec_t)
 
 domain_use_interactive_fds(ipsec_t)
 


### PR DESCRIPTION
This partially reverts the de4416903 ("Allow ipsec_t read/write tpm devices") commit as writing should not be necessary.

Resolves: rhbz#2147380