### PR TITLE
Allow plymouthd map dri and framebuffer devices

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -335,6 +335,9 @@ dev_manage_all_chr_files(kernel_t)
 dev_mounton(kernel_t)
 dev_filetrans_all_named_dev(kernel_t)
 term_filetrans_all_named_dev(kernel_t)
+# mapping video devices is needed for plymouthd
+dev_map_dri(kernel_t)
+dev_map_framebuffer(kernel_t)
 
 # Mount root file system. Used when loading a policy
 # from initrd, then mounting the root filesystem


### PR DESCRIPTION
The plymouthd services is executed in initramfs and keeps running in the kernel_t domain if it is not killed during after switchroot.

The commit addresses the following AVC denial:

type=AVC msg=audit(1677891760.806:83): avc:  denied  { map } for  pid=375 comm="plymouthd" path="/dev/dri/card0" dev="devtmpfs" ino=378 scontext=system_u:system_r:kernel_t:s0 tcontext=system_u:object_r:dri_device_t:s0 tclass=chr_file permissive=1

Resolves: rhbz#2175351