### PR TITLE
Dontaudit systemd-gpt-generator the sys_admin capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1165,6 +1165,7 @@ systemd_read_efivarfs(systemd_hwdb_t)
 #
 
 allow systemd_gpt_generator_t self:capability sys_rawio;
+dontaudit systemd_gpt_generator_t self:capability sys_admin;
 allow systemd_gpt_generator_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 dev_read_sysfs(systemd_gpt_generator_t)


### PR DESCRIPTION
It turns out dissect_image() is called with flags to add partitions, but generators are executed too early, before udev starts and can deal with partitions. A request to resolve the issue in systemd will be raised.

Resolves: rhbz#2141998