### PR TITLE
Allow pdns name_bind and name_connect all ports

### DIFF
--- a/policy/modules/contrib/pdns.te
+++ b/policy/modules/contrib/pdns.te
@@ -48,8 +48,9 @@ kernel_read_network_state(pdns_t)
 kernel_read_system_state(pdns_t)
 
 corenet_tcp_bind_dns_port(pdns_t)
-corenet_udp_bind_dns_port(pdns_t)
 corenet_tcp_bind_transproxy_port(pdns_t)
+corenet_tcp_connect_all_ports(pdns_t)
+corenet_udp_bind_all_ports(pdns_t)
 
 manage_dirs_pattern(pdns_t, pdns_var_lib_t, pdns_var_lib_t)
 manage_files_pattern(pdns_t, pdns_var_lib_t, pdns_var_lib_t)
@@ -60,12 +61,17 @@ files_pid_filetrans(pdns_t, pdns_var_run_t, { file sock_file })
 manage_files_pattern(pdns_t, pdns_var_run_t, pdns_var_run_t)
 manage_sock_files_pattern(pdns_t, pdns_var_run_t, pdns_var_run_t)
 
-auth_use_nsswitch(pdns_t)
+optional_policy(`
+	auth_use_nsswitch(pdns_t)
+')
 
-corenet_udp_bind_generic_port(pdns_t)
+optional_policy(`
+	kerberos_read_keytab(pdns_t)
+')
 
-logging_send_syslog_msg(pdns_t)
-
+optional_policy(`
+	logging_send_syslog_msg(pdns_t)
+')
 
 ########################################
 #


### PR DESCRIPTION
Allow powerdns name bind all udp sockets and name connect all tcp sockets. allow powerdns read the kerberos key table.

Resolves: rhbz#2047945