### PR TITLE
Label /var/lib/httpd/md(/.*)? with httpd_sys_rw_content_t

### DIFF
--- a/policy/modules/contrib/apache.fc
+++ b/policy/modules/contrib/apache.fc
@@ -122,6 +122,7 @@ ifdef(`distro_suse', `
 /var/lib/dokuwiki(/.*)?			gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /var/lib/drupal.*			gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /var/lib/htdig(/.*)?			gen_context(system_u:object_r:httpd_sys_content_t,s0)
+/var/lib/httpd/md(/.*)?			gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /var/lib/httpd(/.*)?			gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/ipsilon(/.*)?          gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/lighttpd(/.*)?			gen_context(system_u:object_r:httpd_var_lib_t,s0)


### PR DESCRIPTION
This is required for the mod_md apache httpd module which needs to be able to manage stored certificates.

Resolves: rhbz#2005889