### PR TITLE
Change systemd-network-generator transition to include the file class

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1214,7 +1214,7 @@ optional_policy(`
 # systemd_network_generator domain
 #
 
-init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, dir)
+init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, dir, "network")
 
 sysnet_manage_config(systemd_network_generator_t)
 sysnet_manage_config_dirs(systemd_network_generator_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1215,6 +1215,7 @@ optional_policy(`
 #
 
 init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, dir, "network")
+init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, file)
 
 sysnet_manage_config(systemd_network_generator_t)
 sysnet_manage_config_dirs(systemd_network_generator_t)


### PR DESCRIPTION
This is a follow-up commit to f1d705ff01 ("Change file transition for systemd-network-generator") as systemd-network-generator actually creates a file in /run/systemd before moving it to /run/systemd/network, see strace log:
renameat(AT_FDCWD</root>, "/run/systemd/.#network8e6806e244d4b87a", AT_FDCWD</root>, "/run/systemd/network/91-default.network") = 0

so the transition needs to be defined also for a file.

Resolves: rhbz#2230226