### PR TITLE
Allow qemu-ga get fixed disk devices attributes

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1810,6 +1810,8 @@ init_read_utmp(virt_qemu_ga_t)
 
 modutils_exec_kmod(virt_qemu_ga_t)
 
+storage_getattr_fixed_disk_dev(virt_qemu_ga_t)
+
 sysnet_dns_name_resolve(virt_qemu_ga_t)
 
 systemd_exec_systemctl(virt_qemu_ga_t)


### PR DESCRIPTION
This permission is required when a vm is configured to use a partition on a virtual-aware disk.

The commit addresses the following AVC denial:
type=AVC msg=audit(1688972387.597:836): avc:  denied  { getattr } for  pid=1154 comm="qemu-ga" path="/dev/vda5" dev="devtmpfs" ino=426 scontext=system_u:system_r:virt_qemu_ga_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=0

Resolves: rhbz#2221576