### PR TITLE
contrib/virt: Optional policies for passt lifecycle handling in libvirt

### DIFF
--- a/policy/modules/contrib/passt.if
+++ b/policy/modules/contrib/passt.if
@@ -1,0 +1,100 @@
+interface(`passt_domtrans',`
+	gen_require(`
+		type passt_t, passt_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, passt_exec_t, passt_t)
+')
+
+interface(`passt_socket_dir',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow passt_t $1:dir add_entry_dir_perms;
+')
+
+interface(`passt_socket_create',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow passt_t $1:sock_file create;
+')
+
+interface(`passt_socket_use',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow $1 passt_t:unix_stream_socket connectto;
+	allow $1 $2:sock_file { read write };
+	allow passt_t $2:sock_file { read write };
+')
+
+interface(`passt_socket_delete',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow $1 $2:sock_file unlink;
+')
+
+interface(`passt_logfile_dir',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow passt_t $1:dir add_entry_dir_perms;
+')
+
+interface(`passt_logfile_use',`
+	gen_require(`
+		type passt_t;
+	')
+
+	logging_log_file($1);
+	allow passt_t $1:file { create open read write };
+')
+
+interface(`passt_pidfile_dir',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow passt_t $1:dir add_entry_dir_perms;
+')
+
+interface(`passt_pidfile_write',`
+	gen_require(`
+		type passt_t;
+	')
+
+	files_pid_file($1);
+	allow passt_t $1:file { create open write };
+')
+
+interface(`passt_pidfile_read',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow $1 $2:file { open read };
+')
+
+interface(`passt_pidfile_delete',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow $1 $2:file unlink;
+')
+
+interface(`passt_kill',`
+	gen_require(`
+		type passt_t;
+	')
+
+	allow $1 passt_t:process { signal sigkill };
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -719,6 +719,38 @@ optional_policy(`
 ')
 
 optional_policy(`
+	passt_socket_dir(user_tmp_t)
+	passt_socket_dir(virt_var_run_t)
+
+	passt_socket_create(user_tmp_t)
+	passt_socket_create(virt_var_run_t)
+
+	passt_socket_use(virt_domain, user_tmp_t)
+	passt_socket_use(virt_domain, virt_var_run_t)
+
+	passt_socket_delete(virtd_t, user_tmp_t)
+	passt_socket_delete(virtd_t, virt_var_run_t)
+
+	passt_pidfile_dir(user_tmp_t)
+	passt_pidfile_dir(qemu_var_run_t)
+
+	passt_pidfile_write(user_tmp_t)
+	passt_pidfile_write(virt_var_run_t)
+
+	passt_pidfile_delete(virtd_t, user_tmp_t)
+	passt_pidfile_delete(virtd_t, virt_var_run_t)
+
+	passt_logfile_dir(user_tmp_t)
+	passt_logfile_dir(qemu_var_run_t)
+
+	passt_logfile_use(user_tmp_t)
+	passt_logfile_use(virt_var_run_t)
+
+	passt_domtrans(virtd_t)
+	passt_kill(virtd_t)
+')
+
+optional_policy(`
 	firewalld_dbus_chat(virtd_t)
 ')
 


### PR DESCRIPTION
```
These optional policies rely on new interfaces which are now exported
by passt-selinux0^20230310.g70c0765-1. Interface compatibility
doesn't need to be preserved as libvirt currently isn't able to start
passt (unless SELinux is in permissive mode), and was never able to.

In detail:

- passt_domtrans() implements the domain transition to passt_t and
  allows to execute passt(1)

- passt_kill() allows libvirtd to terminate the process, which is
  only needed in case the guest didn't start (otherwise, passt will
  terminate by itself)

- passt_socket_dir() allows passt to add the socket directory entry
  to the paths required for root (virt_var_run_t) and non-root
  (user_tmp_t) operation

- passt_socket_create() allows passt to create the socket file itself

- passt_socket_use() allows qemu (from its virt_domain) to open the
  interface to passt, which is a UNIX domain socket, with contexts
  supporting guest domain root operation (path in qemu_var_run_t
  context) and non-root (user_tmp_t)

- path_socket_delete() allows libvirtd to delete the socket file

- passt_pidfile_dir() allows passt to add its PID file directory
  entry (qemu_var_run_t for guest domains started by root,
  user_tmp_t otherwise)

- passt_pidfile_write() allows passt to write its PID file

- passt_pidfile_delete() allows libvirtd to delete the PID file

- passt_logfile_dir() allows passt to add the directory entry for
  its log file

- passt_logfile_use() allows passt to create, write and manipulate
  the log file itself. Note that passt can't delete its own log
  file, as it has no access to the filesystem after initalisation
  and sandboxing.
```