### PR TITLE
Allow sysadm_t to connect to iscsid using a unix domain stream socket

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -366,6 +366,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	iscsi_stream_connect(sysadm_t)
+')
+
+optional_policy(`
 	kerberos_exec_kadmind(sysadm_t)
 	kerberos_filetrans_named_content(sysadm_t)
 ')


### PR DESCRIPTION
Need to allow sysadm_t to connect to iscsid using a unix domain stream socket as root user runs in sysadm_t domain when mls is used while it runs in unconfined_t domain with targeted policy.