### PR TITLE
Allow virt_domain read device sysctls

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -880,6 +880,7 @@ read_files_pattern(virt_domain, virt_content_t, virt_content_t)
 dontaudit virt_domain virt_content_t:file write_file_perms;
 dontaudit virt_domain virt_content_t:dir write;
 
+kernel_read_device_sysctls(virt_domain)
 kernel_read_net_sysctls(virt_domain)
 kernel_read_network_state(virt_domain)
 kernel_ib_access_unlabeled_pkeys(virt_domain)


### PR DESCRIPTION
This denial appears when a vm is configured with 3D acceleration enabled.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(13.10.2022 15:38:15.538:1556) : proctitle=/usr/bin/qemu-system-x86_64 -name guest=f37beta,debug-threads=on -S -object {"qom-type":"secret","id":"masterKey0","format":"raw type=PATH msg=audit(13.10.2022 15:38:15.538:1556) : item=0 name=/proc/sys/dev/i915/perf_stream_paranoid inode=27625 dev=00:17 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_dev_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(13.10.2022 15:38:15.538:1556) : arch=x86_64 syscall=newfstatat success=yes exit=0 a0=AT_FDCWD a1=0x7f2d4d9fcee8 a2=0x7ffc229e3210 a3=0x0 items=1 ppid=1 pid=136663 auid=unset uid=qemu gid=qemu euid=qemu suid=qemu fsuid=qemu egid=qemu sgid=qemu fsgid=qemu tty=(none) ses=unset comm=qemu-system-x86 exe=/usr/bin/qemu-system-x86_64 subj=system_u:system_r:svirt_t:s0:c641,c1000 key=(null) type=AVC msg=audit(13.10.2022 15:38:15.538:1556) : avc:  denied  { getattr } for  pid=136663 comm=qemu-system-x86 path=/proc/sys/dev/i915/perf_stream_paranoid dev="proc" ino=27625 scontext=system_u:system_r:svirt_t:s0:c641,c1000 tcontext=system_u:object_r:sysctl_dev_t:s0 tclass=file permissive=1 type=AVC msg=audit(13.10.2022 15:38:15.538:1556) : avc:  denied  { search } for  pid=136663 comm=qemu-system-x86 name=dev dev="proc" ino=27623 scontext=system_u:system_r:svirt_t:s0:c641,c1000 tcontext=system_u:object_r:sysctl_dev_t:s0 tclass=dir permissive=1

Resolves: rhbz#2143886