### PR TITLE
Allow nm-cloud-setup dispatcher plugin restart nm services

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -570,6 +570,7 @@ allow NetworkManager_dispatcher_custom_t self:unix_dgram_socket { create_socket_
 
 allow NetworkManager_dispatcher_t NetworkManager_unit_file_t:file getattr;
 allow NetworkManager_dispatcher_cloud_t NetworkManager_unit_file_t:file getattr;
+allow NetworkManager_dispatcher_cloud_t NetworkManager_unit_file_t:service { start status stop };
 
 list_dirs_pattern(NetworkManager_dispatcher_t, NetworkManager_etc_t, NetworkManager_dispatcher_script_t)
 list_dirs_pattern(networkmanager_dispatcher_plugin, NetworkManager_etc_t, NetworkManager_dispatcher_script_t)


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(01/04/2023 03:34:51.332:39) : pid=1 uid=root auid=unset ses=unset subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=unset uid=root gid=root path=/usr/lib/systemd/system/nm-cloud-setup.service cmdline="" function="bus_unit_method_start_generic" scontext=system_u:system_r:NetworkManager_dispatcher_cloud_t:s0 tcontext=system_u:object_r:NetworkManager_unit_file_t:s0 tclass=service permissive=0  exe=/usr/lib/systemd/systemd sauid=root hostname=? addr=? terminal=?'

Resolves: rhbz#2154414