### PR TITLE
Allow load_policy_t write to unallocated ttys

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -209,6 +209,7 @@ selinux_set_all_booleans(load_policy_t)
 
 term_use_console(load_policy_t)
 term_list_ptys(load_policy_t)
+term_write_unallocated_ttys(load_policy_t)
 
 init_use_script_fds(load_policy_t)
 init_use_script_ptys(load_policy_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(11/23/2022 12:30:02.176:225) : proctitle=/usr/sbin/load_policy type=PATH msg=audit(11/23/2022 12:30:02.176:225) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=8389283 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(11/23/2022 12:30:02.176:225) : item=0 name=/usr/sbin/load_policy inode=9819508 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:load_policy_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(11/23/2022 12:30:02.176:225) : cwd=/ type=EXECVE msg=audit(11/23/2022 12:30:02.176:225) : argc=1 a0=/usr/sbin/load_policy type=SYSCALL msg=audit(11/23/2022 12:30:02.176:225) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55b6f9939a10 a1=0x55b6f9939750 a2=0x55b6f9938700 a3=0x8 items=2 ppid=6765 pid=6809 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=2 comm=load_policy exe=/usr/sbin/load_policy subj=unconfined_u:unconfined_r:load_policy_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(11/23/2022 12:30:02.176:225) : avc:  denied  { read write } for  pid=6809 comm=load_policy path=/dev/tty0 dev="devtmpfs" ino=13 scontext=unconfined_u:unconfined_r:load_policy_t:s0-s0:c0.c1023 tcontext=system_u:object_r:tty_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2145181