### PR TITLE
Allow rabbitmq to read network sysctls

### DIFF
--- a/policy/modules/contrib/rabbitmq.te
+++ b/policy/modules/contrib/rabbitmq.te
@@ -85,6 +85,7 @@ kernel_dgram_send(rabbitmq_t)
 
 kernel_read_system_state(rabbitmq_t)
 kernel_read_fs_sysctls(rabbitmq_t)
+kernel_read_net_sysctls(rabbitmq_t)
 
 corecmd_exec_bin(rabbitmq_t)
 corecmd_exec_shell(rabbitmq_t)


### PR DESCRIPTION
When rabbitmq is deployed with IPv6 enabled, inet_gethost command tries to access /proc/sys/net/ipv6/conf/all/disable_ipv6, but this has not been allowed.

This adds the rule so that this access is allowed.

Addresses the following AVC denials:

type=AVC msg=audit(1680541632.613:9934): avc:  denied  { search } for  pid=81170 comm="inet_gethost" name="net" dev="proc" ino=14337 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1680541632.613:9934): avc:  denied  { read } for  pid=81170 comm="inet_gethost" name="disable_ipv6" dev="proc" ino=171751 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1
type=AVC msg=audit(1680541632.613:9934): avc:  denied  { open } for  pid=81170 comm="inet_gethost" path="/proc/sys/net/ipv6/conf/all/disable_ipv6" dev="proc" ino=171751 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1
type=AVC msg=audit(1680541632.614:9935): avc:  denied  { getattr } for  pid=81170 comm="inet_gethost" path="/proc/sys/net/ipv6/conf/all/disable_ipv6" dev="proc" ino=171751 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1

Resolves: rhbz#2184999