### PR TITLE
Assign keyutils_request_t the system_r role

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -6,6 +6,9 @@ files_type(keyutils_request_exec_t)
 type keyutils_request_t;
 domain_type(keyutils_request_t)
 domain_entry_file(keyutils_request_t, keyutils_request_exec_t)
+role system_r types keyutils_request_t;
+
+allow keyutils_request_t self:unix_dgram_socket create_socket_perms;
 
 kernel_view_key(keyutils_request_t)
 kernel_read_key(keyutils_request_t)

--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -446,9 +446,11 @@ files_type(nfsidmap_exec_t)
 type nfsidmap_t;
 domain_type(nfsidmap_t)
 domain_entry_file(nfsidmap_t, nfsidmap_exec_t)
+role system_r types nfsidmap_t;
 
 allow nfsidmap_t self:key write;
 allow nfsidmap_t self:netlink_route_socket r_netlink_socket_perms;
+allow nfsidmap_t self:udp_socket create_socket_perms;
 
 kernel_setattr_key(nfsidmap_t)
 


### PR DESCRIPTION
Addresses the following SELINUX_ERR denial:

type=SELINUX_ERR msg=audit(02/17/2023 08:46:50.362:149) : op=security_compute_sid invalid_context=system_u:system_r:keyutils_request_t:s0 scontext=system_u:system_r:kernel_t:s0 tcontext=system_u:object_r:keyutils_request_exec_t:s0 tclass=process