### PR TITLE
Allow keyutils-dns-resolver read/view kernel key ring

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -32,5 +32,8 @@ can_exec(keyutils_dns_resolver_t, keyutils_dns_resolver_exec_t)
 allow keyutils_dns_resolver_t self:netlink_route_socket r_netlink_socket_perms;
 allow keyutils_dns_resolver_t self:udp_socket create_socket_perms;
 
+kernel_read_key(keyutils_dns_resolver_t)
+kernel_view_key(keyutils_dns_resolver_t)
+
 init_search_pid_dirs(keyutils_dns_resolver_t)
 sysnet_read_config(keyutils_dns_resolver_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1686502135.330:245): avc:  denied  { view } for  pid=3276 comm="key.dns_resolve" scontext=system_u:system_r:keyutils_dns_resolver_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=key permissive=1

Resolves: rhbz#2214076