### PR TITLE
Allow certmonger read the contents of the sysfs filesystem

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -82,6 +82,7 @@ corecmd_exec_shell(certmonger_t)
 
 dev_read_rand(certmonger_t)
 dev_read_urand(certmonger_t)
+dev_read_sysfs(certmonger_t)
 
 domain_use_interactive_fds(certmonger_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(02/07/2023 04:22:50.618:3929) : proctitle=/usr/bin/python3 -I /usr/libexec/certmonger/dogtag-ipa-ca-renew-agent-submit
type=PATH msg=audit(02/07/2023 04:22:50.618:3929) : item=0 name=/sys/devices/system/cpu/possible inode=42 dev=00:15 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(02/07/2023 04:22:50.618:3929) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f9dcfbc79d8 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=25147 pid=25176 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=dogtag-ipa-ca-r exe=/usr/bin/python3.11 subj=system_u:system_r:certmonger_t:s0 key=(null)
type=AVC msg=audit(02/07/2023 04:22:50.618:3929) : avc:  denied  { open } for  pid=25176 comm=dogtag-ipa-ca-r path=/sys/devices/system/cpu/possible dev="sysfs" ino=42 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0