### PR TITLE
Allow kernel to manage its own BPF objects

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -274,6 +274,7 @@ allow kernel_t self:unix_stream_socket connectto;
 allow kernel_t self:fifo_file rw_fifo_file_perms;
 allow kernel_t self:sock_file read_sock_file_perms;
 allow kernel_t self:fd use;
+allow kernel_t self:bpf { map_create map_read map_write prog_load prog_run };
 
 allow kernel_t debugfs_t:dir search_dir_perms;
 


### PR DESCRIPTION
Kernel threads may end up calling __sys_bpf(), which does the usual BPF access checks, so make sure kernel_t is allowed to at least operate on its own BPF fds.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2186595