### PR TITLE
Allow rpcbind read network sysctls

### DIFF
--- a/policy/modules/contrib/rpcbind.te
+++ b/policy/modules/contrib/rpcbind.te
@@ -51,6 +51,7 @@ files_var_lib_filetrans(rpcbind_t, rpcbind_var_lib_t, { file dir sock_file })
 
 kernel_read_system_state(rpcbind_t)
 kernel_read_network_state(rpcbind_t)
+kernel_read_net_sysctls(rpcbind_t)
 kernel_request_load_module(rpcbind_t)
 
 corenet_all_recvfrom_netlabel(rpcbind_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/18/2023 03:14:54.068:617) : proctitle=/usr/bin/rpcbind -w -f type=PATH msg=audit(10/18/2023 03:14:54.068:617) : item=0 name=/proc/sys/net/ipv4/ip_local_reserved_ports nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/18/2023 03:14:54.068:617) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f41fdd74da0 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=5169 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpcbind exe=/usr/bin/rpcbind subj=system_u:system_r:rpcbind_t:s0 key=(null) type=AVC msg=audit(10/18/2023 03:14:54.068:617) : avc:  denied  { search } for  pid=5169 comm=rpcbind name=net dev="proc" ino=2308 scontext=system_u:system_r:rpcbind_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

which appears when the service wants to read /proc/sys/net/ipv4/ip_local_reserved_ports: Oct 18 03:32:54 hostname rpcbind[3245]: Unable to open open /proc/sys/net/ipv4/ip_local_reserved_ports.

Resolves: rhbz#2248137