### PR TITLE
Update policy for systemd-sleep

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1508,6 +1508,8 @@ dontaudit systemd_sleep_t self:capability sys_ptrace;
 # systemd-sleep needs the permission to change sleep state
 allow systemd_sleep_t self:lockdown integrity;
 
+allow systemd_sleep_t systemd_unit_file_t:service { start stop };
+
 kernel_dgram_send(systemd_sleep_t)
 
 corecmd_exec_bin(systemd_sleep_t)
@@ -1518,6 +1520,8 @@ dev_rw_sysfs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)
+
+init_search_var_lib_dirs(systemd_sleep_t)
 
 # systemd-sleep needs to getattr swap partitions
 storage_getattr_fixed_disk_dev(systemd_sleep_t)


### PR DESCRIPTION
These permissions are needed when the systems enters the sleep mode, or when `systemctl suspend-then-hibernate` is executed.

Resolves: rhbz#2188640