### PR TITLE
Allow journald write to cgroup files

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -645,6 +645,7 @@ fs_getattr_all_fs(syslogd_t)
 fs_read_efivarfs_files(syslogd_t)
 fs_search_auto_mountpoints(syslogd_t)
 fs_list_cgroup_dirs(syslogd_t)
+fs_write_cgroup_files(syslogd_t)
 
 miscfiles_manage_generic_cert_files(syslogd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
audit: type=1400 audit(1690227161.760:5): avc:  denied  { write } for  pid=567 comm="systemd-journal" name="memory.pressure" dev="cgroup2" ino=1903 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=1