### PR TITLE
Allow fedora-third-party get generic filesystem attributes

### DIFF
--- a/policy/modules/contrib/fedoratp.te
+++ b/policy/modules/contrib/fedoratp.te
@@ -27,6 +27,8 @@ files_manage_generic_tmp_files(fedoratp_t)
 files_manage_var_lib_dirs(fedoratp_t)
 files_manage_var_lib_files(fedoratp_t)
 
+fs_getattr_xattr_fs(fedoratp_t)
+
 sysnet_dns_name_resolve(fedoratp_t)
 
 term_use_unallocated_ttys(fedoratp_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/28/23 12:12:59.710:717) : proctitle=flatpak remotes --system --show-disabled --columns=name,filter,options type=SYSCALL msg=audit(08/28/23 12:12:59.710:717) : arch=x86_64 syscall=fstatfs success=no exit=EACCES(Permission denied) a0=0x9 a1=0x7ffebf4d0570 a2=0x0 a3=0x0 items=0 ppid=1982 pid=1987 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=tty1 ses=unset comm=flatpak exe=/usr/bin/flatpak subj=system_u:system_r:fedoratp_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(08/28/23 12:12:59.710:717) : avc:  denied  { getattr } for  pid=1987 comm=flatpak name=/ dev="vda3" ino=256 scontext=system_u:system_r:fedoratp_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0

Related: rhbz#2234330
 with '#' will be ignored, and an empty message aborts the commit.