### PR TITLE
Allow rsync read network sysctls

### DIFF
--- a/policy/modules/contrib/rsync.te
+++ b/policy/modules/contrib/rsync.te
@@ -102,6 +102,7 @@ manage_files_pattern(rsync_t, rsync_var_run_t, rsync_var_run_t)
 files_pid_filetrans(rsync_t, rsync_var_run_t, file)
 
 kernel_read_kernel_sysctls(rsync_t)
+kernel_read_net_sysctls(rsync_t)
 kernel_read_system_state(rsync_t)
 kernel_read_network_state(rsync_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/24/2023 07:57:56.152:118) : proctitle=/usr/bin/rsync --daemon --no-detach type=AVC msg=audit(10/24/2023 07:57:56.152:118) : avc:  denied  { search } for  pid=19262 comm=rsync name=net dev="proc" ino=16558 scontext=system_u:system_r:rsync_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(10/24/2023 07:57:56.152:118) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffda176a530 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=0 ppid=19065 pid=19262 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rsync exe=/usr/bin/rsync subj=system_u:system_r:rsync_t:s0 key=(null)

Resolves: RHEL-14638