### PR TITLE
Allow qatlib  to modify hardware state information.

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -37,7 +37,7 @@ files_pid_filetrans(qatlib_t, qatlib_var_run_t, { dir file } )
 corecmd_exec_shell(qatlib_t)
 corecmd_exec_bin(qatlib_t)
 
-dev_read_sysfs(qatlib_t)
+dev_rw_sysfs(qatlib_t)
 
 domain_use_interactive_fds(qatlib_t)
 


### PR DESCRIPTION
Adresses the following denial:
time->Fri Aug 18 04:11:54 2023
type=PROCTITLE msg=audit(1692346314.949:316): proctitle=2F7573722F62696E2F7368002F7573722F7362696E2F7161745F696E69742E7368 type=SYSCALL msg=audit(1692346314.949:316): arch=c000003e syscall=439 success=no exit=-13 a0=ffffff9c a1=5615908bf010 a2=2 a3=200 items=0 ppid=1 pid=61179 auid=4294967295 uid=0 gid=977 euid=0 suid=0 fsuid=0 egid=977 sgid=977 fsgid=977 tty=(none) ses=4294967295 comm="qat_init.sh" exe="/usr/bin/bash" subj=system_u:system_r:qatlib_t:s0 key=(null) type=AVC msg=audit(1692346314.949:316): avc:  denied  { write } for  pid=61179 comm="qat_init.sh" name="sriov_numvfs" dev="sysfs" ino=62315 scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2080443