### PR TITLE
Allow pdns map pdns_var_lib_t files and bind to unreserved ports

### DIFF
--- a/policy/modules/contrib/pdns.te
+++ b/policy/modules/contrib/pdns.te
@@ -54,12 +54,15 @@ corenet_tcp_bind_transproxy_port(pdns_t)
 manage_dirs_pattern(pdns_t, pdns_var_lib_t, pdns_var_lib_t)
 manage_files_pattern(pdns_t, pdns_var_lib_t, pdns_var_lib_t)
 files_var_lib_filetrans(pdns_t, pdns_var_lib_t, { dir file })
+allow pdns_t pdns_var_lib_t:file map;
 
 files_pid_filetrans(pdns_t, pdns_var_run_t, { file sock_file })
 manage_files_pattern(pdns_t, pdns_var_run_t, pdns_var_run_t)
 manage_sock_files_pattern(pdns_t, pdns_var_run_t, pdns_var_run_t)
 
 auth_use_nsswitch(pdns_t)
+
+corenet_udp_bind_generic_port(pdns_t)
 
 logging_send_syslog_msg(pdns_t)
 


### PR DESCRIPTION
Addresses the following AVC denials:

type=PROCTITLE msg=audit(01/05/2023 11:12:47.045:1116) : proctitle=/usr/sbin/pdns_server --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no type=MMAP msg=audit(01/05/2023 11:12:47.045:1116) : fd=11 flags=MAP_SHARED type=SYSCALL msg=audit(01/05/2023 11:12:47.045:1116) : arch=x86_64 syscall=mmap success=yes exit=140315529633792 a0=0x0 a1=0x8000 a2=PROT_READ|PROT_WRITE a3=MAP_SHARED items=0 ppid=1 pid=1809 auid=unset uid=pdns gid=pdns euid=pdns suid=pdns fsuid=pdns egid=pdns sgid=pdns fsgid=pdns tty=(none) ses=unset comm=pdns_server exe=/usr/sbin/pdns_server subj=system_u:system_r:pdns_t:s0 key=(null) type=AVC msg=audit(01/05/2023 11:12:47.045:1116) : avc:  denied  { map } for  pid=1809 comm=pdns_server path=/var/lib/pdns/pdns.sqlite-shm dev="vda2" ino=262244 scontext=system_u:system_r:pdns_t:s0 tcontext=system_u:object_r:pdns_var_lib_t:s0 tclass=file permissive=1

type=PROCTITLE msg=audit(01/05/2023 11:12:47.051:1118) : proctitle=/usr/sbin/pdns_server --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no type=SOCKADDR msg=audit(01/05/2023 11:12:47.051:1118) : saddr={ saddr_fam=inet laddr=0.0.0.0 lport=19112 } type=SYSCALL msg=audit(01/05/2023 11:12:47.051:1118) : arch=x86_64 syscall=bind success=yes exit=0 a0=0x14 a1=0x7f9dc0cd34c0 a2=0x10 a3=0x7f9dc2da0ac0 items=0 ppid=1 pid=1809 auid=unset uid=pdns gid=pdns euid=pdns suid=pdns fsuid=pdns egid=pdns sgid=pdns fsgid=pdns tty=(none) ses=unset comm=pdns/comm-main exe=/usr/sbin/pdns_server subj=system_u:system_r:pdns_t:s0 key=(null) type=AVC msg=audit(01/05/2023 11:12:47.051:1118) : avc:  denied  { name_bind } for  pid=1809 comm=pdns/comm-main src=19112 scontext=system_u:system_r:pdns_t:s0 tcontext=system_u:object_r:unreserved_port_t:s0 tclass=udp_socket permissive=1

Resolves: rhbz#1364611