### PR TITLE
Allow systemd-localed create Xserver config dirs

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -963,6 +963,25 @@ interface(`xserver_manage_config',`
 
 ########################################
 ## <summary>
+##	Create xserver configuration dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xserver_create_config_dirs',`
+	gen_require(`
+		type xserver_etc_t;
+	')
+
+	files_search_etc($1)
+	manage_dirs_pattern($1, xserver_etc_t, xserver_etc_t)
+')
+
+########################################
+## <summary>
 ##	Read xdm-writable configuration files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -863,6 +863,7 @@ systemd_read_efivarfs(systemd_localed_t)
 
 userdom_dbus_send_all_users(systemd_localed_t)
 
+xserver_create_config_dirs(systemd_localed_t)
 xserver_manage_config(systemd_localed_t)
 
 optional_policy(`


### PR DESCRIPTION
systemd-localed manages the X11 keyboard configuration in the /etc/X11/xorg.conf.d/00-keyboard.conf file. This file isn't used just for X11, but is canonically parsed by various Wayland-based tools and such in order to obtain the XKB keyboard layout config (yay legacy).

This works fine if /etc/X11/xorg.conf.d exists which is true when the xorg-x11-server-Xorg package is installed. Since the file is shared with Wayland-based systems, too, systemd-localed needs to be able to create both the file and directory also when Xorg packages are not installed, like in Fedora Asahi Remix images.

The xserver_create_config_dirs() interface was added.

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(09/22/2023 02:50:04.280:504) : proctitle=/usr/lib/systemd/systemd-localed
type=PATH msg=audit(09/22/2023 02:50:04.280:504) : item=1 name=/etc/X11/xorg.conf.d inode=262180 dev=fc:02 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:xserver_etc_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(09/22/2023 02:50:04.280:504) : item=0 name=/etc/X11/ inode=137769 dev=fc:02 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:etc_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(09/22/2023 02:50:04.280:504) : cwd=/
type=SYSCALL msg=audit(09/22/2023 02:50:04.280:504) : arch=x86_64 syscall=mkdirat success=yes exit=0 a0=AT_FDCWD a1=0x5621a26be0ea a2=0755 a3=0x0 items=2 ppid=1 pid=1726 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-localed exe=/usr/lib/systemd/systemd-localed subj=system_u:system_r:systemd_localed_t:s0 key=(null)
type=AVC msg=audit(09/22/2023 02:50:04.280:504) : avc:  denied  { create } for  pid=1726 comm=systemd-localed name=xorg.conf.d scontext=system_u:system_r:systemd_localed_t:s0 tcontext=system_u:object_r:xserver_etc_t:s0 tclass=dir permissive=1

Resolves: rhbz#2240159