### PR TITLE
Allow login_pgm setcap permission

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -593,7 +593,7 @@ allow login_pgm self:netlink_kobject_uevent_socket create_socket_perms;
 allow login_pgm self:netlink_selinux_socket create_socket_perms; 
 allow login_pgm self:capability ipc_lock;
 dontaudit login_pgm self:capability net_admin;
-allow login_pgm self:process setkeycreate;
+allow login_pgm self:process { setcap setkeycreate };
 allow login_pgm self:key manage_key_perms;
 userdom_manage_all_users_keys(login_pgm)
 allow login_pgm nsswitch_domain:key manage_key_perms;


### PR DESCRIPTION
There is a pam_cap module as a part of the libcap package. When a capability is added to the login process using pam_cap, the setcap permission is required.

Example setup:

 echo "cap_dac_read_search exampleuser" > /etc/security/capability.conf
 echo "auth required pam_cap.so" >> /etc/pam.d/postlogin

Addresses the following AVC denial:

type=PROCTITLE msg=audit(03/03/2023 06:30:19.302:505) : proctitle=sshd: exampleuser [priv]
type=SYSCALL msg=audit(03/03/2023 06:30:19.302:505) : arch=x86_64 syscall=capset success=no exit=EACCES(Permission denied) a0=0x55b8338dc6f4 a1=0x55b8338dc6fc a2=0x55b8338dc6fc a3=0x55b83388d010 items=0 ppid=1350 pid=1357 auid=exampleuser uid=root gid=exampleuser euid=root suid=root fsuid=root egid=exampleuser sgid=exampleuser fsgid=exampleuser tty=(none) ses=7 comm=sshd exe=/usr/sbin/sshd subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(03/03/2023 06:30:19.302:505) : avc:  denied  { setcap } for  pid=1357 comm=sshd scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=process permissive=0

Resolves: rhbz#2172541