### PR TITLE
Allow stalld to read /sys/kernel/security/lockdown file

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -43,6 +43,8 @@ domain_use_interactive_fds(stalld_t)
 
 files_read_etc_files(stalld_t)
 
+selinux_read_security_files(stalld_t)
+
 logging_send_syslog_msg(stalld_t)
 
 miscfiles_read_localization(stalld_t)

--- a/policy/modules/kernel/selinux.if
+++ b/policy/modules/kernel/selinux.if
@@ -788,3 +788,24 @@ interface(`selinux_genbool',`
 	fs_type($1)
 	mls_trusted_object($1)
 ')
+
+########################################
+## <summary>
+##      Allow caller to read security_t files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`selinux_read_security_files',`
+	gen_require(`
+		type security_t;
+	')
+
+	dev_search_sysfs($1)
+	allow $1 security_t:dir list_dir_perms;
+	allow $1 security_t:file read_file_perms;
+')
+


### PR DESCRIPTION
The last version of stalld is checking if the system is in lockdown mode.

Add interface to allow read security_t files

Resolves: rhbz#2140673