### PR TITLE
Allow cluster_t dbus chat with various services

### DIFF
--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -219,8 +219,6 @@ init_rw_script_tmp_files(cluster_t)
 init_manage_script_status_files(cluster_t)
 init_dbus_chat(cluster_t)
 
-systemd_dbus_chat_logind(cluster_t)
-
 userdom_delete_user_tmp_files(cluster_t)
 userdom_rw_user_tmp_files(cluster_t)
 userdom_kill_all_users(cluster_t)
@@ -344,6 +342,16 @@ optional_policy(`
 
 optional_policy(`
     sysnet_domtrans_ifconfig(cluster_t)
+')
+
+ optional_policy(`
+	systemd_dbus_chat_hostnamed(cluster_t)
+	systemd_dbus_chat_logind(cluster_t)
+	systemd_dbus_chat_timedated(cluster_t)
+')
+
+optional_policy(`
+	timedatex_dbus_chat(cluster_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
cluster_t, the domain for administrative generic cluster services, was allowed to dbus chat with systemd-hostnamed, systemd-timedated, timedatex.

Resolves: rhbz#2196524