### PR TITLE
Allow sssd domain transition on passkey_child execution conditionally

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -194,6 +194,12 @@ tunable_policy(`sssd_use_usb',`
 ')
 
 optional_policy(`
+	tunable_policy(`sssd_use_usb',`
+		ipa_domtrans_otpd(sssd_t)
+	')
+')
+
+optional_policy(`
 	accountsd_read_fifo_file(sssd_t)
 ')
 


### PR DESCRIPTION
The sssd_pam process needs to execute /usr/libexec/sssd/passkey_child. This commits allows it when the sssd_use_usb boolean is enabled.

Resolves: rhbz#2238224