### PR TITLE
Allow cloud-init domain transition to insights-client domain

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -144,6 +144,10 @@ systemd_exec_systemctl(chronyd_t)
 userdom_dgram_send(chronyd_t)
 
 optional_policy(`
+	cloudform_init_dgram_send(chronyd_t)
+')
+
+optional_policy(`
     cron_dgram_send(chronyd_t)
 ')
 

--- a/policy/modules/contrib/cloudform.if
+++ b/policy/modules/contrib/cloudform.if
@@ -59,6 +59,43 @@ interface(`cloudform_rw_pipes',`
 	allow $1 cloud_init_t:fifo_file rw_fifo_file_perms;
 ')
 
+########################################
+## <summary>
+##	Send a message to cloud-init over a datagram socket.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`cloudform_init_dgram_send',`
+	gen_require(`
+		type cloud_init_t;
+	')
+
+	allow $1 cloud_init_t:unix_dgram_socket sendto;
+')
+
+########################################
+## <summary>
+##	Write to cloud-init temporary files.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`cloudform_init_write_tmp',`
+	gen_require(`
+		type cloud_init_tmp_t;
+	')
+
+	files_search_tmp($1)
+	write_files_pattern($1, cloud_init_tmp_t, cloud_init_tmp_t)
+')
+
 ######################################
 ## <summary>
 ##	Execute mongod in the caller domain.

--- a/policy/modules/contrib/cloudform.te
+++ b/policy/modules/contrib/cloudform.te
@@ -141,6 +141,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	insights_client_domtrans(cloud_init_t)
+')
+
+optional_policy(`
     mount_domtrans(cloud_init_t)
 ')
 

--- a/policy/modules/contrib/dmidecode.te
+++ b/policy/modules/contrib/dmidecode.te
@@ -34,6 +34,10 @@ locallogin_use_fds(dmidecode_t)
 userdom_use_inherited_user_terminals(dmidecode_t)
 
 optional_policy(`
+	cloudform_init_write_tmp(dmidecode_t)
+')
+
+optional_policy(`
     rhsmcertd_rw_lock_files(dmidecode_t)
     rhsmcertd_read_log(dmidecode_t)
 ')


### PR DESCRIPTION
The "insights-client --register" command can be executed from a cloud-init script, so a domain transition should happen on the execution. Could-init uses its runcmd module with a list of commands to be executed init using the generic sh shell.

Resolves: rhbz#2162663