### PR TITLE
Remove the lockdown-class rules from the policy

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -3232,7 +3232,6 @@ interface(`dev_read_raw_memory',`
 
 	read_chr_files_pattern($1, device_t, memory_device_t)
 	allow $1 memory_device_t:chr_file map;
-	allow $1 self:lockdown integrity;
 
 	allow $1 self:capability sys_rawio;
 	typeattribute $1 memory_raw_read;
@@ -5757,7 +5756,6 @@ interface(`dev_map_userio_dev',`
 	')
 
 	allow $1 userio_device_t:chr_file map;
-	allow $1 self:lockdown integrity;
 ')
 
 ########################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -7136,7 +7136,6 @@ interface(`fs_rw_tracefs_files',`
 	')
 
 	rw_files_pattern($1, tracefs_t, tracefs_t)
-	allow $1 self:lockdown confidentiality;
 ')
 
 ########################################
@@ -7157,7 +7156,6 @@ interface(`fs_manage_tracefs_dirs',`
 	')
 
 	manage_dirs_pattern($1, tracefs_t, tracefs_t)
-	allow $1 self:lockdown confidentiality;
 ')
 
 ########################################

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -432,7 +432,6 @@ interface(`kernel_load_module',`
 ## </param>
 #
 interface(`kernel_load_unsigned_module',`
-	allow $1 self:lockdown integrity;
 	kernel_load_module($1)
 ')
 
@@ -882,8 +881,6 @@ interface(`kernel_read_debugfs',`
 		type debugfs_t;
 	')
 
-	allow $1 self:lockdown integrity;
-
 	read_files_pattern($1, debugfs_t, debugfs_t)
 	read_lnk_files_pattern($1, debugfs_t, debugfs_t)
 	list_dirs_pattern($1, debugfs_t, debugfs_t)
@@ -921,8 +918,6 @@ interface(`kernel_manage_debugfs',`
 	gen_require(`
 		type debugfs_t;
 	')
-
-	allow $1 self:lockdown integrity;
 
 	manage_files_pattern($1, debugfs_t, debugfs_t)
     manage_dirs_pattern($1,debugfs_t, debugfs_t)
@@ -1469,7 +1464,6 @@ interface(`kernel_read_core_if',`
 	')
 
 	allow $1 self:capability sys_rawio;
-	allow $1 self:lockdown confidentiality;
 	read_files_pattern($1, proc_t, proc_kcore_t)
 	list_dirs_pattern($1, proc_t, proc_t)
 
@@ -4452,7 +4446,6 @@ interface(`kernel_unlabeled_entry_type',`
 #
 interface(`kernel_kexec_load',`
 	allow $1 self:capability sys_boot;
-	allow $1 self:lockdown integrity;
 ')
 
 ########################################
@@ -4471,7 +4464,6 @@ interface(`kernel_write_perf_event',`
 	# the kernel commit 08ef1af4de5f
 	# (perf/core: Fix unconditional security_locked_down() call)
 	# is backported to stable kernels
-	allow $1 self:lockdown confidentiality;
 	allow $1 self:perf_event write_perf_event_perms;
 ')
 
@@ -4488,7 +4480,6 @@ interface(`kernel_write_perf_event',`
 interface(`kernel_manage_perf_event',`
 	allow $1 self:capability2 perfmon;
 	# The confidentiality permission may not be needed, refer to kernel_write_perf_event()
-	allow $1 self:lockdown confidentiality;
 	allow $1 self:perf_event manage_perf_event_perms;
 ')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -251,12 +251,6 @@ files_type(systemd_pstore_var_lib_t)
 allow systemd_logind_t self:capability { chown kill dac_read_search dac_override fowner sys_tty_config sys_admin };
 allow systemd_logind_t self:capability2 block_suspend;
 
-# systemd-logind reads state from /sys/power, which changes output based on
-# whether hibernations is available, which tries to take the lockdown state
-# into account. So the permission is somewhat unnecessary (systemd-logind
-# doesn't actually try to change anything), but it's better to allow it so that
-# systemd-logind sees the right system state.
-allow systemd_logind_t self:lockdown integrity;
 allow systemd_logind_t self:process getcap;
 allow systemd_logind_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow systemd_logind_t self:unix_dgram_socket create_socket_perms;
@@ -1588,8 +1582,6 @@ allow systemd_sleep_t self:capability { linux_immutable sys_resource };
 # systemd-sleep needs to set timer for suspend-then-hibernate
 allow systemd_sleep_t self:capability2 wake_alarm;
 dontaudit systemd_sleep_t self:capability sys_ptrace;
-# systemd-sleep needs the permission to change sleep state
-allow systemd_sleep_t self:lockdown integrity;
 
 allow systemd_sleep_t systemd_unit_file_t:service { start stop };
 

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -30,8 +30,6 @@ interface(`unconfined_domain_noaudit',`
 	allow $1 self:file manage_file_perms;
 	allow $1 self:dir rw_dir_perms;
 
-	allow $1 self:lockdown { confidentiality integrity };
-
 	# Userland object managers
 	allow $1 self:nscd all_nscd_perms;
 	allow $1 self:dbus all_dbus_perms;


### PR DESCRIPTION
A comprehensive fix for all the problems caused by the lockdown SELinux class was rejected by Linus and for the lack of a better option, the consensus upstream was to just remove the class entirely and stop checking anything in the lockdown hook.

The lockdown class was removed from the upstream kernel in the "selinux: remove the SELinux lockdown implementation" commit and is not present any longer in Fedora 36 and newer.

    Related: rhbz#2017848

    Resolves: rhbz#2145266