### PR TITLE
Allow networkmanager_dispatcher_plugin work with nscd

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -656,6 +656,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	nscd_read_pid(networkmanager_dispatcher_plugin)
+	nscd_socket_use(networkmanager_dispatcher_plugin)
+')
+
+optional_policy(`
 	samba_domtrans_smbcontrol(NetworkManager_dispatcher_winbind_t)
 	samba_read_config(NetworkManager_dispatcher_winbind_t)
 	samba_service_status(NetworkManager_dispatcher_winbind_t)


### PR DESCRIPTION
Using nscd services over a unix stream socket and reading runtime files was allowed for the networkmanager_dispatcher_plugin attribute.

Addresses the following AVC denial and similar ones:

type=PROCTITLE msg=audit(11/29/2022 10:08:18.115:1809) : proctitle=/usr/bin/sh /usr/lib/NetworkManager/dispatcher.d/90-nm-cloud-setup.sh virbr0 down
type=PATH msg=audit(11/29/2022 10:08:18.115:1809) : item=0 name=/var/run/nscd/socket inode=1637 dev=00:19 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:nscd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SOCKADDR msg=audit(11/29/2022 10:08:18.115:1809) : saddr={ saddr_fam=local path=/var/run/nscd/socket }
type=SYSCALL msg=audit(11/29/2022 10:08:18.115:1809) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x3 a1=0x7ffe7039f3e0 a2=0x6e a3=0x5d items=1 ppid=101088 pid=101098 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=90-nm-cloud-set exe=/usr/bin/bash subj=system_u:system_r:NetworkManager_dispatcher_cloud_t:s0 key=(null)
type=AVC msg=audit(11/29/2022 10:08:18.115:1809) : avc:  denied  { connectto } for  pid=101098 comm=90-nm-cloud-set path=/run/nscd/socket scontext=system_u:system_r:NetworkManager_dispatcher_cloud_t:s0 tcontext=system_u:system_r:nscd_t:s0 tclass=unix_stream_socket permissive=1
type=AVC msg=audit(11/29/2022 10:08:18.115:1809) : avc:  denied  { write } for  pid=101098 comm=90-nm-cloud-set name=socket dev="tmpfs" ino=1637 scontext=system_u:system_r:NetworkManager_dispatcher_cloud_t:s0 tcontext=system_u:object_r:nscd_var_run_t:s0 tclass=sock_file permissive=1