### PR TITLE
Allow sendmail LDA connect to sendmail MTA

### DIFF
--- a/policy/modules/contrib/sendmail.te
+++ b/policy/modules/contrib/sendmail.te
@@ -45,7 +45,7 @@ dontaudit sendmail_t self:capability net_admin;
 dontaudit sendmail_t self:capability2 block_suspend;
 allow sendmail_t self:process { setsched setpgid setrlimit signal signull };
 allow sendmail_t self:fifo_file rw_fifo_file_perms;
-allow sendmail_t self:unix_stream_socket create_stream_socket_perms;
+allow sendmail_t self:unix_stream_socket { connectto create_stream_socket_perms };
 allow sendmail_t self:unix_dgram_socket create_socket_perms;
 allow sendmail_t self:tcp_socket create_stream_socket_perms;
 allow sendmail_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
This is required by the service from the opensmtpd package.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/25/2023 09:15:55.743:682) : proctitle=sendmail -S -S -i -- mmalik@redhat.com type=PATH msg=audit(10/25/2023 09:15:55.743:682) : item=0 name=/var/run/smtpd.sock inode=1467 dev=00:19 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sendmail_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(10/25/2023 09:15:55.743:682) : saddr={ saddr_fam=local path=/var/run/smtpd.sock } type=SYSCALL msg=audit(10/25/2023 09:15:55.743:682) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x4 a1=0x7fff78c65450 a2=0x6e a3=0x56061c9e6790 items=1 ppid=7455 pid=7523 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=smtpq sgid=smtpq fsgid=smtpq tty=(none) ses=unset comm=smtpctl exe=/usr/sbin/smtpctl subj=system_u:system_r:sendmail_t:s0 key=(null) type=AVC msg=audit(10/25/2023 09:15:55.743:682) : avc:  denied  { connectto } for  pid=7523 comm=smtpctl path=/run/smtpd.sock scontext=system_u:system_r:sendmail_t:s0 tcontext=system_u:system_r:sendmail_t:s0 tclass=unix_stream_socket permissive=1

Resolves: rhbz#2246115