### PR TITLE
Add policy for coreos installer

### DIFF
--- a/policy/modules.conf
+++ b/policy/modules.conf
@@ -3148,3 +3148,10 @@ afterburn = module
 # nvme_stas
 #
 nvme_stas = module
+
+# Layer: contrib
+# Module: coreos_installer
+#
+# coreos_installer
+#
+coreos_installer = module

--- a/policy/modules/contrib/coreos_installer.fc
+++ b/policy/modules/contrib/coreos_installer.fc
@@ -1,0 +1,7 @@
+/usr/bin/coreos-installer		--	gen_context(system_u:object_r:coreos_installer_exec_t,s0)
+
+/usr/libexec/coreos-installer-disable-device-auto-activation	--	gen_context(system_u:object_r:coreos_installer_exec_t,s0)
+/usr/libexec/coreos-installer-service				--	gen_context(system_u:object_r:coreos_installer_exec_t,s0)
+
+/usr/lib/systemd/system-generators/coreos-installer-generator	--	gen_context(system_u:object_r:coreos_installer_exec_t,s0)
+/usr/lib/systemd/system/coreos-installer.*			--	gen_context(system_u:object_r:coreos_installer_unit_file_t,s0)

--- a/policy/modules/contrib/coreos_installer.if
+++ b/policy/modules/contrib/coreos_installer.if
@@ -1,0 +1,39 @@
+## <summary>policy for coreos_installer</summary>
+
+########################################
+## <summary>
+##	Execute coreos_installer_exec_t in the coreos_installer domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`coreos_installer_domtrans',`
+	gen_require(`
+		type coreos_installer_t, coreos_installer_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, coreos_installer_exec_t, coreos_installer_t)
+')
+
+######################################
+## <summary>
+##	Execute coreos_installer in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`coreos_installer_exec',`
+	gen_require(`
+		type coreos_installer_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, coreos_installer_exec_t)
+')

--- a/policy/modules/contrib/coreos_installer.te
+++ b/policy/modules/contrib/coreos_installer.te
@@ -1,0 +1,47 @@
+policy_module(coreos_installer, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type coreos_installer_t;
+type coreos_installer_exec_t;
+init_daemon_domain(coreos_installer_t, coreos_installer_exec_t)
+
+type coreos_installer_unit_file_t;
+systemd_unit_file(coreos_installer_unit_file_t)
+
+permissive coreos_installer_t;
+
+########################################
+#
+# coreos_installer local policy
+#
+allow coreos_installer_t self:capability { setgid setuid sys_admin };
+allow coreos_installer_t self:process { fork setpgid };
+allow coreos_installer_t self:fifo_file rw_fifo_file_perms;
+allow coreos_installer_t self:unix_stream_socket create_stream_socket_perms;
+
+kernel_read_proc_files(coreos_installer_t)
+
+corecmd_exec_bin(coreos_installer_t)
+corecmd_exec_shell(coreos_installer_t)
+
+dev_write_kmsg(coreos_installer_t)
+
+domain_use_interactive_fds(coreos_installer_t)
+
+files_read_etc_files(coreos_installer_t)
+
+optional_policy(`
+	auth_read_passwd_file(coreos_installer_t)
+')
+
+optional_policy(`
+	miscfiles_read_localization(coreos_installer_t)
+')
+
+optional_policy(`
+	sysnet_dns_name_resolve(coreos_installer_t)
+')


### PR DESCRIPTION
Coreos-installer is a program to assist with installing Fedora CoreOS (FCOS) and Red Hat Enterprise Linux CoreOS (RHCOS). It is used to download and verify an operating system image, install the operating system to a target disk, list Fedora CoreOS images available for download, embed an Ignition config in a live ISO image and wrap an Ignition config in an initrd image

Resovles: rhbz#2005820