### PR TITLE
Allow blueman send general signals to unprivileged user domains

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -102,5 +102,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	userdom_signal_unpriv_users(blueman_t)
+')
+
+optional_policy(`
 	xserver_read_state_xdm(blueman_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1679605411.551:296): avc:  denied  { signal } for  pid=4411 comm="blueman-mechani" scontext=system_u:system_r:blueman_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=process permissive=0

Resolves: rhbz#2181362