### PR TITLE
Allow gssproxy read network sysctls

### DIFF
--- a/policy/modules/contrib/gssproxy.te
+++ b/policy/modules/contrib/gssproxy.te
@@ -39,6 +39,7 @@ manage_sock_files_pattern(gssproxy_t, gssproxy_var_run_t, gssproxy_var_run_t)
 manage_lnk_files_pattern(gssproxy_t, gssproxy_var_run_t, gssproxy_var_run_t)
 files_pid_filetrans(gssproxy_t, gssproxy_var_run_t, { dir file lnk_file sock_file })
 
+kernel_read_net_sysctls(gssproxy_t)
 kernel_rw_rpc_sysctls(gssproxy_t)
 kernel_read_network_state(gssproxy_t)
 kernel_read_system_state(gssproxy_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=AVC msg=audit(04/26/2023 04:52:53.404:931) : avc:  denied  { search } for  pid=532 comm=gssproxy name=net dev="proc" ino=14528 scontext=system_u:system_r:gssproxy_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0