### PR TITLE
Set default file context of /var/lib/authselect/backups to <<none>>

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -285,6 +285,8 @@ ifndef(`distro_redhat',`
 
 /var/lib(/.*)?			gen_context(system_u:object_r:var_lib_t,s0)
 
+/var/lib/authselect/backups	<<none>>
+
 /var/lib/nfs/rpc_pipefs(/.*)?	<<none>>
 
 /var/lib/stickshift/.stickshift-proxy.d(/.*)?   gen_context(system_u:object_r:etc_t,s0)


### PR DESCRIPTION
Authselect creates a backup by copying files with preserving all attributes so they can be correctly restored later, therefore files with various types can be stored in authselect's backups directory.

Resolves: rhbz#2230508