### PR TITLE
Allow all executables bpf map_read and map_write to init

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -581,6 +581,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	init_dontaudit_bpf_map_rw(domain)
 	init_sigchld(domain)
 	init_signull(domain)
 	init_read_machineid(domain)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -3569,6 +3569,24 @@ interface(`init_prog_run_bpf',`
     allow $1 init_t:bpf { map_create map_read map_write prog_load prog_run };
 ')
 
+########################################
+## <summary>
+##	Dontaudit caller domain to map_read/map_write to init.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_dontaudit_bpf_map_rw',`
+	gen_require(`
+		type init_t;
+	')
+
+	dontaudit $1 init_t:bpf { map_read map_write };
+')
+
 #######################################
 ## <summary>
 ##     Allow systemd to watch directories of given type.


### PR DESCRIPTION
These permissions started to be requested after systemd update to v255~rc2 with the new systemd-executor binary.
https://github.com/systemd/systemd/releases/tag/v255-rc2

This commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/23/2023 05:28:41.166:95) : proctitle=/usr/sbin/sshd -D type=PATH msg=audit(11/23/2023 05:28:41.166:95) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=139475 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(11/23/2023 05:28:41.166:95) : item=0 name=/usr/sbin/sshd inode=162518 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sshd_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(11/23/2023 05:28:41.166:95) : argc=2 a0=/usr/sbin/sshd a1=-D type=SYSCALL msg=audit(11/23/2023 05:28:41.166:95) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55ec16ae5b10 a1=0x55ec16ae5bb0 a2=0x55ec16ae58b0 a3=0x55ec16ae5c40 items=2 ppid=1 pid=742 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sshd exe=/usr/sbin/sshd subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(11/23/2023 05:28:41.166:95) : avc:  denied  { map_read map_write } for  pid=742 comm=sshd scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:init_t:s0 tclass=bpf permissive=0

Resolves: rhbz#2250930