### PR TITLE
Boolean: Allow virt_qemu_ga create ssh directory

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1840,6 +1840,7 @@ optional_policy(`
         tunable_policy(`virt_qemu_ga_manage_ssh',`
                 allow virt_qemu_ga_t self:capability { chown dac_override dac_read_search fowner fsetid };
 
+                ssh_create_home_dirs(virt_qemu_ga_t)
 		ssh_manage_home_files(virt_qemu_ga_t)
         ')
 ')

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -908,6 +908,25 @@ interface(`ssh_manage_home_files',`
 	userdom_search_user_home_dirs($1)
 ')
 
+########################################
+## <summary>
+##      Create ssh home directory.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`ssh_create_home_dirs',`
+        gen_require(`
+                type ssh_home_t;
+        ')
+
+        allow $1 ssh_home_t:dir create_dir_perms;
+        setattr_dirs_pattern($1, ssh_home_t, ssh_home_t)
+')
+
 #######################################
 ## <summary>
 ##	Delete from the ssh temp files.


### PR DESCRIPTION
Add interface ssh_create_home_dirs to allow domain to create .ssh directory. Allow virt_qemu_ga create ssh directory in tunable boolean

SSH key could be added to VM, but the .ssh directory cannot be created by VM after creating new user.

Addresses the following denial:
type=PROCTITLE msg=audit(07/19/2023 10:39:00.319:191) : proctitle=/usr/bin/qemu-ga --method=virtio-serial --path=/dev/virtio-ports/org.qemu.guest_agent.0 --block-rpcs=guest-file-open,guest-file- type=SYSCALL msg=audit(07/19/2023 10:39:00.319:191) : arch=x86_64 syscall=mkdir success=no exit=EACCES(Permission denied) a0=0x565274901da0 a1=0700 a2=0x0 a3=0x0 items=0 ppid=1 pid=1050 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=qemu-ga exe=/usr/bin/qemu-ga subj=system_u:system_r:virt_qemu_ga_t:s0 key=(null) type=AVC msg=audit(07/19/2023 10:39:00.319:191) : avc:  denied  { create } for  pid=1050 comm=qemu-ga name=.ssh scontext=system_u:system_r:virt_qemu_ga_t:s0 tcontext=system_u:object_r:ssh_home_t:s0 tclass=dir permissive=0

Resolves: rhbz#2181402