### PR TITLE
Allow key.dns_resolve create and use unix datagram socket

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -40,3 +40,7 @@ kernel_view_key(keyutils_dns_resolver_t)
 
 init_search_pid_dirs(keyutils_dns_resolver_t)
 sysnet_read_config(keyutils_dns_resolver_t)
+
+optional_policy(`
+	avahi_stream_connect(keyutils_dns_resolver_t)
+')

--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -33,6 +33,7 @@ domtrans_pattern(keyutils_request_t, keyutils_dns_resolver_exec_t, keyutils_dns_
 
 allow keyutils_dns_resolver_t self:netlink_route_socket r_netlink_socket_perms;
 allow keyutils_dns_resolver_t self:udp_socket create_socket_perms;
+allow keyutils_dns_resolver_t self:unix_dgram_socket create_socket_perms;
 
 kernel_read_key(keyutils_dns_resolver_t)
 kernel_view_key(keyutils_dns_resolver_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1691747044.496:582): avc:  denied  { create } for  pid=95403 comm="key.dns_resolve" scontext=system_u:system_r:keyutils_dns_resolver_t:s0 tcontext=system_u:system_r:keyutils_dns_resolver_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#2231341