### PR TITLE
Allow wg to send msg to kernel, write to syslog and dbus connections

### DIFF
--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -25,10 +25,12 @@ allow wireguard_t self:udp_socket create_socket_perms;
 allow wireguard_t self:unix_dgram_socket create_socket_perms;
 allow wireguard_t self:unix_stream_socket create_stream_socket_perms;
 
-
+kernel_dgram_send(wireguard_t)
 kernel_request_load_module(wireguard_t)
 
 corecmd_exec_bin(wireguard_t)
+
+dev_write_kmsg(wireguard_t)
 
 domain_use_interactive_fds(wireguard_t)
 
@@ -39,7 +41,15 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dbus_system_bus_client(wireguard_t)
+')
+
+optional_policy(`
 	iptables_domtrans(wireguard_t)
+')
+
+optional_policy(`
+	logging_write_syslog_pid_socket(wireguard_t)
 ')
 
 optional_policy(`
@@ -50,3 +60,4 @@ optional_policy(`
 	sysnet_exec_ifconfig(wireguard_t)
 	sysnet_read_config(wireguard_t)
 ')
+


### PR DESCRIPTION
Allow wireguard to write to the kernel messages device, send messages to kernel unix datagram sockets,
create connections to the system DBUS,
write to the syslog pid sock_files.

Resolves: rhbz#2149452