### PR TITLE
Allow virsh name_connect virt_port_t

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1240,6 +1240,7 @@ corecmd_exec_shell(virsh_t)
 corenet_tcp_sendrecv_generic_if(virsh_t)
 corenet_tcp_sendrecv_generic_node(virsh_t)
 corenet_tcp_connect_soundd_port(virsh_t)
+corenet_tcp_connect_virt_port(virsh_t)
 
 dev_read_rand(virsh_t)
 dev_read_urand(virsh_t)


### PR DESCRIPTION
Allow virsh to tcp connection to the virt port.
Resolves: rhzb#2187290