### PR TITLE
Allow nm-dispatcher winbind plugin read/write samba var files

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -667,6 +667,7 @@ optional_policy(`
 optional_policy(`
 	samba_domtrans_smbcontrol(NetworkManager_dispatcher_winbind_t)
 	samba_read_config(NetworkManager_dispatcher_winbind_t)
+	samba_rw_var_files(NetworkManager_dispatcher_winbind_t)
 	samba_service_status(NetworkManager_dispatcher_winbind_t)
 ')
 


### PR DESCRIPTION
Samba installs a NetworkManager dispatcher hook which getsd executed by the NetworkManager when network status changes. The hook then runs the testparm command to check whether the configuration has been extended to provide an offline logon support. In FreeIPA environment, this means looking into the Samba registry which is stored in the /var/lib/samba/registry.tdb file.

The commit addresses the following AVC denial example: type=AVC msg=audit(1690250776.237:4271): avc:  denied  { read write } for  pid=15249 comm="testparm" name="registry.tdb" dev="vda5" ino=215804 scontext=system_u:system_r:NetworkManager_dispatcher_winbind_t:s0 tcontext=unconfined_u:object_r:samba_var_t:s0 tclass=file permissive=1

Resolves: rhbz#2225377