### PR TITLE
Allow insights-client read and write cluster tmpfs files

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -344,6 +344,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhcs_rw_cluster_tmpfs(insights_client_t)
+')
+
+optional_policy(`
 	rhnsd_read_config(insights_client_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/10/2023 07:57:43.499:1185) : proctitle=/usr/sbin/corosync-cmapctl type=PATH msg=audit(07/10/2023 07:57:43.499:1185) : item=0 name=/dev/shm/qb-12345-678901-21-asdfgh/qb-request-cmap-header inode=110 dev=00:16 mode=file,600 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cluster_tmpfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/10/2023 07:57:43.499:1185) : arch=x86_64 syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x7fff6ce7b390 a2=O_RDWR a3=0x0 items=1 ppid=126009 pid=126010 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=corosync-cmapct exe=/usr/sbin/corosync-cmapctl subj=system_u:system_r:insights_client_t:s0 key=(null) type=AVC msg=audit(07/10/2023 07:57:43.499:1185) : avc:  denied  { write } for  pid=126010 comm=corosync-cmapct name=qb-request-cmap-header dev="tmpfs" ino=110 scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:cluster_tmpfs_t:s0 tclass=file permissive=1

Resolves: rhbz#2221631