### PR TITLE
Label /dev/gnss[0-9] with gnss_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -42,6 +42,7 @@
 /dev/full		-c	gen_context(system_u:object_r:null_device_t,s0)
 /dev/fw.*		-c	gen_context(system_u:object_r:usb_device_t,s0)
 /dev/gfx		-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
+/dev/gnss[0-9]+		-c	gen_context(system_u:object_r:gnss_device_t,s0)
 /dev/graphics		-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
 /dev/gtrsc.*		-c	gen_context(system_u:object_r:clock_device_t,s0)
 /dev/hfmodem		-c	gen_context(system_u:object_r:sound_device_t,s0)

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -141,6 +141,12 @@ type hypervvssd_device_t;
 dev_node(hypervvssd_device_t)
 
 #
+# Type for /dev/gnss0
+#
+type gnss_device_t;
+dev_node(gnss_device_t)
+
+#
 # Type for /dev/ss0
 #
 type gpfs_device_t;


### PR DESCRIPTION
Global Navigation Satellite System (GNSS) kernel subsystem used by GPS devices was added to kernel, exposing a character-device interface (e.g. /dev/gnss0) to user space.
The E810-XXVDA4T NIC is an example of a NIC containing the GNSS module.

This commit labels the device file with the gnss_device_t type.

Resolves: https://issues.redhat.com/browse/RHEL-9936