### PR TITLE
Dontaudit rhsmcertd write memory device

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -93,6 +93,7 @@ corenet_tcp_connect_websm_port(rhsmcertd_t)
 corecmd_exec_bin(rhsmcertd_t)
 corecmd_exec_shell(rhsmcertd_t)
 
+dev_dontaudit_write_raw_memory(rhsmcertd_t)
 dev_read_sysfs(rhsmcertd_t)
 dev_read_rand(rhsmcertd_t)
 dev_read_urand(rhsmcertd_t)


### PR DESCRIPTION
Do not audit attempts to write to raw memory devices

lscpu uses  O_RDONLY to read /dev/mem,
but on ppc64 it uses IBM's librtas.so that mmap /dev/mem using O_RDRW for open().

Resolves: RHEL-1547