### PR TITLE
Allow iptables read all tmpfiles

### DIFF
--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -102,6 +102,7 @@ term_use_all_inherited_terms(iptables_t)
 domain_use_interactive_fds(iptables_t)
 
 files_rw_etc_runtime_files(iptables_t)
+files_read_all_tmp_files(iptables_t)
 files_rw_inherited_tmp_file(iptables_t)
 files_read_kernel_modules(iptables_t)
 


### PR DESCRIPTION
From the files_read_inherited_tmp_files interface was removed the open permission, that allowed iptables to open all tmp files.

On a Kubernetes there is a kubelet agent on each node. In order to create a Pod, kubelet is calling the CRI (e.g. cri-o) which in turn calls CNI plugins to configure the networking part. The CNI plugin, in turn, just calls `nft` to setup nftables rules. When doing so, it uses a temporary file to place there the JSON config and later loads it.

Resolves: rhbz#2172090