### PR TITLE
Allow ipsec read nsfs files

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -192,6 +192,7 @@ files_dontaudit_search_home(ipsec_t)
 files_dontaudit_write_all_files(ipsec_t)
 
 fs_getattr_all_fs(ipsec_t)
+fs_read_nsfs_files(ipsec_mgmt_t)
 fs_search_auto_mountpoints(ipsec_t)
 
 selinux_compute_access_vector(ipsec_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/08/2023 05:55:08.092:376) : proctitle=/usr/bin/sh /sbin/ipsec --piddir type=EXECVE msg=audit(08/08/2023 05:55:08.092:376) : argc=3 a0=/usr/bin/sh a1=/sbin/ipsec a2=--piddir type=SYSCALL msg=audit(08/08/2023 05:55:08.092:376) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x555febdeebf0 a1=0x555febdef4d0 a2=0x555febdecd20 a3=0x8 items=0 ppid=9313 pid=9319 auid=unset uid=frr gid=frr euid=frr suid=frr fsuid=frr egid=frr sgid=frr fsgid=frr tty=(none) ses=unset comm=ipsec exe=/usr/bin/bash subj=system_u:system_r:ipsec_mgmt_t:s0 key=(null) type=AVC msg=audit(08/08/2023 05:55:08.092:376) : avc:  denied  { read } for  pid=9319 comm=ipsec path=net:[4026531840] dev="nsfs" ino=4026531840 scontext=system_u:system_r:ipsec_mgmt_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=0