### PR TITLE
Allow collectd_t read proc_net link files

### DIFF
--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -72,6 +72,7 @@ files_pid_filetrans(collectd_t, collectd_var_run_t, { dir file sock_file})
 kernel_read_all_sysctls(collectd_t)
 kernel_read_all_proc(collectd_t)
 kernel_list_all_proc(collectd_t)
+kernel_read_proc_symlinks(collectd_t)
 
 auth_use_nsswitch(collectd_t)
 


### PR DESCRIPTION
Allow collectd read generic symbolic links in /proc

Resolves: rhbz#2209650