### PR TITLE
Allow kdumpctl_t to list all directories with a filesystem type

### DIFF
--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -148,7 +148,7 @@ files_getattr_all_dirs(kdumpctl_t)
 files_delete_kernel(kdumpctl_t)
 
 fs_getattr_all_fs(kdumpctl_t)
-fs_search_all(kdumpctl_t)
+fs_list_all(kdumpctl_t)
 
 application_executable_ioctl(kdumpctl_t)
 


### PR DESCRIPTION
Need to allow kdumpctl_t to list all directories with a filesystem type as the domain is not unconfined when mls is used.


FYI, below is the denial this commit addresses.

type=AVC msg=audit(1572468079.662:192): avc:  denied  { read } for  pid=2205 comm="find" name="/" dev="efivarfs" ino=11307 scontext=system_u:system_r:kdumpctl_t:s0-s15:c0.c1023 tcontext=system_u:object_r:efivarfs_t:s0 tclass=dir permissive=0