### PR TITLE
Make tuned work with mls policy

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -32,7 +32,7 @@ files_pid_file(tuned_var_run_t)
 # Local policy
 #
 
-allow tuned_t self:capability { net_admin sys_admin sys_nice sys_rawio };
+allow tuned_t self:capability { net_admin sys_admin sys_nice sys_ptrace sys_rawio };
 dontaudit tuned_t self:capability { dac_read_search  sys_tty_config };
 allow tuned_t self:process {  setsched signal };
 allow tuned_t self:fifo_file rw_fifo_file_perms;
@@ -67,13 +67,11 @@ can_exec(tuned_t, tuned_var_run_t)
 
 kernel_read_system_state(tuned_t)
 kernel_read_network_state(tuned_t)
-kernel_read_kernel_sysctls(tuned_t)
 kernel_request_load_module(tuned_t)
-kernel_rw_kernel_sysctl(tuned_t)
-kernel_rw_usermodehelper_state(tuned_t)
-kernel_rw_vm_sysctls(tuned_t)
-kernel_setsched(tuned_t)
 kernel_rw_all_sysctls(tuned_t)
+kernel_rw_security_state(tuned_t)
+kernel_rw_usermodehelper_state(tuned_t)
+kernel_setsched(tuned_t)
 kernel_manage_perf_event(tuned_t)
 
 corecmd_exec_bin(tuned_t)
@@ -82,9 +80,12 @@ corecmd_exec_shell(tuned_t)
 dev_getattr_all_blk_files(tuned_t)
 dev_getattr_all_chr_files(tuned_t)
 dev_read_urand(tuned_t)
+dev_read_raw_memory(tuned_t)
 dev_rw_cpu_microcode(tuned_t)
 dev_rw_sysfs(tuned_t)
 dev_rw_netcontrol(tuned_t)
+
+domain_read_all_domains_state(tuned_t)
 
 files_dontaudit_all_access_check(tuned_t)
 files_dontaudit_search_home(tuned_t)
@@ -94,12 +95,16 @@ fs_getattr_all_fs(tuned_t)
 fs_search_all(tuned_t)
 fs_rw_hugetlbfs_files(tuned_t)
 
+mls_file_read_to_clearance(tuned_t)
+
 auth_use_nsswitch(tuned_t)
 
 logging_send_syslog_msg(tuned_t)
 #bug in tuned
 logging_manage_syslog_config(tuned_t)
 logging_filetrans_named_conf(tuned_t)
+
+systemd_exec_systemctl(tuned_t)
 
 mount_read_pid_files(tuned_t)
 

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4185,8 +4185,14 @@ interface(`kernel_ib_manage_subnet_unlabeled_endports',`
 
 ########################################
 ## <summary>
-##	Allow caller to read the security state symbolic links.
+##	Read and write the security state information.
 ## </summary>
+## <desc>
+##	<p>
+##	Allow the specified domain to read and write
+##	the security state information.
+##     </p>
+## </desc>
 ## <param name="domain">
 ##	<summary>
 ##	Domain allowed access.


### PR DESCRIPTION
Need to allow tuned_t various permissions as the domain is not unconfined when mls is used. Also need to add mlsfilereadtoclr attribute to the domain to meet mls-specific constraints.


FYI, below are the denials this commit addresses.

- +allow tuned_t self:capability { net_admin sys_admin sys_nice sys_ptrace sys_rawio };

type=AVC msg=audit(1585864906.053:216): avc:  denied  { sys_ptrace } for  pid=1105 comm="tuned" capability=19 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tclass=capability permissive=0


- +kernel_rw_security_state(tuned_t)

type=AVC msg=audit(1585864906.053:218): avc:  denied  { write } for  pid=1105 comm="tuned" name="protected_hardlinks" dev="proc" ino=13546 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:object_r:proc_security_t:s0 tclass=file permissive=0
type=AVC msg=audit(1585864906.053:219): avc:  denied  { write } for  pid=1105 comm="tuned" name="protected_symlinks" dev="proc" ino=13547 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:object_r:proc_security_t:s0 tclass=file permissive=0


- +dev_read_raw_memory(tuned_t)

type=AVC msg=audit(1590001419.543:42): avc:  denied  { read } for  pid=984 comm="tuned" name="mem" dev="devtmpfs" ino=11265 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:object_r:memory_device_t:s15:c0.c1023 tclass=chr_file permissive=0


- +domain_read_all_domains_state(tuned_t)

type=AVC msg=audit(1635340704.737:34): avc:  denied  { read } for  pid=629 comm="tuned" name="task" dev="proc" ino=20592 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:system_r:init_t:s0-s15:c0.c1023 tclass=dir permissive=0
type=AVC msg=audit(1635340704.737:35): avc:  denied  { search } for  pid=629 comm="tuned" name="2" dev="proc" ino=14553 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:system_r:kernel_t:s15:c0.c1023 tclass=dir permissive=0
type=AVC msg=audit(1636070809.866:158): avc:  denied  { search } for  pid=699 comm="tuned" name="646" dev="proc" ino=20813 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:system_r:rpcbind_t:s0-s15:c0.c1023 tclass=dir permissive=0
and so on


- +mls_file_read_to_clearance(tuned_t)

type=AVC msg=audit(1603175927.509:53): avc:  denied  { getattr } for  pid=1513 comm="ls" path="/dev/sda" dev="devtmpfs" ino=16375 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:object_r:fixed_disk_device_t:s15:c0.c1023 tclass=blk_file permissive=0

Note that this is necessary to meet the mlsconstrain shown below:

https://github.com/fedora-selinux/selinux-policy/blob/rawhide/policy/mls#L77C1-L82C31

```
# the file "read" ops (note the check is dominance of the low level)
mlsconstrain { dir file lnk_file chr_file blk_file sock_file fifo_file } { read getattr execute }
        (( l1 dom l2 ) or
         (( t1 == mlsfilereadtoclr ) and ( h1 dom l2 )) or
         ( t1 == mlsfileread ) or
         ( t2 == mlstrustedobject ));
```


- +systemd_exec_systemctl(tuned_t)

type=AVC msg=audit(1609974079.417:97): avc:  denied  { execute } for pid=1860 comm="tuned" name="systemctl" dev="vda3" ino=12686210 scontext=system_u:system_r:tuned_t:s0-s15:c0.c1023 tcontext=system_u:object_r:systemd_systemctl_exec_t:s0 tclass=file permissive=0