### PR TITLE
Allow insights-client map generic log files

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -89,7 +89,9 @@ files_pid_filetrans(insights_client_t, insights_client_var_run_t, { dir file })
 
 manage_dirs_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 manage_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
-files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file })
+manage_fifo_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
+manage_sock_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
+files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file fifo_file sock_file })
 allow insights_client_t insights_client_tmp_t:dir relabel_dir_perms;
 allow insights_client_t insights_client_tmp_t:file relabel_dir_perms;
 
@@ -149,6 +151,7 @@ files_getattr_all_pipes(insights_client_t)
 files_getattr_all_sockets(insights_client_t)
 files_manage_etc_symlinks(insights_client_t)
 files_manage_generic_locks(insights_client_t)
+files_map_non_security_files(insights_client_t)
 files_map_read_etc_files(insights_client_t)
 files_read_non_security_files(insights_client_t)
 files_read_all_symlinks(insights_client_t)

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -285,6 +285,7 @@ optional_policy(`
 
 optional_policy(`
 	logging_domtrans_auditctl(insights_client_t)
+	logging_mmap_generic_logs(insights_client_t)
 	logging_mmap_journal(insights_client_t)
 	logging_read_audit_config(insights_client_t)
 	logging_read_audit_log(insights_client_t)

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -57,7 +57,7 @@ allow insights_client_t self:netlink_selinux_socket create_socket_perms;
 allow insights_client_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 allow insights_client_t self:packet_socket create_socket_perms;
 allow insights_client_t self:passwd rootok;
-allow insights_client_t self:process { getattr setfscreate setpgid setrlimit setsched };
+allow insights_client_t self:process { getattr getsession setfscreate setpgid setrlimit setsched };
 allow insights_client_t self:tcp_socket create_socket_perms;
 allow insights_client_t self:udp_socket create_socket_perms;
 allow insights_client_t self:unix_dgram_socket create_socket_perms;


### PR DESCRIPTION
This permission is required when a system is configured to use persistent journal files. The denial can be triggered e. g. by "systemctl status".

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(06/13/2023 08:21:20.521:3138) : proctitle=/bin/systemctl status --all
type=MMAP msg=audit(06/13/2023 08:21:20.521:3138) : fd=5 flags=MAP_SHARED
type=SYSCALL msg=audit(06/13/2023 08:21:20.521:3138) : arch=x86_64 syscall=mmap success=yes exit=140486428573696 a0=0x0 a1=0x800000 a2=PROT_READ a3=MAP_SHARED items=0 ppid=97396 pid=97397 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemctl exe=/usr/bin/systemctl subj=system_u:system_r:insights_client_t:s0 key=(null)
type=AVC msg=audit(06/13/2023 08:21:20.521:3138) : avc:  denied  { map } for  pid=97397 comm=systemctl path=/var/log/journal/system@a601e4b560114ca1a5ff8927086b269d-0000000000001218-0005faaff832e352.journal dev="dm-0" ino=151680 scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=1

Resolves: rhbz#2214572