### PR TITLE
Add list_dir_perms to kerberos_read_keytab

### DIFF
--- a/policy/modules/contrib/kerberos.if
+++ b/policy/modules/contrib/kerberos.if
@@ -199,7 +199,7 @@ interface(`kerberos_read_keytab',`
 	')
 
 	files_search_etc($1)
-    allow $1 krb5_keytab_t:dir search_dir_perms;
+	allow $1 krb5_keytab_t:dir list_dir_perms;
 	allow $1 krb5_keytab_t:file read_file_perms;
 ')
 


### PR DESCRIPTION
In the interface kerberos_read_keytab
is allowed to read krb5_keytab_t files,
but wasn't allowed to read krb5_keytab_t dirs,
which leads to AVC message

Resolves: rhbz#2112729