### PR TITLE
Allow haproxy read hardware state information

### DIFF
--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -673,7 +673,7 @@ corenet_tcp_connect_http_port(haproxy_t)
 corenet_tcp_connect_http_cache_port(haproxy_t)
 corenet_tcp_connect_rtp_media_port(haproxy_t)
 
-dev_list_sysfs(haproxy_t)
+dev_read_sysfs(haproxy_t)
 dev_read_rand(haproxy_t)
 dev_read_urand(haproxy_t)
 


### PR DESCRIPTION
This denial appears on a system with multisocket CPU/NUMA when haproxy wants to read cpumap:

type=AVC msg=audit(1674699790.342:115): avc:  denied  { read } for  pid=1582 comm="haproxy" name="cpumap" dev="sysfs" ino=938 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(1674699790.342:115): arch=x86_64 syscall=openat success=no exit=EACCES a0=ffffff9c a1=7ffc19e43900 a2=0 a3=0 items=0 ppid=1 pid=1582 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=haproxy exe=/usr/sbin/haproxy subj=system_u:system_r:haproxy_t:s0 key=(null)

Resolves: rhbz#2164691