### PR TITLE
Allow logrotate_t to map generic files in /etc

### DIFF
--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -132,6 +132,7 @@ domain_getattr_all_entry_files(logrotate_t)
 # Read /proc/PID directories for all domains.
 domain_read_all_domains_state(logrotate_t)
 
+files_map_etc_files(logrotate_t)
 files_read_etc_runtime_files(logrotate_t)
 files_read_all_pids(logrotate_t)
 files_search_all(logrotate_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -3967,6 +3967,24 @@ interface(`files_read_etc_files',`
 
 ########################################
 ## <summary>
+##	Map generic files in /etc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`files_map_etc_files',`
+	gen_require(`
+		type etc_t;
+	')
+
+	allow $1 etc_t:file map;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to write generic files in /etc.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Need to allow logrotate_t to map generic files in /etc as the domain doesn't have map permission on files with types having base_ro_file_type attribute including etc_t when mls is used.

Specifically, logrotate_t needs map permission on /etc/logrotate.conf with etc_t type.