### PR TITLE
Allow init create and use vsock sockets

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -177,6 +177,7 @@ allow init_t self:capability2 ~{ mac_admin mac_override };
 allow init_t self:cap_userns all_cap_userns_perms;
 allow init_t self:tcp_socket { listen accept };
 allow init_t self:packet_socket create_socket_perms;
+allow init_t self:vsock_socket create_socket_perms;
 allow init_t self:key manage_key_perms;
 allow init_t self:bpf { map_create map_read map_write prog_load prog_run };
 


### PR DESCRIPTION
The commit addresses the following AVC denials:
Oct 05 12:20:55 fedora audit[1]: AVC avc:  denied  { create } for  pid=1 comm="systemd" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=vsock_socket permissive=1 Oct 05 12:20:55 fedora audit[1]: AVC avc:  denied  { bind } for  pid=1 comm="systemd" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=vsock_socket permissive=1 Oct 05 12:20:55 fedora audit[1]: AVC avc:  denied  { connect } for  pid=1 comm="systemd" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=vsock_socket permissive=1 Oct 05 12:20:55 fedora audit[1]: AVC avc:  denied  { getopt } for  pid=1 comm="systemd" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=vsock_socket permissive=1 Oct 05 12:20:55 fedora audit[1]: AVC avc:  denied  { setopt } for  pid=1 comm="systemd" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=vsock_socket permissive=1