### PR TITLE
Make named_zone_t and named_var_run_t a part of the mountpoint attribute

### DIFF
--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -58,11 +58,12 @@ files_tmp_file(named_tmp_t)
 
 type named_var_run_t;
 files_pid_file(named_var_run_t)
+files_mountpoint(named_var_run_t)
 init_daemon_run_dir(named_var_run_t, "named")
 
 # for primary zone files
 type named_zone_t;
-files_type(named_zone_t)
+files_mountpoint(named_zone_t)
 
 type ndc_t;
 type ndc_exec_t;


### PR DESCRIPTION
The bind-chroot service bind-mounts a bunch of files and directories into chrooted directories.

Resolves: RHEL-1954