### PR TITLE
Allow login_userdomain watch systemd-passwd pid dirs

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -464,6 +464,7 @@ optional_policy(`
 	systemd_login_watch_pid_dirs(login_userdomain)
 	systemd_login_watch_session_dirs(login_userdomain)
 	systemd_machined_watch_pid_dirs(login_userdomain)
+	systemd_passwd_watch_pid_dirs(login_userdomain)
 	systemd_resolved_watch_pid_dirs(login_userdomain)
 ')
 


### PR DESCRIPTION
When systemd-tty-ask-password-agent starts as a result of a privileged operation command, it tries to add a watch for /run/systemd/ask-password to be able to continuously process password requests.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(12/09/2022 16:34:42.542:249) : proctitle=/usr/bin/systemd-tty-ask-password-agent --watch
type=PATH msg=audit(12/09/2022 16:34:42.542:249) : item=0 name=/run/systemd/ask-password inode=41 dev=00:18 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_passwd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(12/09/2022 16:34:42.542:249) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0x4 a1=0x55f430b8d087 a2=0x88 a3=0x80800 items=1 ppid=2270 pid=2271 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=pts0 ses=3 comm=systemd-tty-ask exe=/usr/bin/systemd-tty-ask-password-agent subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(12/09/2022 16:34:42.542:249) : avc:  denied  { watch } for  pid=2271 comm=systemd-tty-ask path=/run/systemd/ask-password dev="tmpfs" ino=41 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_passwd_var_run_t:s0 tclass=dir permissive=0