### PR TITLE
Allow admin users to create user namespaces

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1681,16 +1681,18 @@ template(`userdom_admin_user_template',`
 	# Manipulate other users crontab.
 	allow $1_t self:passwd crontab;
 
-    allow $1_t self:bpf { map_create map_read map_write prog_load prog_run };
+	allow $1_t self:bpf { map_create map_read map_write prog_load prog_run };
 
-    allow $1_t self:alg_socket create_stream_socket_perms;
-    allow $1_t self:dccp_socket create_stream_socket_perms;
+	allow $1_t self:alg_socket create_stream_socket_perms;
+	allow $1_t self:dccp_socket create_stream_socket_perms;
 
-    allow $1_t self:cap_userns sys_ptrace;
+	allow $1_t self:cap_userns sys_ptrace;
 
-    tunable_policy(`deny_bluetooth',`',`
-        allow $1_t self:bluetooth_socket create_stream_socket_perms;
-    ')
+	allow $1_t self:user_namespace create;
+
+	tunable_policy(`deny_bluetooth',`',`
+		allow $1_t self:bluetooth_socket create_stream_socket_perms;
+	')
 
 	auth_use_nsswitch($1_t)
 


### PR DESCRIPTION
Admin users should definitely be able to create them. Without this patch, for example, the selinux-testsuite (when run as sysadm_t) detects user namespaces as unsupported and skips the cap_userns test.