### PR TITLE
Allow cupsd to create samba_var_t files

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -383,6 +383,7 @@ optional_policy(`
 
 optional_policy(`
 	samba_read_config(cupsd_t)
+	samba_create_var_files(cupsd_t)
 	samba_rw_var_files(cupsd_t)
 	samba_stream_connect_nmbd(cupsd_t)
 ')

--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -538,6 +538,25 @@ interface(`samba_dontaudit_write_var_files',`
 
 ########################################
 ## <summary>
+##      Allow the specified domain to
+##      create samba /var files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`samba_create_var_files',`
+        gen_require(`
+                type samba_var_t;
+        ')
+
+        create_files_pattern($1, samba_var_t, samba_var_t)
+')
+
+########################################
+## <summary>
 ##	Allow the specified domain to
 ##	read and write samba /var files.
 ## </summary>


### PR DESCRIPTION
Adresses the following denial:
type=AVC msg=audit(1681807537.277:6645): avc:  denied  { write } for  pid=13496 comm="smbspool" name="lock" dev="dm-1" ino=201463076 scontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:samba_var_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1681807537.277:6645): avc:  denied  { add_name } for  pid=13496 comm="smbspool" name="gencache.tdb" scontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:samba_var_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1681807537.277:6645): avc:  denied  { create } for  pid=13496 comm="smbspool" name="gencache.tdb" scontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:samba_var_t:s0 tclass=file permissive=1 type=SYSCALL msg=audit(1681807537.277:6645): arch=c000003e syscall=257 success=yes exit=6 a0=ffffff9c a1=55f0e1e3b5f0 a2=80042 a3=1a4 items=2 ppid=2328 pid=13496 auid=4294967295 uid=0 gid=7 euid=0 suid=0 fsuid=0 egid=7 sgid=7 fsgid=7 tty=(none) ses=4294967295 comm="smbspool" exe="/usr/bin/smbspool" subj=system_u:system_r:cupsd_t:s0-s0:c0.c1023 key=(null)ARCH=x86_64 SYSCALL=openat AUID="unset" UID="root" GID="lp" EUID="root" SUID="root" FSUID="root" EGID="lp" SGID="lp" FSGID="lp" type=PATH msg=audit(1681807537.277:6645): item=0 name="/var/lib/samba/lock/" inode=201463076 dev=fd:01 mode=040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:samba_var_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="root" type=PATH msg=audit(1681807537.277:6645): item=1 name="/var/lib/samba/lock/gencache.tdb" inode=201477594 dev=fd:01 mode=0100600 ouid=0 ogid=7 rdev=00:00 obj=system_u:object_r:samba_var_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="lp"

Resolves: rhbz#2174445