### PR TITLE
Allow keepalived watch var_run dirs

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -90,6 +90,8 @@ dev_read_urand(keepalived_t)
 
 files_dontaudit_mounton_rootfs(keepalived_var_run_t)
 files_mounton_rootfs(keepalived_t)
+files_watch_var_run_dirs(keepalived_t)
+fs_getattr_tmpfs(keepalived_t)
 fs_read_nsfs_files(keepalived_t)
 fs_unmount_tmpfs(keepalived_t)
 


### PR DESCRIPTION
Keepalived requires watch permission,
when keepalived tracked file is located in /var/run

Resolves: rhbz#2186759