### PR TITLE
Add tunable to allow squid listen on snmp port

### DIFF
--- a/policy/modules/contrib/squid.te
+++ b/policy/modules/contrib/squid.te
@@ -21,6 +21,14 @@ gen_tunable(squid_connect_any, false)
 ## </desc>
 gen_tunable(squid_use_tproxy, false)
 
+## <desc>
+##  <p>
+##  Determine whether squid should
+##  have access to snmp port.
+##  </p>
+## </desc>
+gen_tunable(squid_bind_snmp_port, false)
+
 type squid_t;
 type squid_exec_t;
 init_daemon_domain(squid_t, squid_exec_t)
@@ -203,6 +211,10 @@ tunable_policy(`squid_use_tproxy',`
 	corenet_sendrecv_netport_server_packets(squid_t)
 	corenet_tcp_bind_netport_port(squid_t)
 	corenet_tcp_sendrecv_netport_port(squid_t)
+')
+
+tunable_policy(`squid_bind_snmp_port',`
+	corenet_udp_bind_snmp_port(squid_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Squid is able to provide statistics through snmp protocol so there should be option for its selinux policy to allow this.

This change allows squid to listen and reply on standard snmp ports.

Resolves #1601