### PR TITLE
Allow journalctl open user domain ptys and ttys

### DIFF
--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -51,8 +51,8 @@ term_use_generic_ptys(journalctl_t)
 
 userdom_list_user_home_dirs(journalctl_t)
 userdom_read_user_home_content_files(journalctl_t)
-userdom_use_inherited_user_ptys(journalctl_t)
-userdom_use_inherited_user_ttys(journalctl_t)
+userdom_use_user_ptys(journalctl_t)
+userdom_use_user_ttys(journalctl_t)
 userdom_rw_inherited_user_tmp_files(journalctl_t)
 userdom_rw_inherited_user_home_content_files(journalctl_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(04/25/2023 21:22:49.431:10767) : proctitle=less
type=PATH msg=audit(04/25/2023 21:22:49.431:10767) : item=0 name=/dev/pts/2 inode=5 dev=00:17 mode=character,620 ouid=root ogid=tty rdev=88:02 obj=sysadm_u:object_r:user_devpts_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(04/25/2023 21:22:49.431:10767) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55e3fe882420 a2=O_RDONLY a3=0x0 items=1 ppid=246901 pid=246920 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=80 comm=less exe=/usr/bin/less subj=sysadm_u:sysadm_r:journalctl_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(04/25/2023 21:22:49.431:10767) : avc:  denied  { open } for  pid=246920 comm=less path=/dev/pts/2 dev="devpts" ino=5 scontext=sysadm_u:sysadm_r:journalctl_t:s0-s0:c0.c1023 tcontext=sysadm_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0