### PR TITLE
Allow wireguard to rw network sysctls

### DIFF
--- a/policy/modules/contrib/wireguard.if
+++ b/policy/modules/contrib/wireguard.if
@@ -37,3 +37,21 @@ interface(`wireguard_exec',`
 	corecmd_search_bin($1)
 	can_exec($1, wireguard_exec_t)
 ')
+
+########################################
+## <summary>
+##      Read wireguard fifo files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain to not audit.
+##      </summary>
+## </param>
+#
+interface(`wireguard_read_fifo_files',`
+        gen_require(`
+                type wireguard_t;
+        ')
+
+        allow $1 wireguard_t:fifo_file read_fifo_file_perms;
+')

--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -28,6 +28,7 @@ allow wireguard_t self:unix_stream_socket create_stream_socket_perms;
 kernel_dgram_send(wireguard_t)
 kernel_load_module(wireguard_t)
 kernel_request_load_module(wireguard_t)
+kernel_rw_net_sysctls(wireguard_t)
 kernel_search_debugfs(wireguard_t)
 
 corecmd_exec_bin(wireguard_t)

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -209,3 +209,8 @@ optional_policy(`
 optional_policy(`
 	udev_read_db(iptables_t)
 ')
+
+optional_policy(`
+	wireguard_read_fifo_files(iptables_t)
+')
+


### PR DESCRIPTION
Allow wireguard to read and write to sysctl network files. 
Add interface and allow iptables to read wireguard to read fifo files.

Resolves: rhbz#2192154