### PR TITLE
Allow syslog the setpcap capability

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -479,7 +479,7 @@ optional_policy(`
 # sys_admin for the integrated klog of syslog-ng and metalog
 # sys_nice for rsyslog
 # cjp: why net_admin!
-allow syslogd_t self:capability { sys_ptrace dac_read_search dac_override sys_resource sys_tty_config ipc_lock net_admin setgid setuid sys_admin sys_nice chown fsetid setuid setgid net_raw };
+allow syslogd_t self:capability { sys_ptrace dac_read_search dac_override sys_resource sys_tty_config ipc_lock net_admin setgid setuid sys_admin sys_nice chown fsetid setuid setgid setpcap net_raw };
 dontaudit syslogd_t self:capability sys_tty_config;
 dontaudit syslogd_t self:cap_userns { kill sys_ptrace };
 allow syslogd_t self:capability2 { syslog block_suspend };


### PR DESCRIPTION
To minimize security exposure, syslog since v8.2210 limits its capabilities to only a necessary set using libcap-ng. Even for dropping capabilities the setpcap SELinux capability is required.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(11/30/2022 10:34:32.797:579) : proctitle=/usr/sbin/rsyslogd -n type=SYSCALL msg=audit(11/30/2022 10:34:32.797:579) : arch=x86_64 syscall=prctl success=yes exit=0 a0=PR_CAPBSET_DROP a1=chown a2=0x0 a3=0x0 items=0 ppid=1 pid=1917 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rsyslogd exe=/usr/sbin/rsyslogd subj=system_u:system_r:syslogd_t:s0 key=(null) type=AVC msg=audit(11/30/2022 10:34:32.797:579) : avc:  denied  { setpcap } for  pid=1917 comm=rsyslogd capability=setpcap  scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=capability permissive=1

Resolves: rhbz#2149633