### PR TITLE
Allow gpsd use /dev/gnss devices

### DIFF
--- a/policy/modules/contrib/gpsd.te
+++ b/policy/modules/contrib/gpsd.te
@@ -63,6 +63,8 @@ corenet_sendrecv_gpsd_server_packets(gpsd_t)
 corenet_tcp_bind_gpsd_port(gpsd_t)
 corenet_tcp_sendrecv_gpsd_port(gpsd_t)
 
+dev_rw_gnss(gpsd_t)
+dev_setattr_gnss(gpsd_t)
 dev_read_sysfs(gpsd_t)
 dev_rw_realtime_clock(gpsd_t)
 

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -6648,6 +6648,42 @@ interface(`dev_read_vsock',`
 
 ########################################
 ## <summary>
+##	Allow read/write the gnss device
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_rw_gnss',`
+	gen_require(`
+		type device_t, gnss_device_t;
+	')
+
+	rw_chr_files_pattern($1, device_t, gnss_device_t)
+')
+
+########################################
+## <summary>
+##	Allow setattr the gnss device
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_setattr_gnss',`
+	gen_require(`
+		type device_t, gnss_device_t;
+	')
+
+	setattr_chr_files_pattern($1, device_t, gnss_device_t)
+')
+
+########################################
+## <summary>
 ##	Create all named devices with the correct label
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
With the 1e668a5fe0 ("Label /dev/gnss[0-9] with gnss_device_t") commit, a specific label was assigned to the device nodes, but no domain was allowed to actually use it.

Resolves: RHEL-16676