### PR TITLE
Allow keyutils_dns_resolver_t execute keyutils_dns_resolver_exec_t

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -27,6 +27,8 @@ optional_policy(`
 ')
 
 ### policy for the keyutils_dns_resolver_t domain
+can_exec(keyutils_dns_resolver_t, keyutils_dns_resolver_exec_t)
+
 allow keyutils_dns_resolver_t self:netlink_route_socket r_netlink_socket_perms;
 allow keyutils_dns_resolver_t self:udp_socket create_socket_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1685748580.854:518): avc:  denied  { execute } for  pid=74010 comm="key.dns_resolve" path="/usr/sbin/key.dns_resolver" dev="dm-2" ino=281459 scontext=system_u:system_r:keyutils_dns_resolver_t:s0 tcontext=system_u:object_r:keyutils_dns_resolver_exec_t:s0 tclass=file permissive=0

Resolves: rhbz#2212007