### PR TITLE
donaudit virtlogd and dnsmasq execmem

### DIFF
--- a/policy/modules/contrib/dnsmasq.te
+++ b/policy/modules/contrib/dnsmasq.te
@@ -45,6 +45,7 @@ files_tmp_file(dnsmasq_tmp_t)
 allow dnsmasq_t self:capability { chown dac_read_search  net_admin setgid setuid net_raw };
 dontaudit dnsmasq_t self:capability sys_tty_config;
 allow dnsmasq_t self:process { getcap setcap signal_perms };
+dontaudit dnsmasq_t self:process execmem;
 allow dnsmasq_t self:fifo_file rw_fifo_file_perms;
 allow dnsmasq_t self:tcp_socket { accept listen };
 allow dnsmasq_t self:packet_socket create_socket_perms;

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -784,6 +784,8 @@ optional_policy(`
 # virtlogd is allowed to manage files it creates in /var/run/libvirt
 manage_files_pattern(virtlogd_t, virt_var_run_t, virtlogd_var_run_t)
 
+dontaudit virtlogd_t self:process execmem;
+
 # virtlogd needs to read /etc/libvirt/virtlogd.conf only
 allow virtlogd_t virtlogd_etc_t:file read_file_perms;
 files_search_etc(virtlogd_t)


### PR DESCRIPTION
Since 2.73.3 the "G_REGEX_OPTIMIZE" flag was repurposed as a way to request use of the JIT, and the PCRE2 JIT requires executable memory.
Most libvirt use of g_regex was passing G_REGEX_OPTIMIZE, so everything related to libvirt gets to try 'execmem'.

Adresses following AVC:
type=PROCTITLE msg=audit(09/05/2022 11:15:24.621:424) : proctitle=/usr/sbin/virtlogd type=SYSCALL msg=audit(09/05/2022 11:15:24.621:424) : arch=x86_64 syscall=mmap success=no exit=EACCES(Permission denied) a0=0x0 a1=0x10000 a2=PROT_READ|PROT_WRITE|PROT_EXEC a3=MAP_PRIVATE|MAP_ANONYMOUS items=0 ppid=1 pid=3641 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=virtlogd exe=/usr/sbin/virtlogd subj=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(09/05/2022 11:15:24.621:424) : avc:  denied  { execmem } for  pid=3641 comm=virtlogd scontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tclass=process permissive=0

Whenever there's a DHCP request handled from a guest connected to a libvirt NATed network (e.g. the "default" network), dnsmasq spawns the /usr/libexec/libvirt_leaseshelper binary to record guest's IP address (which is then available via 'virsh domifaddr --source lease ...').

Adresses following AVC:
type=AVC msg=audit(1662541300.368:389): avc:  denied  { execmem } for  pid=4853 comm="libvirt_leasesh" scontext=system_u:system_r:dnsmasq_t:s0-s0:c0.c1023 tcontext=system_u:system_r:dnsmasq_t:s0-s0:c0.c1023 tclass=process permissive=0

Fixed: rhbz#2122918