### PR TITLE
Use quay.io as the container image source for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: fedora:rawhide
+      image: quay.io/fedora/fedora:rawhide
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The current rawhide image in Docker registry is out-of-date and fails to install depndencies due to DNF/DNF5 conflict. quay.io should be a more reliable source, as per:
https://discussion.fedoraproject.org/t/84680/4