### PR TITLE
Allow systemd-networkd write to cgroup files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -558,6 +558,7 @@ corenet_udp_bind_dhcpd_port(systemd_networkd_t)
 
 fs_read_xenfs_files(systemd_networkd_t)
 fs_read_nsfs_files(systemd_networkd_t)
+fs_write_cgroup_files(systemd_networkd_t)
 
 dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)


### PR DESCRIPTION
This is a follow-up commit to commits 86aa9d597 ("Allow some systemd services write to cgroup files") and 45c3cb8cb ("Allow journald write to cgroup files").

This commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/06/2023 10:28:28.752:509) : proctitle=/usr/lib/systemd/systemd-networkd type=PATH msg=audit(09/06/2023 10:28:28.752:509) : item=0 name=/proc/self/fd/7 inode=5395 dev=00:1a mode=file,644 ouid=systemd-network ogid=systemd-network rdev=00:00 obj=system_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/06/2023 10:28:28.752:509) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffc8bcb2f50 a2=O_RDWR|O_NOCTTY|O_NONBLOCK|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=3993 auid=unset uid=systemd-network gid=systemd-network euid=systemd-network suid=systemd-network fsuid=systemd-network egid=systemd-network sgid=systemd-network fsgid=systemd-network tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-networkd subj=system_u:system_r:systemd_networkd_t:s0 key=(null) type=AVC msg=audit(09/06/2023 10:28:28.752:509) : avc:  denied  { write } for  pid=3993 comm=systemd-network name=memory.pressure dev="cgroup2" ino=5395 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=0