### PR TITLE
Allow systemd-bootchartd the sys_ptrace userns capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1363,6 +1363,7 @@ systemd_read_efivarfs(systemd_modules_load_t)
 
 allow systemd_bootchart_t self:capability sys_admin;
 allow systemd_bootchart_t self:capability2 wake_alarm;
+allow systemd_bootchart_t self:cap_userns sys_ptrace;
 allow systemd_bootchart_t self:unix_dgram_socket create_socket_perms;
 
 kernel_dgram_send(systemd_bootchart_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(05/26/2023 21:45:20.129:14882) : proctitle=@usr/lib/systemd/systemd-bootchart -r
type=SYSCALL msg=audit(05/26/2023 21:45:20.129:14882) : arch=x86_64 syscall=read success=yes exit=182 a0=0x114 a1=0x559317d74740 a2=0x400 a3=0x1000 items=0 ppid=1 pid=388041 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-bootcha exe=/usr/lib/systemd/systemd-bootchart subj=system_u:system_r:systemd_bootchart_t:s0 key=(null)
type=AVC msg=audit(05/26/2023 21:45:20.129:14882) : avc:  denied  { sys_ptrace } for  pid=388041 comm=systemd-bootcha capability=sys_ptrace  scontext=system_u:system_r:systemd_bootchart_t:s0 tcontext=system_u:system_r:systemd_bootchart_t:s0 tclass=cap_userns permissive=0