### PR TITLE
Make `bootc` be `install_exec_t`

### DIFF
--- a/policy/modules/contrib/anaconda.fc
+++ b/policy/modules/contrib/anaconda.fc
@@ -4,6 +4,7 @@
 /usr/sbin/anaconda      --  gen_context(system_u:object_r:install_exec_t,s0)
 
 /usr/bin/initial-setup  --  gen_context(system_u:object_r:install_exec_t,s0)
+/usr/bin/bootc          --  gen_context(system_u:object_r:install_exec_t,s0)
 /usr/bin/ostree         --  gen_context(system_u:object_r:install_exec_t,s0)
 /usr/bin/rpm-ostree     --  gen_context(system_u:object_r:install_exec_t,s0)
 /usr/libexec/rpm-ostreed --  gen_context(system_u:object_r:install_exec_t,s0)


### PR DESCRIPTION
For the same reasons ostree and rpm-ostree are.
xref https://github.com/containers/bootc/issues/24