### PR TITLE
ci: Move to Rawhide container on fedoraproject.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: fedora:rawhide
+      image: registry.fedoraproject.org/fedora:rawhide
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The one on Dockerhub has been broken for weeks, and isn't refreshed very often.

---

This fixes the ["build" workflow failures](https://github.com/fedora-selinux/selinux-policy/actions/runs/5947467868/job/16129561131?pr=1843). See https://github.com/fedora-selinux/selinux-policy/pull/1843#issuecomment-1681682089 ff. for details.