### PR TITLE
Allow wireguard to create udp sockets and read net_conf

### DIFF
--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -21,8 +21,10 @@ allow wireguard_t self:fifo_file rw_fifo_file_perms;
 allow wireguard_t self:netlink_generic_socket create_socket_perms;
 allow wireguard_t self:netlink_netfilter_socket create_socket_perms;
 allow wireguard_t self:netlink_route_socket create_netlink_socket_perms;
+allow wireguard_t self:udp_socket create_socket_perms;
 allow wireguard_t self:unix_dgram_socket create_socket_perms;
 allow wireguard_t self:unix_stream_socket create_stream_socket_perms;
+
 
 kernel_request_load_module(wireguard_t)
 
@@ -46,4 +48,5 @@ optional_policy(`
 
 optional_policy(`
 	sysnet_exec_ifconfig(wireguard_t)
+	sysnet_read_config(wireguard_t)
 ')


### PR DESCRIPTION
Allow wireguard to read network config files and create its udp sockets

Resolves: rhbz#2129438
rhbz#2149452