### PR TITLE
Allow ssh_agent_type manage generic cache home files

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -748,6 +748,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gnome_manage_generic_cache_files(ssh_agent_type)
+')
+
+optional_policy(`
 	xserver_use_xdm_fds(ssh_agent_type)
 	xserver_rw_xdm_pipes(ssh_agent_type)
 ')


### PR DESCRIPTION
This permission is required when a confined user adds a key from a smartcard to the ssh agent which subsequently caches the results in the user's home cache file. With using the ssh_agent_type attribute, the permission is allowed for user_t, staff_t, and sysadm_t.

Resolves: rhbz#2177704