### PR TITLE
Add additions to dnsmasq interface

### DIFF
--- a/policy/modules/contrib/dnsmasq.if
+++ b/policy/modules/contrib/dnsmasq.if
@@ -215,7 +215,6 @@ interface(`dnsmasq_manage_config',`
 	files_search_etc($1)
 	allow $1 dnsmasq_etc_t:dir manage_dir_perms;
 	allow $1 dnsmasq_etc_t:file manage_file_perms;
-	allow $1 dnsmasq_etc_t:lnk_file read_lnk_file_perms;
 ')
 
 ########################################

--- a/policy/modules/contrib/dnsmasq.if
+++ b/policy/modules/contrib/dnsmasq.if
@@ -193,7 +193,7 @@ interface(`dnsmasq_read_config',`
 
 	files_search_etc($1)
 	allow $1 dnsmasq_etc_t:dir list_dir_perms;
-	read_files_pattern($1, dnsmasq_etc_t, dnsmasq_etc_t)
+	allow $1 dnsmasq_etc_t:file read_file_perms;
 ')
 
 ########################################
@@ -235,7 +235,7 @@ interface(`dnsmasq_write_config',`
 
 	files_search_etc($1)
 	allow $1 dnsmasq_etc_t:dir list_dir_perms;
-	write_files_pattern($1, dnsmasq_etc_t, dnsmasq_etc_t)
+	allow $1 dnsmasq_etc_t:file write_file_perms;
 ')
 
 ########################################

--- a/policy/modules/contrib/dnsmasq.if
+++ b/policy/modules/contrib/dnsmasq.if
@@ -177,7 +177,8 @@ interface(`dnsmasq_kill',`
 
 ########################################
 ## <summary>
-##	Read dnsmasq config files.
+##	Allow the specified domain to read
+##	dnsmasq configuration files.
 ## </summary>
 ## <param name="domain">
 ## <summary>
@@ -190,13 +191,37 @@ interface(`dnsmasq_read_config',`
 		type dnsmasq_etc_t;
 	')
 
-	read_files_pattern($1, dnsmasq_etc_t, dnsmasq_etc_t)
 	files_search_etc($1)
+	allow $1 dnsmasq_etc_t:dir list_dir_perms;
+	read_files_pattern($1, dnsmasq_etc_t, dnsmasq_etc_t)
 ')
 
 ########################################
 ## <summary>
-##	Write dnsmasq config files.
+##	Allow the specified domain to manage
+##	dnsmasq configuration files.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`dnsmasq_manage_config',`
+	gen_require(`
+		type dnsmasq_etc_t;
+	')
+
+	files_search_etc($1)
+	allow $1 dnsmasq_etc_t:dir manage_dir_perms;
+	allow $1 dnsmasq_etc_t:file manage_file_perms;
+	allow $1 dnsmasq_etc_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to write
+##	dnsmasq configuration files.
 ## </summary>
 ## <param name="domain">
 ## <summary>
@@ -209,8 +234,9 @@ interface(`dnsmasq_write_config',`
 		type dnsmasq_etc_t;
 	')
 
-	write_files_pattern($1, dnsmasq_etc_t, dnsmasq_etc_t)
 	files_search_etc($1)
+	allow $1 dnsmasq_etc_t:dir list_dir_perms;
+	write_files_pattern($1, dnsmasq_etc_t, dnsmasq_etc_t)
 ')
 
 ########################################


### PR DESCRIPTION
Hi, please have a look at these suggested changes:

- Allow reading the dnsmasq.d directory that stores additional config files. Currently there's not enough permissions to allow a `read` of the directory.

- Add a new manage_config interface for dnsmasq config files and directory. Thoughts on this one? Only thought to add it for completion sake if someone needed it down the line. How would it affect audit2allow - ie would it recommend this over the write interface which is more restrictive.

- read_lnk_file_perms within dnsmasq_manage_config: I'm not 100% if this is needed. I've seen it sprinkled in other policies for a manage interface and wondered if it would be handy to have it here. Thoughts and guidance?

- Misc comment clean up of dnsmasq.if to make it easier to understand what the interface does.

Thank you.