### PR TITLE
Boolean: allow qemu-ga read ssh home directory

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -198,6 +198,13 @@ gen_tunable(virt_lockd_blk_devs, false)
 ## </desc>
 gen_tunable(virt_qemu_ga_read_nonsecurity_files, false)
 
+## <desc>
+## <p>
+## Allow qemu-ga read ssh home directory content.
+## </p>
+## </desc>
+gen_tunable(virt_qemu_ga_read_ssh, false)
+
 virt_domain_template(svirt)
 role system_r types svirt_t;
 typealias svirt_t alias qemu_t;
@@ -1789,6 +1796,12 @@ tunable_policy(`virt_rw_qemu_ga_data',`
     manage_files_pattern(virt_qemu_ga_t, virt_qemu_ga_data_t, virt_qemu_ga_data_t)
     manage_lnk_files_pattern(virt_qemu_ga_t, virt_qemu_ga_data_t, virt_qemu_ga_data_t)
     manage_dirs_pattern(virt_qemu_ga_t, virt_qemu_ga_data_t, virt_qemu_ga_data_t)
+')
+
+optional_policy(`
+        tunable_policy(`virt_qemu_ga_read_ssh',`
+                ssh_read_user_home_files(virt_qemu_ga_t)
+        ')
 ')
 
 optional_policy(`


### PR DESCRIPTION
QEMU Guest Agent 5.2.0 added some new features including commands for managing guest ssh keys.

Resolves: rhbz#1917024