### PR TITLE
Add policy for synce4l

### DIFF
--- a/policy/modules/contrib/synce4l.fc
+++ b/policy/modules/contrib/synce4l.fc
@@ -1,0 +1,6 @@
+/usr/sbin/synce4l				--	gen_context(system_u:object_r:synce4l_exec_t,s0)
+
+/usr/lib/systemd/system/synce4l\.service	--	gen_context(system_u:object_r:synce4l_unit_file_t,s0)
+
+/etc/synce4l\.conf				--	gen_context(system_u:object_r:synce4l_conf_t,s0)
+

--- a/policy/modules/contrib/synce4l.if
+++ b/policy/modules/contrib/synce4l.if
@@ -1,0 +1,40 @@
+
+## <summary>policy for synce4l</summary>
+
+########################################
+## <summary>
+##	Execute synce4l_exec_t in the synce4l domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`synce4l_domtrans',`
+	gen_require(`
+		type synce4l_t, synce4l_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, synce4l_exec_t, synce4l_t)
+')
+
+######################################
+## <summary>
+##	Execute synce4l in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`synce4l_exec',`
+	gen_require(`
+		type synce4l_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, synce4l_exec_t)
+')

--- a/policy/modules/contrib/synce4l.te
+++ b/policy/modules/contrib/synce4l.te
@@ -1,0 +1,48 @@
+policy_module(synce4l, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type synce4l_t;
+type synce4l_exec_t;
+init_daemon_domain(synce4l_t, synce4l_exec_t)
+
+type synce4l_unit_file_t;
+systemd_unit_file(synce4l_unit_file_t)
+
+type synce4l_conf_t;
+files_config_file(synce4l_conf_t)
+
+permissive synce4l_t;
+
+########################################
+#
+# synce4l local policy
+#
+allow synce4l_t self:capability net_raw;
+allow synce4l_t self:fifo_file rw_fifo_file_perms;
+allow synce4l_t self:packet_socket create_socket_perms;
+allow synce4l_t self:udp_socket create_socket_perms;
+allow synce4l_t self:unix_stream_socket create_stream_socket_perms;
+
+read_files_pattern(synce4l_t, synce4l_conf_t, synce4l_conf_t)
+
+corecmd_exec_shell(synce4l_t)
+
+domain_use_interactive_fds(synce4l_t)
+
+files_read_etc_files(synce4l_t)
+
+optional_policy(`
+	auth_read_passwd_file(synce4l_t)
+')
+
+optional_policy(`
+	logging_send_syslog_msg(synce4l_t)
+')
+
+optional_policy(`
+	miscfiles_read_localization(synce4l_t)
+')


### PR DESCRIPTION
Synce4l is a software implementation of Synchronous Ethernet (SyncE). The design goal is to provide logic to supported hardware by processing Ethernet Synchronization Messaging Channel (ESMC) and control Ethernet Equipment Clock (EEC) on Network Card Interface (NIC). Application can operate in two mutually exclusive input modes: line or external.

Resolves: rhbz#2158402