### PR TITLE
Add map_read map_write to kernel_prog_run_bpf

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4507,7 +4507,7 @@ interface(`kernel_prog_run_bpf',`
 		type init_t;
 	')
 
-    allow $1 kernel_t:bpf prog_run;
+    allow $1 kernel_t:bpf { map_read map_write prog_run };
 ')
 
 ########################################


### PR DESCRIPTION
Add permissions map_read map_write to interface kernel_prog_run_bpf

Addresses the following denial:

type=PROCTITLE msg=audit(09/08/2023 08:54:15.988:1779) : proctitle=bpftool prog
type=SYSCALL msg=audit(09/08/2023 08:54:15.988:1779) : arch=x86_64 syscall=bpf success=no exit=EACCES(Permission denied) a0=BPF_MAP_GET_FD_BY_ID a1=0x7ffcd6d40250 a2=0xc a3=0x0 items=0 ppid=139832 pid=139833 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=18 comm=bpftool exe=/usr/sbin/bpftool subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(09/08/2023 08:54:15.988:1779) : avc: denied { map_read map_write } for pid=139833 comm=bpftool scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:kernel_t:s0 tclass=bpf permissive=0

Resolves: RHEL-2653