### PR TITLE
Allow kdumpctl_t to execmem

### DIFF
--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -157,6 +157,10 @@ selinux_get_enforce_mode(kdumpctl_t)
 storage_raw_read_fixed_disk(kdumpctl_t)
 storage_getattr_fixed_disk_dev(kdumpctl_t)
 
+tunable_policy(`deny_execmem',`',`
+	allow kdumpctl_t self:process execmem;
+')
+
 optional_policy(`
 	networkmanager_dbus_chat(kdumpctl_t)
 ')


### PR DESCRIPTION
Need to explicitly allow kdumpctl_t to execmem as the domain is not unconfined when mls is used.

More specifically, "grep -P" introduced in kdump-lib.sh in the following commit for kexec-tools needs this execmem permission.

kdump-lib: attempt to fix BOOT_IMAGE detection
https://src.fedoraproject.org/rpms/kexec-tools/c/f9c32372d2c8d5e58024d2ddc0b70498c696b5d8