### PR TITLE
Allow certmonger manage cluster library files

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -182,6 +182,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhcs_manage_cluster_lib_files(certmonger_t)
     rhcs_start_haproxy_services(certmonger_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=AVC msg=audit(03/04/2023 15:49:54.072:28926) : avc:  denied  { write } for  pid=2303852 comm=certmonger name=pcsd.key dev="dm-0" ino=34564800 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:object_r:cluster_var_lib_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(03/04/2023 15:49:54.072:28926) : arch=ppc64le syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x1003fc92780 a2=O_RDWR a3=0x0 items=1 ppid=2303849 pid=2303852 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=certmonger exe=/usr/sbin/certmonger subj=system_u:system_r:certmonger_t:s0 key=(null)
type=PATH msg=audit(03/04/2023 15:49:54.072:28926) : item=0 name=/var/lib/pcsd/pcsd.key inode=34564800 dev=fd:00 mode=file,600 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cluster_var_lib_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: rhbz#2177836