### PR TITLE
Allow winbind-rpcd make a TCP connection to the ldap port

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1205,6 +1205,7 @@ kernel_read_network_state(winbind_rpcd_t)
 corecmd_exec_bin(winbind_rpcd_t)
 
 corenet_tcp_connect_ipp_port(winbind_rpcd_t)
+corenet_tcp_connect_ldap_port(winbind_rpcd_t)
 
 dev_getattr_fs(winbind_rpcd_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(12/06/2022 12:58:18.767:2236) : proctitle=/usr/libexec/samba/samba-dcerpcd --libexec-rpcds --ready-signal-fd=35 --np-helper --debuglevel=2 type=SOCKADDR msg=audit(12/06/2022 12:58:18.767:2236) : saddr={ saddr_fam=inet laddr=127.0.0.1 lport=389 } type=SYSCALL msg=audit(12/06/2022 12:58:18.767:2236) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0xf a1=0x55f673a4ace0 a2=0x10 a3=0x0 items=0 ppid=1 pid=7080 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=samba-dcerpcd exe=/usr/libexec/samba/samba-dcerpcd subj=system_u:system_r:winbind_rpcd_t:s0 key=(null) type=AVC msg=audit(12/06/2022 12:58:18.767:2236) : avc:  denied  { name_connect } for  pid=7080 comm=samba-dcerpcd dest=389 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:ldap_port_t:s0 tclass=tcp_socket permissive=0

Resolves: rhbz#2152642