### PR TITLE
Allow gpg read rpm cache

### DIFF
--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -197,6 +197,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rpm_read_db(gpg_t)
+')
+
+optional_policy(`
 	spamassassin_read_spamd_tmp_files(gpg_t)
 ')
 


### PR DESCRIPTION
This permission is required for the usage by insights-client, executing gpg to access data previously created by dnf.

The commit addresses the following denial:
execve("/usr/bin/gpg", ["gpg", "--enable-special-filenames", "--batch", "--no-sk-comments", "--homedir", "/var/cache/dnf/remi-safe-ff04689"..., "--status-fd", "13", "--no-tty", "--charset", "utf8", "--ena ble-progress-filter", "--exit-on-status-write-error", "--ttyname", "/dev/pts/4", "--ttytype", "screen.xterm-256color", "--logger-fd", "15", "--verify", "--", "-&16", "-&18"], 0x7ffdf2897cb0 /* 6 vars */) = 0 [...]
stat("/var/cache/dnf/remi-safe-ff04689114f71b24/pubring", 0x7ffe2297e4b0) = -1 EACCES

Resolves: RHEL-11249