### PR TITLE
Allow systemd services write to cgroup files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -461,6 +461,7 @@ manage_lnk_files_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd
 init_var_lib_filetrans(systemd_machined_t, systemd_machined_var_lib_t, dir, "machines")
 
 fs_read_nsfs_files(systemd_machined_t)
+fs_write_cgroup_files(systemd_machined_t)
 
 kernel_dgram_send(systemd_machined_t)
 # This is a bug, but need for now.
@@ -1015,6 +1016,7 @@ dev_read_sysfs(systemd_timedated_t)
 files_watch_var_run_path(systemd_timedated_t)
 
 fs_getattr_xattr_fs(systemd_timedated_t)
+fs_write_cgroup_files(systemd_timedated_t)
 
 init_dbus_chat(systemd_timedated_t)
 init_status(systemd_timedated_t)
@@ -1250,6 +1252,8 @@ files_watch_root_dirs(systemd_resolved_t)
 files_watch_tmpfs_dirs(systemd_resolved_t)
 files_watch_var_run_dirs(systemd_resolved_t)
 
+fs_write_cgroup_files(systemd_resolved_t)
+
 init_watch_pid_dir(systemd_resolved_t)
 
 sysnet_manage_config(systemd_resolved_t)
@@ -1476,6 +1480,8 @@ manage_sock_files_pattern(systemd_userdbd_t, systemd_userdbd_runtime_t, systemd_
 init_named_pid_filetrans(systemd_userdbd_t, systemd_userdbd_runtime_t, dir, "userdb")
 
 kernel_dgram_send(systemd_userdbd_t)
+
+fs_write_cgroup_files(systemd_userdbd_t)
 
 auth_read_shadow(systemd_userdbd_t)
 auth_use_nsswitch(systemd_userdbd_t)


### PR DESCRIPTION
In systemd, memory pressure handling can be enabled for a specific service setting the MemoryPressureWatch and MemoryPressureThresholdSec options.

Permission of the memory.pressure file from control group of the service are delegated to the service so that unprivileged service payload code can open the file for writing.

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(05/17/2023 06:26:18.059:1402) : proctitle=/usr/lib/systemd/systemd-timesyncd
type=PATH msg=audit(05/17/2023 06:26:18.059:1402) : item=0 name=/proc/self/fd/6 inode=10765 dev=00:19 mode=file,644 ouid=systemd-timesync ogid=systemd-timesync rdev=00:00 obj=system_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/17/2023 06:26:18.059:1402) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fff503b9c00 a2=O_RDWR|O_NOCTTY|O_NONBLOCK|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=77156 auid=unset uid=systemd-timesync gid=systemd-timesync euid=systemd-timesync suid=systemd-timesync fsuid=systemd-timesync egid=systemd-timesync sgid=systemd-timesync fsgid=systemd-timesync tty=(none) ses=unset comm=systemd-timesyn exe=/usr/lib/systemd/systemd-timesyncd subj=system_u:system_r:systemd_timedated_t:s0 key=(null)
type=AVC msg=audit(05/17/2023 06:26:18.059:1402) : avc:  denied  { write } for  pid=77156 comm=systemd-timesyn name=memory.pressure dev="cgroup2" ino=10765 scontext=system_u:system_r:systemd_timedated_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=0