### PR TITLE
Enable NetworkManager and dhclient to use initramfs-configured DHCP connection

### DIFF
--- a/policy/modules/contrib/networkmanager.if
+++ b/policy/modules/contrib/networkmanager.if
@@ -338,6 +338,7 @@ interface(`networkmanager_manage_pid_files',`
 	files_search_pids($1)
 	manage_dirs_pattern($1, NetworkManager_var_run_t, NetworkManager_var_run_t)
 	manage_files_pattern($1, NetworkManager_var_run_t, NetworkManager_var_run_t)
+	allow $1 NetworkManager_var_run_t:file map;
 ')
 
 ########################################

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -276,6 +276,9 @@ userdom_read_home_certs(NetworkManager_t)
 userdom_read_user_home_content_files(NetworkManager_t)
 userdom_dgram_send(NetworkManager_t)
 
+fs_read_tmpfs_files(NetworkManager_t)
+fs_delete_tmpfs_files(NetworkManager_t)
+
 tunable_policy(`use_nfs_home_dirs',`
     fs_read_nfs_files(NetworkManager_t)
 ')


### PR DESCRIPTION
Need to allow NetworkManager_t to read&delete tmpfs_t files and also allow dhcpc_t to map NetworkManager_var_run_t files so that NetworkManager and dhclient can use initramfs-configured DHCP connection.


FYI, this is related to the following fix in nm-manager:

nm-manager: fix selinux label for dhclient lease file from initramfs
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/abeaf6ffc3cb6a612413ffb389dce1d29bfcb35a

NetworkManager_t needs to read&delete tmpfs_t files because of the following lines for copy_lease() and unlink() in nm-manager.c:

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/src/core/nm-manager.c#L3654-3655
```
        if (copy_lease(initramfs_lease, connection_lease)) {
            unlink(initramfs_lease);
```

And /usr/sbin/dhclient process running in dhcpc_t domain needs to map /var/run/NetworkManager/dhclient-*.lease files with NetworkManager_var_run_t type.