### PR TITLE
Revert "Allow winbind-rpcd use its private tmp files"

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -181,9 +181,6 @@ type winbind_rpcd_exec_t;
 application_domain(winbind_rpcd_t, winbind_rpcd_exec_t)
 role system_r types winbind_rpcd_t;
 
-type winbind_rpcd_tmp_t;
-files_tmp_file(winbind_rpcd_tmp_t)
-
 type winbind_log_t;
 logging_log_file(winbind_log_t)
 


### PR DESCRIPTION
This reverts commit 2a1568bd76 which defines a duplicate type winbind_rpcd_tmp_t, already defined in commit eaeecccc66 ("Update samba-dcerpc policy for printing").