### PR TITLE
Allow nvme_stas_t create and use netlink kobject uevent socket

### DIFF
--- a/policy/modules/contrib/nvme_stas.te
+++ b/policy/modules/contrib/nvme_stas.te
@@ -33,7 +33,8 @@ allow nvme_stas_t self:capability { net_admin sys_admin };
 allow nvme_stas_t self:capability2 bpf;
 allow nvme_stas_t self:dbus send_msg;
 allow nvme_stas_t self:fifo_file rw_fifo_file_perms;
-allow nvme_stas_t self:netlink_kobject_uevent_socket { bind create getattr setopt };
+allow nvme_stas_t self:netlink_kobject_uevent_socket create_socket_perms;
+
 allow nvme_stas_t self:process setsched;
 allow nvme_stas_t self:tcp_socket create_stream_socket_perms;
 allow nvme_stas_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
Some permissions were allowed, but not all for stafd be able to use the netlink class socket from the kobject uevent family.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/14/2023 03:16:43.776:934) : proctitle=/usr/bin/python3 /usr/sbin/stafd --syslog type=SYSCALL msg=audit(12/14/2023 03:16:43.776:934) : arch=x86_64 syscall=getsockopt success=no exit=EACCES(Permission denied) a0=0x3 a1=SOL_SOCKET a2=SO_RCVBUF a3=0x7ffcc7b7384c items=0 ppid=1 pid=14412 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stafd exe=/usr/bin/python3.12 subj=system_u:system_r:nvme_stas_t:s0 key=(null) type=AVC msg=audit(12/14/2023 03:16:43.776:934) : avc:  denied  { getopt } for  pid=14412 comm=stafd scontext=system_u:system_r:nvme_stas_t:s0 tcontext=system_u:system_r:nvme_stas_t:s0 tclass=netlink_kobject_uevent_socket permissive=0