### PR TITLE
Revert "Allow insights client map cache_home_t"

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -264,7 +264,6 @@ optional_policy(`
 
 optional_policy(`
 	gnome_search_gconf(insights_client_t)
-	gnome_map_generic_cache_files(insights_client_t)
 	gnome_manage_generic_cache_files(insights_client_t)
 	gnome_manage_home_config(insights_client_t)
 	gnome_manage_home_config_dirs(insights_client_t)


### PR DESCRIPTION
This reverts commit fd7a16634d ("Allow insights client map cache_home_t") which is a subset of already merged abc4d5a608 ("Allow insights-client work with pipe and socket tmp files").