### PR TITLE
Allow udev_t to search all directories with a filesystem type

### DIFF
--- a/policy/modules/system/udev.te
+++ b/policy/modules/system/udev.te
@@ -142,6 +142,7 @@ files_search_mnt(udev_t)
 files_list_tmp(udev_t)
 
 fs_getattr_all_fs(udev_t)
+fs_search_all(udev_t)
 fs_list_auto_mountpoints(udev_t)
 fs_list_hugetlbfs(udev_t)
 fs_read_cgroup_files(udev_t)


### PR DESCRIPTION
Need to allow udev_t to search all directories with a filesystem type as the domain is not unconfined when mls is used.


FYI, below are the denials this commit addresses.

type=AVC msg=audit(1590664127.231:15): avc:  denied  { search } for  pid=733 comm="systemd-udevd" name="events" dev="tracefs" ino=1069 scontext=system_u:system_r:udev_t:s0-s15:c0.c1023 tcontext=system_u:object_r:tracefs_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1594228982.636:14): avc:  denied  { search } for  pid=609 comm="systemd-udevd" name="/" dev="efivarfs" ino=128 scontext=system_u:system_r:udev_t:s0-s15:c0.c1023 tcontext=system_u:object_r:efivarfs_t:s0 tclass=dir permissive=0