### PR TITLE
Update winbind-rpcd policy for printing

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -187,6 +187,9 @@ logging_log_file(winbind_log_t)
 type winbind_rpcd_var_run_t;
 files_pid_file(winbind_rpcd_var_run_t)
 
+type winbind_rpcd_tmp_t;
+files_tmp_file(winbind_rpcd_tmp_t)
+
 type winbind_var_run_t;
 files_pid_file(winbind_var_run_t)
 
@@ -1188,6 +1191,9 @@ write_sock_files_pattern(winbind_rpcd_t, winbind_var_run_t, winbind_var_run_t)
 manage_files_pattern(winbind_rpcd_t, winbind_rpcd_var_run_t, winbind_rpcd_var_run_t)
 files_pid_filetrans(winbind_rpcd_t, winbind_rpcd_var_run_t, { dir file })
 
+manage_files_pattern(winbind_rpcd_t, winbind_rpcd_tmp_t, winbind_rpcd_tmp_t)
+files_tmp_filetrans(winbind_rpcd_t, winbind_rpcd_tmp_t, file)
+
 # access to files of other samba domains
 manage_dirs_pattern(winbind_rpcd_t, samba_share_t, samba_share_t)
 manage_files_pattern(winbind_rpcd_t, samba_share_t, samba_share_t)
@@ -1203,6 +1209,8 @@ manage_dirs_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
 manage_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
 manage_sock_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
 allow winbind_rpcd_t samba_var_t:file { map } ;
+
+delete_files_pattern(winbind_rpcd_t, smbd_tmp_t, smbd_tmp_t)
 
 kernel_read_network_state(winbind_rpcd_t)
 
@@ -1245,6 +1253,10 @@ optional_policy(`
 
 optional_policy(`
 	logging_send_syslog_msg(winbind_rpcd_t)
+')
+
+optional_policy(`
+	lpd_domtrans_lpr(winbind_rpcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
More rules are required when additional permissions are configured in smb.conf for printing with winbind-rpcd in place.

Resolves: rhbz#2210771