### PR TITLE
Allow svirt to rw /dev/udmabuf

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -389,6 +389,8 @@ corenet_udp_bind_all_ports(svirt_t)
 corenet_tcp_bind_all_ports(svirt_t)
 corenet_tcp_connect_all_ports(svirt_t)
 
+dev_rw_dma_dev(svirt_t)
+
 init_dontaudit_read_state(svirt_t)
 
 virt_dontaudit_read_state(svirt_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2142,6 +2142,24 @@ interface(`dev_rw_dlm_control',`
 
 ########################################
 ## <summary>
+##      Read and write the the dma device
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`dev_rw_dma_dev',`
+	gen_require(`
+		type device_t, dma_device_t;
+	')
+
+	rw_chr_files_pattern($1, device_t, dma_device_t)
+')
+
+########################################
+## <summary>
 ##	getattr the dri devices.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
In rhbz#2032406 is added support blob resources for virtio-vga/virtio-gpu device, which requires access to /dev/udmabuf. u-dma-buf is a Linux device driver that allocates contiguous memory blocks in the kernel space as DMA buffers and makes them available from the user space.

Add interface to allow domain read and write the the dma device Allow svirt rw dma_device_t

Addresses the following denial:
time->Tue Jul 18 11:29:31 2023
type=PROCTITLE msg=audit(1689697771.305:3860): proctitle=2F7573722F6C6962657865632F71656D752D6B766D002D6E616D650067756573743D76647061626C6F636B2D746573742C64656275672D746872656164733D6F6E002D53002D6F626A656374007B22716F6D2D74797065223A22736563726574222C226964223A226D61737465724B657930222C22666F726D6174223A227261 type=SYSCALL msg=audit(1689697771.305:3860): arch=c000003e syscall=257 success=yes exit=33 a0=ffffff9c a1=55fe1ab9bda6 a2=2 a3=0 items=0 ppid=1 pid=267438 auid=21811 uid=107 gid=107 euid=107 suid=107 fsuid=107 egid=107 sgid=107 fsgid=107 tty=(none) ses=25 comm="qemu-kvm" exe="/usr/libexec/qemu-kvm" subj=unconfined_u:unconfined_r:svirt_t:s0:c190,c1016 key=(null) type=AVC msg=audit(1689697771.305:3860): avc:  denied  { open } for  pid=267438 comm="qemu-kvm" path="/dev/udmabuf" dev="tmpfs" ino=6 scontext=unconfined_u:unconfined_r:svirt_t:s0:c190,c1016 tcontext=system_u:object_r:dma_device_t:s0 tclass=chr_file permissive=1 type=AVC msg=audit(1689697771.305:3860): avc:  denied  { read write } for  pid=267438 comm="qemu-kvm" name="udmabuf" dev="tmpfs" ino=6 scontext=unconfined_u:unconfined_r:svirt_t:s0:c190,c1016 tcontext=system_u:object_r:dma_device_t:s0 tclass=chr_file permissive=1

Resolves: rhbz#2223727