### PR TITLE
Remove permissive domain for cifs_helper_t

### DIFF
--- a/policy/modules/contrib/cifsutils.te
+++ b/policy/modules/contrib/cifsutils.te
@@ -7,7 +7,6 @@ type cifs_helper_t;
 domain_type(cifs_helper_t)
 application_domain(cifs_helper_t, cifs_helper_exec_t)
 role system_r types cifs_helper_t;
-permissive cifs_helper_t;
 
 allow cifs_helper_t self:capability { setgid setuid sys_chroot };
 allow cifs_helper_t self:process setcap;


### PR DESCRIPTION
This setting was made temporarily to gather enough data for the new cifsutils policy.