### PR TITLE
Add none file context for polyinstantiated tmp dirs

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -220,6 +220,7 @@ ifdef(`distro_redhat',`
 /tmp				gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /tmp-inst			gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /tmp/.*				<<none>>
+/tmp-inst/.*			<<none>>
 /tmp/\.journal			<<none>>
 
 /tmp/lost\+found	-d	gen_context(system_u:object_r:lost_found_t,mls_systemhigh)
@@ -325,6 +326,7 @@ ifndef(`distro_redhat',`
 /var/tmp-inst		-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /var/tmp/tmp-inst	-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
 /var/tmp/.*			<<none>>
+/var/tmp/tmp-inst/.*		<<none>>
 /var/tmp/lost\+found	-d	gen_context(system_u:object_r:lost_found_t,mls_systemhigh)
 /var/tmp/lost\+found/.*		<<none>>
 /var/tmp/vi\.recover	-d	gen_context(system_u:object_r:tmp_t,s0)


### PR DESCRIPTION
The pam_namespace.so module allows setup of private namespaces with polyinstantiated home and tmp directories. While there was a default file context set for the /tmp-inst and /var/tmp/tmp-inst directories already, context for files in those directories inherited the default settings of default_t and tmp_t. This commit adds the explicit <<none>> setting giving services the opportunity to use private types as they need it.

Resolves: rhbz#2099194