### PR TITLE
Allow prosody read network sysctls

### DIFF
--- a/policy/modules/contrib/prosody.te
+++ b/policy/modules/contrib/prosody.te
@@ -62,6 +62,7 @@ files_tmp_filetrans(prosody_t, prosody_tmp_t, { dir file })
 
 can_exec(prosody_t, prosody_exec_t)
 
+kernel_read_net_sysctls(prosody_t)
 kernel_read_system_state(prosody_t)
 
 corecmd_exec_bin(prosody_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1692544400.418:2108): avc:  denied  { search } for  pid=341290 comm="prosody" name="net" dev="proc" ino=187 scontext=system_u:system_r:prosody_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

which appears when the service wants to read /proc/sys/net/ipv4/ip_local_port_range: jun 20 17:13:20 hostname prosody[341290]: [1692544400] libunbound[341290:0] error: failed to read from file: /proc/sys/net/ipv4/ip_local_port_range (Permission denied)

Resolves: rhbz#2176070