### PR TITLE
Allow rpcd_lsad setcap and use generic ptys

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1173,6 +1173,7 @@ optional_policy(`
 allow winbind_rpcd_t self:capability { setgid setuid };
 allow winbind_rpcd_t self:key { read write };
 allow winbind_rpcd_t self:netlink_route_socket create_netlink_socket_perms;
+allow winbind_rpcd_t self:process setcap;
 allow winbind_rpcd_t self:unix_dgram_socket { create_socket_perms sendto };
 allow winbind_rpcd_t self:unix_stream_socket connectto;
 allow winbind_rpcd_t self:udp_socket create_socket_perms;
@@ -1265,6 +1266,10 @@ optional_policy(`
 
 optional_policy(`
 	systemd_userdbd_stream_connect(winbind_rpcd_t)
+')
+
+optional_policy(`
+	term_use_generic_ptys(winbind_rpcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow /usr/libexec/samba/rpcd_lsad running in the winbind_rpcd_t domain the setcap permission to use capset(2) and use generic ptys when a request to change a password is made. Note winbind_rpcd_t is not in the daemon attribute which is a subject of the daemons_use_tty boolean.

The commit addresses the following AVC denials:

type=PROCTITLE msg=audit(05/23/2023 15:45:49.588:911) : proctitle=/usr/libexec/samba/rpcd_lsad --configfile=/etc/samba/smb.conf --worker-group=2 --worker-index=0 --debuglevel=0
type=PATH msg=audit(05/23/2023 15:45:49.588:911) : item=0 name=/dev/pts/2 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/23/2023 15:45:49.588:911) : arch=x86_64 syscall=stat success=no exit=EACCES(Permission denied) a0=0x7ffce321e8c0 a1=0x7ffce321e830 a2=0x7ffce321e830 a3=0x0 items=1 ppid=129672 pid=129682 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpcd_lsad exe=/usr/libexec/samba/rpcd_lsad subj=system_u:system_r:winbind_rpcd_t:s0 key=(null)
type=AVC msg=audit(05/23/2023 15:45:49.588:911) : avc:  denied  { search } for  pid=129682 comm=rpcd_lsad name=/ dev="devpts" ino=1 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=dir permissive=0

type=PROCTITLE msg=audit(05/24/2023 03:08:08.440:1130) : proctitle=/usr/libexec/samba/rpcd_lsad --configfile=/etc/samba/smb.conf --worker-group=2 --worker-index=0 --debuglevel=0
type=SYSCALL msg=audit(05/24/2023 03:08:08.440:1130) : arch=x86_64 syscall=capset success=no exit=EACCES(Permission denied) a0=0x561752d238b4 a1=0x561752d238bc a2=0x561752d238bc a3=0x7ffd6edcd904 items=0 ppid=164904 pid=164906 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpcd_lsad exe=/usr/libexec/samba/rpcd_lsad subj=system_u:system_r:winbind_rpcd_t:s0 key=(null)
type=AVC msg=audit(05/24/2023 03:08:08.440:1130) : avc:  denied  { setcap } for  pid=164906 comm=rpcd_lsad scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:winbind_rpcd_t:s0 tclass=process permissive=0

Resolves: rhbz#2107106