### PR TITLE
Allow nfsidmapd connect to systemd-userdbd with a unix socket

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -471,5 +471,5 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_userdbd_runtime_read_symlinks(nfsidmap_t)
+	systemd_userdbd_stream_connect(nfsidmap_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1686888064.174:4130): avc:  denied  { write } for  pid=657672 comm="nfsidmap" name="io.systemd.DynamicUser" dev="tmpfs" ino=33 scontext=system_u:system_r:nfsidmap_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=sock_file permissive=0

Resolves: rhbz#2215452