### PR TITLE
Allow telnetd read network sysctls

### DIFF
--- a/policy/modules/contrib/telnet.te
+++ b/policy/modules/contrib/telnet.te
@@ -48,6 +48,7 @@ manage_files_pattern(telnetd_t, telnetd_var_run_t, telnetd_var_run_t)
 files_pid_filetrans(telnetd_t, telnetd_var_run_t, file)
 
 kernel_read_kernel_sysctls(telnetd_t)
+kernel_read_net_sysctls(telnetd_t)
 kernel_read_system_state(telnetd_t)
 kernel_read_network_state(telnetd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1682334459.949:7376): avc:  denied  { search } for  pid=29294 comm="in.telnetd" name="net" dev="proc" ino=22653 scontext=system_u:system_r:telnetd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: rhbz#2189184