### PR TITLE
Allow bootupd search EFI directory

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -34,6 +34,7 @@ domain_use_interactive_fds(bootupd_t)
 files_read_etc_files(bootupd_t)
 
 fs_getattr_all_fs(bootupd_t)
+fs_search_dos(bootupd_t)
 
 optional_policy(`
 	miscfiles_read_localization(bootupd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/27/2023 19:22:31.060:6277) : proctitle=/usr/libexec/bootupd daemon -v type=PATH msg=audit(06/27/2023 19:22:31.060:6277) : item=0 name=/boot/efi/EFI inode=1048592 dev=103:03 mode=dir,700 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:dosfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/27/2023 19:22:31.060:6277) : arch=x86_64 syscall=openat success=yes exit=7 a0=0x6 a1=0x5602cecb1310 a2=O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_PATH a3=0x0 items=1 ppid=1 pid=134959 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=bootupd exe=/usr/libexec/bootupd subj=system_u:system_r:bootupd_t:s0 key=(null) type=AVC msg=audit(06/27/2023 19:22:31.060:6277) : avc:  denied  { search } for  pid=134959 comm=bootupd name=/ dev="nvme0n1p3" ino=1 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:dosfs_t:s0 tclass=dir permissive=1

Resolves: rhbz#2218106