### PR TITLE
Allow journalctl relabel with var_log_t and syslogd_var_run_t files

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -509,6 +509,7 @@ files_pid_filetrans(syslogd_t, devlog_t, sock_file)
 
 # create/append log files.
 manage_files_pattern(syslogd_t, var_log_t, var_log_t)
+relabel_files_pattern(syslogd_t, var_log_t, var_log_t)
 allow syslogd_t var_log_t:file map;
 rw_fifo_files_pattern(syslogd_t, var_log_t, var_log_t)
 files_search_spool(syslogd_t)
@@ -533,6 +534,7 @@ files_search_var_lib(syslogd_t)
 allow syslogd_t syslogd_var_run_t:dir watch_dir_perms;
 manage_dirs_pattern(syslogd_t, syslogd_var_run_t, syslogd_var_run_t)
 manage_files_pattern(syslogd_t, syslogd_var_run_t, syslogd_var_run_t)
+relabel_files_pattern(syslogd_t, syslogd_var_run_t, syslogd_var_run_t)
 manage_sock_files_pattern(syslogd_t, syslogd_var_run_t, syslogd_var_run_t)
 mmap_files_pattern(syslogd_t, syslogd_var_run_t, syslogd_var_run_t)
 files_pid_filetrans(syslogd_t, syslogd_var_run_t, { file dir })


### PR DESCRIPTION
The journald service runs in the syslogd_t domain as well as syslog daemons. When journal-offline wants to rotate journal files, which can be in /var/log/journal or /run/log/journal, it modifies all extended attributes, namely copy-on-write and security.selinux content, so relabelfrom and relabelto permissions are needed.

Addresses the following AVC denial:
type=PROCTITLE msg=audit(1670904722.619:48): proctitle="/usr/lib/systemd/systemd-journald" type=SYSCALL msg=audit(1670904722.619:48): arch=c00000b7 syscall=7 success=no exit=-13 a0=1d a1=ffffa0000b78 a2=ffffa0000e10 a3=27 items=0 ppid=1 pid=598 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="journal-offline" exe="/usr/lib/systemd/systemd-journald" subj=system_u:system_r:syslogd_t:s0 key=(null) type=AVC msg=audit(1670904722.619:48): avc:  denied  { relabelfrom } for  pid=598 comm="journal-offline" name=".#system@1d25afdf416a40bb98bce9ac89ae6846-0000000000000001-0005efadd1f07135.journal941ddc8fc49c256a" dev="tmpfs" ino=1026 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=file permissive=0

Resolves: rhbz#2075527