### PR TITLE
Allow nfsd_t to list exports_t dirs

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -241,6 +241,7 @@ allow nfsd_t self:capability { dac_read_search dac_override sys_admin sys_chroot
 allow nfsd_t self:process { setcap };
 
 allow nfsd_t exports_t:file read_file_perms;
+allow nfsd_t exports_t:dir list_dir_perms;
 
 manage_dirs_pattern(nfsd_t, nfsd_tmp_t, nfsd_tmp_t)
 manage_files_pattern(nfsd_t, nfsd_tmp_t, nfsd_tmp_t)


### PR DESCRIPTION
Need to allow nfsd_t to list exports_t dirs as nfs_export_all_ro boolean is off by default when mls is used.