### PR TITLE
Allow qemu-guest-agent create and use vsock socket

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1737,6 +1737,7 @@ allow virt_qemu_ga_t self:passwd passwd;
 
 allow virt_qemu_ga_t self:fifo_file rw_fifo_file_perms;
 allow virt_qemu_ga_t self:unix_stream_socket create_stream_socket_perms;
+allow virt_qemu_ga_t self:vsock_socket create_socket_perms;
 
 allow virt_qemu_ga_t virt_qemu_ga_exec_t:dir search_dir_perms;
 can_exec(virt_qemu_ga_t, virt_qemu_ga_exec_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1665063114.844:460): avc:  denied  { create } for  pid=1310 comm="qemu-ga" scontext=system_u:system_r:virt_qemu_ga_t:s0 tcontext=system_u:system_r:virt_qemu_ga_t:s0 tclass=vsock_socket permissive=1

Resolves: rhbz#2132728