### PR TITLE
Allow nut_domain manage also files and sock_files in /var/run

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -36,7 +36,7 @@ allow nut_domain self:netlink_kobject_uevent_socket create_socket_perms;
 manage_files_pattern(nut_domain, nut_var_run_t, nut_var_run_t)
 manage_dirs_pattern(nut_domain, nut_var_run_t, nut_var_run_t)
 manage_sock_files_pattern(nut_domain, nut_var_run_t, nut_var_run_t)
-files_pid_filetrans(nut_domain, nut_var_run_t, dir)
+files_pid_filetrans(nut_domain, nut_var_run_t, { dir file sock_file })
 
 ########################################
 #


### PR DESCRIPTION
So far there was only a rule for a directory.

Resolves: rhbz#2144194