### PR TITLE
Allow ddclient send e-mail notifications

### DIFF
--- a/policy/modules/contrib/ddclient.if
+++ b/policy/modules/contrib/ddclient.if
@@ -118,3 +118,37 @@ interface(`ddclient_getattr_pid_files',`
 
 	getattr_files_pattern($1, ddclient_var_run_t, ddclient_var_run_t)
 ')
+
+########################################
+## <summary>
+##	Create objects in the ddclient home directory
+##	with an automatic type transition to a specified type
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="type">
+##	<summary>
+##	The type of the object being created.
+##	</summary>
+## </param>
+## <param name="object">
+##      <summary>
+##      The class of the object being created.
+##      </summary>
+## </param>
+## <param name="name">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`ddclient_var_filetrans',`
+	gen_require(`
+		type ddclient_var_t;
+	')
+
+	filetrans_pattern($1, ddclient_var_t, $2, $3, $4)
+')

--- a/policy/modules/contrib/mta.fc
+++ b/policy/modules/contrib/mta.fc
@@ -16,6 +16,7 @@ ifdef(`distro_redhat',`
 /etc/postfix/aliases.*		gen_context(system_u:object_r:etc_aliases_t,s0)
 ')
 
+/var/cache/ddclient/\.esmtp_queue(/.*)?	gen_context(system_u:object_r:mail_home_rw_t,s0)
 /var/lib/arpwatch/\.esmtp_queue(/.*)?	gen_context(system_u:object_r:mail_home_rw_t,s0)
 
 /root/\.forward		--	gen_context(system_u:object_r:mail_home_t,s0)

--- a/policy/modules/contrib/mta.te
+++ b/policy/modules/contrib/mta.te
@@ -131,6 +131,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ddclient_var_filetrans(system_mail_t, mail_home_rw_t, dir, ".esmtp_queue")
+')
+
+optional_policy(`
 	exim_domtrans(user_mail_domain)
 	exim_manage_log(user_mail_domain)
 	exim_manage_spool_files(user_mail_domain)


### PR DESCRIPTION
Label /var/cache/ddclient/.esmtp_queue as mail_home_rw_t and add file transition so that system_mail_t can create the .esmtp_queue directory in ddclient's home with the correct label which is required when the esmtp package is installed to provide the sendmail rpm-capability.

Resolves: rhbz#2247977