### PR TITLE
ci: Only run Rawhide revdeps tests on the rawhide branch

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -25,7 +25,6 @@ jobs:
         message: "Cockpit tests failed for commit {commit_sha}. @martinpitt, @jelly, @mvollmer please check."
     targets:
     - fedora-development
-    - fedora-latest-stable
     tf_extra_params:
       environments:
         - artifacts:


### PR DESCRIPTION
The rawhide branch stopped working on Fedora 39.

---

See discussion in https://github.com/fedora-selinux/selinux-policy/pull/1931#issuecomment-1804189986