### PR TITLE
Keyutils policy fixes

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -11,3 +11,8 @@ role system_r types keyutils_request_t;
 allow keyutils_request_t self:unix_dgram_socket create_socket_perms;
 
 domain_read_view_all_domains_keyrings(keyutils_request_t)
+
+optional_policy(`
+	init_search_pid_dirs(keyutils_request_t)
+	logging_send_syslog_msg(keyutils_request_t)
+')

--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -10,5 +10,4 @@ role system_r types keyutils_request_t;
 
 allow keyutils_request_t self:unix_dgram_socket create_socket_perms;
 
-kernel_view_key(keyutils_request_t)
-kernel_read_key(keyutils_request_t)
+domain_read_view_all_domains_keyrings(keyutils_request_t)


### PR DESCRIPTION
Extend the keyutils_request_t policy to cover denials triggered by the `testcases/kernel/syscalls/request_key/request_key03` test from [LTP](https://github.com/linux-test-project/ltp) on Fedora ELN (not sure why, but the same doesn't occur on Rawhide).

See also: https://gitlab.com/redhat/centos-stream/tests/kernel/kernel-tests/-/issues/1604