### PR TITLE
Allow pulseaudio to write to session_dbusd tmp socket files

### DIFF
--- a/policy/modules/contrib/pulseaudio.te
+++ b/policy/modules/contrib/pulseaudio.te
@@ -137,6 +137,7 @@ optional_policy(`
 	dbus_system_bus_client(pulseaudio_t)
 	dbus_session_bus_client(pulseaudio_t)
 	dbus_connect_session_bus(pulseaudio_t)
+	dbus_write_session_tmp_sock_files(pulseaudio_t)
 
 	optional_policy(`
 		consolekit_dbus_chat(pulseaudio_t)


### PR DESCRIPTION
Fixed: bz#2132942