### PR TITLE
Allow dovecot-deliver write to the main process runtime fifo files

### DIFF
--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -347,6 +347,7 @@ manage_dirs_pattern(dovecot_deliver_t, dovecot_deliver_tmp_t, dovecot_deliver_tm
 manage_files_pattern(dovecot_deliver_t, dovecot_deliver_tmp_t, dovecot_deliver_tmp_t)
 files_tmp_filetrans(dovecot_deliver_t, dovecot_deliver_tmp_t, { file dir })
 
+allow dovecot_deliver_t dovecot_var_run_t:fifo_file write_fifo_file_perms;
 allow dovecot_deliver_t dovecot_var_run_t:dir list_dir_perms;
 read_files_pattern(dovecot_deliver_t, dovecot_var_run_t, dovecot_var_run_t)
 read_sock_files_pattern(dovecot_deliver_t, dovecot_var_run_t, dovecot_var_run_t)


### PR DESCRIPTION
This permission is required when dovecot is configured to use the replication service for high availability.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(02/16/2023 02:59:42.304:105) : proctitle=/usr/libexec/dovecot/deliver -d user@hostname
type=SYSCALL msg=audit(02/16/2023 02:59:42.304:105) : arch=x86_64 syscall=openat success=yes exit=10 a0=AT_FDCWD a1=0x562d39dd0b90 a2=O_WRONLY|O_NONBLOCK a3=0x0 items=0 ppid=1765 pid=1766 auid=unset uid=unknown(1097) gid=unknown(1097) euid=unknown(1097) suid=unknown(1097) fsuid=unknown(1097) egid=unknown(1097) sgid=unknown(1097) fsgid=unknown(1097) tty=(none) ses=unset comm=deliver exe=/usr/libexec/dovecot/dovecot-lda subj=system_u:system_r:dovecot_deliver_t:s0 key=(null) SYSCALL=openat AUID="unset" UID="vmail" GID="vmail" EUID="vmail" SUID="vmail" FSUID="vmail" EGID="vmail" SGID="vmail" FSGID="vmail"
type=AVC msg=audit(02/16/2023 02:59:42.304:105) : avc:  denied  { open } for  pid=1766 comm=deliver path=/run/dovecot/replication-notify-fifo dev="tmpfs" ino=30737 scontext=system_u:system_r:dovecot_deliver_t:s0 tcontext=system_u:object_r:dovecot_var_run_t:s0 tclass=fifo_file permissive=1
type=AVC msg=audit(02/16/2023 02:59:42.304:105) : avc:  denied  { write } for  pid=1766 comm=deliver name=replication-notify-fifo dev="tmpfs" ino=30737 scontext=system_u:system_r:dovecot_deliver_t:s0 tcontext=system_u:object_r:dovecot_var_run_t:s0 tclass=fifo_file permissive=1