### PR TITLE
Allow vpnc read/write inherited vhost net device

### DIFF
--- a/policy/modules/contrib/vpn.te
+++ b/policy/modules/contrib/vpn.te
@@ -75,6 +75,7 @@ corenet_rw_tun_tap_dev(vpnc_t)
 dev_read_rand(vpnc_t)
 dev_read_urand(vpnc_t)
 dev_read_sysfs(vpnc_t)
+dev_rw_inherited_vhost(vpnc_t)
 
 domain_use_interactive_fds(vpnc_t)
 


### PR DESCRIPTION
OpenConnect uses the vhost-net device for tun acceleration to make the tun device's io_uring accessible.
There is no virtualization feature used in this concept.

Resolves: rhbz#2221507