### PR TITLE
Allow apcupsd dbus chat with systemd-logind

### DIFF
--- a/policy/modules/contrib/apcupsd.te
+++ b/policy/modules/contrib/apcupsd.te
@@ -112,6 +112,8 @@ logging_send_syslog_msg(apcupsd_t)
 
 sysnet_dns_name_resolve(apcupsd_t)
 
+systemd_dbus_chat_logind(apcupsd_t)
+
 userdom_use_inherited_user_ttys(apcupsd_t)
 
 optional_policy(`


### PR DESCRIPTION
The permission is required in case of a power outage when apcupsd wants to initiate a shutdown.

Addresses the following USER_AVC denial:

Dec 29 08:41:25 hostname audit[516]: USER_AVC pid=516 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:apcupsd_t:s0 tcontext=system_u:system_r:systemd_logind_t:s0 tclass=dbus permissive=0#012 exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=? terminal=?'

Resolves: rhbz#2157175