### PR TITLE
Boolean: allow qemu-ga manage ssh home directory

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -203,7 +203,7 @@ gen_tunable(virt_qemu_ga_read_nonsecurity_files, false)
 ## Allow qemu-ga read ssh home directory content.
 ## </p>
 ## </desc>
-gen_tunable(virt_qemu_ga_read_ssh, false)
+gen_tunable(virt_qemu_ga_manage_ssh, false)
 
 ## <desc>
 ## <p>
@@ -1812,8 +1812,8 @@ tunable_policy(`virt_rw_qemu_ga_data',`
 ')
 
 optional_policy(`
-        tunable_policy(`virt_qemu_ga_read_ssh',`
-                ssh_read_user_home_files(virt_qemu_ga_t)
+        tunable_policy(`virt_qemu_ga_manage_ssh',`
+		ssh_manage_home_files(virt_qemu_ga_t)
         ')
 ')
 


### PR DESCRIPTION
QEMU Guest Agent 5.2.0 added some new features including commands for managing guest ssh keys.

Resolves: rhbz#1917024