### PR TITLE
Allow unconfined_domain_type use IORING_OP_URING_CMD on self

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -259,7 +259,7 @@ optional_policy(`
 
 # allow special io_uring features
 allow unconfined_domain_type domain:io_uring override_creds;
-allow unconfined_domain_type self:io_uring sqpoll;
+allow unconfined_domain_type self:io_uring { cmd };
 dev_io_uring_cmd_on_all_dev_nodes(unconfined_domain_type)
 files_io_uring_cmd_on_all_files(unconfined_domain_type)
 


### PR DESCRIPTION
Addresses the following denial:

type=AVC msg=audit(1696506406.082:97818): avc:  denied  { cmd } for  pid=541430 comm="io_uring_passth" path="/dev/ng2n1" dev="devtmpfs" ino=745 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=io_uring permissive=0

Resolves: RHEL-11792