### PR TITLE
Label /usr/libexec/openssh/ssh-pkcs11-helper with ssh_agent_exec_t

### DIFF
--- a/policy/modules/services/ssh.fc
+++ b/policy/modules/services/ssh.fc
@@ -30,6 +30,7 @@ HOME_DIR/\.shosts			gen_context(system_u:object_r:ssh_home_t,s0)
 /usr/libexec/nm-ssh-service     --  gen_context(system_u:object_r:ssh_exec_t,s0)
 /usr/libexec/openssh/ssh-keysign --	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
 /usr/libexec/openssh/sshd-keygen   --	gen_context(system_u:object_r:sshd_keygen_exec_t,s0)
+/usr/libexec/openssh/ssh-pkcs11-helper	--	gen_context(system_u:object_r:ssh_agent_exec_t,s0)
 
 /usr/sbin/sshd			--	gen_context(system_u:object_r:sshd_exec_t,s0)
 /usr/sbin/sshd-keygen   --	gen_context(system_u:object_r:sshd_keygen_exec_t,s0)

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -406,6 +406,7 @@ template(`ssh_role_template',`
 	# allow ps to show ssh
 	ps_process_pattern($3, $1_ssh_agent_t)
 
+	can_exec($1_ssh_agent_t, ssh_agent_exec_t)
 	domtrans_pattern($3, ssh_agent_exec_t, $1_ssh_agent_t)
 
 	kernel_read_system_state($1_ssh_agent_t)


### PR DESCRIPTION
ssh-pkcs11-helper is used by ssh-agent to access keys provided by a PKCS#11 token. This commit labels this file with the ssh_agent_exec_t type and allows confined users execute it in the caller domain.

Resolves: rhbz#2177704