### PR TITLE
Add rpc.nfsd the lease capability

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -236,7 +236,7 @@ optional_policy(`
 # NFSD local policy
 #
 
-allow nfsd_t self:capability { dac_read_search dac_override sys_admin sys_chroot sys_rawio sys_resource };
+allow nfsd_t self:capability { dac_read_search dac_override lease sys_admin sys_chroot sys_rawio sys_resource };
 
 allow nfsd_t self:process { setcap };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(22.09.2023 08:55:06.703:16943) : proctitle=/usr/sbin/rpc.nfsd 0 type=SYSCALL msg=audit(22.09.2023 08:55:06.703:16943) : arch=x86_64 syscall=write success=yes exit=2 a0=0x3 a1=0x55cd1ed16c60 a2=0x2 a3=0x0 items=0 ppid=1 pid=47262 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc.nfsd exe=/usr/sbin/rpc.nfsd subj=system_u:system_r:nfsd_t:s0 key=(null) type=AVC msg=audit(22.09.2023 08:55:06.703:16943) : avc:  denied  { lease } for  pid=47262 comm=rpc.nfsd capability=lease  scontext=system_u:system_r:nfsd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=capability permissive=0

Resolves: rhbz#2216408