### PR TITLE
Label /dev/vas with vas_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -152,6 +152,7 @@
 ifdef(`distro_suse', `
 /dev/usbscanner		-c	gen_context(system_u:object_r:scanner_device_t,s0)
 ')
+/dev/vas		-c	gen_context(system_u:object_r:vas_device_t,s0)
 /dev/vmci       -c  gen_context(system_u:object_r:vmci_device_t,s0)
 /dev/vsock       -c  gen_context(system_u:object_r:vsock_device_t,s0)
 /dev/vhci       -c  gen_context(system_u:object_r:vhost_device_t,s0)

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -402,6 +402,9 @@ dev_node(userio_device_t)
 type uhid_device_t;
 dev_node(uhid_device_t)
 
+type vas_device_t;
+dev_node(vas_device_t)
+
 type vfio_device_t;
 dev_node(vfio_device_t)
 


### PR DESCRIPTION
Power9 processor introduced Virtual Accelerator Switchboard (VAS) which allows both userspace and kernel communicate to co-processor (hardware accelerator) referred to as the Nest Accelerator (NX). The NX unit comprises of one or more hardware engines or co-processor types such as 842 compression, GZIP compression and encryption. On power9, userspace applications will have access to only GZIP Compression engine which supports ZLIB and GZIP compression algorithms in the hardware. https://docs.kernel.org/arch/powerpc/vas-api.html