### PR TITLE
Allow nfsidmapd connect to systemd_machined over a unix socket

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -471,5 +471,6 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_machined_stream_connect(nfsidmap_t)
 	systemd_userdbd_stream_connect(nfsidmap_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1688581751.862:466): avc:  denied  { connectto } for  pid=169704 comm="nfsidmap" path="/run/systemd/userdb/io.systemd.Machine" scontext=system_u:system_r:nfsidmap_t:s0 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2219915