### PR TITLE
Allow icecast rename its log files

### DIFF
--- a/policy/modules/contrib/icecast.te
+++ b/policy/modules/contrib/icecast.te
@@ -41,6 +41,7 @@ allow icecast_t self:tcp_socket { accept listen };
 allow icecast_t icecast_log_t:dir setattr_dir_perms;
 append_files_pattern(icecast_t, icecast_log_t, icecast_log_t)
 create_files_pattern(icecast_t, icecast_log_t, icecast_log_t)
+rename_files_pattern(icecast_t, icecast_log_t, icecast_log_t)
 setattr_files_pattern(icecast_t, icecast_log_t, icecast_log_t)
 
 manage_dirs_pattern(icecast_t, icecast_var_run_t, icecast_var_run_t)


### PR DESCRIPTION
This permission is required when icecast is configured with "logarchive 1" and the log file size reaches the "logsize" limit.

Resolves: rhbz#2156763