### PR TITLE
Add ipa_pki_retrieve_key_exec() interface

### DIFF
--- a/policy/modules/contrib/ipa.if
+++ b/policy/modules/contrib/ipa.if
@@ -385,6 +385,27 @@ ifndef(`ipa_custodia_domtrans',`
 
 ######################################
 ## <summary>
+##	Execute ipa-pki-retrieve-key in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`ipa_pki_retrieve_key_exec',`
+	interface(`ipa_pki_retrieve_key_exec',`
+		gen_require(`
+			type ipa_pki_retrieve_key_exec_t;
+		')
+
+		corecmd_search_bin($1)
+		can_exec($1, ipa_pki_retrieve_key_exec_t)
+	')
+')
+
+######################################
+## <summary>
 ##	Execute ipa_custodia in the caller domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The ipa_pki_retrieve_key_exec() interface was added in the decentralized freeipa selinux module, so adding to selinux-policy, too, so that it can be used by other modules.