### PR TITLE
Allow dovecot-auth work with PrivateTmp

### DIFF
--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -324,6 +324,10 @@ optional_policy(`
 	postfix_search_spool(dovecot_auth_t)
 ')
 
+optional_policy(`
+	systemd_private_tmp(dovecot_auth_tmp_t)
+')
+
 ########################################
 #
 # dovecot deliver local policy

--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -200,5 +200,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_private_tmp(kdumpctl_tmp_t)
+')
+
+optional_policy(`
 	unconfined_domain(kdumpctl_t)
 ')


### PR DESCRIPTION
In particular, assign dovecot_auth_t to the systemd_private_tmp_type attribute.

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(22.09.2023 08:55:07.987:16989) : proctitle=/usr/lib/systemd/systemd --switched-root --system --deserialize=35
type=PATH msg=audit(22.09.2023 08:55:07.987:16989) : item=1 name=krb5_97.rcache2 inode=1180153 dev=fd:02 mode=file,600 ouid=dovecot ogid=dovecot rdev=00:00 obj=system_u:object_r:dovecot_auth_tmp_t:s0 nametype=DELETE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(22.09.2023 08:55:07.987:16989) : item=0 name=/ inode=1179778 dev=fd:02 mode=dir,sticky,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:tmp_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(22.09.2023 08:55:07.987:16989) : arch=x86_64 syscall=unlinkat success=no exit=EACCES(Prístup odmietnutý) a0=0x74 a1=0x7fe830008c83 a2=0x0 a3=0x4 items=2 ppid=0 pid=1 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd exe=/usr/lib/systemd/systemd subj=system_u:system_r:init_t:s0 key=(null)
type=AVC msg=audit(22.09.2023 08:55:07.987:16989) : avc:  denied  { unlink } for  pid=1 comm=systemd name=krb5_97.rcache2 dev="dm-2" ino=1180153 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:dovecot_auth_tmp_t:s0 tclass=file permissive=0

Resolves: rhbz#2216408