### PR TITLE
Allow samba-dcerpc service manage samba tmp files

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1210,7 +1210,7 @@ manage_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
 manage_sock_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
 allow winbind_rpcd_t samba_var_t:file { map } ;
 
-delete_files_pattern(winbind_rpcd_t, smbd_tmp_t, smbd_tmp_t)
+manage_files_pattern(winbind_rpcd_t, smbd_tmp_t, smbd_tmp_t)
 
 kernel_read_network_state(winbind_rpcd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/02/2023 20:54:27.856:2487) : proctitle=/usr/libexec/samba/rpcd_spoolss --configfile=/etc/samba/smb.conf --worker-group=7 --worker-index=5 --debuglevel=0 type=PATH msg=audit(08/02/2023 20:54:27.856:2487) : item=0 name=/var/tmp/smbprn.A3oND9 inode=120144 dev=00:1e mode=file,600 ouid=smbuser ogid=smbuser rdev=00:00 obj=system_u:object_r:smbd_tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(08/02/2023 20:54:27.856:2487) : cwd=/tmp type=SYSCALL msg=audit(08/02/2023 20:54:27.856:2487) : arch=x86_64 syscall=openat success=yes exit=22 a0=AT_FDCWD a1=0x55ac23687c1e a2=O_RDONLY a3=0x0 items=1 ppid=31759 pid=31871 auid=unset uid=smb user gid=root euid=smbuser suid=root fsuid=smbuser egid=smbuser sgid=root fsgid=smbuser tty=(none) ses=unset comm=rpcd_spoolss exe=/usr/libexec/samba/rpcd_spoolss subj=system_u:system_r:winbind_rpcd_t:s0 key=(null) type=AVC msg=audit(08/02/2023 20:54:27.856:2487) : avc:  denied  { open } for  pid=31871 comm=rpcd_spoolss path=/var/tmp/smbprn.A3oND9 dev="vda5" ino=120144 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:smbd_tmp_t:s0 tclass=file permissive=1

Resolves: rhbz#2210771