### PR TITLE
Allow unconfined_domain_type use io_uring cmd on domain

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -258,7 +258,7 @@ optional_policy(`
 # be used on an attribute.
 
 # allow special io_uring features
-allow unconfined_domain_type domain:io_uring override_creds;
+allow unconfined_domain_type domain:io_uring { cmd override_creds };
 allow unconfined_domain_type self:io_uring sqpoll;
 dev_io_uring_cmd_on_all_dev_nodes(unconfined_domain_type)
 files_io_uring_cmd_on_all_files(unconfined_domain_type)


### PR DESCRIPTION
This rule allows unconfined_domain_type to execute ioctl commands on the domain attribute asynchronously using the io_uring interface.

Addresses the following denial:
type=AVC msg=audit(1696444258.396:6393): avc:  denied  { cmd } for  pid=41525 comm="socket-io-cmd.t" path="socket:[230442]" dev="sockfs" ino=230442 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=io_uring permissive=0 type=URINGOP msg=audit(1696444258.396:6393): uring_op=46 success=no exit=-13 items=0 ppid=41524 pid=41525 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null)^]UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"

Resolves: RHEL-11792