### PR TITLE
Give kernel_t almost full access to sockets created by userspace

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1109,6 +1109,24 @@ interface(`domain_getattr_all_sockets',`
 
 ########################################
 ## <summary>
+##	Read/write all domains sockets, for all socket types.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`domain_rw_all_sockets',`
+	gen_require(`
+		attribute domain;
+	')
+
+	allow $1 domain:socket_class_set { rw_stream_socket_perms };
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to get the attributes
 ##	of all domains sockets, for all socket types.
 ## </summary>

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -361,6 +361,7 @@ corecmd_bin_domtrans(kernel_t, kernel_generic_helper_t)
 domain_use_all_fds(kernel_t)
 domain_signal_all_domains(kernel_t)
 domain_search_all_domains_state(kernel_t)
+domain_connect_all_stream_sockets(kernel_t)
 
 files_list_root(kernel_t)
 files_list_etc(kernel_t)

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -362,6 +362,7 @@ domain_use_all_fds(kernel_t)
 domain_signal_all_domains(kernel_t)
 domain_search_all_domains_state(kernel_t)
 domain_connect_all_stream_sockets(kernel_t)
+domain_rw_all_sockets(kernel_t)
 
 files_list_root(kernel_t)
 files_list_etc(kernel_t)


### PR DESCRIPTION
(See commit messages for more details.)

A more generic alternative to #1540. Successfully tested with reproducers for bugs 2152848 and 2162738.