### PR TITLE
Allow systemd-resolved send a datagram to journald

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1269,6 +1269,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	logging_dgram_send(systemd_resolved_t)
+')
+
+optional_policy(`
     networkmanager_dbus_chat(systemd_resolved_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1674810195.623:587): avc:  denied  { sendto } for  pid=47442 comm="systemd-resolve" path="/run/systemd/journal/socket" scontext=system_u:system_r:systemd_resolved_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#2165134