### PR TITLE
Allow xenstored map xenfs files

### DIFF
--- a/policy/modules/contrib/xen.te
+++ b/policy/modules/contrib/xen.te
@@ -468,6 +468,7 @@ dev_read_sysfs(xenstored_t)
 
 fs_search_xenfs(xenstored_t)
 fs_manage_xenfs_files(xenstored_t)
+fs_map_xenfs_files(xenstored_t)
 
 term_use_generic_ptys(xenstored_t)
 term_use_console(xenconsoled_t)

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6324,6 +6324,24 @@ interface(`fs_read_xenfs_files',`
 
 ########################################
 ## <summary>
+##	Map files on a XENFS filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_map_xenfs_files',`
+	gen_require(`
+		type xenfs_t;
+	')
+
+	allow $1 xenfs_t:file map;
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete directories
 ##	on a XENFS filesystem.
 ## </summary>


### PR DESCRIPTION
The commit addresses the following AVC denial:
Aug 10 00:24:40 fedora audit[1076]: AVC avc:  denied  { map } for  pid=1076 comm="xenstored" path="/proc/xen/xsd_kva" dev="xenfs" ino=5 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:xenfs_t:s0 tclass=file permissive=0

The fs_map_xenfs_files() interface was added.

Resolves: rhbz#2231508