### PR TITLE
Allow systemd-userdbd the sys_resource capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1461,7 +1461,7 @@ optional_policy(`
 #
 # systemd_userdbd local policy
 #
-allow systemd_userdbd_t self:capability dac_read_search;
+allow systemd_userdbd_t self:capability { dac_read_search sys_resource };
 
 manage_dirs_pattern(systemd_userdbd_t, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
 manage_files_pattern(systemd_userdbd_t, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)


### PR DESCRIPTION
This permission is required for the process be able to set its arg start and end address, refer to prctl(2):

       PR_SET_MM (since Linux 3.3)
              Modify certain kernel  memory  map  descriptor  fields  of  the  calling
              process.   Usually these fields are set by the kernel and dynamic loader
              (see ld.so(8) for more information) and a regular application should not
              use this feature.  However, there are cases, such as self-modifying pro‐
              grams, where a program might find it useful to  change  its  own  memory
              map.

              The  calling  process  must  have  the CAP_SYS_RESOURCE capability.  The
              value in arg2 is one of the options below, while  arg3  provides  a  new
              value  for  the option.  The arg4 and arg5 arguments must be zero if un‐
              used.

              PR_SET_MM_ARG_START
                     Set the address above which the program command line is placed.

              PR_SET_MM_ARG_END
                     Set the address below which the program command line is placed.

Addresses the following AVC denials:

type=PROCTITLE msg=audit(01/04/2023 06:21:21.285:112) : proctitle=(sd-worker) type=SYSCALL msg=audit(01/04/2023 06:21:21.285:112) : arch=x86_64 syscall=prctl success=yes exit=0 a0=PR_SET_MM a1=0x8 a2=0x7fa791901000 a3=0x0 items=0 ppid=1367 pid=1384 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(sd-worker) exe=/usr/lib/systemd/systemd-userdbd subj=system_u:system_r:systemd_userdbd_t:s0 key=(null) type=AVC msg=audit(01/04/2023 06:21:21.285:112) : avc:  denied  { sys_resource } for  pid=1384 comm=(sd-worker) capability=sys_resource  scontext=system_u:system_r:systemd_userdbd_t:s0 tcontext=system_u:system_r:systemd_userdbd_t:s0 tclass=capability permissive=1

type=PROCTITLE msg=audit(01/04/2023 06:21:23.761:156) : proctitle=systemd-userwork: processing... type=SYSCALL msg=audit(01/04/2023 06:21:23.761:156) : arch=x86_64 syscall=prctl success=yes exit=0 a0=PR_SET_MM a1=0x9 a2=0x7fcc48186020 a3=0x0 items=0 ppid=1367 pid=1385 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-userwor exe=/usr/lib/systemd/systemd-userwork subj=system_u:system_r:systemd_userdbd_t:s0 key=(null) type=AVC msg=audit(01/04/2023 06:21:23.761:156) : avc:  denied  { sys_resource } for  pid=1385 comm=systemd-userwor capability=sys_resource  scontext=system_u:system_r:systemd_userdbd_t:s0 tcontext=system_u:system_r:systemd_userdbd_t:s0 tclass=capability permissive=1

Resolves: rhbz#2166509