### PR TITLE
Allow sssd read accountsd fifo files

### DIFF
--- a/policy/modules/contrib/accountsd.if
+++ b/policy/modules/contrib/accountsd.if
@@ -22,6 +22,24 @@ interface(`accountsd_domtrans',`
 
 ########################################
 ## <summary>
+##	Read accountsd fifo files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`accountsd_read_fifo_file',`
+	gen_require(`
+		type accountsd_t;
+	')
+
+	allow $1 accountsd_t:fifo_file read_fifo_file_perms;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read and
 ##	write Accounts Daemon fifo files.
 ## </summary>

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -182,6 +182,10 @@ tunable_policy(`sssd_connect_all_unreserved_ports',`
 ')
 
 optional_policy(`
+	accountsd_read_fifo_file(sssd_t)
+')
+
+optional_policy(`
     bind_read_cache(sssd_t)
 ')
 


### PR DESCRIPTION
The accountsd_read_fifo_file() interface was added.

Addresses the following AVC denial:
type=AVC msg=audit(1679516634.18:292): avc:  denied  { read } for  pid=8651 comm="sss_cache" path="pipe:[291359]" dev="pipefs" ino=291359 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:accountsd_t:s0 tclass=fifo_file permissive=0

Resolves: rhbz#2181010