### PR TITLE
Update sendmail policy module for opensmtpd

### DIFF
--- a/policy/modules/contrib/sendmail.fc
+++ b/policy/modules/contrib/sendmail.fc
@@ -6,3 +6,4 @@
 
 /var/run/sendmail\.pid		--	gen_context(system_u:object_r:sendmail_var_run_t,s0)
 /var/run/sm-client\.pid		--	gen_context(system_u:object_r:sendmail_var_run_t,s0)
+/var/run/smtpd\.sock		-s	gen_context(system_u:object_r:sendmail_var_run_t,s0)

--- a/policy/modules/contrib/sendmail.te
+++ b/policy/modules/contrib/sendmail.te
@@ -40,7 +40,7 @@ role sendmail_unconfined_roles types unconfined_sendmail_t;
 # Sendmail local policy
 #
 
-allow sendmail_t self:capability { dac_read_search dac_override setuid setgid net_bind_service sys_nice chown sys_tty_config };
+allow sendmail_t self:capability { dac_read_search dac_override fowner setuid setgid net_bind_service sys_chroot sys_nice chown sys_tty_config };
 dontaudit sendmail_t self:capability net_admin;
 dontaudit sendmail_t self:capability2 block_suspend;
 allow sendmail_t self:process { setsched setpgid setrlimit signal signull };
@@ -60,8 +60,9 @@ manage_dirs_pattern(sendmail_t, sendmail_tmp_t, sendmail_tmp_t)
 manage_files_pattern(sendmail_t, sendmail_tmp_t, sendmail_tmp_t)
 files_tmp_filetrans(sendmail_t, sendmail_tmp_t, { file dir })
 
-allow sendmail_t sendmail_var_run_t:file manage_file_perms;
-files_pid_filetrans(sendmail_t, sendmail_var_run_t, file)
+manage_dirs_pattern(sendmail_t, sendmail_var_run_t, sendmail_var_run_t)
+manage_sock_files_pattern(sendmail_t, sendmail_var_run_t, sendmail_var_run_t)
+files_pid_filetrans(sendmail_t, sendmail_var_run_t, { file sock_file })
 
 kernel_read_network_state(sendmail_t)
 kernel_read_kernel_sysctls(sendmail_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(05/22/2023 05:05:46.283:115) : proctitle=smtpd: scheduler type=PATH msg=audit(05/22/2023 05:05:46.283:115) : item=0 name=/var/empty/smtpd inode=76088 dev=00:22 mode=dir,711 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:var_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(05/22/2023 05:05:46.283:115) : arch=x86_64 syscall=chroot success=no exit=EPERM(Operation not permitted) a0=0x55cad60088c4 a1=0x7 a2=0x55cad6022620 a3=0x0 items=1 ppid=582 pid=588 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=smtpd exe=/usr/sbin/smtpd subj=system_u:system_r:sendmail_t:s0 key=(null) type=AVC msg=audit(05/22/2023 05:05:46.283:115) : avc:  denied  { sys_chroot } for  pid=588 comm=smtpd capability=sys_chroot  scontext=system_u:system_r:sendmail_t:s0 tcontext=system_u:system_r:sendmail_t:s0 tclass=capability permissive=0

type=PROCTITLE msg=audit(05/23/2023 11:20:38.393:1218) : proctitle=/usr/sbin/smtpd -x queue
type=PATH msg=audit(05/23/2023 11:20:38.393:1218) : item=0 name=/var/spool/smtpd/temporary inode=123282 dev=00:22 mode=dir,000 ouid=smtpq ogid=root rdev=00:00 obj=system_u:object_r:mail_spool_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/23/2023 11:20:38.393:1218) : arch=x86_64 syscall=chmod success=no exit=EPERM(Operation not permitted) a0=0x556b0cf42acc a1=0700 a2=0x0 a3=0x0 items=1 ppid=82051 pid=82056 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=smtpd exe=/usr/sbin/smtpd subj=system_u:system_r:sendmail_t:s0 key=(null)
type=AVC msg=audit(05/23/2023 11:20:38.393:1218) : avc:  denied  { fowner } for  pid=82056 comm=smtpd capability=fowner  scontext=system_u:system_r:sendmail_t:s0 tcontext=system_u:system_r:sendmail_t:s0 tclass=capability permissive=0

Additionally, support for using runtime sock files was added.

Resolves: rhbz#2208696