### PR TITLE
Allow rhsmcertd dbus chat with policykit

### DIFF
--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -125,6 +125,10 @@ optional_policy(`
 	')
 
 	optional_policy(`
+		rhsmcertd_dbus_chat(policykit_t)
+	')
+
+	optional_policy(`
 		rpm_dbus_chat(policykit_t)
 	')
 ')


### PR DESCRIPTION
This journal entry appears:
Aug 03 13:24:40 rhel9 dbus-broker[764]: A security policy denied :1.748 to send method call /org/freedesktop/PolicyKit1/Authority:org.freedesktop.PolicyKit1.Authority.CheckAuthorization to :1.141.

The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(1691061880.508:1007): pid=764 uid=81 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:system_r:policykit_t:s0 tclass=dbus permissive=0 exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=? terminal=?'`