### PR TITLE
Allow icecast connect to kernel using a unix stream socket

### DIFF
--- a/policy/modules/contrib/icecast.te
+++ b/policy/modules/contrib/icecast.te
@@ -49,6 +49,7 @@ manage_files_pattern(icecast_t, icecast_var_run_t, icecast_var_run_t)
 files_pid_filetrans(icecast_t, icecast_var_run_t, { file dir })
 
 kernel_read_system_state(icecast_t)
+kernel_stream_connect(icecast_t)
 
 corenet_all_recvfrom_unlabeled(icecast_t)
 corenet_all_recvfrom_netlabel(icecast_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(04/25/2023 21:20:01.808:10332) : proctitle=/usr/bin/icecast -c /etc/icecast.xml
type=PATH msg=audit(04/25/2023 21:20:01.808:10332) : item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=39 dev=00:18 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SOCKADDR msg=audit(04/25/2023 21:20:01.808:10332) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DynamicUser }
type=SYSCALL msg=audit(04/25/2023 21:20:01.808:10332) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x9 a1=0x7fff4492c9f0 a2=0x2d a3=0x0 items=1 ppid=1 pid=240551 auid=unset uid=root gid=icecast euid=root suid=root fsuid=root egid=icecast sgid=icecast fsgid=icecast tty=(none) ses=unset comm=icecast exe=/usr/bin/icecast subj=system_u:system_r:icecast_t:s0 key=(null)
type=AVC msg=audit(04/25/2023 21:20:01.808:10332) : avc:  denied  { connectto } for  pid=240551 comm=icecast path=/run/systemd/userdb/io.systemd.DynamicUser scontext=system_u:system_r:icecast_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0