### PR TITLE
Make systemd_tmpfiles_t MLS trusted for lowering the level of files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -692,6 +692,7 @@ files_map_system_db_files(systemd_tmpfiles_t)
 mls_file_read_all_levels(systemd_tmpfiles_t)
 mls_file_write_all_levels(systemd_tmpfiles_t)
 mls_file_upgrade(systemd_tmpfiles_t)
+mls_file_downgrade(systemd_tmpfiles_t)
 
 selinux_get_enforce_mode(systemd_tmpfiles_t)
 selinux_setcheckreqprot(systemd_tmpfiles_t)


### PR DESCRIPTION
Need to make systemd_tmpfiles_t MLS trusted for lowering the level of files as the domain needs to lower the levels of device files when mls is used.

Specifically, systemd_tmpfiles_t needs to lower the sensitivity level of /dev/fuse from s15 to s0.

Note that another way we could consider is to change the default sensitivity level of /dev/fuse from s0 to s15 so that the sensitivity level does not need to be lowered from s15 to s0 in the first place. However, the default sensitivity level of /dev/fuse was intentionally changed from s15 (mls_systemhigh) to s0 in the following commit before. So, I don't understand changing it back to s15 (mls_systemhigh) is a good idea.

/dev/fuse should be s0 not mls_high
https://github.com/fedora-selinux/selinux-policy/commit/105e85ac8eaed2fee7c164eb120064b9478d492f