### PR TITLE
Allow sysadm to rw ipmi devices

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -33,7 +33,7 @@ auth_manage_shadow(sysadm_t)
 corecmd_exec_shell(sysadm_t)
 
 dev_filetrans_all_named_dev(sysadm_t)
-dev_read_ipmi_dev(sysadm_t)
+dev_rw_ipmi_dev(sysadm_t)
 dev_rw_autofs(sysadm_t)
 dev_rw_lvm_control(sysadm_t)
 dev_rw_watchdog(sysadm_t)


### PR DESCRIPTION
Allow sysadm_t to read and write ipmi devices.

Resolves: rhbz#2158419