### PR TITLE
Allow login_userdomain create user namespaces

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1688,8 +1688,6 @@ template(`userdom_admin_user_template',`
 
 	allow $1_t self:cap_userns sys_ptrace;
 
-	allow $1_t self:user_namespace create;
-
 	tunable_policy(`deny_bluetooth',`',`
 		allow $1_t self:bluetooth_socket create_stream_socket_perms;
 	')

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -373,6 +373,7 @@ optional_policy(`
 # login_userdomain local policy
 
 allow login_userdomain self:service status;
+allow login_userdomain self:user_namespace create;
 
 corenet_tcp_bind_xmsg_port(login_userdomain)
 


### PR DESCRIPTION
User namespaces are created when the systemd user instance is initialized. The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(04/18/2023 06:16:38.612:436) : proctitle=(ystemctl)
type=SYSCALL msg=audit(04/18/2023 06:16:38.612:436) : arch=x86_64 syscall=unshare success=no exit=EACCES(Permission denied) a0=CLONE_NEWUSER a1=0x7fffde9c8b00 a2=0x0 a3=0x8 items=0 ppid=32893 pid=32903 auid=user19875 uid=user19875 gid=user19875 euid=user19875 suid=user19875 fsuid=user19875 egid=user19875 sgid=user19875 fsgid=user19875 tty=(none) ses=5 comm=(ystemctl) exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(04/18/2023 06:16:38.612:436) : avc:  denied  { create } for  pid=32903 comm=(ystemctl) scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=user_namespace permissive=0