### PR TITLE
Allow snmpd read raw disk data

### DIFF
--- a/policy/modules/contrib/snmp.te
+++ b/policy/modules/contrib/snmp.te
@@ -105,11 +105,9 @@ files_list_all(snmpd_t)
 files_search_all_mountpoints(snmpd_t)
 fs_search_auto_mountpoints(snmpd_t)
 
-storage_dontaudit_read_fixed_disk(snmpd_t)
-storage_dontaudit_read_removable_device(snmpd_t)
+storage_raw_read_fixed_disk(snmpd_t)
+storage_raw_read_removable_device(snmpd_t)
 storage_dontaudit_write_removable_device(snmpd_t)
-storage_getattr_fixed_disk_dev(snmpd_t)
-storage_getattr_removable_dev(snmpd_t)
 
 auth_use_nsswitch(snmpd_t)
 


### PR DESCRIPTION
In particular, the following SNMP OIDs 1.3.6.1.2.1.25.3.6 (hrDiskStorageTable) and 1.3.6.1.2.1.25.3.7 (hrPartitionTable) require the raw devices access.

The commit addresses the following AVC denials example:

type=PROCTITLE msg=audit(05/09/2023 05:22:34.222:302) : proctitle=/usr/sbin/snmpd -LS0-6d -f
type=PATH msg=audit(05/09/2023 05:22:34.222:302) : item=0 name=/dev/sda inode=65179 dev=00:06 mode=block,660 ouid=root ogid=disk rdev=08:00 obj=system_u:object_r:fixed_disk_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/09/2023 05:22:34.222:302) : arch=aarch64 syscall=openat success=yes exit=9 a0=AT_FDCWD a1=0xfffffcdb39b0 a2=O_RDONLY|O_NONBLOCK a3=0x0 items=1 ppid=1 pid=20352 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=snmpd exe=/usr/sbin/snmpd subj=system_u:system_r:snmpd_t:s0 key=(null)
type=AVC msg=audit(05/09/2023 05:22:34.222:302) : avc:  denied  { open } for  pid=20352 comm=snmpd path=/dev/sda dev="devtmpfs" ino=65179 scontext=system_u:system_r:snmpd_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1
type=AVC msg=audit(05/09/2023 05:22:34.222:302) : avc:  denied  { read } for  pid=20352 comm=snmpd name=sda dev="devtmpfs" ino=65179 scontext=system_u:system_r:snmpd_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1

Resolves: rhbz#2160000