### PR TITLE
Allow login_userdomain watch video4linux devices

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5873,6 +5873,24 @@ interface(`dev_write_video_dev',`
 
 ########################################
 ## <summary>
+##	Watch the video4linux devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_watch_video_dev',`
+	gen_require(`
+		type device_t, v4l_device_t;
+	')
+
+	watch_chr_files_pattern($1, device_t, v4l_device_t)
+')
+
+########################################
+## <summary>
 ##	Get the attributes of vfio devices.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -394,6 +394,7 @@ auth_watch_passwd(login_userdomain)
 corecmd_watch_bin_dirs(login_userdomain)
 
 dev_watch_generic_dirs(login_userdomain)
+dev_watch_video_dev(login_userdomain)
 
 files_map_var_lib_files(login_userdomain)
 files_read_var_lib_symlinks(login_userdomain)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(5.9.2023 12:07:57.565:168) : proctitle=/usr/bin/wireplumber type=PATH msg=audit(5.9.2023 12:07:57.565:168) : item=0 name=/dev/video0 inode=897 dev=00:05 mode=character,660 ouid=root ogid=video rdev=51:00 obj=system_u:object_r:v4l_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(5.9.2023 12:07:57.565:168) : arch=x86_64 syscall=inotify_add_watch success=yes exit=1 a0=0x21 a1=0x7ffc93bd14e0 a2=0xc a3=0x0 items=1 ppid=2042 pid=2276 auid=zpytela uid=zpytela gid=zpytela euid=zpytela suid=zpytela fsuid=zpytela egid=zpytela sgid=zpytela fsgid=zpytela tty=(none) ses=3 comm=wireplumber exe=/usr/bin/wireplumber subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(5.9.2023 12:07:57.565:168) : avc:  denied  { watch } for  pid=2276 comm=wireplumber path=/dev/video0 dev="devtmpfs" ino=897 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:v4l_device_t:s0 tclass=chr_file permissive=1

The dev_watch_video_dev() interface was added.