### PR TITLE
Grant kernel_t certain permissions in the system class

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -259,7 +259,7 @@ sid tcp_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)
 
 allow kernel_t self:capability2 ~mac_override;
 allow kernel_t self:capability ~sys_module;
-allow kernel_t self:system module_request;
+allow kernel_t self:system { ipc_info module_request syslog_console syslog_mod syslog_read };
 allow kernel_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
 allow kernel_t self:shm create_shm_perms;
 allow kernel_t self:sem create_sem_perms;


### PR DESCRIPTION
Grant those that are not systemd/service-related except module_load (which has special semantics and shouldn't be needed anyway).

This fixes a denial via plymouthd (started before the policy was loaded, thus ending up with kernel_t), but it makes sense to allow these also for the kernel just in case.

Fixes: 1e8688ea6943 ("Don't make kernel_t an unconfined domain")
Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>