### PR TITLE
Allow tshark the setsched capability

### DIFF
--- a/policy/modules/contrib/wireshark.te
+++ b/policy/modules/contrib/wireshark.te
@@ -35,7 +35,8 @@ userdom_user_tmpfs_file(wireshark_tmpfs_t)
 #
 
 allow wireshark_t self:capability { net_admin net_raw };
-allow wireshark_t self:process { setcap signal getsched };
+allow wireshark_t self:process { setcap signal getsched setsched };
+dontaudit wireshark_t self:process execmem;
 allow wireshark_t self:fifo_file rw_fifo_file_perms;
 allow wireshark_t self:shm create_shm_perms;
 allow wireshark_t self:packet_socket { create_socket_perms map };


### PR DESCRIPTION
The permission is required since wireshark started to use glib threads. Additionally, the execmem permission was dontaudited.

Addresses the following AVC denials:

type=PROCTITLE msg=audit(01/25/2023 07:19:30.348:650) : proctitle=tshark -D
type=SYSCALL msg=audit(01/25/2023 07:19:30.348:650) : arch=x86_64 syscall=sched_setattr success=yes exit=0 a0=0x6b7 a1=0x555db1a84320 a2=0x0 a3=0x60 items=0 ppid=1576 pid=1719 auid=sysadm-user uid=sysadm-user gid=sysadm-user euid=sysadm-user suid=sysadm-user fsuid=sysadm-user egid=sysadm-user sgid=sysadm-user fsgid=sysadm-user tty=pts1 ses=6 comm=tshark exe=/usr/bin/tshark subj=sysadm_u:sysadm_r:wireshark_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(01/25/2023 07:19:30.348:650) : avc:  denied  { setsched } for  pid=1719 comm=tshark scontext=sysadm_u:sysadm_r:wireshark_t:s0-s0:c0.c1023 tcontext=sysadm_u:sysadm_r:wireshark_t:s0-s0:c0.c1023 tclass=process permissive=1

type=PROCTITLE msg=audit(01/25/2023 07:19:41.806:651) : proctitle=tshark -a duration:8
type=SYSCALL msg=audit(01/25/2023 07:19:41.806:651) : arch=x86_64 syscall=mmap success=yes exit=140704080146432 a0=0x0 a1=0x10000 a2=PROT_READ|PROT_WRITE|PROT_EXEC a3=MAP_PRIVATE|MAP_ANONYMOUS items=0 ppid=1576 pid=1762 auid=sysadm-user uid=sysadm-user gid=sysadm-user euid=sysadm-user suid=sysadm-user fsuid=sysadm-user egid=sysadm-user sgid=sysadm-user fsgid=sysadm-user tty=pts1 ses=6 comm=tshark exe=/usr/bin/tshark subj=sysadm_u:sysadm_r:wireshark_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(01/25/2023 07:19:41.806:651) : avc:  denied  { execmem } for  pid=1762 comm=tshark scontext=sysadm_u:sysadm_r:wireshark_t:s0-s0:c0.c1023 tcontext=sysadm_u:sysadm_r:wireshark_t:s0-s0:c0.c1023 tclass=process permissive=1

Resolves: rhbz#2163800