### PR TITLE
Allow samba-rpcd work with passwords

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -471,6 +471,9 @@ tunable_policy(`samba_domain_controller',`
 	usermanage_domtrans_useradd(smbd_t)
 	usermanage_domtrans_groupadd(smbd_t)
 	allow smbd_t self:passwd passwd;
+
+	usermanage_domtrans_passwd(winbind_rpcd_t)
+	allow winbind_rpcd_t self:passwd passwd;
 ')
 
 tunable_policy(`samba_enable_home_dirs',`
@@ -1213,6 +1216,7 @@ term_getattr_pty_fs(winbind_rpcd_t)
 term_use_ptmx(winbind_rpcd_t)
 
 optional_policy(`
+	auth_domtrans_chk_passwd(winbind_rpcd_t)
 	auth_read_passwd(winbind_rpcd_t)
 ')
 


### PR DESCRIPTION
A domain transition on chkpwd was allowed unconditionally and permissions to use the passwd command only when the samba_domain_controller boolean is turned on.

Resolves: rhbz#2107106