### PR TITLE
Add dhcpcd bpf capability to run bpf programs

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -64,6 +64,7 @@ allow dhcpc_t self:capability { dac_read_search fsetid net_admin net_raw net_bin
 dontaudit dhcpc_t self:capability sys_admin;
 # for access("/etc/bashrc", X_OK) on Red Hat
 dontaudit dhcpc_t self:capability { dac_read_search sys_module };
+allow dhcpc_t self:capability2 bpf;
 allow dhcpc_t self:process { getsched setsched getcap setcap setfscreate setrlimit signal_perms };
 allow dhcpc_t self:cap_userns { net_bind_service };
 


### PR DESCRIPTION
In the dhcpcd service, setsockopt() with the SO_ATTACH_FILTER option raises sk_attach_filter() to run a bpf program.
Running a bpf program requires the BPF capability.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/15/2023 07:47:08.158:358) : proctitle=dhcpcd: [privileged proxy] type=SYSCALL msg=audit(11/15/2023 07:47:08.158:358) : arch=x86_64 syscall=setsockopt success=yes exit=0 a0=0x10 a1=SOL_SOCKET a2=SO_ATTACH_FILTER a3=0x7ffcb13e8be0 items=0 ppid=22764 pid=22765 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=dhcpcd exe=/usr/sbin/dhcpcd subj=system_u:system_r:dhcpc_t:s0 key=(null) type=AVC msg=audit(11/15/2023 07:47:08.158:358) : avc:  denied  { bpf } for  pid=22765 comm=dhcpcd capability=bpf  scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:system_r:dhcpc_t:s0 tclass=capability2 permissive=0

Resolves: RHEL-15326