### PR TITLE
Set default file context of HOME_DIR/tmp/.* to <<none>>

### DIFF
--- a/policy/modules/system/userdomain.fc
+++ b/policy/modules/system/userdomain.fc
@@ -23,6 +23,7 @@ HOME_DIR/\.texlive2013(/.*)?		gen_context(system_u:object_r:texlive_home_t,s0)
 HOME_DIR/\.texlive2014(/.*)?		gen_context(system_u:object_r:texlive_home_t,s0)
 HOME_DIR/\.tmp			-d	gen_context(system_u:object_r:user_tmp_t,s0)
 HOME_DIR/tmp			-d	gen_context(system_u:object_r:user_tmp_t,s0)
+HOME_DIR/tmp/.*		<<none>>
 
 /tmp/\.X0-lock		--	gen_context(system_u:object_r:user_tmp_t,s0)
 /tmp/\.X11-unix(/.*)?		gen_context(system_u:object_r:user_tmp_t,s0)


### PR DESCRIPTION
Until now, there was only an entry for a HOME_DIR/tmp directory which means the default context for file in this users' tmp directory is the inherited user_home_t type which is not correct.

The commit addresses the following issue:
restorecon -Frnv /home/username/tmp
Would relabel /home/username/tmp/foo from unconfined_u:object_r:user_tmp_t:s0 to unconfined_u:object_r:user_home_t:s0

Resolves: https://issues.redhat.com/browse/RHEL-1099