### PR TITLE
Allow virt_qemu_ga_t create .ssh dir with correct label

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1836,7 +1836,10 @@ tunable_policy(`virt_rw_qemu_ga_data',`
 ')
 
 optional_policy(`
+    ssh_filetrans_home_content(virt_qemu_ga_t)
         tunable_policy(`virt_qemu_ga_manage_ssh',`
+                allow virt_qemu_ga_t self:capability { chown dac_override dac_read_search fowner fsetid };
+
 		ssh_manage_home_files(virt_qemu_ga_t)
         ')
 ')


### PR DESCRIPTION
Create .ssh directory in the user home directory with an correct label.

Add capabilities: chown dac_override dac_read_search fsetid fowner

Resolves: rhbz#2181402