### PR TITLE
Allow accounts-daemon read generic systemd unit lnk files

### DIFF
--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -97,6 +97,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_read_generic_unit_lnk_files(accountsd_t)
+')
+
+optional_policy(`
 	xserver_read_xdm_tmp_files(accountsd_t)
 	xserver_read_state_xdm(accountsd_t)
 	xserver_dbus_chat_xdm(accountsd_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1687,6 +1687,24 @@ interface(`systemd_getattr_generic_unit_files',`
 
 #######################################
 ## <summary>
+##	Read generic systemd unit lnk files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_generic_unit_lnk_files',`
+	gen_require(`
+		type systemd_unit_file_t;
+	')
+
+	read_lnk_files_pattern($1, systemd_unit_file_t, systemd_unit_file_t)
+')
+
+#######################################
+## <summary>
 ##  Create a directory in the /usr/lib/systemd/system directory.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1679275745.687:87): avc:  denied  { read } for  pid=968 comm="accounts-daemon" name="display-manager.service" dev="sdc3" ino=217901 scontext=system_u:system_r:accountsd_t:s0 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=lnk_file permissive=1

Resolves: rhbz#2179707