### PR TITLE
Allow svirt request the kernel to load a module

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -363,6 +363,8 @@ allow svirt_t self:netlink_route_socket r_netlink_socket_perms;
 
 allow svirt_t virtlogd_t:unix_stream_socket connectto;
 
+kernel_request_load_module(svirt_t)
+
 corenet_udp_sendrecv_generic_if(svirt_t)
 corenet_udp_sendrecv_generic_node(svirt_t)
 corenet_udp_sendrecv_all_ports(svirt_t)


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(1668767748.175:184): avc:  denied  { module_request } for  pid=2361 comm="qemu-kvm" kmod="char-major-10-232" scontext=system_u:system_r:svirt_t:s0:c370,c450 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0

Resolves: rhbz#2144735