### PR TITLE
Allow poweroff search dbus pid directory

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -511,6 +511,9 @@ optional_policy(`
 	# and trigger the respective service unit.
 	systemd_systemctl_domain(kernel)
 	systemd_config_power_services(kernel_systemctl_t)
+	systemd_dbus_chat_logind(kernel_systemctl_t)
+
+	dbus_system_bus_client(kernel_systemctl_t)
 	init_read_utmp(kernel_systemctl_t)
 ')
 


### PR DESCRIPTION
Addresses the following AVC denial:

Feb 27 19:22:38 hostname audit[1002]: AVC avc:  denied  { search } for  pid=1002 comm="poweroff" name="dbus" dev="tmpfs" ino=48 scontext=system_u:system_r:kernel_systemctl_t:s0 tcontext=system_u:object_r:system_dbusd_var_run_t:s0 tclass=dir permissive=0
Feb 27 19:22:38 hostname audit[1002]: SYSCALL arch=c000003e syscall=42 success=no exit=-13 a0=3 a1=5651733e6620 a2=1e a3=7ffe0ca2f2b4 items=0 ppid=2 pid=1002 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="poweroff" exe="/usr/bin/systemctl" subj=system_u:system_r:kernel_systemctl_t:s0 key=(null)
Feb 27 19:22:38 hostname audit: PROCTITLE proctitle="/sbin/poweroff"

Resolves: rhbz#2173759