### PR TITLE
Allow cupsd_t to use bpf capability

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -140,7 +140,7 @@ optional_policy(`
 
 allow cupsd_t self:capability { ipc_lock sys_admin dac_read_search dac_override kill fsetid fowner chown  sys_resource sys_tty_config };
 dontaudit cupsd_t self:capability { sys_tty_config net_admin };
-allow cupsd_t self:capability2 { block_suspend wake_alarm };
+allow cupsd_t self:capability2 { block_suspend bpf wake_alarm };
 allow cupsd_t self:process { getpgid setpgid setsched };
 allow cupsd_t self:unix_stream_socket { accept connectto listen };
 allow cupsd_t self:netlink_selinux_socket create_socket_perms;


### PR DESCRIPTION
Gutenprint uses libusb which in turn uses libudev in such way that it tries to attach a network filter using the setsocketopt syscall on initialization. However, as gutenprint is started by CUPS deamon with cupsd_t context, the action is denied by the current policy.

This patch adds bpf permission to an already existing allow statement for cupsd_t type under which the gutenprint process is running to fix the issue.

Resolves: https://issues.redhat.com/browse/RHEL-3633