### PR TITLE
Allow virtnetworkd domain transition on tc command execution

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1885,6 +1885,7 @@ corenet_rw_tun_tap_dev(virtnetworkd_t)
 
 dev_rw_sysfs(virtnetworkd_t)
 
+sysnet_domtrans_ifconfig(virtnetworkd_t)
 sysnet_read_config(virtnetworkd_t)
 
 optional_policy(`


### PR DESCRIPTION
The tc command is from the iproute-tc (Linux Traffic Control utility) package and has the ifconfig_exec_t type, as well as the ip command.

The commit addresses the following issues reported in journal: hostname audit[1112]: AVC avc:  denied  { execute } for  pid=1112 comm="rpc-virtnetwork" name="tc" dev="vda5" ino=71062 scontext=system_u:system_r:virtnetworkd_t:s0 tcontext=system_u:object_r:ifconfig_exec_t:s0 tclass=file permissive=0 hostname virtnetworkd[1112]: Cannot find 'tc' in path: No such file or directory