### PR TITLE
Allow fido-device-onboard (FDO) read the crack database

### DIFF
--- a/policy/modules/contrib/fdo.te
+++ b/policy/modules/contrib/fdo.te
@@ -152,4 +152,5 @@ optional_policy(`
 optional_policy(`
 	usermanage_domtrans_passwd(fdo_t)
 	usermanage_domtrans_useradd(fdo_t)
+	usermanage_read_crack_db(fdo_t)
 ')


### PR DESCRIPTION
FDO calls /usr/bin/pwmake (part of libpwquality) which links to libcrack which needs to read its dictionaries. Currently, disk reencryption fails with the following journal entries:
Oct 19 16:21:58 hostname fdo-client-linuxapp[1232]:  2023-10-19T16:21:58.175Z INFO  fdo_client_linuxapp::serviceinfo > Initiating disk re-encryption, disk-label: /dev/vda3, pin: tpm2, config: {}, reencrypt: true Oct 19 16:21:58 hostname audit[1488]: AVC avc:  denied  { search } for  pid=1488 comm="pwmake" name="cracklib" dev="dm-1" ino=164196 scontext=system_u:system_r:fdo_t:s0 tcontext=system_u:object_r:crack_db_t:s0 tclass=dir permissive=0
Oct 19 16:21:58 hostname audit[1488]: SYSCALL arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=7ffd0d8e1000 a2=0 a3=0 items=0 ppid=1477 pid=1488 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="pwmake" exe="/usr/bin/pwmake" subj=system_u:>
Oct 19 16:21:58 hostname fdo-client-linuxapp[1232]:  2023-10-19T16:21:58.256Z ERROR fdo_client_linuxapp              > ServiceInfo failed, error: Error processing returned serviceinfo

Resolves: rhbz#2245935