### PR TITLE
Allow upsmon execute upsmon via a helper script

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -74,6 +74,8 @@ allow nut_upsmon_t self:tcp_socket create_socket_perms;
 allow nut_upsmon_t self:unix_dgram_socket { create_socket_perms sendto };
 allow nut_upsmon_t self:unix_stream_socket { create_socket_perms connectto };
 
+can_exec(nut_upsmon_t, nut_upsmon_exec_t)
+
 read_files_pattern(nut_upsmon_t, nut_conf_t, nut_conf_t)
 
 kernel_read_kernel_sysctls(nut_upsmon_t)


### PR DESCRIPTION
The NUT UPS monitor service (upsmon) can be configured to execute a notification helper (upssched) which can use a custom script to run upsmon again, e. g. to shut the system down.

The commit addresses the following AVC denial:
type=AVC msg=audit(1690760021.301:222): avc:  denied  { execute_no_trans } for  pid=2267 comm="upssched-handle" path="/usr/sbin/upsmon" dev="dm-0" ino=27404 scontext=system_u:system_r:nut_upsmon_t:s0 tcontext=system_u:object_r:nut_upsmon_exec_t:s0 tclass=file permissive=1

Resolves: rhbz#2228245