### PR TITLE
Allow systemd-coredump create user_namespace

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1120,6 +1120,7 @@ allow systemd_coredump_t self:cap_userns { dac_read_search dac_override sys_admi
 allow systemd_coredump_t self:process setcap;
 
 allow systemd_coredump_t self:unix_stream_socket connectto;
+allow systemd_coredump_t self:user_namespace create;
 
 manage_files_pattern(systemd_coredump_t, systemd_coredump_tmpfs_t, systemd_coredump_tmpfs_t)
 fs_tmpfs_filetrans(systemd_coredump_t, systemd_coredump_tmpfs_t, file )


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(12/07/2022 11:18:41.029:14749) : proctitle=/usr/lib/systemd/systemd-coredump
type=SYSCALL msg=audit(12/07/2022 11:18:41.029:14749) : arch=x86_64 syscall=clone success=no exit=EACCES(Permission denied) a0=0x10020011 a1=0x0 a2=CLONE_VM|CLONE_FS|CLONE_PTRACE|CLONE_VFORK|CLONE_THREAD|CLONE_NEWNS|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_DETACHED|CLONE_UNTRACED|CLONE_CHILD_SETTID|CLONE_NEWUTS|CLONE_NEWIPC|CLONE_NEWUSER|CLONE_NEWPID a3=0x0 items=0 ppid=1 pid=350922 auid=unset uid=systemd-coredump gid=systemd-coredump euid=systemd-coredump suid=systemd-coredump fsuid=systemd-coredump egid=systemd-coredump sgid=systemd-coredump fsgid=systemd-coredump tty=(none) ses=unset comm=systemd-coredum exe=/usr/lib/systemd/systemd-coredump subj=system_u:system_r:systemd_coredump_t:s0 key=(null)
type=AVC msg=audit(12/07/2022 11:18:41.029:14749) : avc: denied { create } for pid=350922 comm=systemd-coredum scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=user_namespace permissive=0