### PR TITLE
Replace cifsutils_helper_domtrans() with keyutils_request_domtrans_to()

### DIFF
--- a/policy/modules/contrib/cifsutils.if
+++ b/policy/modules/contrib/cifsutils.if
@@ -1,19 +1,1 @@
 ## <summary>Utilities for managing CIFS mounts</summary>
-
-#######################################
-## <summary>
-##	Execute cifs-helper in the cifs-helper domain.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`cifsutils_helper_domtrans',`
-	gen_require(`
-		type cifs_helper_t, cifs_helper_exec_t;
-	')
-
-	domtrans_pattern($1, cifs_helper_exec_t, cifs_helper_t)
-')

--- a/policy/modules/contrib/cifsutils.te
+++ b/policy/modules/contrib/cifsutils.te
@@ -28,6 +28,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# /etc/request-key.d/cifs.spnego.conf
+	keyutils_request_domtrans_to(cifs_helper_t, cifs_helper_exec_t)
+')
+
+optional_policy(`
 	miscfiles_read_generic_certs(cifs_helper_t)
 ')
 

--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -22,10 +22,6 @@ allow keyutils_request_t self:unix_dgram_socket create_socket_perms;
 domain_read_view_all_domains_keyrings(keyutils_request_t)
 
 optional_policy(`
-	cifsutils_helper_domtrans(keyutils_request_t)
-')
-
-optional_policy(`
 	init_search_pid_dirs(keyutils_request_t)
 	logging_send_syslog_msg(keyutils_request_t)
 ')


### PR DESCRIPTION
rpc.te already uses this interface to "register" a keyutils helper, so make cifsutils.te do the same instead of creating another interface.