### PR TITLE
Allow ndc read hardware state information

### DIFF
--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -291,6 +291,7 @@ corenet_sendrecv_rndc_client_packets(ndc_t)
 
 dev_read_rand(ndc_t)
 dev_read_urand(ndc_t)
+dev_read_sysfs(ndc_t)
 
 domain_use_interactive_fds(ndc_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1669718595.620:4317): avc:  denied  { read } for  pid=1996229 comm="rndc" name="enabled" dev="sysfs" ino=3770 scontext=system_u:system_r:ndc_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

where enabled is
3770 -rw-r--r--. 1 root root 4096 Nov 26 17:00 /sys/kernel/mm/transparent_hugepage/enabled

Resolves: rhbz#2149254