### PR TITLE
Label /etc/aliases.lmdb with etc_aliases_t

### DIFF
--- a/policy/modules/contrib/mta.fc
+++ b/policy/modules/contrib/mta.fc
@@ -8,6 +8,7 @@ HOME_DIR/.maildir(/.*)?		gen_context(system_u:object_r:mail_home_rw_t,s0)
 
 /etc/aliases		--	gen_context(system_u:object_r:etc_aliases_t,s0)
 /etc/aliases\.db	--	gen_context(system_u:object_r:etc_aliases_t,s0)
+/etc/aliases\.lmdb	--	gen_context(system_u:object_r:etc_aliases_t,s0)
 /etc/mail(/.*)?			gen_context(system_u:object_r:etc_mail_t,s0)
 /etc/mail/aliases.*	--	gen_context(system_u:object_r:etc_aliases_t,s0)
 /etc/mail/.*\.db	--	gen_context(system_u:object_r:etc_aliases_t,s0)

--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -213,6 +213,7 @@ mta_getattr_spool(postfix_master_t)
 ifdef(`distro_redhat',`
 	# for newer main.cf that uses /etc/aliases
 	mta_manage_aliases(postfix_master_t)
+	mta_map_aliases(postfix_master_t)
 	mta_etc_filetrans_aliases(postfix_master_t)
 ')
 
@@ -329,10 +330,6 @@ corecmd_exec_bin(postfix_local_t)
 
 logging_dontaudit_search_logs(postfix_local_t)
 
-mta_delete_spool(postfix_local_t)
-# Handle vacation script
-mta_send_mail(postfix_local_t)
-
 userdom_read_user_home_content_files(postfix_local_t)
 userdom_exec_user_bin_files(postfix_local_t)
 
@@ -371,6 +368,13 @@ optional_policy(`
 	mailman_manage_data_files(postfix_local_t)
 	mailman_append_log(postfix_local_t)
 	mailman_read_log(postfix_local_t)
+')
+
+optional_policy(`
+	mta_delete_spool(postfix_local_t)
+	mta_map_aliases(postfix_local_t)
+	# Handle vacation script
+	mta_send_mail(postfix_local_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
New postfix starts to use lmdb instead of libdb, so a new filename is used for the compiled database. Additionally, postfix/master needs to be able to map the database file.

Resolves: rhbz#2242898