### PR TITLE
Allow passt manage qemu pid sockfiles

### DIFF
--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -1839,7 +1839,7 @@ interface(`virt_create_qemu_pid_files',`
 
 ########################################
 ## <summary>
-##     Create qemu PID socket files.
+##     Manage qemu PID socket files.
 ## </summary>
 ## <param name="domain">
 ##     <summary>
@@ -1847,11 +1847,11 @@ interface(`virt_create_qemu_pid_files',`
 ##     </summary>
 ## </param>
 #
-interface(`virt_create_qemu_pid_sock_files',`
+interface(`virt_manage_qemu_pid_sock_files',`
        gen_require(`
                type qemu_var_run_t;
        ')
 
        files_search_pids($1)
-       create_fifo_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
+       manage_sock_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
 ')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1067,7 +1067,7 @@ optional_policy(`
 		passt_stub(svirt_t)
 		virt_write_qemu_pid_files(passt_t)
 		virt_create_qemu_pid_files(passt_t)
-		virt_create_qemu_pid_sock_files(passt_t)
+		virt_manage_qemu_pid_sock_files(passt_t)
 		virt_read_pid_files(passt_t)
 		virt_svirt_write_tmp(passt_t)
 	')


### PR DESCRIPTION
Addresses the following AVC denial:

type=PROCTITLE msg=audit(03/27/2023 05:32:18.732:3235) : proctitle=/usr/bin/passt --one-off --socket /run/libvirt/qemu/passt/2-rhel-net0.socket --mac-addr 52:54:00:10:bd:dd --pid /run/libvirt/qem
type=AVC msg=audit(03/27/2023 05:32:18.732:3235) : avc:  denied  { remove_name } for  pid=176553 comm=passt name=2-rhel-net0.socket dev="tmpfs" ino=3380 scontext=system_u:system_r:passt_t:s0:c85,c179 tcontext=system_u:object_r:qemu_var_run_t:s0 tclass=dir permissive=1
type=AVC msg=audit(03/27/2023 05:32:18.732:3235) : avc:  denied  { unlink } for  pid=176553 comm=passt name=2-rhel-net0.socket dev="tmpfs" ino=3380 scontext=system_u:system_r:passt_t:s0:c85,c179 tcontext=system_u:object_r:qemu_var_run_t:s0 tclass=sock_file permissive=1
type=SYSCALL msg=audit(03/27/2023 05:32:18.732:3235) : arch=x86_64 syscall=unlink success=yes exit=0 a0=0x7fff5f905622 a1=0x7fff5f905620 a2=0xffffffffffffff00 a3=0x1 items=0 ppid=173728 pid=176553 auid=unset uid=unknown(107) gid=unknown(107) euid=unknown(107) suid=unknown(107) fsuid=unknown(107) egid=unknown(107) sgid=unknown(107) fsgid=unknown(107) tty=(none) ses=unset comm=passt exe=/usr/bin/passt subj=system_u:system_r:passt_t:s0:c85,c179 key=(null)

Resolves: rhbz#2172268