### PR TITLE
Allow unconfined_domain_type use IORING_OP_URING_CMD on all device nodes

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -7545,3 +7545,21 @@ interface(`dev_filetrans_xserver_named_dev',`
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "card8")
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "card9")
 ')
+
+########################################
+## <summary>
+##	Allow to use IORING_OP_URING_CMD on all device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_io_uring_cmd_on_all_dev_nodes',`
+	gen_require(`
+		attribute device_node;
+	')
+
+	allow $1 device_node:io_uring cmd;
+')

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -255,6 +255,7 @@ optional_policy(`
 # allow special io_uring features
 allow unconfined_domain_type domain:io_uring override_creds;
 allow unconfined_domain_type self:io_uring sqpoll;
+dev_io_uring_cmd_on_all_dev_nodes(unconfined_domain_type)
 files_io_uring_cmd_on_all_files(unconfined_domain_type)
 
 # allow using the user_namespace class


### PR DESCRIPTION
The dev_io_uring_cmd_on_all_dev_nodes() interface was added.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/28/2023 16:24:03.598:214) : proctitle=./iouring t2 type=SYSCALL msg=audit(04/28/2023 16:24:03.598:214) : arch=x86_64 syscall=io_uring_enter success=yes exit=1 a0=0x4 a1=0x1 a2=0x0 a3=0x0 items=0 ppid=932 pid=1106 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=1 comm=iouring exe=/root/sources/audit-testsuite/tests/io_uring/iouring subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null) type=URINGOP msg=audit(04/28/2023 16:24:03.598:214) : uring_op=uring_cmd success=no exit=EACCES(Permission denied) items=0 ppid=932 pid=1106 uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(04/28/2023 16:24:03.598:214) : avc:  denied  { cmd } for  pid=1106 comm=iouring path=/dev/null dev="devtmpfs" ino=4 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=system_u:object_r:null_device_t:s0 tclass=io_uring permissive=0

Resolves: rhbz#2191703