### PR TITLE
Allow kernel_t to manage and execute all files

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1800,6 +1800,32 @@ interface(`files_manage_all_files',`
 
 ########################################
 ## <summary>
+##	Grant execute access to all files on the filesystem,
+##	except the listed exceptions.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="exception_types" optional="true">
+##	<summary>
+##	The types to be excluded.  Each type or attribute
+##	must be negated by the caller.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_mmap_exec_all_files',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	mmap_exec_files_pattern($1, { file_type $2 }, { file_type $2 })
+')
+
+########################################
+## <summary>
 ##	Search the contents of all directories on
 ##	extended attribute filesystems.
 ## </summary>

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1788,10 +1788,14 @@ interface(`files_manage_all_files',`
 	manage_sock_files_pattern($1, { file_type $2 }, { file_type $2 })
 
 	# satisfy the assertions:
-	seutil_create_bin_policy($1)
 	files_manage_kernel_modules($1)
-    auth_reader_shadow($1)
-    auth_writer_shadow($1)
+	optional_policy(`
+		seutil_create_bin_policy($1)
+	')
+	optional_policy(`
+		auth_reader_shadow($1)
+		auth_writer_shadow($1)
+	')
 ')
 
 ########################################

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -362,12 +362,14 @@ domain_use_all_fds(kernel_t)
 domain_signal_all_domains(kernel_t)
 domain_search_all_domains_state(kernel_t)
 
-files_list_root(kernel_t)
-files_list_etc(kernel_t)
-files_list_home(kernel_t)
-files_read_usr_files(kernel_t)
-files_manage_mounttab(kernel_t)
-files_manage_generic_spool_dirs(kernel_t)
+files_manage_all_files(kernel_t)
+# The 'execute' permission on lower inodes is checked against the mounter
+# cred by overlayfs, so we need to grant it to allow overlay mounts created
+# during early boot to work.
+# In itself, this doesn't allow the kernel to execute all files - an 
+# execute_no_trans permission or a type transition is also needed to grant
+# that ability (and we are much more strict about those).
+files_mmap_exec_all_files(kernel_t)
 
 mcs_process_set_categories(kernel_t)
 mcs_file_read_all(kernel_t)


### PR DESCRIPTION
This is needed to get early overlay mounts to work - see the comment and
this bug:
https://bugzilla.redhat.com/show_bug.cgi?id=2154428
    
Allowing to manage all files may not be strictly necessary, but not
allowing it may bite us later and there is not much point in confining
kernel's file operations beyond the helper execution anyway.

---

Note that this will make the current `sekinux-policy/kernel-confined-exec` test fail - https://src.fedoraproject.org/tests/selinux/pull-request/358 needs to be merged before bringing this into Fedora.