### PR TITLE
Allow ip an explicit domain transition to other domains

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -309,7 +309,9 @@ optional_policy(`
 # Ifconfig local policy
 #
 
+allow ifconfig_t self:bpf { prog_load prog_run };
 allow ifconfig_t self:capability { net_raw net_admin sys_admin sys_tty_config };
+allow ifconfig_t self:capability2 { bpf perfmon };
 allow ifconfig_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execheap execstack };
 allow ifconfig_t self:fd use;
 allow ifconfig_t self:fifo_file rw_fifo_file_perms;
@@ -385,6 +387,8 @@ files_read_etc_files(ifconfig_t)
 files_read_etc_runtime_files(ifconfig_t)
 files_read_usr_files(ifconfig_t)
 
+fs_manage_cgroup_dirs(ifconfig_t)
+fs_rw_cgroup_files(ifconfig_t)
 fs_getattr_xattr_fs(ifconfig_t)
 fs_unmount_xattr_fs(ifconfig_t)
 fs_search_auto_mountpoints(ifconfig_t)
@@ -393,6 +397,7 @@ fs_mount_nsfs(ifconfig_t)
 fs_unmount_nsfs(ifconfig_t)
 
 selinux_dontaudit_getattr_fs(ifconfig_t)
+selinux_compute_create_context(ifconfig_t)
 
 term_dontaudit_use_console(ifconfig_t)
 term_dontaudit_use_all_ttys(ifconfig_t)
@@ -427,6 +432,14 @@ ifdef(`distro_ubuntu',`
 	optional_policy(`
 		unconfined_domain(ifconfig_t)
 	')
+')
+
+optional_policy(`
+	apache_domtrans(ifconfig_t)
+')
+
+optional_policy(`
+	bind_domtrans(ifconfig_t)
 ')
 
 optional_policy(`
@@ -486,6 +499,10 @@ optional_policy(`
 
 optional_policy(`
 	ppp_use_fds(ifconfig_t)
+')
+
+optional_policy(`
+	ssh_domtrans(ifconfig_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The ip-vrf command can be used to manage virtual routing of other network services. This commit backs the use case with allowing an explicit domain transition from ip to httpd, sshd, and named using setexeccon(3) and additionally a few related permissions.

Resolves: RHEL-9981