### PR TITLE
Allow rhsmcert request the kernel to load a module

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -80,6 +80,7 @@ kernel_read_net_sysctls(rhsmcertd_t)
 kernel_read_state(rhsmcertd_t)
 kernel_read_system_state(rhsmcertd_t)
 kernel_read_sysctl(rhsmcertd_t)
+kernel_request_load_module(rhsmcertd_t)
 kernel_signull(rhsmcertd_t)
 
 corenet_tcp_bind_generic_node(rhsmcertd_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1683874450.081:120): avc:  denied  { module_request } for  pid=2803 comm="rhsm-service" kmod="tcp-ulp-tls" scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=1

Resolves: rhbz#2203359