### PR TITLE
Allow cupsd dbus chat with xdm

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -408,6 +408,10 @@ optional_policy(`
     vmware_read_system_config(cupsd_t)
 ')
 
+optional_policy(`
+	xserver_dbus_chat_xdm(cupsd_t)
+')
+
 ########################################
 #
 # Configuration daemon local policy


### PR DESCRIPTION
When a printer status is changed, cupsd sends a dbus notification through its /usr/lib/cups/notifier/dbus notifier. dbus-broker wants to relay the message to the registered consumer /usr/libexec/gsd-print-notifications.

The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(11/17/2022 14:07:50.723:319) : pid=755 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tclass=dbus permissive=0  exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'

Resolves: rhbz#2143641