### PR TITLE
Allow auditd read all domains process state

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -241,6 +241,7 @@ corenet_sendrecv_audit_server_packets(auditd_t)
 corecmd_exec_bin(auditd_t)
 corecmd_exec_shell(auditd_t)
 
+domain_read_all_domains_state(auditd_t)
 domain_use_interactive_fds(auditd_t)
 
 files_read_etc_files(auditd_t)


### PR DESCRIPTION
This is required by a recently added auditd feature that reads /proc/*/sessionid of (presumably) various processes, namely the one that sent a signal, to get additional information about the process to be included into the audit message.

Reproducible e. g. with a log rotation request like this: kill -USR1 `pidof auditd`

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/19/2023 10:47:09.559:323) : proctitle=/sbin/auditd type=PATH msg=audit(10/19/2023 10:47:09.559:323) : item=0 name=/proc/4187/sessionid inode=30488 dev=00:14 mode=file,444 ouid=root ogid=root rdev=00:00 obj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/19/2023 10:47:09.559:323) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x7ffd03a75470 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=4555 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=auditd exe=/usr/sbin/auditd subj=system_u:system_r:auditd_t:s0 key=(null) type=AVC msg=audit(10/19/2023 10:47:09.559:323) : avc:  denied  { open } for  pid=4555 comm=auditd path=/proc/4187/sessionid dev="proc" ino=30488 scontext=system_u:system_r:auditd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1 type=AVC msg=audit(10/19/2023 10:47:09.559:323) : avc:  denied  { read } for  pid=4555 comm=auditd name=sessionid dev="proc" ino=30488 scontext=system_u:system_r:auditd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1 type=AVC msg=audit(10/19/2023 10:47:09.559:323) : avc:  denied  { search } for  pid=4555 comm=auditd name=4187 dev="proc" ino=28732 scontext=system_u:system_r:auditd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dir permissive=1

Resolves: RHEL-14285