### PR TITLE
Allow subscription-manager execute ip

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -131,6 +131,7 @@ miscfiles_relabel_generic_cert(rhsmcertd_t)
 nis_use_ypbind(rhsmcertd_t)
 
 sysnet_dns_name_resolve(rhsmcertd_t)
+sysnet_exec_ifconfig(rhsmcertd_t)
 
 ifdef(`hide_broken_symptoms',`
     exec_files_pattern(rhsmcertd_t, rhsmcertd_tmp_t, rhsmcertd_tmp_t)


### PR DESCRIPTION
A new version of subscription-manager uses the ip command to collect network facts.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/01/2023 09:22:20.810:330) : proctitle=/usr/bin/python3 /usr/libexec/rhsmcertd-worker type=PATH msg=audit(06/01/2023 09:22:20.810:330) : item=0 name=/usr/sbin/ip inode=6400837 dev=fd:01 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ifconfig_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/01/2023 09:22:20.810:330) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x7f3447196cf0 a1=0x7f3447167c50 a2=0x7ffe9c2d0750 a3=0x2 items=1 ppid=4822 pid=4945 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsmcertd-worke exe=/usr/bin/python3.9 subj=system_u:system_r:rhsmcertd_t:s0 key=(null) type=AVC msg=audit(06/01/2023 09:22:20.810:330) : avc:  denied  { execute } for  pid=4945 comm=rhsmcertd-worke name=ip dev="vda1" ino=6400837 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u

Resolves: rhbz#2211566