### PR TITLE
Allow wg sys_module cap, send_msg on the system dbus, search debugfs dir

### DIFF
--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -16,7 +16,7 @@ systemd_unit_file(wireguard_unit_file_t)
 #
 # wireguard local policy
 #
-allow wireguard_t self:capability { net_admin };
+allow wireguard_t self:capability { net_admin net_bind_service };
 allow wireguard_t self:fifo_file rw_fifo_file_perms;
 allow wireguard_t self:netlink_generic_socket create_socket_perms;
 allow wireguard_t self:netlink_netfilter_socket create_socket_perms;
@@ -26,7 +26,9 @@ allow wireguard_t self:unix_dgram_socket create_socket_perms;
 allow wireguard_t self:unix_stream_socket create_stream_socket_perms;
 
 kernel_dgram_send(wireguard_t)
+kernel_load_module(wireguard_t)
 kernel_request_load_module(wireguard_t)
+kernel_search_debugfs(wireguard_t)
 
 corecmd_exec_bin(wireguard_t)
 


### PR DESCRIPTION
Allow wireguard to unrestricted kernel modification. Allow wireguard low port binding.
Allow wireguard to send a message on the system DBUS. Allow wireguard to search the contents of a kernel debugging filesystem.

Resolves: rhbz#2176487