### PR TITLE
Allow keepalived_t to use sys_ptrace of cap_userns

### DIFF
--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -39,6 +39,7 @@ files_tmpfs_file(keepalived_tmpfs_t)
 
 allow keepalived_t self:capability { net_admin net_raw kill dac_read_search setuid setgid sys_admin sys_nice sys_ptrace };
 allow keepalived_t self:capability2 bpf;
+allow keepalived_t self:cap_userns { sys_ptrace };
 allow keepalived_t self:process { signal_perms getpgid setpgid setsched setrlimit };
 allow keepalived_t self:icmp_socket create_socket_perms;
 allow keepalived_t self:netlink_socket create_socket_perms;


### PR DESCRIPTION
Addresses the following AVC:

type=PROCTITLE msg=audit(12/08/2023 12:28:47.900:784) : proctitle=netstat -apn
type=PATH msg=audit(12/08/2023 12:28:47.900:784) : item=0 name=/proc/834/fd/0 inode=183233 dev=00:14 mode=link,500 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:devicekit_power_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(12/08/2023 12:28:47.900:784) : cwd=/
type=SYSCALL msg=audit(12/08/2023 12:28:47.900:784) : arch=x86_64 syscall=readlink success=yes exit=9 a0=0x7ffd2369a070 a1=0x7ffd23699e50 a2=0x1d a3=0xe items=1 ppid=66687 pid=66689 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=netstat exe=/usr/bin/netstat subj=system_u:system_r:keepalived_t:s0 key=(null)
type=AVC msg=audit(12/08/2023 12:28:47.900:784) : avc:  denied  { sys_ptrace } for  pid=66689 comm=netstat capability=sys_ptrace  scontext=system_u:system_r:keepalived_t:s0 tcontext=system_u:system_r:keepalived_t:s0 tclass=cap_userns permissive=1

Resolves: RHEL-17156