### PR TITLE
Update pkcsslotd policy for sandboxing

### DIFF
--- a/policy/modules/contrib/pkcs.fc
+++ b/policy/modules/contrib/pkcs.fc
@@ -12,4 +12,5 @@
 
 /var/lock/opencryptoki(/.*)?	gen_context(system_u:object_r:pkcs_slotd_lock_t,s0)
 
+/var/run/opencryptoki(/.*)?	gen_context(system_u:object_r:pkcs_slotd_var_run_t,s0)
 /var/run/pkcsslotd.*	gen_context(system_u:object_r:pkcs_slotd_var_run_t,s0)

--- a/policy/modules/contrib/pkcs.if
+++ b/policy/modules/contrib/pkcs.if
@@ -62,6 +62,24 @@ interface(`pkcs_rw_shm',`
 
 ########################################
 ## <summary>
+##	Destroy pkcsslotd sysv shared memory segments.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pkcs_destroy_shm',`
+	gen_require(`
+		type pkcs_slotd_t;
+	')
+
+	allow $1 pkcs_slotd_t:shm destroy;
+')
+
+########################################
+## <summary>
 ##	Connect to pkcs using a unix
 ##	domain stream socket.
 ## </summary>
@@ -162,6 +180,25 @@ interface(`pkcs_tmpfs_named_filetrans',`
 
 ########################################
 ## <summary>
+##	Delete pkcs files in the tmpfs directories
+##	with a private type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pkcs_delete_tmpfs_files',`
+	gen_require(`
+		type pkcs_slotd_tmpfs_t;
+	')
+
+	allow $1 pkcs_slotd_tmpfs_t:file delete_file_perms;
+')
+
+########################################
+## <summary>
 ##	Use opencryptoki services
 ## </summary>
 ## <param name="domain">
@@ -176,7 +213,7 @@ interface(`pkcs_use_opencryptoki',`
         type pkcs_slotd_tmpfs_t;
 	')
 
-    allow $1 self:capability fsetid;
+    allow $1 self:capability { fsetid ipc_owner };
     allow pkcs_slotd_t $1:process signull;
     allow $1 pkcs_slotd_tmpfs_t:file { create_file_perms mmap_rw_file_perms };
 

--- a/policy/modules/contrib/pkcs.te
+++ b/policy/modules/contrib/pkcs.te
@@ -10,6 +10,7 @@ type pkcs_slotd_exec_t;
 typealias pkcs_slotd_t alias pkcsslotd_t;
 typealias pkcs_slotd_exec_t alias pkcsslotd_exec_t;
 init_daemon_domain(pkcs_slotd_t, pkcs_slotd_exec_t)
+init_nnp_daemon_domain(pkcs_slotd_t)
 
 type pkcs_slotd_initrc_exec_t;
 init_script_file(pkcs_slotd_initrc_exec_t)
@@ -45,11 +46,12 @@ systemd_unit_file(pkcs_slotd_unit_file_t)
 # Local policy
 #
 
-allow pkcs_slotd_t self:capability { fsetid kill chown };
+allow pkcs_slotd_t self:capability { chown fsetid kill setgid setuid };
 dontaudit pkcs_slotd_t self:capability sys_admin;
 allow pkcs_slotd_t self:capability2 bpf;
 allow pkcs_slotd_t self:fifo_file rw_fifo_file_perms;
 allow pkcs_slotd_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow pkcs_slotd_t self:process setcap;
 allow pkcs_slotd_t self:sem create_sem_perms;
 allow pkcs_slotd_t self:shm create_shm_perms;
 allow pkcs_slotd_t self:unix_stream_socket { accept listen };
@@ -79,6 +81,8 @@ files_tmp_filetrans(pkcs_slotd_t, pkcs_slotd_tmp_t, dir)
 manage_dirs_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
 manage_files_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
 fs_tmpfs_filetrans(pkcs_slotd_t, pkcs_slotd_tmpfs_t, { file dir })
+
+can_exec(pkcs_slotd_t, pkcs_slotd_exec_t)
 
 auth_use_nsswitch(pkcs_slotd_t)
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -550,6 +550,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	pkcs_delete_tmpfs_files(init_t)
+	pkcs_destroy_shm(init_t)
+')
+
+optional_policy(`
     raid_manage_mdadm_pid(init_t)
 	raid_relabel_mdadm_var_run_content(init_t)
     raid_stream_connect(init_t)


### PR DESCRIPTION
The updated opencryptoki package contains miscellaneous service sandboxing features which also need to be backed by selinux-policy update, namely setting capabilities, allowing NNP transition, removing IPC means after the service stops.

Resolves: rhbz#2208162