### PR TITLE
Allow systemd-sleep send a message to syslog over a unix dgram socket (f39)

### DIFF
--- a/policy/modules/contrib/alsa.te
+++ b/policy/modules/contrib/alsa.te
@@ -88,6 +88,8 @@ dev_write_sound(alsa_t)
 
 files_search_var_lib(alsa_t)
 
+fs_getattr_xattr_fs(alsa_t)
+
 modutils_domtrans_kmod(alsa_t)
 
 term_dontaudit_use_console(alsa_t)

--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -1372,6 +1372,10 @@ optional_policy(`
 	')
 ')
 
+optional_policy(`
+	systemd_private_tmp(httpd_php_tmp_t)
+')
+
 ########################################
 #
 # Apache suexec local policy

--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -58,6 +58,7 @@ files_tmp_filetrans(certmonger_t, certmonger_tmp_t, { file dir })
 allow certmonger_t certmonger_tmp_t:file map;
 
 kernel_read_kernel_sysctls(certmonger_t)
+kernel_read_net_sysctls(certmonger_t)
 kernel_read_system_state(certmonger_t)
 kernel_read_network_state(certmonger_t)
 

--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -100,6 +100,8 @@ init_read_utmp(collectd_t)
 
 logging_send_syslog_msg(collectd_t)
 
+storage_raw_read_fixed_disk_blk_device(collectd_t)
+
 sysnet_dns_name_resolve(collectd_t)
 
 tunable_policy(`use_ecryptfs_home_dirs',`

--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -137,6 +137,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	udev_read_pid_files(collectd_t)
+')
+
+optional_policy(`
 	virt_read_config(collectd_t)
 	virt_stream_connect(collectd_t)
 ')

--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -610,6 +610,7 @@ allow spamd_update_t self:fifo_file manage_fifo_file_perms;
 allow spamd_update_t self:unix_dgram_socket create_socket_perms;
 allow spamd_update_t self:unix_stream_socket create_stream_socket_perms;
 allow spamd_update_t self:capability { dac_read_search dac_override };
+allow spamd_update_t self:cap_userns sys_ptrace;
 
 manage_dirs_pattern(spamd_update_t, spamd_tmp_t, spamd_tmp_t)
 manage_files_pattern(spamd_update_t, spamd_tmp_t, spamd_tmp_t)

--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -105,6 +105,30 @@ interface(`storage_dontaudit_setattr_fixed_disk_dev',`
 
 ########################################
 ## <summary>
+##	Allow the caller to directly read from a fixed disk device.
+##	This is extremly dangerous as it can bypass the
+##	SELinux protections for filesystem objects, and
+##	should only be used by trusted domains.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`storage_raw_read_fixed_disk_blk_device',`
+	gen_require(`
+		attribute fixed_disk_raw_read;
+		type fixed_disk_device_t;
+	')
+
+	dev_list_all_dev_nodes($1)
+	allow $1 fixed_disk_device_t:blk_file read_blk_file_perms;
+	typeattribute $1 fixed_disk_raw_read;
+')
+
+########################################
+## <summary>
 ##	Allow the caller to directly read from a fixed disk.
 ##	This is extremly dangerous as it can bypass the
 ##	SELinux protections for filesystem objects, and

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1560,6 +1560,10 @@ storage_getattr_fixed_disk_dev(systemd_sleep_t)
 storage_getattr_removable_dev(systemd_sleep_t)
 
 optional_policy(`
+	logging_dgram_send(systemd_sleep_t)
+')
+
+optional_policy(`
 	sysstat_domtrans(systemd_sleep_t)
 ')
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1549,6 +1549,7 @@ dev_rw_sysfs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
 
 fs_create_efivarfs_files(systemd_sleep_t)
+fs_setattr_efivarfs_files(systemd_sleep_t)
 fs_rw_efivarfs_files(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1702592947.333:248): avc:  denied  { sendto } for  pid=7245 comm="systemd-sleep" path="/run/systemd/journal/socket" scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#2254628