### PR TITLE
Improve default file context(None) of /var/lib/authselect/backups

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -285,7 +285,7 @@ ifndef(`distro_redhat',`
 
 /var/lib(/.*)?			gen_context(system_u:object_r:var_lib_t,s0)
 
-/var/lib/authselect/backups	<<none>>
+/var/lib/authselect/backups(/.*)?	<<none>>
 
 /var/lib/nfs/rpc_pipefs(/.*)?	<<none>>
 


### PR DESCRIPTION
Following fix improves(commit: 01c6e6f2a08f7bb1f5810d4a556b9b4e6fbfdc8d) the default file context for /var/lib/authselect/backups to all sub objects under this directory to None.`