### PR TITLE
Label /usr/lib/systemd/system/proftpd.* & vsftpd.* with ftpd_unit_file_t

### DIFF
--- a/policy/modules/contrib/ftp.fc
+++ b/policy/modules/contrib/ftp.fc
@@ -1,7 +1,7 @@
 /etc/proftpd\.conf	--	gen_context(system_u:object_r:ftpd_etc_t,s0)
 
-/usr/lib/systemd/system/vsftpd.* 	--	gen_context(system_u:object_r:iptables_unit_file_t,s0)
-/usr/lib/systemd/system/proftpd.*	--	gen_context(system_u:object_r:iptables_unit_file_t,s0)
+/usr/lib/systemd/system/vsftpd.*	--	gen_context(system_u:object_r:ftpd_unit_file_t,s0)
+/usr/lib/systemd/system/proftpd.*	--	gen_context(system_u:object_r:ftpd_unit_file_t,s0)
 
 /etc/cron\.monthly/proftpd	--	gen_context(system_u:object_r:ftpd_exec_t,s0)
 


### PR DESCRIPTION
The files (/usr/lib/systemd/system/proftpd.* & /usr/lib/systemd/system/vsftpd.*) were labeled as 'iptables_unit_file_t' in the ftp.fc  rather than 'ftpd_unit_file_t',

Resolves: rhbz#2188173