### PR TITLE
Allow insights-client get quotas of all filesystems

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -47,7 +47,7 @@ systemd_unit_file(insights_client_unit_file_t)
 #
 # insights_client local policy
 #
-allow insights_client_t self:capability { dac_override dac_read_search fowner ipc_owner kill net_admin setgid setuid sys_admin sys_nice sys_ptrace sys_rawio sys_resource };
+allow insights_client_t self:capability { dac_override dac_read_search fowner ipc_owner kill net_admin net_raw setgid setuid sys_admin sys_nice sys_ptrace sys_rawio sys_resource };
 allow insights_client_t self:cap_userns sys_ptrace;
 allow insights_client_t self:fifo_file rw_fifo_file_perms;
 allow insights_client_t self:netlink_generic_socket create_socket_perms;
@@ -55,6 +55,7 @@ allow insights_client_t self:netlink_netfilter_socket create_socket_perms;
 allow insights_client_t self:netlink_route_socket create_netlink_socket_perms;
 allow insights_client_t self:netlink_selinux_socket create_socket_perms;
 allow insights_client_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
+allow insights_client_t self:packet_socket create_socket_perms;
 allow insights_client_t self:passwd rootok;
 allow insights_client_t self:process { getattr setfscreate setpgid setrlimit setsched };
 allow insights_client_t self:tcp_socket create_socket_perms;
@@ -314,6 +315,7 @@ optional_policy(`
 
 optional_policy(`
 	networkmanager_dbus_chat(insights_client_t)
+	networkmanager_stream_connect(insights_client_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -392,6 +392,7 @@ optional_policy(`
 
 optional_policy(`
 	unconfined_server_create_shm(insights_client_t)
+	unconfined_server_read_semaphores(insights_client_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -154,6 +154,7 @@ files_read_all_symlinks(insights_client_t)
 files_status_etc(insights_client_t)
 files_write_generic_tmp_sock_files(insights_client_t)
 
+fs_get_all_fs_quotas(insights_client_t)
 fs_getattr_all_fs(insights_client_t)
 fs_getattr_all_files(insights_client_t)
 fs_read_configfs_dirs(insights_client_t)

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -393,3 +393,21 @@ interface(`unconfined_server_create_shm',`
 
 	allow $1 unconfined_service_t:shm create_shm_perms;
 ')
+
+#######################################
+## <summary>
+##	Allow the specified domain read unconfined service semaphores
+## </summary>
+##	<param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_server_read_semaphores',`
+	gen_require(`
+		type unconfined_service_t;
+	')
+
+	allow $1 unconfined_service_t:sem r_sem_perms;
+')


### PR DESCRIPTION
Addresses the following AVC denial:

node=hostname type=PROCTITLE msg=audit(04/12/2023 13:18:11.020:2413893) : proctitle=/usr/sbin/repquota -agnpuv
node=hostname type=PATH msg=audit(04/12/2023 13:18:11.020:2413893) : item=1 name=/dev/sda1 inode=14423 dev=00:06 mode=block,660 ouid=root ogid=disk rdev=08:01 obj=system_u:object_r:fixed_disk_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
node=hostname type=PATH msg=audit(04/12/2023 13:18:11.020:2413893) : item=0 name=/dev/sda1 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
node=hostname type=CWD msg=audit(04/12/2023 13:18:11.020:2413893) : cwd=/
node=hostname type=SYSCALL msg=audit(04/12/2023 13:18:11.020:2413893) : arch=x86_64 syscall=quotactl success=no exit=ESRCH(No such process) a0=0x80000500 a1=0x55c243810650 a2=0x0 a3=0x7ffef89e3280 items=2 ppid=2190684 pid=2190685 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=repquota exe=/usr/sbin/repquota subj=system_u:system_r:insights_client_t:s0 key=(null)
node=hostname type=AVC msg=audit(04/12/2023 13:18:11.020:2413893) : avc:  denied  { quotaget } for  pid=2190685 comm=repquota scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1

Resolves: rhbz#2183351