### PR TITLE
Dontaudit aide the execmem permission

### DIFF
--- a/policy/modules/contrib/aide.te
+++ b/policy/modules/contrib/aide.te
@@ -27,6 +27,7 @@ files_type(aide_db_t)
 
 allow aide_t self:capability { dac_read_search  fowner ipc_lock sys_admin };
 allow aide_t self:process signal;
+dontaudit aide_t self:process execmem;
 
 manage_files_pattern(aide_t, aide_db_t, aide_db_t)
 files_var_lib_filetrans(aide_t, aide_db_t, { dir file })


### PR DESCRIPTION
This denial happens because using the pcre library was replaced with pcre2 which uses JIT compilation.

Resolves: rhbz#2217165