### PR TITLE
Permit kernel_t to change the user identity in object contexts

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -369,6 +369,9 @@ domain_signal_all_domains(kernel_t)
 domain_search_all_domains_state(kernel_t)
 domain_connect_all_stream_sockets(kernel_t)
 domain_rw_all_sockets(kernel_t)
+# Needed for overlayfs mounter checks
+# (see: https://bugzilla.redhat.com/show_bug.cgi?id=2215454)
+domain_obj_id_change_exemption(kernel_t)
 
 files_manage_all_files(kernel_t)
 # The 'execute' permission on lower inodes is checked against the mounter


### PR DESCRIPTION
This is needed to make overlayfs mounts created before initial policy load work correctly.

Resolves: rhbz#2215454