### PR TITLE
Allow user_u and staff_u get attributes of non-security dirs

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -636,6 +636,24 @@ interface(`files_dontaudit_getattr_all_dirs',`
 
 ########################################
 ## <summary>
+##	Get attributes of all non-security directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_getattr_non_security_dirs',`
+	gen_require(`
+		attribute non_security_file_type;
+	')
+
+	allow $1 non_security_file_type:dir getattr_dir_perms;
+')
+
+########################################
+## <summary>
 ##	List all non-security directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1523,6 +1523,7 @@ tunable_policy(`deny_bluetooth',`',`
 
 	storage_rw_fuse($1_t)
 
+	files_getattr_non_security_dirs($1_t)
 	files_exec_usr_files($1_t)
    # cjp: why?
 	files_read_kernel_symbol_table($1_t)


### PR DESCRIPTION
By default, unprivileged users are allowed get only file attributes of directories with the type which is in the base_file_type SELinux attribute.

The commit addresses the following issue:
  $ ls -l /var
ls: cannot access '/var/account': Permission denied total 12
d??????????  ? ?    ?       ?            ? account
drwxr-xr-x.  2 root root    6 Jun 21  2021 adm
...

Resolves: rhbz#2216151