### PR TITLE
Allow systemd-rfkill the bpf capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -947,6 +947,7 @@ tunable_policy(`systemd_socket_proxyd_connect_any',`
 #
 
 allow systemd_rfkill_t self:capability { net_admin sys_admin};
+allow systemd_rfkill_t self:capability2 bpf;
 allow systemd_rfkill_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 manage_files_pattern(systemd_rfkill_t, systemd_rfkill_var_lib_t, systemd_rfkill_var_lib_t)


### PR DESCRIPTION
Linux Socket Filtering (LSF) is derived from the Berkeley Packet Filter and uses the same mechanism to allow a user-space program to attach a filter onto any socket and allow or disallow certain types of data to come through the socket.
The systemd-rfkill service wants to listen only to related udev events, so it needs to set a filter for which the bpf capability is required.

Addresses the following USER_AVC denial:
type=AVC msg=audit(1669160827.102:10): avc:  denied  { bpf } for  pid=954 comm="systemd-rfkill" capability=39  scontext=system_u:system_r:systemd_rfkill_t:s0 tcontext=system_u:system_r:systemd_rfkill_t:s0 tclass=capability2 permissive=0

Resolves: rhbz#2149390