### PR TITLE
Allow logrotate dbus chat with systemd-hostnamed

### DIFF
--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -178,6 +178,7 @@ systemd_reload_all_services(logrotate_t)
 systemd_status_all_unit_files(logrotate_t)
 systemd_dbus_chat_logind(logrotate_t)
 systemd_config_generic_services(logrotate_t)
+systemd_dbus_chat_hostnamed(logrotate_t)
 init_stream_connect(logrotate_t)
 init_reload_transient_unit(logrotate_t)
 


### PR DESCRIPTION
This denials appears when a service operating on a network is called from logrotate to perform an action, like ejabber to reopen its logs after logrotate finishes.

The commit addresses the following USER_AVC denial:

type=USER_AVC msg=audit(1676761204.161:9833): pid=543 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:logrotate_t:s0 tcontext=system_u:system_r:systemd_hostnamed_t:s0 tclass=dbus permissive=0  exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=? terminal=?'UID="dbus" AUID="unset" SAUID="dbus"

Resolves: rhbz#2171294