### PR TITLE
[DO NOT MERGE] userdom_base_user_template: Define role corresponding to the new user

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -27,7 +27,6 @@ template(`userdom_base_user_template',`
 		attribute userdomain;
 		type user_devpts_t, user_tty_device_t;
 		class context contains;
-		role $1_r;
 	')
 
 	attribute $1_file_type;
@@ -39,6 +38,7 @@ template(`userdom_base_user_template',`
 	corecmd_bin_entry_type($1_t)
 	domain_user_exemption_target($1_t)
 	ubac_constrained($1_t)
+	role $1_r;
 	role $1_r types $1_t;
 	allow system_r $1_r;
 


### PR DESCRIPTION
The template creates a new SELinux user, but requires the corresponding role, meaning that the policy utilizing the interface needs to look as follos to work:

role <name>_r;
userdom_base_user_template(<name>)

This also breaks the policy generated by
sepolicy generate --term_user -n <username>