### PR TITLE
Allow rshim bpf cap2 and read sssd public files

### DIFF
--- a/policy/modules/contrib/rshim.te
+++ b/policy/modules/contrib/rshim.te
@@ -18,6 +18,7 @@ permissive rshim_t;
 #
 # rshim local policy
 #
+allow rshim_t self:capability2 bpf;
 allow rshim_t self:fifo_file rw_fifo_file_perms;
 allow rshim_t self:netlink_kobject_uevent_socket { bind create getattr setopt };
 allow rshim_t self:process { fork };
@@ -28,8 +29,6 @@ kernel_read_proc_files(rshim_t)
 
 corecmd_exec_shell(rshim_t)
 
-auth_read_passwd_file(rshim_t)
-
 dev_read_sysfs(rshim_t)
 
 domain_use_interactive_fds(rshim_t)
@@ -37,13 +36,29 @@ domain_use_interactive_fds(rshim_t)
 files_read_etc_files(rshim_t)
 files_read_kernel_modules(rshim_t)
 
-logging_send_syslog_msg(rshim_t)
+optional_policy(`
+	auth_read_passwd_file(rshim_t)
+')
 
-miscfiles_read_localization(rshim_t)
+optional_policy(`
+	logging_send_syslog_msg(rshim_t)
+')
 
-modutils_exec_kmod(rshim_t)
-modutils_getattr_module_deps(rshim_t)
-modutils_read_module_config(rshim_t)
-modutils_read_module_deps_files(rshim_t)
+optional_policy(`
+	miscfiles_read_localization(rshim_t)
+')
 
-udev_read_pid_files(rshim_t)
+optional_policy(`
+	modutils_exec_kmod(rshim_t)
+	modutils_getattr_module_deps(rshim_t)
+	modutils_read_module_config(rshim_t)
+	modutils_read_module_deps_files(rshim_t)
+')
+
+optional_policy(`
+        sssd_read_public_files(rshim_t)
+')
+
+optional_policy(`
+	udev_read_pid_files(rshim_t)
+')


### PR DESCRIPTION
Addresses the following AVC denial:
type=AVC msg=audit(12/15/2022 10:59:12.605:1082) : avc:  denied  { search } for  pid=102791 comm=sh name=mc dev="dm-0" ino=34190411 scontext=system_u:system_r:rshim_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=dir permissive=1

type=AVC msg=audit(12/15/2022 10:59:12.605:1082) : avc:  denied  { search } for  pid=102791 comm=sh name=sss dev="dm-0" ino=34190410 scontext=system_u:system_r:rshim_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=dir permissive=1

type=PROCTITLE msg=audit(12/15/2022 10:59:12.605:1083) : proctitle=/usr/sbin/rshim
type=SYSCALL msg=audit(12/15/2022 10:59:12.605:1083) : arch=ppc64le syscall=setsockopt success=yes exit=0 a0=0x6 a1=SOL_SOCKET a2=SO_ATTACH_FILTER a3=0x7ffff12cec18 items=0 ppid=1 pid=102790 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rshim exe=/usr/sbin/rshim subj=system_u:system_r:rshim_t:s0 key=(null)
type=AVC msg=audit(12/15/2022 10:59:12.605:1083) : avc:  denied  { bpf } for  pid=102790 comm=rshim capability=bpf  scontext=system_u:system_r:rshim_t:s0 tcontext=system_u:system_r:rshim_t:s0 tclass=capability2 permissive=1



Resolves: rhbz#2080439