### PR TITLE
Set the MLS range of fsdaemon_t to s0 - mls_systemhigh

### DIFF
--- a/policy/modules/contrib/smartmon.te
+++ b/policy/modules/contrib/smartmon.te
@@ -30,7 +30,7 @@ type fsdaemon_tmp_t;
 files_tmp_file(fsdaemon_tmp_t)
 
 ifdef(`enable_mls',`
-	init_ranged_daemon_domain(fsdaemon_t, fsdaemon_exec_t, mls_systemhigh)
+	init_ranged_daemon_domain(fsdaemon_t, fsdaemon_exec_t, s0 - mls_systemhigh)
 ')
 
 ########################################


### PR DESCRIPTION
Need to set the MLS range of fsdaemon_t to s0 - mls_systemhigh to meet mls-specific constraints when the domain tries to write to sock_file /var/run/systemd/notify with init_var_run_t type having sensitivity level s0.

FYI, below is the denial this commit addresses.

type=AVC msg=audit(1611583033.083:202): avc:  denied  { write } for  pid=1375  comm="smartd" name="notify" dev="tmpfs" ino=15758 scontext=system_u:system_r:fsdaemon_t:s15:c0.c1023 tcontext=system_u:object_r:init_var_run_t:s0 tclass=sock_file permissive=0