### PR TITLE
Add support for syslogd unconfined scripts

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -27,6 +27,8 @@
 /usr/lib/systemd/systemd-journald		--	gen_context(system_u:object_r:syslogd_exec_t,s0)
 /usr/lib/systemd/systemd-kmsg-syslogd	--	gen_context(system_u:object_r:syslogd_exec_t,s0)
 
+/usr/libexec/rsyslog(/.*)?	gen_context(system_u:object_r:syslogd_unconfined_script_exec_t,s0)
+
 /usr/centreon/log(/.*)?	gen_context(system_u:object_r:var_log_t,s0)
 
 /usr/sbin/audispd	--	gen_context(system_u:object_r:audisp_exec_t,s0)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -114,6 +114,12 @@ mls_trusted_object(syslogd_t)
 type syslogd_initrc_exec_t;
 init_script_file(syslogd_initrc_exec_t)
 
+type syslogd_unconfined_script_t;
+type syslogd_unconfined_script_exec_t;
+role system_r types syslogd_unconfined_script_t;
+application_domain(syslogd_unconfined_script_t, syslogd_unconfined_script_exec_t)
+domtrans_pattern(syslogd_t, syslogd_unconfined_script_exec_t, syslogd_unconfined_script_t)
+
 type syslogd_tmp_t;
 files_tmp_file(syslogd_tmp_t)
 
@@ -801,3 +807,13 @@ ifdef(`hide_broken_symptoms',`
 ')
 
 logging_stream_connect_syslog(syslog_client_type)
+
+########################################
+#
+# syslogd_unconfined_script_t local policy
+#
+
+optional_policy(`
+	unconfined_domain(syslogd_unconfined_script_t)
+
+')


### PR DESCRIPTION
With using the omprog keyword (Program integration Output module), rsyslog can be configured to execute arbitrary commands as a part of its processing. This commit labels files in the /usr/libexec/rsyslog path with the syslogd_unconfined_script_exec_t type and defines a transition to the syslogd_unconfined_script_t domain which is unconfined.

Resolves: RHEL-10087