### PR TITLE
Label /usr/sbin/sos with sosreport_exec_t

### DIFF
--- a/policy/modules/contrib/sosreport.fc
+++ b/policy/modules/contrib/sosreport.fc
@@ -1,3 +1,4 @@
+/usr/sbin/sos		--	gen_context(system_u:object_r:sosreport_exec_t,s0)
 /usr/sbin/sosreport	--	gen_context(system_u:object_r:sosreport_exec_t,s0)
 
 /\.ismount-test-file	--	gen_context(system_u:object_r:sosreport_tmp_t,s0)


### PR DESCRIPTION
The 'sosreport' command has been deprecated in favor of the new 'sos' command, so the command needs to have the same label.

Resolves: rhbz#2167731