### PR TITLE
Allow keepalived to set resource limits

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -39,7 +39,7 @@ files_tmpfs_file(keepalived_tmpfs_t)
 
 allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_admin sys_nice sys_ptrace };
 allow keepalived_t self:capability2 bpf;
-allow keepalived_t self:process { signal_perms getpgid setpgid setsched };
+allow keepalived_t self:process { signal_perms getpgid setpgid setsched setrlimit };
 allow keepalived_t self:icmp_socket create_socket_perms;
 allow keepalived_t self:netlink_socket create_socket_perms;
 allow keepalived_t self:netlink_generic_socket create_socket_perms;


### PR DESCRIPTION
Addresses the following AVC denial:
type=PROCTITLE msg=audit(12/06/2022 06:01:28.343:362) : proctitle=/usr/sbin/keepalived --dont-fork -D type=SYSCALL msg=audit(12/06/2022 06:01:28.343:362) : arch=x86_64 syscall=prlimit64 success=no exit=EACCES(Permission denied) a0=0x0 a1=0xf a2=0x7ffcac307690 a3=0x0 items=0 ppid=4738 pid=4740 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=keepalived exe=/usr/sbin/keepalived subj=system_u:system_r:keepalived_t:s0 key=(null) type=AVC msg=audit(12/06/2022 06:01:28.343:362) : avc:  denied  { setrlimit } for  pid=4740 comm=keepalived scontext=system_u:system_r:keepalived_t:s0 tcontext=system_u:system_r:keepalived_t:s0 tclass=process permissive=0

Resolves: rhbz#2151212