### PR TITLE
Label /dev/userfaultfd with userfaultfd_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -228,6 +228,7 @@ ifdef(`distro_suse', `
 /dev/usb/lp.*		-c	gen_context(system_u:object_r:printer_device_t,s0)
 /dev/usb/mdc800.*	-c	gen_context(system_u:object_r:scanner_device_t,s0)
 /dev/usb/scanner.*	-c	gen_context(system_u:object_r:scanner_device_t,s0)
+/dev/userfaultfd	-c	gen_context(system_u:object_r:userfaultfd_device_t,s0)
 
 /dev/vmbus/hv_vss		-c	gen_context(system_u:object_r:hypervvssd_device_t,s0)
 /dev/vmbus/hv_kvp		-c	gen_context(system_u:object_r:hypervkvp_device_t,s0)

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -379,6 +379,12 @@ type usbmon_device_t;
 dev_node(usbmon_device_t)
 
 #
+# Type for /dev/userfaultfd
+#
+type userfaultfd_device_t;
+dev_node(userfaultfd_device_t)
+
+#
 # userio_device_t is the type for /dev/uio[0-9]+
 #
 type userio_device_t;


### PR DESCRIPTION
The userfaultfd() system call allows one thread to handle page faults for another in user space. Since the 2d5de004e009 ("userfaultfd: add /dev/userfaultfd for fine grained access control") commit, a character device file /dev/userfaultfd exists which gives access to this functionality without the need to call userfaultfd().

Resolves: rhbz#2175290