### PR TITLE
Add use_nfs_home_dirs boolean for mozilla_plugin

### DIFF
--- a/policy/modules/contrib/mozilla.te
+++ b/policy/modules/contrib/mozilla.te
@@ -758,3 +758,7 @@ tunable_policy(`mozilla_plugin_bind_unreserved_ports',`
     corenet_tcp_bind_unreserved_ports(mozilla_plugin_t)
     corenet_udp_bind_all_unreserved_ports(mozilla_plugin_t)
 ')
+
+tunable_policy(`use_nfs_home_dirs',`
+    fs_exec_nfs_files(mozilla_plugin_t)
+')


### PR DESCRIPTION
SELinux prevents users from watching or listening any DRM content, when their home directories are hosted on the nfs server.

Addresses the following denial:
type=PROCTITLE msg=audit(15.06.2023 19:37:06.157:2349) : proctitle=/usr/lib64/firefox/plugin-container /home/tomek/.mozilla/firefox/default/gmp-widevinecdm/4.10.2557.0 13316 gmplugin type=MMAP msg=audit(15.06.2023 19:37:06.157:2349) : fd=17 flags=MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE type=SYSCALL msg=audit(15.06.2023 19:37:06.157:2349) : arch=x86_64 syscall=mmap success=yes exit=139730748620800 a0=0x7f1599a2c000 a1=0x5a6000 a2=PROT_READ|PROT_EXEC a3=MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE items=0 ppid=13316 pid=13774 auid=tomek uid=tomek gid=tomek euid=tomek suid=tomek fsuid=tomek egid=tomek sgid=tomek fsgid=tomek tty=(none) ses=3 comm=MainThread exe=/usr/lib64/firefox/plugin-container subj=unconfined_u:unconfined_r:mozilla_plugin_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(15.06.2023 19:37:06.157:2349) : avc:  denied  { execute } for  pid=13774 comm=MainThread path=/home/tomek/.mozilla/firefox/default/gmp-widevinecdm/4.10.2557.0/libwidevinecdm.so dev="0:55" ino=4607770 scontext=unconfined_u:unconfined_r:mozilla_plugin_t:s0-s0:c0.c1023 tcontext=system_u:object_r:nfs_t:s0 tclass=file permissive=1

Resolves: rhbz#2214298