### PR TITLE
Fix labeling for no-stub-resolv.conf

### DIFF
--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -41,7 +41,7 @@ ifdef(`distro_redhat',`
 /var/run/systemd/resolve/stub-resolv\.conf  gen_context(system_u:object_r:net_conf_t,s0)
 ')
 /var/run/NetworkManager/resolv\.conf.*   --  gen_context(system_u:object_r:net_conf_t,s0)
-/var/run/NetworkManager/no-stub-resolv\.conf   --  gen_context(system_u:object_r:net_conf_t,s0)
+/var/run/NetworkManager/no-stub-resolv\.conf.*   --  gen_context(system_u:object_r:net_conf_t,s0)
 
 /var/run/cloud-init(/.*)?     gen_context(system_u:object_r:net_conf_t,s0)
 

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1140,6 +1140,7 @@ interface(`sysnet_filetrans_systemd_resolved',`
 	')
 
 	optional_policy(`
+		systemd_resolved_pid_filetrans($1, net_conf_t, file, "no-stub-resolv.conf")
 		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf")
 		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
 		systemd_resolved_pid_filetrans($1, net_conf_t, { file lnk_file }, "stub-resolv.conf")


### PR DESCRIPTION
Restorecon command relabels /run/NetworkManager/no-stub-resolv.conf from system_u:object_r:NetworkManager_var_run_t:s0 to system_u:object_r:net_conf_t:s0.

Resolves: rhbz#2148390