### PR TITLE
Fix the CI to work with DNF5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           else
             tag='f$releasever-build'
           fi
-          dnf builddep --nogpgcheck --repofrompath "koji,https://kojipkgs.fedoraproject.org/repos/$tag/latest/\$arch/" -y --srpm *.src.rpm
+          dnf builddep --nogpgcheck --repofrompath "koji,https://kojipkgs.fedoraproject.org/repos/$tag/latest/\$arch/" -y *.src.rpm
       - run: rpmbuild --define "_topdir $PWD/rpmbuild" -rb *.src.rpm
       - name: Store binary RPMs as artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The --srpm parameter is no longer supported by DNF5 (default in rawhide) and it doesn't seem to be needed even with the old DNF, so just remove it.