### PR TITLE
Allow systemd-sleep read udev pid files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1538,5 +1538,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	udev_read_pid_files(systemd_sleep_t)
+')
+
+optional_policy(`
 	unconfined_server_domtrans(systemd_sleep_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=AVC msg=audit(1685448667.201:1720): avc:  denied  { open } for  pid=145045 comm="systemd-sleep" path="/run/udev/data/+power_supply:BAT1" dev="tmpfs" ino=16724 scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0

Resolves: rhbz#2211062