### PR TITLE
Allow systemd-sleep send a message to syslog over a unix dgram socket

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1616,6 +1616,10 @@ storage_getattr_fixed_disk_dev(systemd_sleep_t)
 storage_getattr_removable_dev(systemd_sleep_t)
 
 optional_policy(`
+	logging_dgram_send(systemd_sleep_t)
+')
+
+optional_policy(`
 	sysstat_domtrans(systemd_sleep_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1702592947.333:248): avc:  denied  { sendto } for  pid=7245 comm="systemd-sleep" path="/run/systemd/journal/socket" scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#2254628