### PR TITLE
Dontaudit ftpd the execmem permission

### DIFF
--- a/policy/modules/contrib/ftp.te
+++ b/policy/modules/contrib/ftp.te
@@ -137,6 +137,7 @@ ifdef(`enable_mls',`
 allow ftpd_t self:capability { dac_read_search dac_override chown fowner fsetid ipc_lock kill setgid setuid sys_chroot sys_admin sys_nice sys_resource };
 dontaudit ftpd_t self:capability sys_tty_config;
 allow ftpd_t self:process { getcap getpgid setcap setsched setrlimit signal_perms };
+dontaudit ftpd_t self:process execmem;
 allow ftpd_t self:fifo_file rw_fifo_file_perms;
 allow ftpd_t self:unix_dgram_socket sendto;
 allow ftpd_t self:unix_stream_socket { accept listen };


### PR DESCRIPTION
The following AVC denial will be dontaudited:

type=AVC msg=audit(1673174151.123:562134): avc:  denied  { execmem } for  pid=2352865 comm="proftpd" scontext=system_u:system_r:ftpd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:ftpd_t:s0-s0:c0.c1023 tclass=process permissive=0

Resolves: rhbz#2161705