### PR TITLE
Allow fedora-third-party read /sys and proc

### DIFF
--- a/policy/modules/contrib/fedoratp.te
+++ b/policy/modules/contrib/fedoratp.te
@@ -13,9 +13,13 @@ allow fedoratp_t self:capability { dac_override sys_nice };
 allow fedoratp_t self:process setsched;
 allow fedoratp_t self:unix_dgram_socket create_socket_perms;
 
+kernel_read_proc_files(fedoratp_t)
+
 corecmd_exec_bin(fedoratp_t)
 
 corenet_tcp_connect_http_port(fedoratp_t)
+
+dev_read_sysfs(fedoratp_t)
 
 files_manage_system_conf_files(fedoratp_t)
 files_manage_generic_tmp_dirs(fedoratp_t)


### PR DESCRIPTION
In particular, read the contents of the sysfs filesystem (/sys/devices/system/cpu/possible) and read generic files in /proc (/proc/stat) was allowed.

The commit addresses the following AVC denials:

type=PROCTITLE msg=audit(07/25/2023 22:34:07.666:8974) : proctitle=/usr/bin/python3 /usr/bin/fedora-third-party refresh
type=PATH msg=audit(07/25/2023 22:34:07.666:8974) : item=0 name=/sys/devices/system/cpu/possible inode=42 dev=00:16 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(07/25/2023 22:34:07.666:8974) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fa181da8a20 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=213804 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=fedora-third-pa exe=/usr/bin/python3.12 subj=system_u:system_r:fedoratp_t:s0 key=(null)
type=AVC msg=audit(07/25/2023 22:34:07.666:8974) : avc:  denied  { read } for  pid=213804 comm=fedora-third-pa name=possible dev="sysfs" ino=42 scontext=system_u:system_r:fedoratp_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

type=PROCTITLE msg=audit(07/25/2023 22:34:07.666:8975) : proctitle=/usr/bin/python3 /usr/bin/fedora-third-party refresh
type=PATH msg=audit(07/25/2023 22:34:07.666:8975) : item=0 name=/proc/stat inode=4026532026 dev=00:15 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:proc_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(07/25/2023 22:34:07.666:8975) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fa181da2a17 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=213804 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=fedora-third-pa exe=/usr/bin/python3.12 subj=system_u:system_r:fedoratp_t:s0 key=(null)
type=AVC msg=audit(07/25/2023 22:34:07.666:8975) : avc:  denied  { read } for  pid=213804 comm=fedora-third-pa name=stat dev="proc" ino=4026532026 scontext=system_u:system_r:fedoratp_t:s0 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=0