### PR TITLE
Allow targetd write to the syslog pid sock_file

### DIFF
--- a/policy/modules/contrib/targetd.te
+++ b/policy/modules/contrib/targetd.te
@@ -111,6 +111,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	logging_write_syslog_pid_socket(targetd_t)
+')
+
+optional_policy(`
 	lvm_domtrans(targetd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/02/2023 06:38:38.833:703) : proctitle=targetd type=PATH msg=audit(10/02/2023 06:38:38.833:703) : item=0 name=/run/systemd/journal/socket inode=48 dev=00:19 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:syslogd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(10/02/2023 06:38:38.833:703) : saddr={ saddr_fam=local path=/run/systemd/journal/socket } type=SYSCALL msg=audit(10/02/2023 06:38:38.833:703) : arch=x86_64 syscall=sendmsg success=no exit=EACCES(Permission denied) a0=0x3 a1=0x7fff65b66ea0 a2=MSG_NOSIGNAL a3=0x60 items=1 ppid=1 pid=10087 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=targetd exe=/usr/bin/python3.12 subj=system_u:system_r:targetd_t:s0 key=(null) type=AVC msg=audit(10/02/2023 06:38:38.833:703) : avc:  denied  { write } for  pid=10087 comm=targetd name=socket dev="tmpfs" ino=48 scontext=system_u:system_r:targetd_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=sock_file permissive=0