### PR TITLE
Allow spamc read hardware state information files

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -333,6 +333,8 @@ corecmd_read_bin_files(spamc_t)
 corecmd_read_bin_pipes(spamc_t)
 corecmd_read_bin_sockets(spamc_t)
 
+dev_read_sysfs(spamc_t)
+
 domain_use_interactive_fds(spamc_t)
 
 files_read_etc_runtime_files(spamc_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1669306540.93:728): avc:  denied  { read } for  pid=9800 comm="pyzor" name="possible" dev="sysfs" ino=42 scontext=system_u:system_r:spamc_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2148277