### PR TITLE
Allow systemd-resolved watch tmpfs directories

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1246,6 +1246,8 @@ dev_read_sysfs(systemd_resolved_t)
 files_watch_root_dirs(systemd_resolved_t)
 files_watch_var_run_dirs(systemd_resolved_t)
 
+fs_watch_tmpfs(systemd_resolved_t)
+
 init_watch_pid_dir(systemd_resolved_t)
 
 sysnet_manage_config(systemd_resolved_t)


### PR DESCRIPTION
This permission is required when the system is booted with systemd.volatile=overlay. Overlay filesystems are mounted as ramfs or tmpfs, the tmpfs_t type is assigned to "/".

Addresses the following AVC denial:

type=AVC msg=audit(1663671100.753:186): avc:  denied  { watch } for  pid=674 comm="systemd-resolve" path="/" dev="overlay" ino=2 scontext=system_u:system_r:systemd_resolved_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=0

Resolves: rhbz#2128246