### PR TITLE
Allow NetworkManager_dispatcher_dhclient_t to read the DHCP configuration files

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -676,6 +676,7 @@ optional_policy(`
 optional_policy(`
 	sysnet_exec_ifconfig(networkmanager_dispatcher_plugin)
 	sysnet_read_config(networkmanager_dispatcher_plugin)
+	sysnet_read_dhcp_config(NetworkManager_dispatcher_dhclient_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Need to allow NetworkManager_dispatcher_dhclient_t to read the DHCP configuration files since 11-dhclient process running in that domain accesses /etc/dhcp/dhclient.d/*.sh and /etc/dhcp directory has dhcp_etc_t type.