### PR TITLE
Allow ntp to bind and connect to ntske port.

### DIFF
--- a/policy/modules/contrib/ntp.te
+++ b/policy/modules/contrib/ntp.te
@@ -99,6 +99,9 @@ corenet_tcp_connect_ntp_port(ntpd_t)
 corenet_sendrecv_ntp_server_packets(ntpd_t)
 corenet_sendrecv_ntp_client_packets(ntpd_t)
 
+corenet_tcp_bind_ntske_port(ntpd_t)
+corenet_tcp_connect_ntske_port(ntpd_t)
+
 corecmd_exec_bin(ntpd_t)
 corecmd_exec_shell(ntpd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/30/2023 04:46:52.693:699) : proctitle=/usr/sbin/ntpd -g -N -u ntp:ntp type=SOCKADDR msg=audit(10/30/2023 04:46:52.693:699) : saddr={ saddr_fam=inet6 laddr=2001:67c:2550:d::7 lport=4460 } type=SYSCALL msg=audit(10/30/2023 04:46:52.693:699) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x4 a1=0x7fdc94003570 a2=0x1c a3=0x4000 items=0 ppid=1 pid=4646 auid=unset uid=ntp gid=ntp euid=ntp suid=ntp fsuid=ntp egid=ntp sgid=ntp fsgid=ntp tty=(none) ses=unset comm=ntpd exe=/usr/sbin/ntpd subj=system_u:system_r:ntpd_t:s0 key=(null) type=AVC msg=audit(10/30/2023 04:46:52.693:699) : avc:  denied  { name_connect } for  pid=4646 comm=ntpd dest=4460 scontext=system_u:system_r:ntpd_t:s0 tcontext=system_u:object_r:ntske_port_t:s0 tclass=tcp_socket permissive=0

The NTP daemon can be configured as a NTS-enabled client or server. For client, appending "server add.rr.eee.ss nts [other options]" to ntp.conf for connecting to an NTS-enabled server will trigger the above AVC denial. For server, append "nts enable" "nts key /path/to/key.pem" "nts cert /path/to/cert.pem" lines in ntp.conf to enable NTS server functionality, which triggers a similar AVC denial attempting to bind to TCP port 4460.

Resolves: #2246805, RHEL-15085