### PR TITLE
Allow rpcd_t search sysctl_net_t dirs

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -160,6 +160,7 @@ kernel_read_system_state(rpcd_t)
 kernel_write_proc_files(rpcd_t)
 kernel_read_network_state(rpcd_t)
 # for rpc.rquotad
+kernel_search_network_sysctl(rpcd_t)
 kernel_read_sysctl(rpcd_t)
 kernel_rw_fs_sysctls(rpcd_t)
 kernel_dontaudit_getattr_core_if(rpcd_t)


### PR DESCRIPTION
Allow rpcd search network sysctl directories

Resolves: rhbz#2175516