### PR TITLE
Allow insights-client execmem

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -182,6 +182,10 @@ seutil_read_module_store(insights_client_t)
 
 storage_raw_read_fixed_disk(insights_client_t)
 
+tunable_policy(`deny_execmem',`',`
+	allow insights_client_t self:process execmem;
+')
+
 optional_policy(`
 	abrt_dbus_chat(insights_client_t)
 ')


### PR DESCRIPTION
This permission is required for the insights-client service when it executes a command which is not SELinux confined and it requests the permission, like dotnet. The permission can still be denied by turning on the deny_execmem tunable which is off by default.

Resolves: rhbz#2207894