### PR TITLE
Allow kernel_generic_helper_t to execute mount(1)

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -364,6 +364,13 @@ corecmd_bin_domtrans(kernel_t, kernel_generic_helper_t)
 
 allow kernel_generic_helper_t kernel_t:fifo_file read_inherited_fifo_file_perms;
 
+# Enable running `/usr/bin/env [u]mount ...` to support ZFS automounting.
+# See the module/os/linux/zfs/zfs_ctldir.c file in
+# https://github.com/openzfs/zfs/ for the usermode helper calls.
+optional_policy(`
+	mount_domtrans(kernel_generic_helper_t)
+')
+
 domain_use_all_fds(kernel_t)
 domain_signal_all_domains(kernel_t)
 domain_search_all_domains_state(kernel_t)


### PR DESCRIPTION
ZFS executes `/usr/bin/env [u]mount <...>` as a usermode helper, so allow kernel_generic_helper_t to execute mount_exec_t with a transition to mount_t to make it work.

Fixes #1878