### PR TITLE
Allow insights-client dbus chat with abrt

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -176,6 +176,10 @@ seutil_read_module_store(insights_client_t)
 storage_raw_read_fixed_disk(insights_client_t)
 
 optional_policy(`
+	abrt_dbus_chat(insights_client_t)
+')
+
+optional_policy(`
 	apache_exec_modules(insights_client_t)
 	apache_read_semaphores(insights_client_t)
 ')


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(12/13/2022 05:33:31.685:568) : pid=688 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_call interface=org.freedesktop.DBus.Properties member=GetAll dest=org.freedesktop.timedate1 spid=26179 tpid=26180 scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:system_r:timedatex_t:s0 tclass=dbus permissive=0  exe=/usr/bin/dbus-daemon sauid=dbus hostname=? addr=? terminal=?'

Resolves: rhbz#2152867