### PR TITLE
Allow rhcd create and write to .run_insights_client_next_boot

### DIFF
--- a/policy/modules/contrib/insights_client.fc
+++ b/policy/modules/contrib/insights_client.fc
@@ -7,6 +7,7 @@
 /etc/insights-client/\.lastupload			--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 /etc/insights-client/\.last-upload\.results		--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 /etc/insights-client/\.registered			--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
+/etc/insights-client/\.run_insights_client_next_boot	--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 /etc/insights-client/\.unregistered			--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 /etc/insights-client/insights-client-egg-release	--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 /etc/insights-client/machine-id				--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -100,6 +100,7 @@ interface(`insights_client_filetrans_named_content',`
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".lastupload")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".last-upload.results")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".registered")
+	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".run_insights_client_next_boot")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".unregistered")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "insights-client-egg-release")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "machine-id")
@@ -164,7 +165,26 @@ interface(`insights_client_read_config',`
 
 	files_search_etc($1)
 	read_files_pattern($1, insights_client_etc_t, insights_client_etc_t)
-	read_files_pattern($1, insights_client_etc_rw_t, insights_client_etc_rw_t)
+	read_files_pattern($1, insights_client_etc_t, insights_client_etc_rw_t)
+')
+
+########################################
+## <summary>
+##	Write insights_client r/w config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_write_config',`
+	gen_require(`
+		type insights_client_etc_t, insights_client_etc_rw_t;
+	')
+
+	files_search_etc($1)
+	write_files_pattern($1, insights_client_etc_t, insights_client_etc_rw_t)
 ')
 
 ########################################

--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -102,6 +102,7 @@ files_status_etc(rhcd_t)
 
 fs_getattr_all_fs(rhcd_t)
 
+init_status(rhcd_t)
 init_view_key(rhcd_t)
 
 libs_exec_ldconfig(rhcd_t)
@@ -149,7 +150,9 @@ optional_policy(`
 
 optional_policy(`
 	insights_client_domtrans(rhcd_t)
+	insights_client_filetrans_named_content(rhcd_t)
 	insights_client_read_config(rhcd_t)
+	insights_client_write_config(rhcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1698765256.045:428): avc:  denied  { write } for  pid=27592 comm="python3" name="insights-client" dev="vda4" ino=17667170 scontext=system_u:system_r:rhcd_t:s0 tcontext=system_u:object_r:insights_client_etc_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1698765256.045:428): avc:  denied  { add_name } for  pid=27592 comm="python3" name=".run_insights_client_next_boot" scontext=system_u:system_r:rhcd_t:s0 tcontext=system_u:object_r:insights_client_etc_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1698765256.045:428): avc:  denied  { create } for  pid=27592 comm="python3" name=".run_insights_client_next_boot" scontext=system_u:system_r:rhcd_t:s0 tcontext=system_u:object_r:insights_client_etc_t:s0 tclass=file permissive=1 type=AVC msg=audit(1698765256.045:428): avc:  denied  { write } for  pid=27592 comm="python3" path="/etc/insights-client/.run_insights_client_next_boot" dev="vda4" ino=17695366 scontext=system_u:system_r:rhcd_t:s0 tcontext=system_u:object_r:insights_client_etc_t:s0 tclass=file permissive=1