### PR TITLE
Allow prosody manage its runtime socket files

### DIFF
--- a/policy/modules/contrib/prosody.te
+++ b/policy/modules/contrib/prosody.te
@@ -48,6 +48,7 @@ files_var_lib_filetrans(prosody_t, prosody_var_lib_t, { dir file lnk_file })
 manage_dirs_pattern(prosody_t, prosody_var_run_t, prosody_var_run_t)
 manage_files_pattern(prosody_t, prosody_var_run_t, prosody_var_run_t)
 manage_lnk_files_pattern(prosody_t, prosody_var_run_t, prosody_var_run_t)
+manage_sock_files_pattern(prosody_t, prosody_var_run_t, prosody_var_run_t)
 files_pid_filetrans(prosody_t, prosody_var_run_t, { dir file lnk_file })
 
 manage_dirs_pattern(prosody_t, prosody_log_t, prosody_log_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/03/2023 08:57:18.294:337) : proctitle=/usr/bin/lua /usr/bin/prosody -F type=PATH msg=audit(01/03/2023 08:57:18.294:337) : item=1 name=/run/prosody/prosody.sock nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(01/03/2023 08:57:18.294:337) : item=0 name=/run/prosody/ inode=38265 dev=00:18 mode=dir,755 ouid=prosody ogid=prosody rdev=00:00 obj=system_u:object_r:prosody_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(01/03/2023 08:57:18.294:337) : saddr={ saddr_fam=local path=/run/prosody/prosody.sock } type=SYSCALL msg=audit(01/03/2023 08:57:18.294:337) : arch=x86_64 syscall=bind success=no exit=EACCES(Permission denied) a0=0xb a1=0x7ffd9391a080 a2=0x1b a3=0xfffffffe items=2 ppid=1 pid=6151 auid=unset uid=prosody gid=prosody euid=prosody suid=prosody fsuid=prosody egid=prosody sgid=prosody fsgid=prosody tty=(none) ses=unset comm=prosody exe=/usr/bin/lua subj=system_u:system_r:prosody_t:s0 key=(null) type=AVC msg=audit(01/03/2023 08:57:18.294:337) : avc:  denied  { create } for  pid=6151 comm=prosody name=prosody.sock scontext=system_u:system_r:prosody_t:s0 tcontext=system_u:object_r:prosody_var_run_t:s0 tclass=sock_file permissive=0

Resolves: rhbz#2157902