### PR TITLE
Allow ntp to bind and connect to ntske port.

### DIFF
--- a/policy/modules/contrib/ntp.te
+++ b/policy/modules/contrib/ntp.te
@@ -99,6 +99,9 @@ corenet_tcp_connect_ntp_port(ntpd_t)
 corenet_sendrecv_ntp_server_packets(ntpd_t)
 corenet_sendrecv_ntp_client_packets(ntpd_t)
 
+corenet_tcp_bind_ntske_port(ntpd_t)
+corenet_tcp_connect_ntske_port(ntpd_t)
+
 corecmd_exec_bin(ntpd_t)
 corecmd_exec_shell(ntpd_t)
 


### PR DESCRIPTION
See: https://bugzilla.redhat.com/show_bug.cgi?id=2246805

https://issues.redhat.com/browse/RHEL-15085