### PR TITLE
Allow sa-update write syslogd_var_run_t and kmsg_device_t

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -639,6 +639,7 @@ corecmd_exec_bin(spamd_update_t)
 corecmd_exec_shell(spamd_update_t)
 
 dev_read_urand(spamd_update_t)
+dev_write_kmsg(spamd_update_t)
 
 domain_use_interactive_fds(spamd_update_t)
 domain_read_all_domains_state(spamd_update_t)
@@ -671,6 +672,7 @@ optional_policy(`
 
 optional_policy(`
 	logging_send_syslog_msg(spamd_update_t)
+	logging_write_syslog_pid_socket(spamd_update_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow spamassassin-update to write the kernel messages device Allow spamassassin-update to write the syslog pid sock_file.

Addresses following denials:
type=PROCTITLE msg=audit(04/24/2023 16:56:43.558:6730) : proctitle=systemctl --quiet is-active mimedefang.service type=PATH msg=audit(04/24/2023 16:56:43.558:6730) : item=0 name=/run/systemd/journal/socket inode=50 dev=00:18 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:syslogd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(04/24/2023 16:56:43.558:6730) : cwd=/ type=SOCKADDR msg=audit(04/24/2023 16:56:43.558:6730) : saddr={ saddr_fam=local path=/run/systemd/journal/socket } type=SYSCALL msg=audit(04/24/2023 16:56:43.558:6730) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x3 a1=0x7fffdd22dae0 a2=0x1e a3=0x7fffdd22db60 items=1 ppid=704324 pid=704886 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemctl exe=/usr/bin/systemctl subj=system_u:system_r:spamd_update_t:s0 key=(null) type=AVC msg=audit(04/24/2023 16:56:43.558:6730) : avc:  denied  { write } for  pid=704886 comm=systemctl name=socket dev="tmpfs" ino=50 scontext=system_u:system_r:spamd_update_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=sock_file permissive=0 ----
type=PROCTITLE msg=audit(04/24/2023 16:56:43.559:6731) : proctitle=systemctl --quiet is-active mimedefang.service type=PATH msg=audit(04/24/2023 16:56:43.559:6731) : item=0 name=/dev/kmsg inode=10 dev=00:05 mode=character,644 ouid=root ogid=root rdev=01:0b obj=system_u:object_r:kmsg_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(04/24/2023 16:56:43.559:6731) : cwd=/ type=SYSCALL msg=audit(04/24/2023 16:56:43.559:6731) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f4b9e6b3c43 a2=O_WRONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=704324 pid=704886 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemctl exe=/usr/bin/systemctl subj=system_u:system_r:spamd_update_t:s0 key=(null) type=AVC msg=audit(04/24/2023 16:56:43.559:6731) : avc:  denied  { write } for  pid=704886 comm=systemctl name=kmsg dev="devtmpfs" ino=10 scontext=system_u:system_r:spamd_update_t:s0 tcontext=system_u:object_r:kmsg_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2208349