### PR TITLE
Allow dovecot_auth_t connect to postgresql using UNIX socket

### DIFF
--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -328,6 +328,10 @@ optional_policy(`
 	systemd_private_tmp(dovecot_auth_tmp_t)
 ')
 
+optional_policy(`
+    postgresql_stream_connect(dovecot_auth_t)
+')
+
 ########################################
 #
 # dovecot deliver local policy


### PR DESCRIPTION
Addreses following AVCs:

type=AVC msg=audit(1700326791.924:28417): avc:  denied  { write } for  pid=379029 comm="auth" name=".s.PGSQL.5432" dev="tmpfs" ino=21504 scontext=system_u:system_r:dovecot_auth_t:s0 tcontext=system_u:object_r:postgresql_var_run_t:s0 tclass=sock_file permissive=0
type=SYSCALL msg=audit(1700326791.924:28417): arch=c000003e syscall=42 success=no exit=-13 a0=14 a1=5635d4b2bc20 a2=6e a3=7f06cf6a4c48 items=0 ppid=378824 pid=379029 auid=4294967295 uid=97 gid=97 euid=97 suid=97 fsuid=97 egid=97 sgid=97 fsgid=97 tty=(none) ses=4294967295 comm="auth" exe="/usr/libexec/dovecot/auth" subj=system_u:system_r:dovecot_auth_t:s0 key=(null)ARCH=x86_64 SYSCALL=connect AUID="unset" UID="dovecot" GID="dovecot" EUID="dovecot" SUID="dovecot" FSUID="dovecot" EGID="dovecot" SGID="dovecot" FSGID="dovecot"
type=PROCTITLE msg=audit(1700326791.924:28417): proctitle="dovecot/auth"
type=AVC msg=audit(1700326791.960:28418): avc:  denied  { write } for  pid=379030 comm="auth" name=".s.PGSQL.5432" dev="tmpfs" ino=21504 scontext=system_u:system_r:dovecot_auth_t:s0 tcontext=system_u:object_r:postgresql_var_run_t:s0 tclass=sock_file permissive=0
type=SYSCALL msg=audit(1700326791.960:28418): arch=c000003e syscall=42 success=no exit=-13 a0=d a1=56244e950630 a2=6e a3=7fe995ddbc48 items=0 ppid=378824 pid=379030 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="auth" exe="/usr/libexec/dovecot/auth" subj=system_u:system_r:dovecot_auth_t:s0 key=(null)ARCH=x86_64 SYSCALL=connect AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
type=PROCTITLE msg=audit(1700326791.960:28418): proctitle=646F7665636F742F61757468002D77
type=AVC msg=audit(1700326791.967:28419): avc:  denied  { write } for  pid=379029 comm="auth" name=".s.PGSQL.5432" dev="tmpfs" ino=21504 scontext=system_u:system_r:dovecot_auth_t:s0 tcontext=system_u:object_r:postgresql_var_run_t:s0 tclass=sock_file permissive=0
type=SYSCALL msg=audit(1700326791.967:28419): arch=c000003e syscall=42 success=no exit=-13 a0=16 a1=5635d4b38ae0 a2=6e a3=7f06cf6a4c48 items=0 ppid=378824 pid=379029 auid=4294967295 uid=97 gid=97 euid=97 suid=97 fsuid=97 egid=97 sgid=97 fsgid=97 tty=(none) ses=4294967295 comm="auth" exe="/usr/libexec/dovecot/auth" subj=system_u:system_r:dovecot_auth_t:s0 key=(null)ARCH=x86_64 SYSCALL=connect AUID="unset" UID="dovecot" GID="dovecot" EUID="dovecot" SUID="dovecot" FSUID="dovecot" EGID="dovecot" SGID="dovecot" FSGID="dovecot"
type=PROCTITLE msg=audit(1700326791.967:28419): proctitle="dovecot/auth"

Resolves: RHEL-16850