### PR TITLE
ci: Fix version number of packit generated srpms

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -1,6 +1,7 @@
 # See https://packit.dev/docs/configuration/
 
 specfile_path: tmp/rpm/selinux-policy.spec
+upstream_tag_template: "v{version}"
 
 actions:
   post-upstream-clone:


### PR DESCRIPTION
Our tags have a `v` prefix. Tell packit about it, so that it generates
correct `Version:` numbers in the spec.

----

Current TF installability tests currently fails on the "v38" vs. "38" version conflict as in #1843. As this is a separate issue from revdeps testing, and much more urgent, I'm sending a separate PR. I started with an [empty commit](https://github.com/fedora-selinux/selinux-policy/commit/3d669d09954ad1f781d6fd44cfaa37d34fddffe1) which [failed like this](https://artifacts.dev.testing-farm.io/7175381a-4b00-4984-80ff-1d215ac6dc10/).