### PR TITLE
Update cifs interfaces to include fs_search_auto_mountpoints()

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -1242,6 +1242,7 @@ interface(`fs_list_cifs',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	allow $1 cifs_t:dir list_dir_perms;
 ')
 
@@ -1298,6 +1299,7 @@ interface(`fs_read_cifs_files',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	allow $1 cifs_t:dir list_dir_perms;
 	read_files_pattern($1, cifs_t, cifs_t)
 ')
@@ -1641,6 +1643,7 @@ interface(`fs_read_cifs_symlinks',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	allow $1 cifs_t:dir list_dir_perms;
 	read_lnk_files_pattern($1, cifs_t, cifs_t)
 ')
@@ -1661,6 +1664,7 @@ interface(`fs_read_cifs_named_pipes',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	read_fifo_files_pattern($1, cifs_t, cifs_t)
 ')
 
@@ -1680,6 +1684,7 @@ interface(`fs_read_cifs_named_sockets',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	read_sock_files_pattern($1, cifs_t, cifs_t)
 ')
 
@@ -1743,6 +1748,7 @@ interface(`fs_manage_cifs_dirs',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	allow $1 cifs_t:dir manage_dir_perms;
 ')
 
@@ -1783,6 +1789,7 @@ interface(`fs_manage_cifs_files',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	manage_files_pattern($1, cifs_t, cifs_t)
 ')
 
@@ -1822,6 +1829,7 @@ interface(`fs_manage_cifs_symlinks',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	manage_lnk_files_pattern($1, cifs_t, cifs_t)
 ')
 
@@ -1841,6 +1849,7 @@ interface(`fs_manage_cifs_named_pipes',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	manage_fifo_files_pattern($1, cifs_t, cifs_t)
 ')
 
@@ -1860,6 +1869,7 @@ interface(`fs_manage_cifs_named_sockets',`
 		type cifs_t;
 	')
 
+	fs_search_auto_mountpoints($1)
 	manage_sock_files_pattern($1, cifs_t, cifs_t)
 ')
 


### PR DESCRIPTION
Several cifs interfaces in filesystem.if were updated to have fs_search_auto_mountpoints() in interfaces accessing cifs files, similar to nfs interfaces.

Resolves: RHEL-14072