### PR TITLE
Do not label /usr/bin/systemd-notify with systemd_notify_exec_t

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -6,7 +6,6 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /etc/machine-info		--		gen_context(system_u:object_r:hostname_etc_t,s0)
 /etc/udev/.*hwdb.*	--	gen_context(system_u:object_r:systemd_hwdb_etc_t,s0)
 
-/bin/systemd-notify				--		gen_context(system_u:object_r:systemd_notify_exec_t,s0)
 /bin/systemctl					--	gen_context(system_u:object_r:systemd_systemctl_exec_t,s0)
 /bin/systemd-tty-ask-password-agent		--		gen_context(system_u:object_r:systemd_passwd_agent_exec_t,s0)
 /bin/systemd-tmpfiles				--		gen_context(system_u:object_r:systemd_tmpfiles_exec_t,s0)
@@ -14,7 +13,6 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 
 /usr/bin/systemctl				--	gen_context(system_u:object_r:systemd_systemctl_exec_t,s0)
 /usr/bin/systemd-gnome-ask-password-agent	--		gen_context(system_u:object_r:systemd_passwd_agent_exec_t,s0)
-/usr/bin/systemd-notify				--		gen_context(system_u:object_r:systemd_notify_exec_t,s0)
 /usr/bin/systemd-tmpfiles			--		gen_context(system_u:object_r:systemd_tmpfiles_exec_t,s0)
 /usr/bin/systemd-tty-ask-password-agent		--		gen_context(system_u:object_r:systemd_passwd_agent_exec_t,s0)
 /usr/bin/systemd-hwdb		--	gen_context(system_u:object_r:systemd_hwdb_exec_t,s0)


### PR DESCRIPTION
The systemd-notify binary was not expected to use as a separate service, but rather a helper to notify PID 1 about some particular service state. This includes user services. As a result, particular label for the binary does not seem to be helpful.