### PR TITLE
Dontaudit systemd-hwdb dac_override capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1190,6 +1190,8 @@ optional_policy(`
 #
 # systemd_hwdb domain
 #
+dontaudit systemd_hwdb_t self:capability dac_override;
+
 manage_files_pattern(systemd_hwdb_t, systemd_hwdb_etc_t, systemd_hwdb_etc_t)
 allow systemd_hwdb_t systemd_hwdb_etc_t:file {relabelfrom relabelto};
 files_etc_filetrans(systemd_hwdb_t, systemd_hwdb_etc_t, file)


### PR DESCRIPTION
When systemd-hwdb creates the /etc/udev/hwdb.bin file, dac_override check appears as a result of calling the linkat() syscall. Despite the AVC, the syscall succeeds and the file is created successfully. This seems to be caused by kernel checks order which would use improving, the proper change in kernel may not be easily achieved though.

This commit dontaudits the dac_override capability. Additionally, a simple workaround is available for environments where it can be used: sysctl -w fs.protected_hardlinks=0

Related: rhbz#2240221