### PR TITLE
Allow systemd-sleep read/write efivarfs variables

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -6988,6 +6988,25 @@ interface(`fs_read_efivarfs_files',`
 
 #######################################
 ## <summary>
+##	Read and write files in efivarfs
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_rw_efivarfs_files',`
+	gen_require(`
+		type efivarfs_t;
+	')
+
+	rw_files_pattern($1, efivarfs_t, efivarfs_t)
+')
+
+#######################################
+## <summary>
 ##      Manage efivarfs files 
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1515,7 +1515,7 @@ systemd_read_efivarfs(systemd_userdbd_t)
 # systemd_sleep local policy
 #
 
-allow systemd_sleep_t self:capability sys_resource;
+allow systemd_sleep_t self:capability { linux_immutable sys_resource };
 # systemd-sleep needs to set timer for suspend-then-hibernate
 allow systemd_sleep_t self:capability2 wake_alarm;
 dontaudit systemd_sleep_t self:capability sys_ptrace;
@@ -1532,6 +1532,8 @@ corecmd_exec_shell(systemd_sleep_t)
 dev_create_sysfs_files(systemd_sleep_t)
 dev_rw_sysfs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
+
+fs_rw_efivarfs_files(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial examples: type=AVC msg=audit(09/25/2023 04:21:31.281:610) : avc:  denied  { write open } for  pid=18107 comm=systemd-sleep path=/sys/firmware/efi/efivars/HibernateLocation-8cf2644b-4b0b-428f-9387-6d876050dc67 dev="efivarfs" ino=160797 scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:object_r:efivarfs_t:s0 tclass=file permissive=1 type=AVC msg=audit(09/25/2023 05:05:33.538:650) : avc:  denied  { linux_immutable } for  pid=20005 comm=systemd-sleep capability=linux_immutable  scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:system_r:systemd_sleep_t:s0 tclass=capability permissive=1

The fs_rw_efivarfs_files() interface was added.

Resolves: rhbz#2240320