### PR TITLE
Allow chronyc read network sysctls

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -226,6 +226,7 @@ files_tmp_filetrans(chronyc_t, chronyd_tmp_t, file)
 
 kernel_read_system_state(chronyc_t)
 kernel_read_network_state(chronyc_t)
+kernel_read_net_sysctls(chronyc_t)
 
 auth_use_nsswitch(chronyc_t)
 


### PR DESCRIPTION
Addresses the following AVC denial:

type=PATH msg=audit(03/03/2023 06:20:20.737:71) : item=0 name=/proc/sys/net/ipv6/conf/all/disable_ipv6 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(03/03/2023 06:20:20.737:71) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffc27b6dd40 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=1188 pid=1229 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=1 comm=chronyc exe=/usr/bin/chronyc subj=unconfined_u:unconfined_r:chronyc_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(03/03/2023 06:20:20.737:71) : avc:  denied  { search } for  pid=1229 comm=chronyc name=net dev="proc" ino=11662 scontext=unconfined_u:unconfined_r:chronyc_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: rhbz#2173604