### PR TITLE
Allow systemd-gpt-generator mount a tmpfs filesystem

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1189,6 +1189,8 @@ files_list_tmp(systemd_gpt_generator_t)
 files_list_usr(systemd_gpt_generator_t)
 files_list_var(systemd_gpt_generator_t)
 
+fs_mount_tmpfs(systemd_gpt_generator_t)
+
 fstools_exec(systemd_gpt_generator_t)
 
 mls_file_read_to_clearance(systemd_gpt_generator_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(07/25/2023 06:19:37.853:316) : avc:  denied  { mount } for  pid=29092 comm=systemd-gpt-aut name=/ dev="tmpfs" ino=1 scontext=system_u:system_r:systemd_gpt_generator_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=1