### PR TITLE
Allow systemd-modules-load load kernel modules

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1319,6 +1319,7 @@ allow systemd_modules_load_t self:system module_load;
 kernel_dgram_send(systemd_modules_load_t)
 kernel_load_unsigned_module(systemd_modules_load_t)
 kernel_ib_access_unlabeled_pkeys(systemd_modules_load_t)
+kernel_request_load_module(systemd_modules_load_t)
 
 corecmd_exec_bin(systemd_modules_load_t)
 corecmd_exec_shell(systemd_modules_load_t)


### PR DESCRIPTION
Addresses the following AVC denial:
audit: type=1400 audit(1637193601.011:3): avc:  denied  { module_request } for  pid=368 comm="systemd-modules" kmod="mdio:00000000001000100001011000100010" scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=1