### PR TITLE
Allow sssd send SIGKILL to passkey_child running in ipa_otpd_t

### DIFF
--- a/policy/modules/contrib/ipa.if
+++ b/policy/modules/contrib/ipa.if
@@ -42,6 +42,27 @@ ifndef(`ipa_stream_connect_otpd',`
 
 ########################################
 ## <summary>
+##	Send sigkill to ipa-otpd.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+#
+ifndef(`ipa_sigkill_otpd',`
+	interface(`ipa_sigkill_otpd',`
+		gen_require(`
+			type ipa_otpd_t;
+		')
+
+		allow $1 ipa_otpd_t:process sigkill;
+	')
+')
+
+########################################
+## <summary>
 ##	Connect to ipa-ods-exporter over a unix stream socket.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -242,6 +242,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ipa_sigkill_otpd(sssd_t)
+')
+
+optional_policy(`
 	ldap_stream_connect(sssd_t)
 	ldap_read_certs(sssd_t)
 ')


### PR DESCRIPTION
The sssd service uses SIGKILL to communicate between different components, in this case sssd_pam, running in the sssd_t domain, and passkey_child, running in the ipa_otpd_t domain.

This commit addresses the following AVC denial:
type=AVC msg=audit(1695299812.149:579): avc:  denied  { sigkill } for  pid=940 comm="sssd_pam" scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:ipa_otpd_t:s0 tclass=process permissive=1

Resolves: rhbz#2240193