### PR TITLE
Allow thumb_t append to init unix domain stream sockets

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -105,6 +105,8 @@ tunable_policy(`selinuxuser_execmod',`
 	libs_legacy_use_shared_libs(thumb_t)
 ')
 
+init_append_stream_sockets(thumb_t)
+
 libs_dontaudit_setattr_lib_dirs(thumb_t)
 
 logging_send_syslog_msg(thumb_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1701466420.881:575): avc:  denied  { append } for  pid=22070 comm="gdk-pixbuf-thum" path="socket:[25140]" dev="sockfs" ino=25140 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2252637