### PR TITLE
Allow sysadm_t run initrc_t script and role access

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -90,7 +90,7 @@ init_halt(sysadm_t)
 init_undefined(sysadm_t)
 init_ioctl_stream_sockets(sysadm_t)
 init_prog_run_bpf(sysadm_t)
-init_domtrans_script(sysadm_t)
+init_run_script(sysadm_t, sysadm_r)
 
 logging_filetrans_named_content(sysadm_t)
 logging_map_audit_config(sysadm_t)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1187,6 +1187,32 @@ interface(`init_domtrans_script',`
 
 ########################################
 ## <summary>
+##	Execute init scripts with a domain transition
+##	and allow the specified role the init script type
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`init_run_script',`
+	gen_require(`
+		type initrc_t;
+	')
+
+	init_domtrans_script($1)
+	role $2 types initrc_t;
+')
+
+########################################
+## <summary>
 ##	Execute a file in a bin directory
 ##	in the initrc_t domain 
 ## </summary>


### PR DESCRIPTION
The init_run_script() interface was added.

Addresses the following SELINUX_ERR denials:

type=PROCTITLE msg=audit(05/05/2022 05:11:51.666:421) : proctitle=/bin/sh /etc/init.d/foo status type=SYSCALL msg=audit(05/05/2022 05:11:51.666:421) : arch=x86_64 syscall=socket success=yes exit=4 a0=local a1=SOCK_STREAM a2=ip a3=0x0 items=0 ppid=22124 pid=22131 auid=sysadm-user uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts1 ses=8 comm=foo exe=/usr/bin/bash subj=sysadm_u:system_r:initrc_t:s0 key=(null) type=SELINUX_ERR msg=audit(05/05/2022 05:11:51.666:421) : op=security_compute_sid invalid_context=sysadm_u:system_r:initrc_t:s0 scontext=sysadm_u:system_r:initrc_t:s0 tcontext=sysadm_u:system_r:initrc_t:s0 tclass=unix_stream_socket type=SELINUX_ERR msg=audit(05/05/2022 05:11:51.666:421) : op=security_compute_sid invalid_context=sysadm_u:system_r:initrc_t:s0 scontext=sysadm_u:system_r:initrc_t:s0 tcontext=sysadm_u:system_r:initrc_t:s0 tclass=unix_stream_socket

Resolves: rhbz#2039662