### PR TITLE
Allow ssh_agent_type create a sockfile in /run/USER

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -91,6 +91,7 @@ type ssh_agent_tmp_t;
 typealias ssh_agent_tmp_t alias { user_ssh_agent_tmp_t staff_ssh_agent_tmp_t sysadm_ssh_agent_tmp_t };
 typealias ssh_agent_tmp_t alias { auditadm_ssh_agent_tmp_t secadm_ssh_agent_tmp_t };
 userdom_user_tmp_file(ssh_agent_tmp_t)
+userdom_user_tmp_filetrans(ssh_agent_type, ssh_agent_tmp_t, sock_file)
 
 type ssh_keysign_t;
 type ssh_keysign_exec_t;


### PR DESCRIPTION
This commit adds a file transition which applies to process types which are in the ssh-agent typeattribute, so the /run/user/1000/ssh-agent.socket file is created with the ssh_agent_tmp_t type.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(5.9.2023 12:07:59.736:170) : proctitle=/usr/bin/ssh-agent -a /run/user/1000/ssh-agent.socket type=PATH msg=audit(5.9.2023 12:07:59.736:170) : item=1 name=/run/user/1000/ssh-agent.socket inode=121 dev=00:46 mode=socket,600 ouid=zpytela ogid=zpytela rdev=00:00 obj=staff_u:object_r:user_tmp_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(5.9.2023 12:07:59.736:170) : item=0 name=/run/user/1000/ inode=1 dev=00:46 mode=dir,700 ouid=zpytela ogid=zpytela rdev=00:00 obj=staff_u:object_r:user_tmp_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(5.9.2023 12:07:59.736:170) : saddr={ saddr_fam=local path=/run/user/1000/ssh-agent.socket } type=SYSCALL msg=audit(5.9.2023 12:07:59.736:170) : arch=x86_64 syscall=bind success=yes exit=0 a0=0x4 a1=0x7ffd04a217e0 a2=0x6e a3=0x0 items=2 ppid=2042 pid=2523 auid=zpytela uid=zpytela gid=zpytela euid=zpytela suid=zpytela fsuid=zpytela egid=zpytela sgid=zpytela fsgid=zpytela tty=(none) ses=3 comm=ssh-agent exe=/usr/bin/ssh-agent subj=staff_u:staff_r:staff_ssh_agent_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(5.9.2023 12:07:59.736:170) : avc:  denied  { create } for  pid=2523 comm=ssh-agent name=ssh-agent.socket scontext=staff_u:staff_r:staff_ssh_agent_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:user_tmp_t:s0 tclass=sock_file permissive=1