### PR TITLE
Allow nsd_crond_t write nsd_var_run_t & connectto nsd_t

### DIFF
--- a/policy/modules/contrib/nsd.te
+++ b/policy/modules/contrib/nsd.te
@@ -138,6 +138,8 @@ ps_process_pattern(nsd_crond_t, nsd_t)
 manage_files_pattern(nsd_crond_t, nsd_zone_t, nsd_zone_t)
 filetrans_pattern(nsd_crond_t, nsd_conf_t, nsd_zone_t, file)
 
+stream_connect_pattern(nsd_crond_t, nsd_var_run_t, nsd_var_run_t, nsd_t)
+
 can_exec(nsd_crond_t, nsd_exec_t)
 
 kernel_read_system_state(nsd_crond_t)


### PR DESCRIPTION
Allow nsd_crond_t connect to nsd_t unix_stream_socket Allow nsd_crond_t manage nsd_var_run_t sock_files

Resolves: rhbz#2209973