### PR TITLE
Allow keyutils_dns_resolver_exec_t be en entrypoint

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -13,7 +13,7 @@ role system_r types keyutils_request_t;
 
 type keyutils_dns_resolver_t;
 domain_type(keyutils_dns_resolver_t)
-domtrans_pattern(keyutils_request_t, keyutils_dns_resolver_exec_t, keyutils_dns_resolver_t)
+domain_entry_file(keyutils_dns_resolver_t, keyutils_dns_resolver_exec_t)
 role system_r types keyutils_dns_resolver_t;
 
 ### policy for the keyutils_request_t domain
@@ -28,6 +28,8 @@ optional_policy(`
 
 ### policy for the keyutils_dns_resolver_t domain
 can_exec(keyutils_dns_resolver_t, keyutils_dns_resolver_exec_t)
+
+domtrans_pattern(keyutils_request_t, keyutils_dns_resolver_exec_t, keyutils_dns_resolver_t)
 
 allow keyutils_dns_resolver_t self:netlink_route_socket r_netlink_socket_perms;
 allow keyutils_dns_resolver_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
Allow keyutils_dns_resolver_exec_t be en entrypoint for keyutils_dns_resolver_t.

The commit addresses the following AVC denial:
type=AVC msg=audit(2023-06-16 16:22:41.722:806) : avc:  denied  { entrypoint } for  pid=79110 comm=request-key path=/usr/sbin/key.dns_resolver dev="dm-0" ino=117500121 scontext=system_u:system_r:keyutils_dns_resolver_t:s0 tcontext=system_u:object_r:keyutils_dns_resolver_exec_t:s0 tclass=file permissive=0

Resolves: rhbz#2182643