### PR TITLE
Allow systemd-time-wait-sync.service to add a watch for /run/systemd/

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -997,6 +997,7 @@ manage_files_pattern(systemd_timedated_t, systemd_timedated_var_lib_t, systemd_t
 read_lnk_files_pattern(systemd_timedated_t, systemd_timedated_var_lib_t, systemd_timedated_var_lib_t)
 init_var_lib_filetrans(systemd_timedated_t, systemd_timedated_var_lib_t, dir, "timesync")
 allow systemd_timedated_t systemd_networkd_var_run_t:dir watch_dir_perms;
+allow systemd_timedated_t init_var_run_t:dir watch;
 
 list_dirs_pattern(systemd_timedated_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 read_files_pattern(systemd_timedated_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)


### PR DESCRIPTION
Fixes: rhbz#1971057