### PR TITLE
Allow kdump create and use its memfd: objects

### DIFF
--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -31,6 +31,9 @@ files_lock_file(kdump_lock_t)
 type kdump_log_t;
 logging_log_file(kdump_log_t)
 
+type kdump_tmpfs_t;
+files_tmpfs_file(kdump_tmpfs_t)
+
 type kdumpctl_t;
 type kdumpctl_exec_t;
 init_daemon_domain(kdumpctl_t, kdumpctl_exec_t)
@@ -63,6 +66,9 @@ manage_dirs_pattern(kdump_t, kdump_lock_t, kdump_lock_t)
 manage_files_pattern(kdump_t, kdump_lock_t, kdump_lock_t)
 manage_lnk_files_pattern(kdump_t, kdump_lock_t, kdump_lock_t)
 files_lock_filetrans(kdump_t, kdump_lock_t, { dir file lnk_file })
+
+manage_files_pattern(kdump_t, kdump_tmpfs_t, kdump_tmpfs_t)
+fs_tmpfs_filetrans(kdump_t, kdump_tmpfs_t, file)
 
 files_manage_generic_tmp_files(kdump_t)
 files_read_etc_runtime_files(kdump_t)


### PR DESCRIPTION
These permissions are required sinc3 kexec-tools v2.0.27. The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/01/2023 06:17:18.196:81) : proctitle=/sbin/kexec -s -d -p --command-line=BOOT_IMAGE=(hd0,gpt2)/vmlinuz-6.6.0-0.rc0.20230830git6c1b980a7e79.1.fc40.x86_64 ro rootflags type=SYSCALL msg=audit(09/01/2023 06:17:18.196:81) : arch=x86_64 syscall=write success=yes exit=14584456 a0=0x3 a1=0x7f813e417010 a2=0xde8a88 a3=0x22 items=0 ppid=795 pid=1208 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=kexec exe=/usr/sbin/kexec subj=system_u:system_r:kdump_t:s0 key=(null) type=AVC msg=audit(09/01/2023 06:17:18.196:81) : avc:  denied  { write } for  pid=1208 comm=kexec path=/memfd:kernel (deleted) dev="tmpfs" ino=2051 scontext=system_u:system_r:kdump_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1