### PR TITLE
Change init_audit_control default value to true

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -56,7 +56,7 @@ gen_tunable(init_create_dirs, true)
 ## Allow init audit_control capability
 ## </p>
 ## </desc>
-gen_tunable(init_audit_control, false)
+gen_tunable(init_audit_control, true)
 
 # used for direct running of init scripts
 # by admin domains


### PR DESCRIPTION
Systemd attempts to use audit fd to check if it is running in the initial namespace as kernel does not have support for audit outside initial namespace, so the existing init_audit_control tunable needs to change its default value to true.

Resolves: rhbz#2213571