### PR TITLE
Allow sysadm_t to mmap modules_object_t files

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -45,6 +45,7 @@ domain_dontaudit_read_all_domains_state(sysadm_t)
 domain_read_view_all_domains_keyrings(sysadm_t)
 
 files_read_kernel_modules(sysadm_t)
+files_map_kernel_modules(sysadm_t)
 files_filetrans_named_content(sysadm_t)
 files_status_etc(sysadm_t)
 files_unconfined(sysadm_t)


### PR DESCRIPTION
Need to allow sysadm_t to mmap modules_object_t files as root user runs in sysadm_t domain when mls is used while it runs in unconfined_t domain with targeted policy.