### PR TITLE
Allow plymouthd read init process state

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -423,6 +423,8 @@ optional_policy(`
 	init_dbus_chat(kernel_t)
 	init_sigchld(kernel_t)
 	init_dyntrans(kernel_t)
+	# required actually for plymouthd
+	init_read_state(kernel_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The plymouthd services is executed in initramfs and keeps running in the kernel_t domain if it is not killed during after switchroot.

The commit addresses the following AVC denial:

type=AVC msg=audit(1680373014.556:258): avc:  denied  { read } for  pid=382 comm="plymouthd" name="stat" dev="proc" ino=20331 scontext=system_u:system_r:kernel_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=file permissive=0

Resolves: rhbz#2183752