### PR TITLE
Change file transition for systemd-network-generator

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1214,7 +1214,7 @@ optional_policy(`
 # systemd_network_generator domain
 #
 
-init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, dir, "network")
+init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, dir)
 
 sysnet_manage_config(systemd_network_generator_t)
 sysnet_manage_config_dirs(systemd_network_generator_t)


### PR DESCRIPTION
Previously, a file transition in /run/systemd was defined for systemd-network-generator only when it created the network directory. It stopped working though as the generator started to use unpredictable temporary file name:

type=PROCTITLE msg=audit(08/09/2023 03:04:03.671:119) : proctitle=/usr/lib/systemd/systemd-network-generator
type=PATH msg=audit(08/09/2023 03:04:03.671:119) : item=1 name=/run/systemd/.#network9498d551e123e9f4 inode=1144 dev=00:19 mode=file,600 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(08/09/2023 03:04:03.671:119) : item=0 name=/run/systemd/ inode=2 dev=00:19 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(08/09/2023 03:04:03.671:119) : arch=x86_64 syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x559b2aa89ca0 a2=O_RDWR|O_CREAT|O_EXCL|O_NOCTTY|O_CLOEXEC a3=0x180 items=2 ppid=1 pid=889 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-network-generator subj=system_u:system_r:systemd_network_generator_t:s0 key=(null)
type=AVC msg=audit(08/09/2023 03:04:03.671:119) : avc:  denied  { read write open } for  pid=889 comm=systemd-network path=/run/systemd/.#network9498d551e123e9f4 dev="tmpfs" ino=1144 scontext=system_u:system_r:systemd_network_generator_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=file permissive=1
type=AVC msg=audit(08/09/2023 03:04:03.671:119) : avc:  denied  { create } for  pid=889 comm=systemd-network name=.#network9498d551e123e9f4 scontext=system_u:system_r:systemd_network_generator_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=file permissive=1

which is renamed later, so in this commit the named transition is changed to an unnamed one.

Resolves: rhbz#2230226