### PR TITLE
Allow firewalld rw ica_tmpfs_t files

### DIFF
--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -132,6 +132,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ica_rw_map_tmpfs_files(firewalld_t)
+')
+
+optional_policy(`
 	iptables_domtrans(firewalld_t)
 	iptables_read_var_run(firewalld_t)
 ')


### PR DESCRIPTION
When restarting the firewalld service on systems where the openssl-ibmca engine is configured systemwide, SELinux prevents firewalld to read and write ica tmpfs files

Resolves: rhbz#2207487