### PR TITLE
A blueman read the contents of the sysfs filesystem

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -54,6 +54,7 @@ kernel_request_load_module(blueman_t)
 
 corecmd_exec_bin(blueman_t)
 
+dev_read_sysfs(blueman_t)
 dev_read_rand(blueman_t)
 dev_read_urand(blueman_t)
 dev_rw_wireless(blueman_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1689902373.900:111): avc:  denied  { read } for  pid=1905 comm="blueman-mechani" name="possible" dev="sysfs" ino=42 scontext=system_u:system_r:blueman_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2224461