### PR TITLE
Label /var/run/tmpfiles.d/static-nodes.conf with kmod_var_run_t

### DIFF
--- a/policy/modules/system/modutils.fc
+++ b/policy/modules/system/modutils.fc
@@ -35,3 +35,4 @@ ifdef(`distro_gentoo',`
 /usr/lib/modules/modprobe\.conf -- 	gen_context(system_u:object_r:modules_conf_t,s0)
 
 /var/run/tmpfiles.d/kmod.conf --	gen_context(system_u:object_r:kmod_var_run_t,s0)
+/var/run/tmpfiles.d/static-nodes.conf --	gen_context(system_u:object_r:kmod_var_run_t,s0)


### PR DESCRIPTION
Need to label /var/run/tmpfiles.d/static-nodes.conf with kmod_var_run_t type as kmod_t domain is not unconfined when mls is used.