### PR TITLE
Allow plymouthd read/write X server miscellaneous devices

### DIFF
--- a/policy/modules/contrib/plymouthd.te
+++ b/policy/modules/contrib/plymouthd.te
@@ -67,6 +67,7 @@ dev_read_sysfs(plymouthd_t)
 dev_read_framebuffer(plymouthd_t)
 dev_write_framebuffer(plymouthd_t)
 dev_map_framebuffer(plymouthd_t)
+dev_rw_xserver_misc(plymouthd_t)
 
 domain_use_interactive_fds(plymouthd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:

AVC avc: denied { read write } for pid=995 comm="plymouthd" name="card1" dev="devtmpfs" ino=469 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:object_r:xserver_misc_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2101151