### PR TITLE
Allow spamd_update_t read hardware state information

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -638,6 +638,7 @@ corenet_tcp_connect_http_port(spamd_update_t)
 corecmd_exec_bin(spamd_update_t)
 corecmd_exec_shell(spamd_update_t)
 
+dev_read_sysfs(spamd_update_t)
 dev_read_urand(spamd_update_t)
 
 domain_use_interactive_fds(spamd_update_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(22.11.2023 00:00:01.062:16243) : proctitle=/usr/bin/pgrep -f mimedefang type=PATH msg=audit(22.11.2023 00:00:01.062:16243) : item=0 name=/sys/devices/system/node/node0/meminfo inode=4205 dev=00:17 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(22.11.2023 00:00:01.062:16243) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x7ffea7c5d680 a2=O_RDONLY a3=0x0 items=1 ppid=58833 pid=58835 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pgrep exe=/usr/bin/pgrep subj=system_u:system_r:spamd_update_t:s0 key=(null) type=AVC msg=audit(22.11.2023 00:00:01.062:16243) : avc:  denied  { open } for  pid=58835 comm=pgrep path=/sys/devices/system/node/node0/meminfo dev="sysfs" ino=4205 scontext=system_u:system_r:spamd_update_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1 type=AVC msg=audit(22.11.2023 00:00:01.062:16243) : avc:  denied  { read } for  pid=58835 comm=pgrep name=meminfo dev="sysfs" ino=4205 scontext=system_u:system_r:spamd_update_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1

Resolves: rhbz#2251274