### PR TITLE
Allow blueman watch generic device dirs

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -58,6 +58,7 @@ dev_read_rand(blueman_t)
 dev_read_urand(blueman_t)
 dev_rw_wireless(blueman_t)
 dev_rwx_zero(blueman_t)
+dev_watch_generic_dirs(blueman_t)
 
 domain_use_interactive_fds(blueman_t)
 domain_dontaudit_ptrace_all_domains(blueman_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1679157743.258:415): avc:  denied  { watch } for  pid=38811 comm="blueman-rfcomm-" path="/dev" dev="devtmpfs" ino=1 scontext=system_u:system_r:blueman_t:s0 tcontext=system_u:object_r:device_t:s0 tclass=dir permissive=0

Resolves: rhbz#2179560