### PR TITLE
Additional support for rpmdb_migrate

### DIFF
--- a/policy/modules/contrib/rpm.te
+++ b/policy/modules/contrib/rpm.te
@@ -260,25 +260,32 @@ optional_policy(`
 # rpmdb local policy
 #
 
-allow rpmdb_t rpm_var_lib_t:file map;
-allow rpmdb_t rpmdb_tmp_t:file map;
+can_exec(rpmdb_t, rpm_exec_t)
 
 manage_dirs_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
 manage_files_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
-files_usr_filetrans(rpmdb_t, rpm_var_lib_t, dir)
-files_var_lib_filetrans(rpmdb_t, rpm_var_lib_t, dir)
+read_lnk_files_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
+allow rpmdb_t rpm_var_lib_t:file map;
 
 manage_dirs_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)
 manage_files_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)
 files_tmp_filetrans(rpmdb_t, rpmdb_tmp_t, { file dir })
+allow rpmdb_t rpmdb_tmp_t:file map;
+
+corecmd_exec_bin(rpmdb_t)
+corecmd_exec_shell(rpmdb_t)
+
+files_rw_inherited_non_security_files(rpmdb_t)
+files_usr_filetrans(rpmdb_t, rpm_var_lib_t, dir)
+files_var_lib_filetrans(rpmdb_t, rpm_var_lib_t, dir)
+
+sysnet_dontaudit_read_config(rpmdb_t)
 
 term_use_all_inherited_terms(rpmdb_t)
 
-auth_dontaudit_read_passwd(rpmdb_t)
-
-files_rw_inherited_non_security_files(rpmdb_t)
-
-sysnet_dontaudit_read_config(rpmdb_t)
+optional_policy(`
+	auth_dontaudit_read_passwd(rpmdb_t)
+')
 
 optional_policy(`
 	miscfiles_read_generic_certs(rpmdb_t)


### PR DESCRIPTION
Since the 3a99b00da4 ("Label /usr/lib/rpm/rpmdb_migrate with rpmdb_exec_t") commit, selinux-policy supports the rpmdb-migrate.service which is executed after the first boot to a newer Fedora release to migrate the rpm database from /var/lib/rpm to /usr/lib/sysimage/rpm. Additional permissions started to be required recently.

Resolves: rhbz#2164752