### PR TITLE
Dontaudit targetd search httpd config dirs

### DIFF
--- a/policy/modules/contrib/apache.if
+++ b/policy/modules/contrib/apache.if
@@ -740,6 +740,25 @@ interface(`apache_search_config',`
 
 ########################################
 ## <summary>
+##	Dontaudit the specified domain to search
+##	apache configuration dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`apache_dontaudit_search_config',`
+	gen_require(`
+		type httpd_config_t;
+	')
+
+	dontaudit $1 httpd_config_t:dir search_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Allow the specified domain to read
 ##	apache configuration files.
 ## </summary>

--- a/policy/modules/contrib/targetd.te
+++ b/policy/modules/contrib/targetd.te
@@ -102,6 +102,10 @@ storage_raw_read_removable_device(targetd_t)
 sysnet_read_config(targetd_t)
 
 optional_policy(`
+	apache_dontaudit_search_config(targetd_t)
+')
+
+optional_policy(`
 	gnome_read_generic_data_home_dirs(targetd_t)
 ')
 


### PR DESCRIPTION
targetd, as other python scripts looking for the mime.types file, use the mimetypes.py library which has a predefined set of directories, many of them legacy which are not used any longer.

The apache_dontaudit_search_config() interface was added.

Resolves: rhbz#2203720