### PR TITLE
Allow certmonger dbus chat with the cron system domain

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -130,6 +130,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cron_dbus_chat_system_job(certmonger_t)
+')
+
+optional_policy(`
 	dbus_connect_system_bus(certmonger_t)
 	dbus_system_bus_client(certmonger_t)
 ')


### PR DESCRIPTION
Addresses the following USER_AVC denial:

type=USER_AVC msg=audit(1676295025.654:492962): pid=928 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for msgtype=method_return dest=:1.133676 spid=1026 tpid=2179712 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:system_r:system_cronjob_t:s0-s0:c0.c1023 tclass=dbus permissive=0  exe="/usr/bin/dbus-daemon" sauid=81 hostname=? addr=? terminal=?'

Resolves: rhbz#2173289