### PR TITLE
Add chromium_sandbox_t setcap capability

### DIFF
--- a/policy/modules/contrib/chrome.te
+++ b/policy/modules/contrib/chrome.te
@@ -34,8 +34,7 @@ userdom_user_home_content(chrome_sandbox_home_t)
 allow chrome_sandbox_t self:capability2 block_suspend;
 allow chrome_sandbox_t self:capability { chown dac_read_search  fsetid setgid setuid sys_admin sys_chroot sys_ptrace };
 dontaudit chrome_sandbox_t self:capability sys_nice;
-allow chrome_sandbox_t self:process { signal_perms setrlimit execmem execstack };
-allow chrome_sandbox_t self:process setsched;
+allow chrome_sandbox_t self:process { execmem execstack setcap setrlimit setsched signal_perms };
 allow chrome_sandbox_t self:fifo_file manage_fifo_file_perms;
 allow chrome_sandbox_t self:unix_stream_socket create_stream_socket_perms;
 allow chrome_sandbox_t self:unix_dgram_socket { create_socket_perms sendto };


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(05/07/2023 09:05:24.510:7304) : proctitle=/usr/lib64/chromium-browser/chromium-browser --type=zygote --crashpad-handler-pid=68828 --enable-crash-reporter=,Fedora Project
type=AVC msg=audit(05/07/2023 09:05:24.510:7304) : avc:  denied  { setcap } for  pid=72523 comm=chromium-browse scontext=unconfined_u:unconfined_r:chrome_sandbox_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:chrome_sandbox_t:s0-s0:c0.c1023 tclass=process permissive=0
type=SYSCALL msg=audit(05/07/2023 09:05:24.510:7304) : arch=x86_64 syscall=capset success=no exit=EACCES(Permission denied) a0=0x7ffd7da22980 a1=0x7ffd7da22960 a2=0x7f884b3818b8 a3=0x0 items=0 ppid=68845 pid=72523 auid=unknown(1200) uid=unknown(1200) gid=unknown(1200) euid=unknown(1200) suid=unknown(1200) fsuid=unknown(1200) egid=unknown(1200) sgid=unknown(1200) fsgid=unknown(1200) tty=(none) ses=34 comm=chromium-browse exe=/usr/lib64/chromium-browser/chromium-browser subj=unconfined_u:unconfined_r:chrome_sandbox_t:s0-s0:c0.c1023 key=(null)

Resolves: rhbz#2196008