### PR TITLE
Allow rpc.statd to search network sysctl dirs

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -159,6 +159,7 @@ can_exec(rpcd_t, rpcd_exec_t)
 kernel_read_system_state(rpcd_t)
 kernel_write_proc_files(rpcd_t)
 kernel_read_network_state(rpcd_t)
+kernel_search_network_sysctl(rpcd_t)
 # for rpc.rquotad
 kernel_read_sysctl(rpcd_t)
 kernel_rw_fs_sysctls(rpcd_t)


### PR DESCRIPTION
Addresses the following AVC denial:

time->Wed Mar  1 08:23:45 2023
type=PROCTITLE msg=audit(1677677025.236:151): proctitle="/usr/sbin/rpc.statd" type=SYSCALL msg=audit(1677677025.236:151): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=7ffc8ff7d990 a2=80100 a3=0 items=0 ppid=1 pid=21104 auid=4294967295 uid=29 gid=29 euid=29 suid=29 fsuid=29 egid=29 sgid=29 fsgid=29 tty=(none) ses=4294967295 comm="rpc.statd" exe="/usr/sbin/rpc.statd" subj=system_u:system_r:rpcd_t:s0 key=(null) type=AVC msg=audit(1677677025.236:151): avc:  denied  { search } for  pid=21104 comm="rpc.statd" name="net" dev="proc" ino=34064 scontext=system_u:system_r:rpcd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: rhbz#2175516