### PR TITLE
Label /var/run/auditd.state as auditd_var_run_t

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -76,6 +76,7 @@ ifdef(`distro_redhat',`
 /var/run/audit_events	-s	gen_context(system_u:object_r:auditd_var_run_t,mls_systemhigh)
 /var/run/audispd_events	-s	gen_context(system_u:object_r:audisp_var_run_t,mls_systemhigh)
 /var/run/auditd\.pid	--	gen_context(system_u:object_r:auditd_var_run_t,mls_systemhigh)
+/var/run/auditd\.state	--	gen_context(system_u:object_r:auditd_var_run_t,mls_systemhigh)
 /var/run/auditd_sock	-s	gen_context(system_u:object_r:auditd_var_run_t,mls_systemhigh)
 /var/run/klogd\.pid	--	gen_context(system_u:object_r:klogd_var_run_t,s0)
 /var/run/log		-s	gen_context(system_u:object_r:devlog_t,s0)


### PR DESCRIPTION
/var/run/auditd.state is used by auditd to dump its internal state upon user request. When created, it has correct type. However, when relabeled, its type changes to var_run_t and auditd cannot access it anymore.

Resolves: RHEL-14374