### PR TITLE
Allow logwatch_mail_t read network sysctls

### DIFF
--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -198,6 +198,8 @@ manage_files_pattern(logwatch_mail_t, logwatch_cache_t, logwatch_cache_t)
 
 manage_files_pattern(logwatch_mail_t, logwatch_tmp_t, logwatch_tmp_t)
 
+kernel_read_net_sysctls(logwatch_mail_t)
+
 dev_read_rand(logwatch_mail_t)
 dev_read_urand(logwatch_mail_t)
 dev_read_sysfs(logwatch_mail_t)


### PR DESCRIPTION
Addresses the following AVC denial:

type=AVC msg=audit(1680192422.976:513): avc:  denied  { open } for  pid=9788 comm="sendmail" path="/proc/sys/net/ipv6/conf/all/disable_ipv6" dev="proc" ino=33052 scontext=system_u:system_r:logwatch_mail_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=0

Resolves: rhbz#2208763