### PR TITLE
Allow system mail service read inherited certmonger runtime files

### DIFF
--- a/policy/modules/contrib/certmonger.if
+++ b/policy/modules/contrib/certmonger.if
@@ -80,6 +80,25 @@ interface(`certmonger_read_pid_files',`
 
 ########################################
 ## <summary>
+##	Read inherited certmonger PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`certmonger_read_inherited_pid_files',`
+	gen_require(`
+		type certmonger_var_run_t;
+	')
+
+	files_search_pids($1)
+	allow $1 certmonger_var_run_t:file read_inherited_file_perms;
+')
+
+########################################
+## <summary>
 ##	Search certmonger lib directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/mta.te
+++ b/policy/modules/contrib/mta.te
@@ -257,6 +257,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	certmonger_read_inherited_pid_files(system_mail_t)
+')
+
+optional_policy(`
 	courier_stream_connect_authdaemon(system_mail_t)
 ')
 


### PR DESCRIPTION
The certmonger_read_inherited_pid_files() interface was added.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(11/15/2022 16:34:10.124:221) : proctitle=send-mail -i -- root type=EXECVE msg=audit(11/15/2022 16:34:10.124:221) : argc=4 a0=send-mail a1=-i a2=-- a3=root type=SYSCALL msg=audit(11/15/2022 16:34:10.124:221) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x5557f5afd3d2 a1=0x5557f6a68cf0 a2=0x7ffdd47a7b00 a3=0x8 items=0 ppid=1 pid=5164 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sendmail exe=/usr/sbin/sendmail.postfix subj=system_u:system_r:system_mail_t:s0 key=(null) type=AVC msg=audit(11/15/2022 16:34:10.124:221) : avc:  denied  { read } for  pid=5164 comm=sendmail path=/run/certmonger/Rs3AjFJm (deleted) dev="tmpfs" ino=49425 scontext=system_u:system_r:system_mail_t:s0 tcontext=system_u:object_r:certmonger_var_run_t:s0 tclass=file permissive=0

Resolves: rhbz#2143337