### PR TITLE
Allow lldpad connect to systemd-userdbd over a unix socket

### DIFF
--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -92,6 +92,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_userdbd_stream_connect(lldpad_t)
+')
+
+optional_policy(`
     unconfined_dgram_send(lldpad_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(04/27/2023 02:38:59.444:888) : proctitle=/usr/sbin/lldpd -x
type=PATH msg=audit(04/27/2023 02:38:59.444:888) : item=0 name=/run/systemd/userdb/io.systemd.DropIn inode=458 dev=00:18 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SOCKADDR msg=audit(04/27/2023 02:38:59.444:888) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DropIn }
type=SYSCALL msg=audit(04/27/2023 02:38:59.444:888) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x5 a1=0x7fff631f1030 a2=0x28 a3=0x4 items=1 ppid=1 pid=14273 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=lldpd exe=/usr/sbin/lldpd subj=system_u:system_r:lldpad_t:s0 key=(null)
type=AVC msg=audit(04/27/2023 02:38:59.444:888) : avc:  denied  { connectto } for  pid=14273 comm=lldpd path=/run/systemd/userdb/io.systemd.Multiplexer scontext=system_u:system_r:lldpad_t:s0 tcontext=system_u:system_r:systemd_userdbd_t:s0 tclass=unix_stream_socket permissive=0