### PR TITLE
Dontaudit the execute permission on sock_file globally

### DIFF
--- a/policy/modules/contrib/openshift.te
+++ b/policy/modules/contrib/openshift.te
@@ -219,7 +219,6 @@ allow openshift_domain openshift_initrc_t:tcp_socket getattr;
 
 dontaudit openshift_domain openshift_initrc_tmp_t:file append;
 dontaudit openshift_domain openshift_var_run_t:file append;
-dontaudit openshift_domain openshift_file_type:sock_file execute;
 
 kernel_dontaudit_search_network_state(openshift_domain)
 kernel_dontaudit_list_all_proc(openshift_domain)

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -173,6 +173,9 @@ files_mmap_usr_files(domain)
 files_read_all_base_ro_files(domain)
 files_dontaudit_getattr_kernel_symbol_table(domain)
 files_dontaudit_map_all_dirs(domain)
+# Executing a socket is nonsense, yet such access checks can technically
+# happen, so dontaudit them
+files_dontaudit_execute_all_sockets(domain)
 
 fs_dontaudit_map_all_dirs(domain)
 

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1623,6 +1623,25 @@ interface(`files_dontaudit_read_all_sockets',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to execute
+##	any named socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`files_dontaudit_execute_all_sockets',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	dontaudit $1 file_type:sock_file execute;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read
 ##	of all security file types.
 ## </summary>

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -594,7 +594,6 @@ interface(`userdom_exec_user_tmp_files',`
 
 	allow $1 user_tmp_t:file entrypoint;
 	exec_files_pattern($1, user_tmp_t, user_tmp_t)
-	dontaudit $1 user_tmp_t:sock_file execute;
 	files_search_tmp($1)
 ')
 
@@ -3068,8 +3067,7 @@ interface(`userdom_exec_user_home_content_files',`
 
 	files_search_home($1)
 	exec_files_pattern($1, { user_home_dir_t user_home_type }, user_home_type)
-	dontaudit $1 user_home_type:sock_file execute;
-	')
+')
 
 ########################################
 ## <summary>


### PR DESCRIPTION
It is a nonsensical combination, so it doesn't matter if it's allowed or denied. Remove the few existing rules involving it and instead add a global dontaudit.

Related: rhbz#2216408