### PR TITLE
Allow system_mail_t manage exim spool files and dirs

### DIFF
--- a/policy/modules/contrib/mta.te
+++ b/policy/modules/contrib/mta.te
@@ -288,6 +288,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	exim_manage_spool_dirs(system_mail_t)
+	exim_manage_spool_files(system_mail_t)
+')
+
+optional_policy(`
 	fail2ban_append_log(user_mail_domain)
 	fail2ban_dontaudit_leaks(user_mail_domain)
 	fail2ban_rw_inherited_tmp_files(mta_user_agent)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/18/2023 15:34:00.039:457) : proctitle=sendmail -i root type=PATH msg=audit(10/18/2023 15:34:00.039:457) : item=1 name=/var/spool/exim/input/q inode=35651983 dev=fd:01 mode=dir,750 ouid=exim ogid=exim rdev=00:00 obj=system_u:object_r:exim_spool_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(10/18/2023 15:34:00.039:457) : item=0 name=/var/spool/exim/input/ inode=23069062 dev=fd:01 mode=dir,750 ouid=exim ogid=exim rdev=00:00 obj=system_u:object_r:exim_spool_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/18/2023 15:34:00.039:457) : arch=x86_64 syscall=mkdir success=yes exit=0 a0=0x561dccdd0b28 a1=0750 a2=0xffffffffffffff78 a3=0x0 items=2 ppid=25465 pid=25470 auid=root uid=exim gid=exim euid=exim suid=exim fsuid=exim egid=exim sgid=exim fsgid=exim tty=(none) ses=10 comm=sendmail exe=/usr/sbin/exim subj=system_u:system_r:system_mail_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(10/18/2023 15:34:00.039:457) : avc:  denied  { create } for  pid=25470 comm=sendmail name=q scontext=system_u:system_r:system_mail_t:s0-s0:c0.c1023 tcontext=system_u:object_r:exim_spool_t:s0 tclass=dir permissive=1

Resolves: RHEL-14110