### PR TITLE
Allow sudodomain read var auth files

### DIFF
--- a/policy/modules/admin/sudo.te
+++ b/policy/modules/admin/sudo.te
@@ -92,6 +92,7 @@ term_use_ptmx(sudodomain)
 # sudo stores a token in the pam_pid directory
 auth_manage_pam_pid(sudodomain)
 auth_manage_faillog(sudodomain)
+auth_read_var_auth(sudodomain)
 auth_rw_lastlog(sudodomain)
 
 application_signal(sudodomain)


### PR DESCRIPTION
This permission is required when pam is configured to use files in the /var/auth directory with var_auth_t type, e. g. pam_securid using RSA authentication as a part of the pam stack. The failure is reported in journal as:
[...] sudo: PAM unable to dlopen(/usr/lib64/security/pam_securid.so): /var/ace/lib/64bit/libpamrest.so: cannot open shared object file: Permission denied

Resolves: RHEL-16708