### PR TITLE
Allow rpm_t sys_admin capability

### DIFF
--- a/policy/modules/contrib/rpm.te
+++ b/policy/modules/contrib/rpm.te
@@ -75,7 +75,7 @@ files_tmpfs_file(rpm_script_tmpfs_t)
 #
 
 allow rpm_t self:capability2 block_suspend;
-allow rpm_t self:capability { audit_write chown dac_read_search dac_override fowner setfcap fsetid ipc_lock setgid setuid sys_chroot sys_nice sys_tty_config mknod };
+allow rpm_t self:capability { audit_write chown dac_read_search dac_override fowner setfcap fsetid ipc_lock setgid setuid sys_admin sys_chroot sys_nice sys_tty_config mknod };
 allow rpm_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execstack execheap };
 allow rpm_t self:process { getattr setexec setfscreate setrlimit };
 allow rpm_t self:fd use;


### PR DESCRIPTION
Need to allow rpm_t sys_admin capability as the domain is not unconfined when mls is used.

FYI, rpm_t needs this capability to handle IMA signatures, which was recently introduced as described below. More specifically, setxattr() system call to set security.ima attribute needs this capability.

https://fedoraproject.org/wiki/Changes/Signed_RPM_Contents