### PR TITLE
Allow nm-dispatcher tlp plugin create tlp dirs

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -687,6 +687,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tlp_create_pid_dirs(NetworkManager_dispatcher_tlp_t)
 	tlp_manage_pid_files(NetworkManager_dispatcher_tlp_t)
 	tlp_filetrans_named_content(NetworkManager_dispatcher_tlp_t)
 ')

--- a/policy/modules/contrib/tlp.if
+++ b/policy/modules/contrib/tlp.if
@@ -141,7 +141,7 @@ interface(`tlp_systemctl',`
 
 ########################################
 ## <summary>
-##	Read all dbus pid files
+##	Manage tlp pid files
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -156,6 +156,25 @@ interface(`tlp_manage_pid_files',`
 
 	files_search_pids($1)
 	manage_files_pattern($1, tlp_var_run_t, tlp_var_run_t)
+')
+
+########################################
+## <summary>
+##	Create tlp pid directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tlp_create_pid_dirs',`
+	gen_require(`
+		type tlp_var_run_t;
+	')
+
+	files_search_pids($1)
+	create_dirs_pattern($1, tlp_var_run_t, tlp_var_run_t)
 ')
 
 ########################################


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1680957705.132:1272): avc:  denied  { create } for  pid=24056 comm="mkdir" name="tlp" scontext=system_u:system_r:NetworkManager_dispatcher_tlp_t:s0 tcontext=system_u:object_r:tlp_var_run_t:s0 tclass=dir permissive=0

The tlp_create_pid_dirs() interface was added.

Resolves: rhbz#2185367