### PR TITLE
Allow collectd connect to statsd port

### DIFF
--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -80,6 +80,7 @@ corecmd_exec_bin(collectd_t)
 
 corenet_udp_bind_generic_node(collectd_t)
 corenet_udp_bind_collectd_port(collectd_t)
+corenet_udp_bind_statsd_port(collectd_t)
 corenet_tcp_connect_lmtp_port(collectd_t)
 corenet_tcp_bind_bacula_port(collectd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/15/2023 06:07:12.970:297) : proctitle=/usr/sbin/collectd type=SOCKADDR msg=audit(12/15/2023 06:07:12.970:297) : saddr={ saddr_fam=inet6 laddr=:: lport=8125 } type=SYSCALL msg=audit(12/15/2023 06:07:12.970:297) : arch=x86_64 syscall=bind success=no exit=EACCES(Permission denied) a0=0x5 a1=0x7f15000011c0 a2=0x1c a3=0x0 items=0 ppid=1 pid=7810 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=collectd exe=/usr/sbin/collectd subj=system_u:system_r:collectd_t:s0 key=(null) type=AVC msg=audit(12/15/2023 06:07:12.970:297) : avc:  denied  { name_bind } for  pid=7810 comm=collectd src=8125 scontext=system_u:system_r:collectd_t:s0 tcontext=system_u:object_r:statsd_port_t:s0 tclass=udp_socket permissive=0

Resolves: RHEL-19482