### PR TITLE
Allow postfix/smtpd read kerberos key table

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -700,10 +700,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	kerberos_read_keytab(postfix_smtp_t)
-')
-
-optional_policy(`
 	milter_stream_connect_all(postfix_smtp_t)
 ')
 
@@ -739,6 +735,10 @@ optional_policy(`
 optional_policy(`
 	dovecot_stream_connect_auth(postfix_smtpd_t)
 	dovecot_stream_connect(postfix_smtpd_t)
+')
+
+optional_policy(`
+	kerberos_read_keytab(postfix_smtpd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
With the 451140e4c ("Allow postfix/smtp and postfix/virtual read kerberos key table") commit, the permissions to read kerberos key table was allow for postfix/smtp instead of postfix/smtpd according to the bug report.

Resolves: rhbz#1983308