### PR TITLE
Dontaudit keepalived setattr on keepalived_unconfined_script_exec_t

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -147,6 +147,8 @@ optional_policy(`
 	allow keepalived_t keepalived_unconfined_script_exec_t:dir search_dir_perms;
 	allow keepalived_t keepalived_unconfined_script_exec_t:dir read_file_perms;
 	allow keepalived_t keepalived_unconfined_script_exec_t:file ioctl;
+	dontaudit keepalived_t keepalived_unconfined_script_exec_t:file setattr;
+
 
 	init_dbus_chat(keepalived_unconfined_script_t)
 


### PR DESCRIPTION
Keepalived can be configured to execute periodically a VRRP script. Keepalived does sanity checks on such a script through calling the check_script_secure() function, which internally relies on libmagic magic_file() function which internally opens/reads the file, then closes it and tries restore its access time.

Resolves: RHEL-14029