### PR TITLE
Allow sssd io_uring sqpoll permission

### DIFF
--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -77,6 +77,7 @@ role ndc_roles types ndc_t;
 allow named_t self:capability { chown dac_read_search dac_override fowner kill net_admin net_raw setgid setuid sys_chroot sys_nice sys_resource };
 dontaudit named_t self:capability sys_tty_config;
 allow named_t self:capability2 block_suspend;
+allow named_t self:io_uring sqpoll;
 allow named_t self:process { setsched getcap setcap setrlimit signal_perms };
 allow named_t self:fifo_file rw_fifo_file_perms;
 allow named_t self:unix_stream_socket { accept connectto listen };
@@ -263,6 +264,7 @@ optional_policy(`
 
 allow ndc_t self:capability { dac_read_search  net_admin };
 allow ndc_t self:capability2 block_suspend;
+allow ndc_t self:io_uring sqpoll;
 allow ndc_t self:process { fork signal_perms };
 dontaudit ndc_t self:process setsched;
 allow ndc_t self:fifo_file rw_fifo_file_perms;

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -61,6 +61,7 @@ role system_r types sssd_selinux_manager_t;
 allow sssd_t self:capability { dac_override ipc_lock chown dac_read_search  kill net_admin sys_nice fowner setgid setuid sys_admin sys_resource };
 allow sssd_t self:process { setfscreate setsched sigkill signal getsched setrlimit setpgid setcap};
 allow sssd_t self:fifo_file rw_fifo_file_perms;
+allow sssd_t self:io_uring sqpoll;
 allow sssd_t self:key manage_key_perms;
 allow sssd_t self:unix_stream_socket { create_stream_socket_perms connectto };
 


### PR DESCRIPTION
In the d2c31f429b libuv commit ("linux: introduce io_uring support", https://github.com/libuv/libuv/commit/d2c31f429b)
support for io_uring was added which requires the sqpoll SELinux permissions for services linked with libuv or executing a non-confined command (e. g. /usr/bin/nsupdate) which is linked with libuv.

The commit addresses the following AVC denial:
type=AVC msg=audit(1689629587.147:175): avc:  denied  { sqpoll } for  pid=3950 comm="nsupdate" scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:sssd_t:s0 tclass=io_uring permissive=0

Resolves: rhbz#2223441