### PR TITLE
Allow  winbind_rpcd_t processes access when samba_export_all_* is on

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -604,6 +604,11 @@ tunable_policy(`samba_export_all_ro',`
     files_dontaudit_list_security_dirs(nmbd_t)
     files_dontaudit_search_security_files(nmbd_t)
     files_dontaudit_read_security_files(nmbd_t)
+    fs_read_noxattr_fs_files(winbind_rpcd_t)
+    files_read_non_security_files(winbind_rpcd_t)
+    files_dontaudit_list_security_dirs(winbind_rpcd_t)
+    files_dontaudit_search_security_files(winbind_rpcd_t)
+    files_dontaudit_read_security_files(winbind_rpcd_t)
 ')
 
 tunable_policy(`samba_export_all_rw',`
@@ -620,6 +625,12 @@ tunable_policy(`samba_export_all_rw',`
     files_dontaudit_list_security_dirs(nmbd_t)
     files_dontaudit_search_security_files(nmbd_t)
     files_dontaudit_read_security_files(nmbd_t)
+    fs_manage_noxattr_fs_files(winbind_rpcd_t)
+    files_manage_non_security_files(winbind_rpcd_t)
+    files_manage_non_security_dirs(winbind_rpcd_t)
+    files_dontaudit_list_security_dirs(winbind_rpcd_t)
+    files_dontaudit_search_security_files(winbind_rpcd_t)
+    files_dontaudit_read_security_files(winbind_rpcd_t)
 ')
 
 userdom_filetrans_home_content(nmbd_t)


### PR DESCRIPTION
This commit expand the commit 7367896085 to include winbind_rpcd_t process to access all samba shares when boolean samba_export_all_rw or samba_export_all_ro is enabled.