### PR TITLE
Allow unconfined user filetransition for sudo log files

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -169,3 +169,21 @@ interface(`sudo_manage_db',`
     manage_dirs_pattern($1, sudo_db_t, sudo_db_t)
     manage_files_pattern($1, sudo_db_t, sudo_db_t)
 ')
+
+########################################
+## <summary>
+## 	Transition to sudo log named content
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`sudo_filetrans_named_content_log',`
+	gen_require(`
+		type sudo_log_t;
+	')
+
+	logging_log_filetrans($1, sudo_log_t, file, "sudo.log")
+')

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -91,6 +91,8 @@ logging_send_syslog_msg(unconfined_t)
 
 mount_entry_type(unconfined_t)
 
+sudo_filetrans_named_content_log(unconfined_t)
+
 systemd_config_all_services(unconfined_t)
 
 ssh_dyntransition_to(unconfined_t)


### PR DESCRIPTION
When "Defaults logfile=/var/log/sudo.log" is specified in sudo configuration along with the documentation, an unconfined user needs to have a named file transition defined to create the log file with a proper type.
This is a follow-up on the 2ce62be20d63 ("Allow sudodomain use sudo.log as a logfile") commit which was sufficient for confined administrators.

The sudo_filetrans_named_content_log() interface was created.

Resolves: rhbz#2164047