### PR TITLE
Label /var/log/kdump.log with kdump_log_t

### DIFF
--- a/policy/modules/contrib/kdump.fc
+++ b/policy/modules/contrib/kdump.fc
@@ -16,3 +16,5 @@
 /var/lib/kdump(/.*)?		gen_context(system_u:object_r:kdump_var_lib_t,s0)
 
 /var/lock/kdump(/.*)?   gen_context(system_u:object_r:kdump_lock_t,s0)
+
+/var/log/kdump.log	--	gen_context(system_u:object_r:kdump_log_t,s0)

--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -28,6 +28,9 @@ systemd_unit_file(kdump_unit_file_t)
 type kdump_lock_t;
 files_lock_file(kdump_lock_t)
 
+type kdump_log_t;
+logging_log_file(kdump_log_t)
+
 type kdumpctl_t;
 type kdumpctl_exec_t;
 init_daemon_domain(kdumpctl_t, kdumpctl_exec_t)
@@ -99,6 +102,9 @@ allow kdumpctl_t self:unix_stream_socket create_stream_socket_perms;
 
 manage_files_pattern(kdumpctl_t, kdump_lock_t, kdump_lock_t)
 files_lock_filetrans(kdumpctl_t, kdump_lock_t, file, "kdump")
+
+manage_files_pattern(kdumpctl_t, kdump_log_t, kdump_log_t)
+logging_log_filetrans(kdumpctl_t, kdump_log_t, file)
 
 manage_dirs_pattern(kdumpctl_t, kdumpctl_tmp_t, kdumpctl_tmp_t)
 manage_chr_files_pattern(kdumpctl_t, kdumpctl_tmp_t, kdumpctl_tmp_t)


### PR DESCRIPTION
Need to label /var/log/kdump.log with kdump_log_t type as kdumpctl_t domain is not unconfined when mls is used.

FYI, /var/log/kdump.log was introduced in kdumpctl in the following commit for kexec-tools.

kdumpctl: add the '-d' option to enable the kexec loading debugging messages
https://src.fedoraproject.org/rpms/kexec-tools/c/88a8b94de9994264f1520441656300d6658801da