### PR TITLE
Allow cloud-init manage gpg admin home content

### DIFF
--- a/policy/modules/contrib/cloudform.te
+++ b/policy/modules/contrib/cloudform.te
@@ -121,6 +121,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gpg_manage_admin_home_content(cloud_init_t)
+')
+
+optional_policy(`
 	rhsmcertd_dbus_chat(cloud_init_t)
 ')
 


### PR DESCRIPTION
Resolves: rhbz#2203201