### PR TITLE
Update qatlib policy

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -22,7 +22,7 @@ files_pid_file(qatlib_var_run_t)
 #
 # qatlib local policy
 #
-allow qatlib_t self:capability { sys_admin };
+allow qatlib_t self:capability { sys_admin sys_module };
 allow qatlib_t self:fifo_file rw_fifo_file_perms;
 allow qatlib_t self:system module_load;
 allow qatlib_t self:unix_stream_socket create_stream_socket_perms;
@@ -37,6 +37,7 @@ manage_files_pattern(qatlib_t, qatlib_var_run_t, qatlib_var_run_t)
 manage_sock_files_pattern(qatlib_t, qatlib_var_run_t, qatlib_var_run_t)
 files_pid_filetrans(qatlib_t, qatlib_var_run_t, { dir file sock_file } )
 
+kernel_load_module(qatlib_t)
 kernel_read_proc_files(qatlib_t)
 kernel_request_load_module(qatlib_t)
 

--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -33,7 +33,8 @@ list_dirs_pattern(qatlib_t, qatlib_conf_t, qatlib_conf_t)
 
 manage_dirs_pattern(qatlib_t, qatlib_var_run_t, qatlib_var_run_t)
 manage_files_pattern(qatlib_t, qatlib_var_run_t, qatlib_var_run_t)
-files_pid_filetrans(qatlib_t, qatlib_var_run_t, { dir file } )
+manage_sock_files_pattern(qatlib_t, qatlib_var_run_t, qatlib_var_run_t)
+files_pid_filetrans(qatlib_t, qatlib_var_run_t, { dir file sock_file } )
 
 kernel_read_proc_files(qatlib_t)
 kernel_request_load_module(qatlib_t)

--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -22,6 +22,7 @@ files_pid_file(qatlib_var_run_t)
 #
 # qatlib local policy
 #
+allow qatlib_t self:capability { sys_admin };
 allow qatlib_t self:fifo_file rw_fifo_file_perms;
 allow qatlib_t self:system module_load;
 allow qatlib_t self:unix_stream_socket create_stream_socket_perms;
@@ -56,6 +57,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	miscfiles_read_hwdata(qatlib_t)
 	miscfiles_read_localization(qatlib_t)
 ')
 

--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -43,6 +43,7 @@ corecmd_exec_bin(qatlib_t)
 
 dev_create_sysfs_files(qatlib_t)
 dev_rw_sysfs(qatlib_t)
+dev_rw_vfio_dev(qatlib_t)
 dev_setattr_generic_dirs(qatlib_t)
 
 domain_use_interactive_fds(qatlib_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(12.12.2023 09:16:26.851:299) : proctitle=/usr/sbin/qatmgr --policy=0 type=SYSCALL msg=audit(12.12.2023 09:16:26.851:299) : arch=x86_64 syscall=ioctl success=yes exit=0 a0=0x5 a1=0x3b69 a2=0x3 a3=0x70000000004 items=0 ppid=1 pid=63688 auid=unset uid=root gid=qat euid=root suid=root fsuid=root egid=qat sgid=qat fsgid=qat tty=(none) ses=unset comm=qatmgr exe=/usr/sbin/qatmgr subj=system_u:system_r:qatlib_t:s0 key=(null) type=AVC msg=audit(12.12.2023 09:16:26.851:299) : avc:  denied  { ioctl } for  pid=63688 comm=qatmgr path=/dev/vfio/465 dev="devtmpfs" ino=2030 ioctlcmd=0x3b69 scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:vfio_device_t:s0 tclass=chr_file permissive=1

type=PROCTITLE msg=audit(12.12.2023 09:16:31.459:301) : proctitle=/usr/sbin/qatmgr --policy=0
type=PATH msg=audit(12.12.2023 09:16:31.459:301) : item=1 name=(null) inode=3808 dev=00:18 mode=socket,660 ouid=root ogid=qat rdev=00:00 obj=system_u:object_r:var_run_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(12.12.2023 09:16:31.459:301) : item=0 name=(null) inode=3633 dev=00:18 mode=dir,755 ouid=root ogid=qat rdev=00:00 obj=system_u:object_r:var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(12.12.2023 09:16:31.459:301) : arch=x86_64 syscall=bind success=yes exit=0 a0=0x3 a1=0x7ffdd4804e30 a2=0x6e a3=0x9 items=2 ppid=1 pid=63688 auid=unset uid=root gid=qat euid=root suid=root fsuid=root egid=qat sgid=qat fsgid=qat tty=(none) ses=unset comm=qatmgr exe=/usr/sbin/qatmgr subj=system_u:system_r:qatlib_t:s0 key=(null)
type=AVC msg=audit(12.12.2023 09:16:31.459:301) : avc:  denied  { create } for  pid=63688 comm=qatmgr name=qatmgr.sock scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=sock_file permissive=1

Resolves: RHEL-17947