### PR TITLE
Allow nscd watch system db dirs

### DIFF
--- a/policy/modules/contrib/nscd.te
+++ b/policy/modules/contrib/nscd.te
@@ -113,6 +113,7 @@ files_read_etc_runtime_files(nscd_t)
 files_watch_etc_dirs(nscd_t)
 files_watch_etc_files(nscd_t)
 files_map_system_db_files(nscd_t)
+files_watch_system_db_dirs(nscd_t)
 files_watch_system_db_files(nscd_t)
 
 logging_send_audit_msgs(nscd_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6103,6 +6103,24 @@ interface(`files_manage_system_db_files',`
 
 ######################################
 ## <summary>
+##	Watch manageable system db dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_system_db_dirs',`
+	gen_require(`
+		type system_db_t;
+	')
+
+	allow $1 system_db_t:dir watch_dir_perms;
+')
+
+######################################
+## <summary>
 ##	Watch manageable system db files in /var/db.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The files_watch_system_db_dirs() interface was added.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/28/2023 09:49:50.777:3968) : proctitle=/usr/sbin/nscd type=PATH msg=audit(07/28/2023 09:49:50.777:3968) : item=0 name=/var/db inode=2847 dev=fd:00 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:system_db_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/28/2023 09:49:50.777:3968) : arch=x86_64 syscall=inotify_add_watch success=yes exit=2 a0=0x3 a1=0x7f5ca1a1c2dc a2=0xd80 a3=0x4000 items=1 ppid=82240 pid=82241 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=nscd exe=/usr/sbin/nscd subj=system_u:system_r:nscd_t:s0 key=(null) type=AVC msg=audit(07/28/2023 09:49:50.777:3968) : avc:  denied  { watch } for  pid=82241 comm=nscd path=/var/db dev="dm-0" ino=2847 scontext=system_u:system_r:nscd_t:s0 tcontext=system_u:object_r:system_db_t:s0 tclass=dir permissive=1

Resolves: rhbz#2152124