### PR TITLE
Allow sysadm read ipmi devices

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -33,6 +33,7 @@ auth_manage_shadow(sysadm_t)
 corecmd_exec_shell(sysadm_t)
 
 dev_filetrans_all_named_dev(sysadm_t)
+dev_read_ipmi_dev(sysadm_t)
 dev_rw_autofs(sysadm_t)
 dev_rw_lvm_control(sysadm_t)
 dev_rw_watchdog(sysadm_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1669648723.147:15): avc:  denied  { read write } for  pid=19673 comm="ipmitool" name="ipmi0" dev="devtmpfs" ino=3636 scontext=staff_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2148561