### PR TITLE
Allow systemd-fstab-generator read all symlinks

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1982,6 +1982,24 @@ interface(`files_dontaudit_map_all_dirs',`
 
 ########################################
 ## <summary>
+##	Read all lnk_files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_read_all_lnk_files',`
+	gen_require(`
+		attribute file_type;
+	')
+
+	allow $1 file_type:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Get the attributes of all filesystems
 ##	with the type of a file.
 ## </summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1238,6 +1238,7 @@ optional_policy(`
 #
 # systemd_fstab_generator_t 
 #
+allow systemd_fstab_generator_t self:capability dac_override;
 dev_write_sysfs_dirs(systemd_fstab_generator_t)
 
 files_read_etc_files(systemd_fstab_generator_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1242,6 +1242,8 @@ allow systemd_fstab_generator_t self:capability dac_override;
 dev_write_sysfs_dirs(systemd_fstab_generator_t)
 
 files_read_etc_files(systemd_fstab_generator_t)
+files_read_all_lnk_files(systemd_fstab_generator_t)
+files_search_all(systemd_fstab_generator_t)
 
 fstools_exec(systemd_fstab_generator_t)
 


### PR DESCRIPTION
    The fstab-generator canonicalizes paths before creating a mount unit,
    so it needs to be able to read all symlinks.
    This is required in ostree systems which have /home as a symlink to
    /var/home.
    
    Resolves: rhbz#2244878
