### PR TITLE
Label /usr/lib/rpm/rpmdb_migrate with rpmdb_exec_t

### DIFF
--- a/policy/modules/contrib/rpm.fc
+++ b/policy/modules/contrib/rpm.fc
@@ -18,6 +18,11 @@
 /usr/bin/repoquery		--	gen_context(system_u:object_r:rpm_exec_t,s0)		
 /usr/bin/zif 			--	gen_context(system_u:object_r:rpm_exec_t,s0)
 
+/usr/lib/rpm/rpmdb_migrate	--	gen_context(system_u:object_r:rpmdb_exec_t,s0)
+
+# This is in /usr, but is expected to be variable content from a policy perspective (#2042149)
+/usr/lib/sysimage/rpm(/.*)?		gen_context(system_u:object_r:rpm_var_lib_t,s0)
+
 /usr/libexec/packagekitd	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/libexec/yumDBUSBackend.py	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/libexec/pegasus/pycmpiLMI_Software-cimprovagt  --  gen_context(system_u:object_r:rpm_exec_t,s0)
@@ -62,9 +67,6 @@ ifdef(`distro_redhat', `
 /var/lib/rpmrebuilddb.*(/.*)?  gen_context(system_u:object_r:rpm_var_lib_t,s0)
 /var/lib/yum(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
 /var/lib/dnf(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
-
-# This is in /usr, but is expected to be variable content from a policy perspective (#2042149)
-/usr/lib/sysimage/rpm(/.*)?		gen_context(system_u:object_r:rpm_var_lib_t,s0)
 
 /var/log/dnf.log.*		--	gen_context(system_u:object_r:rpm_log_t,s0)
 /var/log/dnf.librepo.log.*	--	gen_context(system_u:object_r:rpm_log_t,s0)


### PR DESCRIPTION
The /usr/lib/rpm/rpmdb_migrate wrapper is executed from the rpmdb-migrate.service unit to migrate the rpm database from /var/lib/rpm to /usr/lib/sysimage/rpm using /usr/bin/rpmdb. The service is started during the first boot after upgrade.

Resolves: rhbz#2086377