### PR TITLE
Allow exim read network sysctls

### DIFF
--- a/policy/modules/contrib/exim.te
+++ b/policy/modules/contrib/exim.te
@@ -104,6 +104,7 @@ can_exec(exim_t, exim_exec_t)
 
 kernel_read_crypto_sysctls(exim_t)
 kernel_read_kernel_sysctls(exim_t)
+kernel_read_net_sysctls(exim_t)
 kernel_read_network_state(exim_t)
 kernel_read_system_state(exim_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1685423685.876:788): avc:  denied  { search } for  pid=41331 comm="exim" name="net" dev="proc" ino=736304 scontext=system_u:system_r:exim_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: rhbz#2211025