### PR TITLE
Allow mongodb read network sysctls

### DIFF
--- a/policy/modules/contrib/mongodb.te
+++ b/policy/modules/contrib/mongodb.te
@@ -71,6 +71,7 @@ kernel_read_proc_symlinks(mongod_t)
 
 kernel_read_system_state(mongod_t)
 kernel_read_network_state(mongod_t)
+kernel_read_fs_sysctls(mongod_t)
 kernel_read_net_sysctls(mongod_t)
 kernel_read_vm_sysctls(mongod_t)
 

--- a/policy/modules/contrib/mongodb.te
+++ b/policy/modules/contrib/mongodb.te
@@ -71,6 +71,7 @@ kernel_read_proc_symlinks(mongod_t)
 
 kernel_read_system_state(mongod_t)
 kernel_read_network_state(mongod_t)
+kernel_read_net_sysctls(mongod_t)
 kernel_read_vm_sysctls(mongod_t)
 
 corecmd_exec_bin(mongod_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1673324219.586:214): avc:  denied  { search } for  pid=930 comm="mongod" name="net" dev="proc" ino=15624 scontext=system_u:system_r:mongod_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: rhbz#2159599