### PR TITLE
Allow upsd to send signal to itself

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -1,4 +1,4 @@
-policy_module(nut, 1.3.0)
+policy_module(nut, 1.3.1)
 
 ########################################
 #
@@ -43,6 +43,7 @@ files_pid_filetrans(nut_domain, nut_var_run_t, { dir file sock_file })
 # Local policy for upsd
 #
 
+allow nut_upsd_t self:capability kill;
 allow nut_upsd_t self:unix_dgram_socket { create_socket_perms sendto };
 allow nut_upsd_t self:tcp_socket connected_stream_socket_perms;
 


### PR DESCRIPTION
This is required for systemctl reload nut-server

Addresses the following AVC denial:

type=AVC msg=audit(1673477932.190:38451): avc:  denied  { kill } for  pid=22403 comm="upsd" capability=5  scontext=system_u:system_r:nut_upsd_t:s0 tcontext=system_u:system_r:nut_upsd_t:s0 tclass=capability permissive=0