### PR TITLE
Allow sssd use usb devices conditionally

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -21,6 +21,13 @@ gen_tunable(sssd_access_kernel_keys, false)
 ## </desc>
 gen_tunable(sssd_connect_all_unreserved_ports, false)
 
+## <desc>
+## <p>
+##	Allow sssd use usb devices
+## </p>
+## </desc>
+gen_tunable(sssd_use_usb, false)
+
 type sssd_t;
 type sssd_exec_t;
 init_daemon_domain(sssd_t, sssd_exec_t)
@@ -180,6 +187,10 @@ tunable_policy(`sssd_access_kernel_keys',`
 
 tunable_policy(`sssd_connect_all_unreserved_ports',`
 	corenet_tcp_connect_all_unreserved_ports(sssd_t)
+')
+
+tunable_policy(`sssd_use_usb',`
+	dev_rw_generic_usb_dev(sssd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The sssd service was allowed to read and write usb devices when the "sssd_use_usb" boolean is turned on. The boolean is off by default. The permissions are needed for passkeys integration using FIDO2 tokens.

The commit addresses the following AVC denial:
type=AVC msg=audit(1688990400.922:161): avc:  denied  { read write } for  pid=3108 comm="passkey_child" name="hidraw1" dev="devtmpfs" ino=994 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:object_r:usb_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2223989