### PR TITLE
Allow gpsd,oddjob,oddjob_mkhomedir rw user domain pty

### DIFF
--- a/policy/modules/contrib/gpsd.te
+++ b/policy/modules/contrib/gpsd.te
@@ -98,3 +98,7 @@ optional_policy(`
 optional_policy(`
 	udev_read_db(gpsd_t)
 ')
+
+optional_policy(`
+	userdom_use_user_ptys(gpsd_t)
+')

--- a/policy/modules/contrib/oddjob.te
+++ b/policy/modules/contrib/oddjob.te
@@ -73,6 +73,10 @@ optional_policy(`
     init_dbus_chat(oddjob_t)
 ')
 
+optional_policy(`
+	userdom_use_user_ptys(oddjob_t)
+')
+
 ifdef(`ipa_helper_noatsecure',`
 	optional_policy(`
 		ipa_helper_noatsecure(oddjob_t)
@@ -122,3 +126,6 @@ optional_policy(`
     dbus_system_bus_client(oddjob_mkhomedir_t)
 ')
 
+optional_policy(`
+	userdom_use_user_ptys(oddjob_mkhomedir_t)
+')


### PR DESCRIPTION
gpsd is a new package being added to RHEL9.3
and SELinux prevents gpsd to write anything to the tty, which breaks things like --help and --version.

After removing the dontaudit rules from active SELinux policy, the following SELinux denials appear: ----
type=PROCTITLE msg=audit(07/17/2023 07:12:31.727:348) : proctitle=gpsd --help type=EXECVE msg=audit(07/17/2023 07:12:31.727:348) : argc=2 a0=gpsd a1=--help type=SYSCALL msg=audit(07/17/2023 07:12:31.727:348) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55ec612b8c80 a1=0x55ec612b35d0 a2=0x55ec61288c80 a3=0x8 items=0 ppid=4246 pid=4617 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=4 comm=gpsd exe=/usr/sbin/gpsd subj=unconfined_u:unconfined_r:gpsd_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(07/17/2023 07:12:31.727:348) : avc:  denied  { read append } for  pid=4617 comm=gpsd path=/dev/pts/0 dev="devpts" ino=3 scontext=unconfined_u:unconfined_r:gpsd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0 type=AVC msg=audit(07/17/2023 07:12:31.727:348) : avc:  denied  { read append } for  pid=4617 comm=gpsd path=/dev/pts/0 dev="devpts" ino=3 scontext=unconfined_u:unconfined_r:gpsd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0 type=AVC msg=audit(07/17/2023 07:12:31.727:348) : avc:  denied  { read append } for  pid=4617 comm=gpsd path=/dev/pts/0 dev="devpts" ino=3 scontext=unconfined_u:unconfined_r:gpsd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0 type=AVC msg=audit(07/17/2023 07:12:31.727:348) : avc:  denied  { read write } for  pid=4617 comm=gpsd path=/dev/pts/0 dev="devpts" ino=3 scontext=unconfined_u:unconfined_r:gpsd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=0

The oddjobd and oddjob_mkhomedir_t are affected too.

Resolves: rhbz#2223305