### PR TITLE
Allow init_t nnp domain transition to policykit_t

### DIFF
--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -10,6 +10,7 @@ attribute policykit_domain;
 type policykit_t, policykit_domain;
 type policykit_exec_t;
 init_daemon_domain(policykit_t, policykit_exec_t)
+init_nnp_daemon_domain(policykit_t)
 
 type policykit_auth_t, policykit_domain;
 type policykit_auth_exec_t;


### PR DESCRIPTION
The permission is required in a new polkit version which contains miscellaneous service sandboxing features.

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(05/24/2023 08:38:07.724:1699) : proctitle=/usr/lib/polkit-1/polkitd --no-debug
type=PATH msg=audit(05/24/2023 08:38:07.724:1699) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=9730 dev=00:22 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(05/24/2023 08:38:07.724:1699) : item=0 name=/usr/lib/polkit-1/polkitd inode=127332 dev=00:22 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:policykit_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=EXECVE msg=audit(05/24/2023 08:38:07.724:1699) : argc=2 a0=/usr/lib/polkit-1/polkitd a1=--no-debug
type=SYSCALL msg=audit(05/24/2023 08:38:07.724:1699) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55d5c8320000 a1=0x55d5c8355810 a2=0x55d5caa00ef0 a3=0x1 items=2 ppid=1 pid=142587 auid=unset uid=polkitd gid=polkitd euid=polkitd suid=polkitd fsuid=polkitd egid=polkitd sgid=polkitd fsgid=polkitd tty=(none) ses=unset comm=polkitd exe=/usr/lib/polkit-1/polkitd subj=system_u:system_r:init_t:s0 key=(null)
type=SELINUX_ERR msg=audit(05/24/2023 08:38:07.724:1699) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:policykit_t:s0
type=AVC msg=audit(05/24/2023 08:38:07.724:1699) : avc:  denied  { nnp_transition } for  pid=142587 comm=(polkitd) scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:policykit_t:s0 tclass=process2 permissive=0