### PR TITLE
Add support for ksshaskpass

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -164,6 +164,7 @@ read_lnk_files_pattern(ssh_t, ssh_home_t, ssh_home_t)
 manage_dirs_pattern(ssh_server, ssh_home_t, ssh_home_t)
 manage_files_pattern(ssh_server, ssh_home_t, ssh_home_t)
 
+kernel_read_device_sysctls(ssh_t)
 kernel_read_kernel_sysctls(ssh_t)
 kernel_read_system_state(ssh_t)
 
@@ -180,6 +181,7 @@ corenet_rw_tun_tap_dev(ssh_t)
 
 dev_read_rand(ssh_t)
 dev_read_urand(ssh_t)
+dev_read_sysfs(ssh_t)
 
 fs_getattr_all_fs(ssh_t)
 fs_search_auto_mountpoints(ssh_t)
@@ -204,6 +206,7 @@ term_use_ptmx(ssh_t)
 auth_use_nsswitch(ssh_t)
 
 miscfiles_read_generic_certs(ssh_t)
+miscfiles_read_hwdata(ssh_t)
 
 seutil_read_config(ssh_t)
 
@@ -238,6 +241,9 @@ ifdef(`enable_mcs',`
 ')
 
 optional_policy(`
+	gnome_read_generic_cache_files(ssh_t)
+	gnome_map_generic_cache_files(ssh_t)
+	gnome_read_home_config(ssh_t)
 	gnome_stream_connect_gkeyringd(ssh_t)
 ')
 
@@ -253,6 +259,7 @@ optional_policy(`
 optional_policy(`
 	xserver_user_x_domain_template(ssh, ssh_t, ssh_tmpfs_t)
 	xserver_domtrans_xauth(ssh_t)
+	xserver_map_user_fonts(ssh_t)
 ')
 
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -241,6 +241,11 @@ ifdef(`enable_mcs',`
 ')
 
 optional_policy(`
+	dbus_write_session_tmp_sock_files(ssh_t)
+	dbus_stream_connect_session_bus(ssh_t)
+')
+
+optional_policy(`
 	gnome_read_generic_cache_files(ssh_t)
 	gnome_map_generic_cache_files(ssh_t)
 	gnome_read_home_config(ssh_t)

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -2215,6 +2215,26 @@ interface(`xserver_read_home_fonts',`
 
 ########################################
 ## <summary>
+##	Map user homedir fonts.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`xserver_map_user_fonts',`
+	gen_require(`
+		type user_fonts_t, user_fonts_cache_t;
+	')
+
+	allow $1 user_fonts_t:file map;
+	allow $1 user_fonts_cache_t:file map;
+')
+
+########################################
+## <summary>
 ##	Manage user fonts dir.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
After setting SSH_ASKPASS=ksshaskpass in xdg environment, ksshaskpass is invoked as a graphical helper to read a passphrase from the user. This requires additional permissions.