### PR TITLE
Allow httpd tcp connect to redis port conditionally

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -109,6 +109,13 @@ gen_tunable(httpd_can_network_memcache, false)
 
 ## <desc>
 ## <p>
+## Allow httpd to connect to redis
+## </p>
+## </desc>
+gen_tunable(httpd_can_network_redis, false)
+
+## <desc>
+## <p>
 ## Allow httpd to act as a relay
 ## </p>
 ## </desc>
@@ -741,6 +748,10 @@ tunable_policy(`httpd_can_network_connect_db',`
 
 tunable_policy(`httpd_can_network_memcache',`
 	corenet_tcp_connect_memcache_port(httpd_t)
+')
+
+tunable_policy(`httpd_can_network_redis',`
+	corenet_tcp_connect_redis_port(httpd_t)
 ')
 
 tunable_policy(`httpd_can_network_relay',`


### PR DESCRIPTION
The httpd_can_network_redis boolean was added which is off by default.

Resolves: rhbz#2213965