### PR TITLE
Add label virt_qemu_ga_tmp_t to /tmp/qemu-ga/ and /var/tmp/qemu-ga/

### DIFF
--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -132,3 +132,6 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?   gen_context(system_u:object_r:svirt_
 
 /var/log/qemu-ga\.log.*           --      gen_context(system_u:object_r:virt_qemu_ga_log_t,s0)
 /var/log/qemu-ga(/.*)?		gen_context(system_u:object_r:virt_qemu_ga_log_t,s0)
+
+/var/tmp/qemu-ga(/.*)?			gen_context(system_u:object_r:virt_qemu_ga_tmp_t,s0)
+/tmp/qemu-ga(/.*)?			gen_context(system_u:object_r:virt_qemu_ga_tmp_t,s0)


### PR DESCRIPTION
The open on tmp files used to be granted by mistake to all domains and by fixing this qemu-ga lost the ability to open these files by default.

Resolves: rhbz#2152121