### PR TITLE
Allow cifs-helper read sssd kerberos configuration files

### DIFF
--- a/policy/modules/contrib/cifsutils.fc
+++ b/policy/modules/contrib/cifsutils.fc
@@ -1,1 +1,2 @@
 /usr/sbin/cifs\.upcall	--	gen_context(system_u:object_r:cifs_helper_exec_t,s0)
+/usr/sbin/cifs\.idmap	--	gen_context(system_u:object_r:cifs_helper_exec_t,s0)

--- a/policy/modules/contrib/cifsutils.te
+++ b/policy/modules/contrib/cifsutils.te
@@ -53,5 +53,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_stream_connect(cifs_helper_t)
+')
+
+optional_policy(`
 	userdom_read_all_users_state(cifs_helper_t)
 ')

--- a/policy/modules/contrib/cifsutils.te
+++ b/policy/modules/contrib/cifsutils.te
@@ -37,6 +37,10 @@ optional_policy(`
 optional_policy(`
 	kerberos_read_config(cifs_helper_t)
 	kerberos_read_keytab(cifs_helper_t)
+
+	optional_policy(`
+		sssd_read_public_files(cifs_helper_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial, gathered before labeling cifs.upcall:

type=AVC msg=audit(1679441085.287:237): avc:  denied  { read } for  pid=3442 comm="cifs.upcall" name="krb5.include.d" dev="dm-0" ino=158247 scontext=system_u:system_r:keyutils_request_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=dir permissive=1

Resolves: rhbz#2180634