### PR TITLE
Label systemd-journald feature LogNamespace

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -62,7 +62,7 @@ ifdef(`distro_suse', `
 /var/log/audit(/.*)?		gen_context(system_u:object_r:auditd_log_t,mls_systemhigh)
 /var/run/log(/.*)?		gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
 /var/run/systemd/journal(/.*)?	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
-
+/var/run/systemd/journal\.[^/]+(/.*)?	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
 ifndef(`distro_gentoo',`
 /var/log/audit\.log.*	--	gen_context(system_u:object_r:auditd_log_t,mls_systemhigh)
 ')
@@ -83,8 +83,9 @@ ifdef(`distro_redhat',`
 /var/run/syslogd\.pid	--	gen_context(system_u:object_r:syslogd_var_run_t,mls_systemhigh)
 /var/run/syslog-ng.ctl	--	gen_context(system_u:object_r:syslogd_var_run_t,s0)
 /var/run/syslog-ng(/.*)?	gen_context(system_u:object_r:syslogd_var_run_t,s0)
-/var/run/systemd/journal/syslog	-s	gen_context(system_u:object_r:devlog_t,mls_systemhigh)
-
+/var/run/systemd/journal/syslog		-s	gen_context(system_u:object_r:devlog_t,mls_systemhigh)
+/var/run/systemd/journal\.[^/]+/syslog	-s	gen_context(system_u:object_r:devlog_t,mls_systemhigh)
+/var/run/systemd/journal\.[^/]+/dev-log	-s	gen_context(system_u:object_r:devlog_t,mls_systemhigh)
 /var/spool/audit(/.*)?		gen_context(system_u:object_r:audit_spool_t,mls_systemhigh)
 /var/spool/bacula/log(/.*)? 	gen_context(system_u:object_r:var_log_t,s0)
 /var/spool/postfix/pid	-d	gen_context(system_u:object_r:var_run_t,s0)


### PR DESCRIPTION
Systemd-journald introduced feature `LogNamespace` to isolate certain logs. These names space are created from a template service `systemd-journald@.service`. For example to activate a LogNamespace `testcase` we use: `# systemctl start systemd-journald@testcase.service`

LogNamespaces were created with wrong SELinux context init_var_run_t, instead of syslogd_var_run_t and devlog_t.

Resolves: rhbz#2124797