### PR TITLE
Allow sssd read symlinks in /etc/sssd

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -76,6 +76,7 @@ allow sssd_t self:unix_stream_socket { create_stream_socket_perms connectto };
 allow sssd_t sssd_exec_t:file execute_no_trans;
 
 read_files_pattern(sssd_t, sssd_conf_t, sssd_conf_t)
+read_lnk_files_pattern(sssd_t, sssd_conf_t, sssd_conf_t)
 list_dirs_pattern(sssd_t, sssd_conf_t, sssd_conf_t)
 
 manage_dirs_pattern(sssd_t, sssd_public_t, sssd_public_t)


### PR DESCRIPTION
Previously, sssd was allowed to read only plain configuration files in /etc/sssd. Since this commit it is allowed to read symlinks, too, which supports a scenario where sssd_auth_ca_db.pem points to /etc/ipa/ca.crt so that cert renewals are automatically picked up, with no administrative overhead.

Resolves: https://github.com/SSSD/sssd/issues/6611