### PR TITLE
Allow collectd read udev pid files

### DIFF
--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -100,6 +100,8 @@ init_read_utmp(collectd_t)
 
 logging_send_syslog_msg(collectd_t)
 
+storage_raw_read_fixed_disk_blk_device(collectd_t)
+
 sysnet_dns_name_resolve(collectd_t)
 
 tunable_policy(`use_ecryptfs_home_dirs',`

--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -137,6 +137,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	udev_read_pid_files(collectd_t)
+')
+
+optional_policy(`
 	virt_read_config(collectd_t)
 	virt_stream_connect(collectd_t)
 ')

--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -105,6 +105,30 @@ interface(`storage_dontaudit_setattr_fixed_disk_dev',`
 
 ########################################
 ## <summary>
+##	Allow the caller to directly read from a fixed disk device.
+##	This is extremly dangerous as it can bypass the
+##	SELinux protections for filesystem objects, and
+##	should only be used by trusted domains.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`storage_raw_read_fixed_disk_blk_device',`
+	gen_require(`
+		attribute fixed_disk_raw_read;
+		type fixed_disk_device_t;
+	')
+
+	dev_list_all_dev_nodes($1)
+	allow $1 fixed_disk_device_t:blk_file read_blk_file_perms;
+	typeattribute $1 fixed_disk_raw_read;
+')
+
+########################################
+## <summary>
 ##	Allow the caller to directly read from a fixed disk.
 ##	This is extremly dangerous as it can bypass the
 ##	SELinux protections for filesystem objects, and


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/13/2023 11:36:52.646:207) : proctitle=/usr/sbin/collectd type=PATH msg=audit(11/13/2023 11:36:52.646:207) : item=0 name=/run/udev/data/b259:0 inode=1253 dev=00:1a mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:udev_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(11/13/2023 11:36:52.646:207) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fd79ce6d850 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=1632 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=reader#0 exe=/usr/sbin/collectd subj=system_u:system_r:collectd_t:s0 key=(null) type=AVC msg=audit(11/13/2023 11:36:52.646:207) : avc:  denied  { read } for  pid=1632 comm=reader#0 name=b259:0 dev="tmpfs" ino=1253 scontext=system_u:system_r:collectd_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=0

Resolves: rhbz#2249257