### PR TITLE
Allow samba-dcerpcd connect to systemd_machined over a unix socket

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1264,6 +1264,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_machined_stream_connect(winbind_rpcd_t)
 	systemd_userdbd_stream_connect(winbind_rpcd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1684646002.435:1902): avc:  denied  { connectto } for  pid=27491 comm="rpcd_winreg" path="/run/systemd/userdb/io.systemd.Machine" scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2208845