### PR TITLE
Label /usr/sbin/mariadbd with mysqld_exec_t

### DIFF
--- a/policy/modules/contrib/mysql.fc
+++ b/policy/modules/contrib/mysql.fc
@@ -40,6 +40,8 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /usr/bin/mariadbd-safe-helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
+/usr/sbin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+
 /usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 #


### PR DESCRIPTION
This label applies only on systems /usr/sbin/mariadbd is a plain file, a symlink still should get the bin_t type.