### PR TITLE
Allow postfix_master_t map postfix data files

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -124,7 +124,7 @@ mta_filetrans_aliases(postfix_master_t, postfix_etc_t)
 can_exec(postfix_master_t, postfix_exec_t)
 
 allow postfix_master_t postfix_data_t:dir manage_dir_perms;
-allow postfix_master_t postfix_data_t:file manage_file_perms;
+allow postfix_master_t postfix_data_t:file { manage_file_perms map };
 
 allow postfix_master_t postfix_keytab_t:file read_file_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
Nov 03 16:25:28 audit[294288]: AVC avc:  denied  { map } for  pid=294288 comm="postscreen" path="/var/lib/postfix/postscreen_cache.lmdb" dev="dm-1" ino=25200449 scontext=system_u:system_r:postfix_master_t:s0 tcontext=system_u:object_r:postfix_data_t:s0 tclass=file permissive=0

Resolves: rhbz#2247848