### PR TITLE
Allow sudodomain use sudo.log as a logfile

### DIFF
--- a/policy/modules/admin/sudo.fc
+++ b/policy/modules/admin/sudo.fc
@@ -4,3 +4,4 @@
 /var/db/sudo(/.*)?		gen_context(system_u:object_r:sudo_db_t,s0)
 
 /var/log/sudo-io(/.*)?		gen_context(system_u:object_r:sudo_log_t,s0)
+/var/log/sudo\.log	--	gen_context(system_u:object_r:sudo_log_t,s0)

--- a/policy/modules/admin/sudo.te
+++ b/policy/modules/admin/sudo.te
@@ -25,6 +25,7 @@ manage_files_pattern(sudodomain, sudo_db_t, sudo_db_t)
 manage_dirs_pattern(sudodomain, sudo_log_t, sudo_log_t)
 manage_files_pattern(sudodomain, sudo_log_t, sudo_log_t)
 logging_log_filetrans(sudodomain, sudo_log_t, dir, "sudo-io")
+logging_log_filetrans(sudodomain, sudo_log_t, file, "sudo.log")
 
 ##############################
 #


### PR DESCRIPTION
By default, sudo logs events using syslog, but setting the logfile option in sudoers turns on logging to a file. This commit supports a file transition for /var/log/sudo.log.

Resolves: rhbz#2143762