### PR TITLE
Allow tlp read generic SSL certificates

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -65,6 +65,8 @@ files_load_kernel_modules(tlp_t)
 init_status(tlp_t)
 init_stream_connectto(tlp_t)
 
+miscfiles_read_generic_certs(tlp_t)
+
 modutils_exec_kmod(tlp_t)
 modutils_read_module_config(tlp_t)
 modutils_read_module_deps_files(tlp_t)


### PR DESCRIPTION
Addresses the following AVC denial and further ones:

type=AVC msg=audit(1659568944.632:728): avc:  denied  { search } for  pid=34604 comm="modinfo" name="pki" dev="dm-1" ino=2490465 scontext=system_u:system_r:tlp_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=0

Resolves: rhbz#2115141