### PR TITLE
Remove nsplugin_role from mozilla.if

### DIFF
--- a/policy/modules/contrib/mozilla.if
+++ b/policy/modules/contrib/mozilla.if
@@ -54,10 +54,6 @@ interface(`mozilla_role',`
 	userdom_manage_tmp_role($1, mozilla_t)
 
 	optional_policy(`
-		nsplugin_role($1, mozilla_t)
-	')
-
-	optional_policy(`
 		pulseaudio_role($1, mozilla_t)
 		pulseaudio_filetrans_admin_home_content(mozilla_t)
 		pulseaudio_filetrans_home_content(mozilla_t)


### PR DESCRIPTION
Nsplugin module was removed from SELinux policy,
but interface nsplugin_role was still included in mozilla_role interface, which caused syntax error, when using this interface.

Resolves: rhbz#2221251