### PR TITLE
Allow redis get user names

### DIFF
--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -122,8 +122,9 @@ optional_policy(`
 ')
 
 optional_policy(`
-    sssd_read_public_files(redis_t)
-    sssd_search_lib(redis_t)
+	sssd_read_public_files(redis_t)
+	sssd_search_lib(redis_t)
+	sssd_stream_connect(redis_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This commit replaces auth_read_passwd_file(redis_t) introduced in the 51f6e947fe84 ("Allow redis-sentinel execute a notification script") commit with auth_read_passwd(redis_t) which also includes communication with sssd.

Resolves: rhbz#2112228