### PR TITLE
Allow ftpd read network sysctls

### DIFF
--- a/policy/modules/contrib/ftp.te
+++ b/policy/modules/contrib/ftp.te
@@ -177,6 +177,7 @@ logging_log_filetrans(ftpd_t, xferlog_t, { dir file })
 kernel_read_kernel_sysctls(ftpd_t)
 kernel_read_system_state(ftpd_t)
 kernel_read_network_state(ftpd_t)
+kernel_read_net_sysctls(ftpd_t)
 
 dev_read_sysfs(ftpd_t)
 dev_read_urand(ftpd_t)


### PR DESCRIPTION
Addresses the following AVC denials:

type=AVC msg=audit(03/07/2023 04:35:15.297:333) : avc:  denied  { open } for  pid=13228 comm=proftpd path=/proc/sys/net/ipv6/conf/all/disable_ipv6 dev="proc" ino=39195 scontext=system_u:system_r:ftpd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1
type=AVC msg=audit(03/07/2023 04:35:15.297:333) : avc:  denied  { read } for  pid=13228 comm=proftpd name=disable_ipv6 dev="proc" ino=39195 scontext=system_u:system_r:ftpd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1
type=AVC msg=audit(03/07/2023 04:35:15.297:333) : avc:  denied  { search } for  pid=13228 comm=proftpd name=net dev="proc" ino=11662 scontext=system_u:system_r:ftpd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=1

Resolves: rhbz#2175856