### PR TITLE
Allow systemd_network_generator_t notify systemd manager

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1217,6 +1217,10 @@ init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, dir, "network"
 sysnet_manage_config(systemd_network_generator_t)
 sysnet_manage_config_dirs(systemd_network_generator_t)
 
+optional_policy(`
+	logging_send_syslog_msg(systemd_network_generator_t)
+')
+
 #######################################
 #
 # systemd_resolved domain


### PR DESCRIPTION
Allow systemd-network-generator send system log messages

Logging support for the network generator was added by systemd commit
8b24bcdfa8 ("network-generator: Add missing log_setup()",
https://github.com/systemd/systemd/commit/8b24bcdfa8).

Resolves: rhbz#2223571