### PR TITLE
Allow systemd-coredump mounton /usr

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -3701,6 +3701,24 @@ interface(`files_mounton_etc',`
 
 ########################################
 ## <summary>
+##	Mounton directories on the /usr filesystem
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_mounton_usr',`
+	gen_require(`
+		type usr_t;
+	')
+
+	allow $1 usr_t:dir mounton;
+')
+
+########################################
+## <summary>
 ##	Search the contents of /etc directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1144,6 +1144,7 @@ files_read_non_security_files(systemd_coredump_t)
 files_map_non_security_files(systemd_coredump_t)
 
 files_mounton_rootfs(systemd_coredump_t)
+files_mounton_usr(systemd_coredump_t)
 
 fs_getattr_nsfs_files(systemd_coredump_t)
 


### PR DESCRIPTION
The files_mounton_usr() interface was added.

Addresses the following AVC denial:
type=AVC msg=audit(1680965603.852:5360): avc:  denied  { mounton } for  pid=2016312 comm="(sd-parse-elf)" path="/" dev="sda4" ino=2 scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=dir permissive=1

Resolves: rhbz#2185385