### PR TITLE
Allow kernel threads to use fds from all domains

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -348,6 +348,34 @@ interface(`domain_cron_exemption_target',`
 ########################################
 ## <summary>
 ##	Inherit and use file descriptors from
+##	all domains.
+## </summary>
+## <desc>
+##	<p>
+##	Allow the specified domain to inherit and use file
+##	descriptors from all domains.  This does not allow
+##	access to the objects being referenced by the file
+##	descriptors.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <infoflow type="read" weight="1"/>
+#
+interface(`domain_use_all_fds',`
+	gen_require(`
+		attribute domain;
+	')
+
+	allow $1 domain:fd use;
+')
+
+########################################
+## <summary>
+##	Inherit and use file descriptors from
 ##	domains with interactive programs.
 ## </summary>
 ## <desc>

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -357,6 +357,7 @@ role system_r types kernel_generic_helper_t;
 corecmd_bin_entry_type(kernel_generic_helper_t)
 corecmd_bin_domtrans(kernel_t, kernel_generic_helper_t)
 
+domain_use_all_fds(kernel_t)
 domain_signal_all_domains(kernel_t)
 domain_search_all_domains_state(kernel_t)
 


### PR DESCRIPTION
In specific scenrios, the kernel may need to access file handles opened by userspace domains. For example, selinux-testsuite fails on the filesystem tests unless kernel_t is allowed to use fsadm_t's fds.

Since we generally trust the kernel to handle any file handle correctly, we can allow it to use all domains' fds rather than trying to limit it only to specific domains.

Fixes: 1e8688ea6943 ("Don't make kernel_t an unconfined domain")
Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>