### PR TITLE
Allow abrt_t read kernel persistent storage files

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -231,6 +231,7 @@ fs_read_nfs_symlinks(abrt_t)
 fs_search_all(abrt_t)
 fs_getattr_nsfs_files(abrt_t)
 fs_map_dos_files(abrt_t)
+fs_read_pstore_files(abrt_t)
 
 storage_dontaudit_read_fixed_disk(abrt_t)
 


### PR DESCRIPTION
abrt-merge-pstoreoops is an abrt internal plugin to scans pstore sysfs files.

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(05/17/2023 04:18:29.691:247) : proctitle=abrt-merge-pstoreoops -o dmesg-efi-168429098401001 dmesg-efi-168429098402001 dmesg-efi-168429098403001 dmesg-efi-168429098404001
type=SYSCALL msg=audit(05/17/2023 04:18:29.691:247) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffc51f0bd6f a2=O_RDONLY a3=0x0 items=0 ppid=2465 pid=2466 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=abrt-merge-psto exe=/usr/bin/abrt-merge-pstoreoops subj=system_u:system_r:abrt_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(05/17/2023 04:18:29.691:247) : avc:  denied  { read } for  pid=2466 comm=abrt-merge-psto name=dmesg-efi-168429098401001 dev="pstore" ino=12495 scontext=system_u:system_r:abrt_t:s0-s0:c0.c1023 tcontext=system_u:object_r:pstore_t:s0 tclass=file permissive=0

Resolves: rhbz#2207914