### PR TITLE
Allow init create and use netlink netfilter socket

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -175,6 +175,7 @@ ifdef(`enable_mls',`
 allow init_t self:capability ~{ audit_control audit_write sys_module };
 allow init_t self:capability2 ~{ mac_admin mac_override };
 allow init_t self:cap_userns all_cap_userns_perms;
+allow init_t self:netlink_netfilter_socket create_socket_perms;
 allow init_t self:tcp_socket { listen accept };
 allow init_t self:packet_socket create_socket_perms;
 allow init_t self:vsock_socket create_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(12/08/2023 06:07:03.373:259) : avc:  denied  { create } for  pid=1 comm=systemd scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=netlink_netfilter_socket permissive=1

Resolves: rhbz#2250935