### PR TITLE
Allow fsadm_t the file mounton permission

### DIFF
--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -37,6 +37,7 @@ dontaudit fsadm_t self:capability net_admin;
 allow fsadm_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execmem execheap execstack };
 allow fsadm_t self:fd use;
 allow fsadm_t self:fifo_file rw_fifo_file_perms;
+allow fsadm_t self:file mounton;
 allow fsadm_t self:sock_file read_sock_file_perms;
 allow fsadm_t self:unix_dgram_socket create_socket_perms;
 allow fsadm_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
Triggered by "/usr/lib/systemd/systemd-makefs swap /dev/zram0" after an update of systemd to v254.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/19/2023 07:37:16.973:160) : proctitle=(mkfs) type=PATH msg=audit(07/19/2023 07:37:16.973:160) : item=1 name=/dev/null inode=4 dev=00:05 mode=character,666 ouid=root ogid=root rdev=01:03 obj=system_u:object_r:null_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(07/19/2023 07:37:16.973:160) : item=0 name=/proc/self/fd/3 inode=21301 dev=00:15 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:fsadm_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/19/2023 07:37:16.973:160) : arch=x86_64 syscall=mount success=yes exit=0 a0=0x7f160d6e1a93 a1=0x7ffe97e3ee10 a2=0x0 a3=MS_BIND items=2 ppid=829 pid=830 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(mkfs) exe=/usr/lib/systemd/systemd-makefs subj=system_u:system_r:fsadm_t:s0 key=(null) type=AVC msg=audit(07/19/2023 07:37:16.973:160) : avc:  denied  { mounton } for  pid=830 comm=(mkfs) path=/proc/830/mounts dev="proc" ino=21301 scontext=system_u:system_r:fsadm_t:s0 tcontext=system_u:system_r:fsadm_t:s0 tclass=file permissive=1

Resolves: rhbz#2223788