### PR TITLE
Allow fsadm_t to get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -142,6 +142,7 @@ fs_read_tmpfs_symlinks(fsadm_t)
 fs_manage_nfs_files(fsadm_t)
 fs_manage_cifs_files(fsadm_t)
 fs_rw_hugetlbfs_files(fsadm_t)
+fs_getattr_cgroup(fsadm_t)
 # Recreate /mnt/cdrom.
 files_manage_mnt_dirs(fsadm_t)
 # for tune2fs


### PR DESCRIPTION
Need to allow fsadm_t to get attributes of cgroup filesystems as the domain is not unconfined when mls is used.

Specifically, systemd-fsck running in fsadm_t domain needs this permission.