### PR TITLE
Update cyrus_stream_connect() to use sockets in /run

### DIFF
--- a/policy/modules/contrib/cyrus.if
+++ b/policy/modules/contrib/cyrus.if
@@ -52,9 +52,12 @@ interface(`cyrus_write_data',`
 #
 interface(`cyrus_stream_connect',`
 	gen_require(`
-		type cyrus_t, cyrus_var_lib_t;
+		type cyrus_t, cyrus_var_lib_t, cyrus_var_run_t;
 	')
 
+	files_search_pids($1)
+	stream_connect_pattern($1, cyrus_var_run_t, cyrus_var_run_t, cyrus_t)
+	# deprecated, new socket location is in /run
 	files_search_var_lib($1)
 	stream_connect_pattern($1, cyrus_var_lib_t, cyrus_var_lib_t, cyrus_t)
 ')


### PR DESCRIPTION
The Cyrus IMAP socket has moved from "/var/lib/imap/socket/lmtp" to "/run/cyrus/socket/lmtp", therefore the cyrus_stream_connect() interface needs to be updated.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(2023-01-26 14:59:25.110:23439) : proctitle=sendmail: ./30QGlLWc393699 localhost: user open type=PATH msg=audit(2023-01-26 14:59:25.110:23439) : item=0 name=/run/cyrus/socket/lmtp inode=66752 dev=00:18 mode=socket,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cyrus_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(2023-01-26 14:59:25.110:23439) : arch=x86_64 syscall=lstat success=no exit=EACCES(Permission denied) a0=0x7ffdccb6e970 a1=0x7ffdccb6e8e0 a2=0x7ffdccb6e8e0 a3=0x9 items=1 ppid=2455 pid=415005 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=smmsp sgid=smmsp fsgid=smmsp tty=(none) ses=unset comm=sendmail exe=/usr/sbin/sendmail.sendmail subj=system_u:system_r:sendmail_t:s0 key=(null) type=AVC msg=audit(2023-01-26 14:59:25.110:23439) : avc:  denied  { getattr } for  pid=415005 comm=sendmail path=/run/cyrus/socket/lmtp dev="tmpfs" ino=66752 scontext=system_u:system_r:sendmail_t:s0 tcontext=system_u:object_r:cyrus_var_run_t:s0 tclass=sock_file permissive=0

Resolves: rhbz#2165752