### PR TITLE
Allow apcupsd cgi scripts read /sys

### DIFF
--- a/policy/modules/contrib/apcupsd.te
+++ b/policy/modules/contrib/apcupsd.te
@@ -156,5 +156,7 @@ optional_policy(`
 	corenet_udp_sendrecv_generic_node(apcupsd_cgi_script_t)
 	corenet_udp_sendrecv_all_ports(apcupsd_cgi_script_t)
 
+	dev_read_sysfs(apcupsd_cgi_script_t)
+
 	sysnet_dns_name_resolve(apcupsd_cgi_script_t)
 ')


### PR DESCRIPTION
In particular, reading the /sys/devices/system/cpu/possible file was requested.

The commit addresses the following AVC denials:
type=AVC msg=audit(1696352910.805:100420): avc:  denied  { read } for  pid=1542297 comm="upsimage.cgi" name="possible" dev="sysfs" ino=42 scontext=system_u:system_r:apcupsd_cgi_script_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2242120