### PR TITLE
Allow kernel_t to manage and relabel all files

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1765,8 +1765,12 @@ interface(`files_relabel_all_files',`
 	relabel_chr_files_pattern($1, { file_type $2 }, { file_type $2 })
 
 	# satisfy the assertions:
-	seutil_relabelto_bin_policy($1)
-    auth_relabelto_shadow($1)
+	optional_policy(`
+		seutil_relabelto_bin_policy($1)
+	')
+	optional_policy(`
+		auth_relabelto_shadow($1)
+	')
 ')
 
 ########################################

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1841,6 +1841,44 @@ interface(`files_manage_all_files',`
 
 ########################################
 ## <summary>
+##	Manage all block device files on the filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_manage_all_blk_files',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	manage_blk_files_pattern($1, file_type, file_type)
+')
+
+########################################
+## <summary>
+##	Manage all character device files on the filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_manage_all_chr_files',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	manage_chr_files_pattern($1, file_type, file_type)
+')
+
+########################################
+## <summary>
 ##	Grant execute access to all files on the filesystem,
 ##	except the listed exceptions.
 ## </summary>

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -385,6 +385,9 @@ domain_rw_all_sockets(kernel_t)
 domain_obj_id_change_exemption(kernel_t)
 
 files_manage_all_files(kernel_t)
+files_manage_all_blk_files(kernel_t)
+files_manage_all_chr_files(kernel_t)
+files_relabel_all_files(kernel_t)
 # The 'execute' permission on lower inodes is checked against the mounter
 # cred by overlayfs, so we need to grant it to allow overlay mounts created
 # during early boot to work.


### PR DESCRIPTION
Extend the abitlity to manage all files also to character & block device files and also allow relabeling any file.

This is required for early boot overlay mounts to fully work, but may be needed for other legitimate oprations as well.

See also: https://github.com/ostreedev/ostree/pull/3062