### PR TITLE
Allow nm-dispatcher plugins read generic files in /proc

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -584,6 +584,7 @@ manage_files_pattern(NetworkManager_dispatcher_console_t, NetworkManager_dispatc
 
 read_files_pattern(NetworkManager_dispatcher_dnssec_t, NetworkManager_etc_t, NetworkManager_etc_rw_t)
 
+kernel_read_proc_files(networkmanager_dispatcher_plugin)
 kernel_request_load_module(NetworkManager_dispatcher_ddclient_t)
 
 auth_read_passwd(networkmanager_dispatcher_plugin)


### PR DESCRIPTION
It turns out the systemctl command needs to read /proc/cpuinfo at the aarch64 architecture, so the permission was allowed for the networkmanager_dispatcher_plugin attribute.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(26.1.2023 15:30:09.970:47) : proctitle=/bin/systemctl --no-block reload iscsi.service type=SYSCALL msg=audit(26.1.2023 15:30:09.970:47) : arch=aarch64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0xffff9b8f5170 a2=O_RDONLY a3=0x0 items=0 ppid=1186 pid=1188 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemctl exe=/usr/bin/systemctl subj=system_u:system_r:NetworkManager_dispatcher_iscsid_t:s0 key=(null) type=AVC msg=audit(26.1.2023 15:30:09.970:47) : avc:  denied  { open } for  pid=1188 comm=systemctl path=/proc/cpuinfo dev="proc" ino=4026531987 scontext=system_u:system_r:NetworkManager_dispatcher_iscsid_t:s0 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=1 type=AVC msg=audit(26.1.2023 15:30:09.970:47) : avc:  denied  { read } for  pid=1188 comm=systemctl name=cpuinfo dev="proc" ino=4026531987 scontext=system_u:system_r:NetworkManager_dispatcher_iscsid_t:s0 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=1

Resolves: rhbz#2164845