### PR TITLE
Allow systemd-sleep create efivarfs files

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -638,6 +638,7 @@ corenet_tcp_connect_http_port(spamd_update_t)
 corecmd_exec_bin(spamd_update_t)
 corecmd_exec_shell(spamd_update_t)
 
+dev_read_sysfs(spamd_update_t)
 dev_read_urand(spamd_update_t)
 
 domain_use_interactive_fds(spamd_update_t)

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -7026,6 +7026,25 @@ interface(`fs_rw_efivarfs_files',`
 
 #######################################
 ## <summary>
+##      Create efivarfs files 
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_create_efivarfs_files',`
+        gen_require(`
+                type efivarfs_t;
+        ')
+
+        create_files_pattern($1, efivarfs_t, efivarfs_t)
+')
+
+#######################################
+## <summary>
 ##      Manage efivarfs files 
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1548,6 +1548,7 @@ dev_create_sysfs_files(systemd_sleep_t)
 dev_rw_sysfs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
 
+fs_create_efivarfs_files(systemd_sleep_t)
 fs_rw_efivarfs_files(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1700090306.889:353): avc:  denied  { write } for  pid=4539 comm="systemd-sleep" name="/" dev="efivarfs" ino=18441 scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:object_r:efivarfs_t:s0 tclass=dir permissive=0

Resolves: rhbz#2249928