### PR TITLE
Allow the spamd_update_t domain get generic filesystem attributes

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -642,6 +642,8 @@ dev_read_urand(spamd_update_t)
 domain_use_interactive_fds(spamd_update_t)
 domain_read_all_domains_state(spamd_update_t)
 
+fs_getattr_xattr_fs(spamd_update_t)
+
 spamassassin_systemctl(spamd_update_t)
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(10/24/2022 19:27:35.904:3855) : proctitle=systemctl condrestart spamassassin.service type=SYSCALL msg=audit(10/24/2022 19:27:35.904:3855) : arch=aarch64 syscall=fstatfs success=no exit=EACCES(Permission denied) a0=0x3 a1=0xffffff1981b0 a2=0xffffa64ffb88 a3=0x0 items=0 ppid=584811 pid=585375 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemctl exe=/usr/bin/systemctl subj=system_u:system_r:spamd_update_t:s0 key=(null) type=AVC msg=audit(10/24/2022 19:27:35.904:3855) : avc:  denied  { getattr } for  pid=585375 comm=systemctl name=/ dev="dm-0" ino=128 scontext=system_u:system_r:spamd_update_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0

Resolves: rhbz#2144501