### PR TITLE
Allow openconnect vpn open vhost net device

### DIFF
--- a/policy/modules/contrib/vpn.te
+++ b/policy/modules/contrib/vpn.te
@@ -75,7 +75,7 @@ corenet_rw_tun_tap_dev(vpnc_t)
 dev_read_rand(vpnc_t)
 dev_read_urand(vpnc_t)
 dev_read_sysfs(vpnc_t)
-dev_rw_inherited_vhost(vpnc_t)
+dev_rw_vhost(vpnc_t)
 
 domain_use_interactive_fds(vpnc_t)
 


### PR DESCRIPTION
With the 13726aa15 commit ("Allow openconnect vpn read/write inherited vhost net device"), only permissions for inherited files were allowed. It turned also additional permissions are needed.

Resolves: rhbz#2234359