### PR TITLE
Allow insights-client manage fsadm pid files

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -241,6 +241,7 @@ optional_policy(`
 
 optional_policy(`
 	fstools_domtrans(insights_client_t)
+	fsadm_manage_pid(insights_client_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The interface also includes allowing fsadm filetrans named content. Addresses the following and subsequent AVC denials:

type=PROCTITLE msg=audit(02/02/2023 06:17:58.638:56606) : proctitle=oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_ospp --results /var/tmp/insights-client/insights-archive-ei5gnpg type=PATH msg=audit(02/02/2023 06:17:58.638:56606) : item=1 name=/run/blkid/blkid.tab-1VSWOP inode=4414099 dev=00:18 mode=file,600 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:fsadm_var_run_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(02/02/2023 06:17:58.638:56606) : item=0 name=/run/blkid/ inode=34590 dev=00:18 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:fsadm_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/02/2023 06:17:58.638:56606) : arch=x86_64 syscall=openat success=yes exit=26 a0=AT_FDCWD a1=0x7f136c00a460 a2=O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC a3=0x180 items=2 ppid=640141 pid=641171 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=probe_worker exe=/usr/bin/oscap subj=system_u:system_r:insights_client_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/02/2023 06:17:58.638:56606) : avc:  denied  { create } for  pid=641171 comm=probe_worker name=blkid.tab-1VSWOP scontext=system_u:system_r:insights_client_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fsadm_var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(02/02/2023 06:17:58.638:56606) : avc:  denied  { add_name } for  pid=641171 comm=probe_worker name=blkid.tab-1VSWOP scontext=system_u:system_r:insights_client_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fsadm_var_run_t:s0 tclass=dir permissive=1 type=AVC msg=audit(02/02/2023 06:17:58.638:56606) : avc:  denied  { write } for  pid=641171 comm=probe_worker name=blkid dev="tmpfs" ino=34590 scontext=system_u:system_r:insights_client_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fsadm_var_run_t:s0 tclass=dir permissive=1

Resolves: rhbz#2166802