### PR TITLE
Allow xdm work with fs sysctl, fusefs, rpm, user namespaces

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -439,6 +439,7 @@ allow xdm_t self:process { setexec setpgid getattr getcap setcap getsched getses
 allow xdm_t self:fifo_file rw_fifo_file_perms;
 allow xdm_t self:shm create_shm_perms;
 allow xdm_t self:sem create_sem_perms;
+allow xdm_t self:user_namespace create;
 allow xdm_t self:unix_stream_socket { connectto create_stream_socket_perms };
 allow xdm_t self:unix_dgram_socket { create_socket_perms sendto listen };
 allow xdm_t self:tcp_socket create_stream_socket_perms;
@@ -473,6 +474,7 @@ userdom_delete_user_home_content_files(xdm_t)
 userdom_signull_unpriv_users(xdm_t)
 userdom_dontaudit_read_admin_home_lnk_files(xdm_t)
 
+kernel_read_fs_sysctls(xdm_t)
 kernel_read_vm_sysctls(xdm_t)
 
 # Allow gdm to run gdm-binary
@@ -734,6 +736,8 @@ miscfiles_read_hwdata(xdm_t)
 miscfiles_map_generic_certs(xdm_t)
 miscfiles_read_certs(xdm_t)
 
+storage_rw_fuse(xdm_t)
+
 systemd_write_inhibit_pipes(xdm_t)
 systemd_dbus_chat_localed(xdm_t)
 systemd_dbus_chat_hostnamed(xdm_t)
@@ -796,6 +800,10 @@ tunable_policy(`use_ecryptfs_home_dirs',`
 
 ### filename transitions ###
 userdom_filetrans_generic_home_content(xdm_t)
+
+optional_policy(`
+	alsa_read_lib(xdm_t)
+')
 
 optional_policy(`
     dbus_exec_dbusd(xdm_t)
@@ -870,6 +878,10 @@ optional_policy(`
 
 optional_policy(`
     remotelogin_signull(xdm_t)
+')
+
+optional_policy(`
+	rpm_dbus_chat(xdm_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following AVC/USER_AVC denials:
-
type=SYSCALL msg=audit(02/22/2023 11:45:06.084:176) : arch=x86_64 syscall=clone success=yes exit=1784 a0=0x3c020011 a1=0x0 a2=CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_PTRACE|CLONE_VFORK|CLONE_PARENT|CLONE_THREAD|CLONE_NEWNS|CLONE_PARENT_SETTID|CLONE_DETACHED|CLONE_UNTRACED|CLONE_CHILD_SETTID|CLONE_STOPPED|CLONE_NEWIPC|CLONE_NEWNET|CLONE_IO a3=0x557a57e0f2c0 items=0 ppid=1763 pid=1783 auid=unset uid=gnome-initial-setup gid=gnome-initial-setup euid=gnome-initial-setup suid=gnome-initial-setup fsuid=gnome-initial-setup egid=gnome-initial-setup sgid=gnome-initial-setup fsgid=gnome-initial-setup tty=tty1 ses=unset comm=bwrap exe=/usr/bin/bwrap subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/22/2023 11:45:06.084:176) : avc:  denied  { create } for  pid=1783 comm=bwrap scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tclass=user_namespace permissive=1 -
type=SYSCALL msg=audit(02/22/2023 11:45:06.207:177) : arch=x86_64 syscall=openat success=yes exit=11 a0=AT_FDCWD a1=0x7fb2544c2063 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=1816 auid=unset uid=gnome-initial-setup gid=gnome-initial-setup euid=gnome-initial-setup suid=gnome-initial-setup fsuid=gnome-initial-setup egid=gnome-initial-setup sgid=gnome-initial-setup fsgid=gnome-initial-setup tty=tty1 ses=unset comm=fuse mainloop exe=/usr/libexec/xdg-document-portal subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/22/2023 11:45:06.207:177) : avc:  denied  { open } for  pid=1816 comm=fuse mainloop path=/proc/sys/fs/pipe-max-size dev="proc" ino=24766 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_fs_t:s0 tclass=file permissive=1 type=AVC msg=audit(02/22/2023 11:45:06.207:177) : avc:  denied  { read } for  pid=1816 comm=fuse mainloop name=pipe-max-size dev="proc" ino=24766 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_fs_t:s0 tclass=file permissive=1 -
type=PROCTITLE msg=audit(02/22/2023 13:38:58.589:270) : proctitle=/usr/bin/spice-vdagent type=PATH msg=audit(02/22/2023 13:38:58.589:270) : item=0 name=/var/lib/alsa/conf.d nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/22/2023 13:38:58.589:270) : arch=x86_64 syscall=access success=no exit=ENOENT(No such file or directory) a0=0x55a8493b9a00 a1=R_OK a2=0x0 a3=0x7fd97a3cfac0 items=1 ppid=1 pid=1426 auid=unset uid=gnome-initial-setup gid=gnome-initial-setup euid=gnome-initial-setup suid=gnome-initial-setup fsuid=gnome-initial-setup egid=gnome-initial-setup sgid=gnome-initial-setup fsgid=gnome-initial-setup tty=(none) ses=unset comm=spice-vdagent exe=/usr/bin/spice-vdagent subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/22/2023 13:38:58.589:270) : avc:  denied  { search } for  pid=1426 comm=spice-vdagent name=alsa dev="vda3" ino=145656 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:alsa_var_lib_t:s0 tclass=dir permissive=1 -
type=PROCTITLE msg=audit(02/22/2023 13:06:55.235:242) : proctitle=/usr/libexec/xdg-document-portal type=SYSCALL msg=audit(02/22/2023 13:06:55.235:242) : arch=x86_64 syscall=recvmsg success=yes exit=1 a0=0x8 a1=0x7fd0f7ffea50 a2=0x0 a3=0x7fd0f7fff990 items=0 ppid=1 pid=1788 auid=unset uid=gnome-initial-setup gid=gnome-initial-setup euid=gnome-initial-setup suid=gnome-initial-setup fsuid=gnome-initial-setup egid=gnome-initial-setup sgid=gnome-initial-setup fsgid=gnome-initial-setup tty=tty1 ses=unset comm=fuse mainloop exe=/usr/libexec/xdg-document-portal subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/22/2023 13:06:55.235:242) : avc:  denied  { read write } for  pid=1788 comm=fuse mainloop path=/dev/fuse dev="devtmpfs" ino=167 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fuse_device_t:s0 tclass=chr_file permissive=1 -
type=USER_AVC msg=audit(02/22/2023 13:06:37.020:204) : pid=757 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:rpm_t:s0 tclass=dbus permissive=1 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?' -

Resolves: rhbz#2028637