### PR TITLE
Label /usr/libexec/selinux/selinux-autorelabel with semanage_exec_t

### DIFF
--- a/policy/modules/system/selinuxutil.fc
+++ b/policy/modules/system/selinuxutil.fc
@@ -36,6 +36,8 @@
 
 /usr/lib/selinux(/.*)?			gen_context(system_u:object_r:policy_src_t,s0)
 
+/usr/libexec/selinux/selinux-autorelabel	--	gen_context(system_u:object_r:semanage_exec_t,s0)
+
 /usr/sbin/load_policy		--	gen_context(system_u:object_r:load_policy_exec_t,s0)
 /usr/sbin/restorecon		--	gen_context(system_u:object_r:setfiles_exec_t,s0)
 /usr/sbin/restorecond		--	gen_context(system_u:object_r:restorecond_exec_t,s0)


### PR DESCRIPTION
The script is executed from the selinux-autorelabel.service.