### PR TITLE
Allow qatlib to read sssd public files

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -50,6 +50,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_read_public_files(qatlib_t)
+')
+
+optional_policy(`
 	systemd_search_unit_dirs(qatlib_t)
 ')
 


### PR DESCRIPTION
Addresses the following denials:
time->Tue Jul 11 09:05:07 2023
type=PROCTITLE msg=audit(1689080707.653:86): proctitle=2F7573722F62696E2F7368002F7573722F7362696E2F7161745F696E69742E7368 type=SYSCALL msg=audit(1689080707.653:86): arch=c000003e syscall=257 success=no exit=-2 a0=ffffff9c a1=560294e45ca0 a2=80000 a3=0 items=0 ppid=1 pid=18658 auid=4294967295 uid=0 gid=991 euid=0 suid=0 fsuid=0 egid=991 sgid=991 fsgid=991 tty=(none) ses=4294967295 comm="qat_init.sh" exe="/usr/bin/bash" subj=system_u:system_r:qatlib_t:s0 key=(null) type=AVC msg=audit(1689080707.653:86): avc:  denied  { search } for  pid=18658 comm="qat_init.sh" name="mc" dev="dm-0" ino=472069 scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1689080707.653:86): avc:  denied  { search } for  pid=18658 comm="qat_init.sh" name="sss" dev="dm-0" ino=472068 scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=dir permissive=1

Resolves: rhbz#2080443