### PR TITLE
Allow init_t to manage the dhcp client state files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -771,6 +771,7 @@ ifdef(`distro_redhat',`
     ')
 
     optional_policy(`
+        sysnet_manage_dhcpc_state(init_t)
         sysnet_relabelfrom_dhcpc_state(init_t)
         sysnet_setattr_dhcp_state(init_t)
     ')


### PR DESCRIPTION
Need to allow init_t to manage the dhcp client state files as the process of import-state service runs in that domain when mls is used while it runs in unconfined_service_t domain with targeted policy.


FYI, below is the denial this commit addresses.

audit(1615330079.292:7): avc:  denied  { add_name } for  pid=1168 comm="cp" name="dhclient-c9935e25-13d2-42b8-adb3-63d628e36e48-ens3.lease" scontext=system_u:system_r:init_t:s0-s15:c0.c1023 tcontext=system_u:object_r:dhcpc_state_t:s0 tclass=dir permissive=0