### PR TITLE
Allow ModemManager all permissions for netlink route socket

### DIFF
--- a/policy/modules/contrib/modemmanager.te
+++ b/policy/modules/contrib/modemmanager.te
@@ -36,6 +36,7 @@ auth_read_passwd(modemmanager_t)
 
 corecmd_exec_bin(modemmanager_t)
 
+dev_create_sysfs_files(modemmanager_t)
 dev_rw_sysfs(modemmanager_t)
 dev_read_urand(modemmanager_t)
 dev_rw_modem(modemmanager_t)

--- a/policy/modules/contrib/modemmanager.te
+++ b/policy/modules/contrib/modemmanager.te
@@ -26,7 +26,7 @@ allow modemmanager_t self:process { getsched signal };
 allow modemmanager_t self:fifo_file rw_fifo_file_perms;
 allow modemmanager_t self:unix_stream_socket {connectto create_stream_socket_perms};
 allow modemmanager_t self:netlink_kobject_uevent_socket create_socket_perms;
-allow modemmanager_t self:netlink_route_socket create_socket_perms;
+allow modemmanager_t self:netlink_route_socket create_netlink_socket_perms;
 allow modemmanager_t self:qipcrtr_socket create_socket_perms;
 
 kernel_read_system_state(modemmanager_t)


### PR DESCRIPTION
Before, the create_socket_perms permission set was used. Since this commit create_netlink_socket_perms is used instead which allows also nlmsg_read and nlmsg_write.

Resolves: rhbz#2149560