### PR TITLE
Allow systemd-timedated watch init runtime dir

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1017,6 +1017,7 @@ fs_getattr_xattr_fs(systemd_timedated_t)
 
 init_dbus_chat(systemd_timedated_t)
 init_status(systemd_timedated_t)
+init_watch_pid_dir(systemd_timedated_t)
 
 kernel_read_network_state(systemd_timedated_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:
Dec 08 06:43:24 audit[7055]: AVC avc:  denied  { watch } for  pid=7055 comm="systemd-timesyn" path="/run/systemd" dev="tmpfs" ino=2 scontext=system_u:system_r:systemd_timedated_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0

Resolves: rhbz#2151806