### PR TITLE
Allow opafm search nfs directories

### DIFF
--- a/policy/modules/contrib/opafm.te
+++ b/policy/modules/contrib/opafm.te
@@ -47,6 +47,8 @@ dev_rw_infiniband_mgmt_dev(opafm_t)
 dev_list_sysfs(opafm_t)
 dev_read_sysfs(opafm_t)
 
+fs_search_nfs(opafm_t)
+
 libs_exec_lib_files(opafm_t)
 
 logging_send_syslog_msg(opafm_t)


### PR DESCRIPTION
The kdump service can be configured to save vmcores to a nfs target. The opafm service also needs access to it.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/30/2023 22:29:46.916:163) : proctitle=/usr/lib/opa-fm/runtime/sm -e sm_0 type=SYSCALL msg=audit(11/30/2023 22:29:46.916:163) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55b6fb046c00 a2=0x7ffe1192fa60 a3=0x0 items=0 ppid=2431 pid=2435 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sm exe=/usr/lib/opa-fm/runtime/sm subj=system_u:system_r:opafm_t:s0 key=(null)

Resolves: RHEL-17820