### PR TITLE
Allow nfsd get attributes of all filesystems

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -344,6 +344,7 @@ term_filetrans_all_named_dev(kernel_t)
 dev_map_dri(kernel_t)
 dev_map_framebuffer(kernel_t)
 
+fs_getattr_all_fs(kernel_t)
 # Mount root file system. Used when loading a policy
 # from initrd, then mounting the root filesystem
 fs_mount_all_fs(kernel_t)
@@ -494,8 +495,6 @@ optional_policy(`
 	corenet_udp_bind_generic_node(kernel_t)
 	corenet_sendrecv_portmap_client_packets(kernel_t)
 	corenet_sendrecv_generic_server_packets(kernel_t)
-
-	fs_getattr_xattr_fs(kernel_t)
 
 	auth_dontaudit_getattr_shadow(kernel_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1680632459.060:1061): avc:  denied  { getattr } for  pid=1635 comm="nfsd" name="/" dev="tmpfs" ino=1 scontext=system_u:system_r:kernel_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0

Resolves: rhbz#2184456