### PR TITLE
Allow staff_t getattr init pid chr & blk files and read krb5

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -70,6 +70,8 @@ auth_run_pam_console(staff_t, staff_r)
 
 init_dbus_chat(staff_t)
 init_dbus_chat_script(staff_t)
+init_getattr_pid_blk_file(staff_t)
+init_getattr_pid_chr_file(staff_t)
 init_status(staff_t)
 
 miscfiles_read_hwdata(staff_t)
@@ -175,6 +177,10 @@ optional_policy(`
 
 optional_policy(`
 	journalctl_role(staff_r, staff_t)
+')
+
+optional_policy(`
+	kerberos_read_keytab(staff_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2645,6 +2645,42 @@ interface(`init_watch_pid_dir',`
     allow $1 init_var_run_t:dir watch_dir_perms;
 ')
 
+########################################
+## <summary>
+##      Get the attributes of block nodes in the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`init_getattr_pid_blk_file',`
+        gen_require(`
+                type init_var_run_t;
+        ')
+
+        allow $1 init_var_run_t:blk_file getattr;
+')
+
+########################################
+## <summary>
+##      Get the attributes of character device nodes in the /run/systemd directory.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`init_getattr_pid_chr_file',`
+        gen_require(`
+                type init_var_run_t;
+        ')
+
+        allow $1 init_var_run_t:chr_file getattr;
+')
+
 #######################################
 ## <summary>
 ##  Create objects in /run/systemd directory


### PR DESCRIPTION
Add interface to get the attributes of block and character device nodes in the /run/systemd directory.

Resolves: rhbz#2112729