### PR TITLE
Allow snapperd connect to kernel over a unix domain stream socket

### DIFF
--- a/policy/modules/contrib/snapper.te
+++ b/policy/modules/contrib/snapper.te
@@ -44,6 +44,7 @@ allow snapperd_t snapperd_data_t:file relabelfrom;
 snapper_filetrans_named_content(snapperd_t)
 
 kernel_setsched(snapperd_t)
+kernel_stream_connect(snapperd_t)
 
 domain_read_all_domains_state(snapperd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1688819048.481:309): avc:  denied  { connectto } for  pid=8009 comm="snapperd" path="/run/systemd/userdb/io.systemd.DynamicUser" scontext=system_u:system_r:snapperd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2221396