### PR TITLE
Add journalctl the sys_resource capability

### DIFF
--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -18,6 +18,7 @@ role journalctl_roles types journalctl_t;
 #
 # journalctl local policy
 #
+allow journalctl_t self:capability sys_resource;
 allow journalctl_t self:process { fork setrlimit signal_perms };
 
 allow journalctl_t self:fifo_file manage_fifo_file_perms;


### PR DESCRIPTION
The journalctl command runs in the journalctl_t domain when executed by a confined user (user, staff, sysadm). When is invoked with pager, prctl() is called to change the process name.

Addresses the following AVC denial:

type=PROCTITLE msg=audit(02/02/2023 12:55:12.623:1405) : proctitle=(pager)
type=SYSCALL msg=audit(02/02/2023 12:55:12.623:1405) : arch=x86_64 syscall=prctl success=yes exit=0 a0=PR_SET_MM a1=0x8 a2=0x7fd1a3f52000 a3=0x0 items=0 ppid=25495 pid=25516 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=39 comm=(pager) exe=/usr/bin/journalctl subj=sysadm_u:sysadm_r:journalctl_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(02/02/2023 12:55:12.623:1405) : avc:  denied  { sys_resource } for  pid=25516 comm=(pager) capability=sys_resource  scontext=sysadm_u:sysadm_r:journalctl_t:s0-s0:c0.c1023 tcontext=sysadm_u:sysadm_r:journalctl_t:s0-s0:c0.c1023 tclass=capability permissive=1

Resolves: rhbz#2136189