### PR TITLE
Allow rpmdb_migrate execute rpmdb

### DIFF
--- a/policy/modules/contrib/rpm.te
+++ b/policy/modules/contrib/rpm.te
@@ -261,6 +261,7 @@ optional_policy(`
 #
 
 can_exec(rpmdb_t, rpm_exec_t)
+can_exec(rpmdb_t, rpmdb_exec_t)
 
 manage_dirs_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)
 manage_files_pattern(rpmdb_t, rpm_var_lib_t, rpm_var_lib_t)


### PR DESCRIPTION
There is a chain of commands executed in the rpmdb-migrate service. A command running in the rpmdb_t context need to execute another one in the same context.

The commit addresses the following AVC denial:
type=AVC msg=audit(1682710462.695:1049): avc:  denied  { execute_no_trans } for  pid=361861 comm="rpm" path="/usr/bin/rpmdb" dev="dm-1" ino=1998503 scontext=unconfined_u:unconfined_r:rpmdb_t:s0-s0:c0.c1023 tcontext=system_u:object_r:rpmdb_exec_t:s0 tclass=file permissive=0

Resolves: rhbz#2191724