### PR TITLE
Allow polkit execute pkla-check-authorization with nnp transition

### DIFF
--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -60,6 +60,7 @@ policykit_domtrans_auth(policykit_t)
 allow policykit_t policykit_auth_exec_t:file map;
 
 allow policykit_t policykit_auth_t:process signal;
+allow policykit_t policykit_auth_t:process2 nnp_transition;
 
 can_exec(policykit_t, policykit_exec_t)
 corecmd_exec_bin(policykit_t)


### PR DESCRIPTION
The permission is required in a new polkit version which contains miscellaneous service sandboxing features.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/04/2023 03:21:02.352:135) : proctitle=/usr/lib/polkit-1/polkitd --no-debug type=PATH msg=audit(08/04/2023 03:21:02.352:135) : item=0 name=/usr/bin/pkla-check-authorization inode=151681 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:policykit_auth_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/04/2023 03:21:02.352:135) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x7f6b50005630 a1=0x7f6b500055f0 a2=0x558c69d2e660 a3=0x0 items=1 ppid=811 pid=854 auid=unset uid=polkitd gid=polkitd euid=polkitd suid=polkitd fsuid=polkitd egid=polkitd sgid=polkitd fsgid=polkitd tty=(none) ses=unset comm=polkitd exe=/usr/lib/polkit-1/polkitd subj=system_u:system_r:policykit_t:s0 key=(null) type=AVC msg=audit(08/04/2023 03:21:02.352:135) : avc:  denied  { execute_no_trans } for  pid=854 comm=polkitd path=/usr/bin/pkla-check-authorization dev="vda2" ino=151681 scontext=system_u:system_r:policykit_t:s0 tcontext=system_u:object_r:policykit_auth_exec_t:s0 tclass=file permissive=0 type=SELINUX_ERR msg=audit(08/04/2023 03:21:02.352:135) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:policykit_t:s0 newcontext=system_u:system_r:policykit_auth_t:s0 type=AVC msg=audit(08/04/2023 03:21:02.352:135) : avc:  denied  { nnp_transition } for  pid=854 comm=polkitd scontext=system_u:system_r:policykit_t:s0 tcontext=system_u:system_r:policykit_auth_t:s0 tclass=process2 permissive=0sesearch -A -s policykit_t -t policykit_auth_exec_t -c file -p execute_no_trans