### PR TITLE
Allow nagios-mail-plugin exec postfix master

### DIFF
--- a/policy/modules/contrib/nagios.te
+++ b/policy/modules/contrib/nagios.te
@@ -486,6 +486,7 @@ optional_policy(`
 
 optional_policy(`
 	postfix_stream_connect_master(nagios_mail_plugin_t)
+	postfix_exec_master(nagios_mail_plugin_t)
 	postfix_exec_postqueue(nagios_mail_plugin_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=AVC msg=audit(31/01/23 16:35:11.355:8240919) : avc:  denied  { getattr } for  pid=24840 comm=check_mailq path=/usr/sbin/postfix dev="dm-0" ino=26137930 scontext=system_u:system_r:nagios_mail_plugin_t:s0 tcontext=system_u:object_r:postfix_master_exec_t:s0 tclass=file permissive=0

Related: rhbz#2174374