### PR TITLE
Allow unconfined_service_t to create .gnupg labeled as gpg_secret_t

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -45,3 +45,7 @@ optional_policy(`
 optional_policy(`
 	container_runtime_domtrans(unconfined_service_t)
 ')
+
+optional_policy(`
+    gpg_manage_admin_home_content(unconfined_service_t)
+')


### PR DESCRIPTION
System is connected to Red Hat Insights via "/usr/bi/rhc connect" command executed using systemd service. This results that process rhc has label unconfined_service_t. The process creates directory /root/.gnupg. Following commint adds type transition defined as: "type_transition unconfined_service_t admin_home_t:dir gpg_secret_t .gnupg;"

To ensure the directory gets the correct SELinux label also for regular user, file transition rules were also added.