### PR TITLE
Add default type for /var/run/systemd/journal.*

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -62,6 +62,7 @@ ifdef(`distro_suse', `
 /var/log/audit(/.*)?		gen_context(system_u:object_r:auditd_log_t,mls_systemhigh)
 /var/run/log(/.*)?		gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
 /var/run/systemd/journal(/.*)?	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
+/var/run/systemd/journal\.[^/]+(/.*)?	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
 
 ifndef(`distro_gentoo',`
 /var/log/audit\.log.*	--	gen_context(system_u:object_r:auditd_log_t,mls_systemhigh)


### PR DESCRIPTION
Journal namespaces are a mechanism for isolating logs of one projects consisting of one or more services. Additional namespaces are created by starting an instance of the systemd-journald@.service template. Service units is then assigned to a specific journal namespace through the LogNamespace= unit file setting.

This commit adds syslogd_var_run_t as the default file context specification for /var/run/systemd/journal\.[^/]+(/.*)?

Resolves: rhbz#2124797