### PR TITLE
Allow sysadm_t read/write ipmi devices

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -33,7 +33,7 @@ auth_manage_shadow(sysadm_t)
 corecmd_exec_shell(sysadm_t)
 
 dev_filetrans_all_named_dev(sysadm_t)
-dev_read_ipmi_dev(sysadm_t)
+dev_rw_ipmi_dev(sysadm_t)
 dev_rw_autofs(sysadm_t)
 dev_rw_lvm_control(sysadm_t)
 dev_rw_watchdog(sysadm_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(01/04/2023 07:49:55.712:299) : proctitle=ipmitool mc info type=PATH msg=audit(01/04/2023 07:49:55.712:299) : item=0 name=/dev/ipmi0 inode=1368 dev=00:06 mode=character,600 ouid=root ogid=root rdev=f2:00 obj=system_u:object_r:ipmi_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/04/2023 07:49:55.712:299) : arch=aarch64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0xfffff9d982b8 a2=O_RDWR a3=0x0 items=1 ppid=18946 pid=19074 auid=sysadm-user uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts1 ses=3 comm=ipmitool exe=/usr/bin/ipmitool subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(01/04/2023 07:49:55.712:299) : avc:  denied  { write } for  pid=19074 comm=ipmitool name=ipmi0 dev="devtmpfs" ino=1368 scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:ipmi_device_t:s0 tclass=chr_file permissive=1

Resolves: rhbz#2148561