### PR TITLE
Add policy for bootupd

### DIFF
--- a/policy/modules/contrib/bootupd.fc
+++ b/policy/modules/contrib/bootupd.fc
@@ -1,0 +1,7 @@
+/usr/bin/bootupctl			--	gen_context(system_u:object_r:bootupd_exec_t,s0)
+/usr/libexec/bootupd			--	gen_context(system_u:object_r:bootupd_exec_t,s0)
+
+/usr/lib/systemd/system/bootupd\.service	--	gen_context(system_u:object_r:bootupd_unit_file_t,s0)
+/usr/lib/systemd/system/bootupd\.socket		--	gen_context(system_u:object_r:bootupd_unit_file_t,s0)
+
+/var/run/bootupd\.sock			-s	gen_context(system_u:object_r:bootupd_var_run_t,s0)

--- a/policy/modules/contrib/bootupd.if
+++ b/policy/modules/contrib/bootupd.if
@@ -1,0 +1,39 @@
+## <summary>policy for bootupd</summary>
+
+########################################
+## <summary>
+##	Execute bootupd_exec_t in the bootupd domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`bootupd_domtrans',`
+	gen_require(`
+		type bootupd_t, bootupd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, bootupd_exec_t, bootupd_t)
+')
+
+######################################
+## <summary>
+##	Execute bootupd in the caller domain.
+## </summary>
+## <param name="domain">
+##    <summary>
+##	Domain allowed access.
+##    </summary>
+## </param>
+#
+interface(`bootupd_exec',`
+	gen_require(`
+		type bootupd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, bootupd_exec_t)
+')

--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -1,0 +1,40 @@
+policy_module(bootupd, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type bootupd_t;
+type bootupd_exec_t;
+init_daemon_domain(bootupd_t, bootupd_exec_t)
+
+type bootupd_unit_file_t;
+systemd_unit_file(bootupd_unit_file_t)
+
+type bootupd_var_run_t;
+files_pid_file(bootupd_var_run_t)
+
+permissive bootupd_t;
+
+########################################
+#
+# bootupd local policy
+#
+allow bootupd_t self:capability { setgid setuid };
+allow bootupd_t self:process { fork setpgid };
+allow bootupd_t self:fifo_file rw_fifo_file_perms;
+allow bootupd_t self:unix_dgram_socket create_socket_perms;
+allow bootupd_t self:unix_stream_socket create_stream_socket_perms;
+
+kernel_dgram_send(bootupd_t)
+
+domain_use_interactive_fds(bootupd_t)
+
+files_read_etc_files(bootupd_t)
+
+fs_getattr_all_fs(bootupd_t)
+
+optional_policy(`
+	miscfiles_read_localization(bootupd_t)
+')


### PR DESCRIPTION
Bootupd is a small socket activated program that takes care of updating the bootloader.

resolves: rhbz#2044508