### PR TITLE
Allow spamd_update_t the sys_ptrace capability in user namespace

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -610,6 +610,7 @@ allow spamd_update_t self:fifo_file manage_fifo_file_perms;
 allow spamd_update_t self:unix_dgram_socket create_socket_perms;
 allow spamd_update_t self:unix_stream_socket create_stream_socket_perms;
 allow spamd_update_t self:capability { dac_read_search dac_override };
+allow spamd_update_t self:cap_userns sys_ptrace;
 
 manage_dirs_pattern(spamd_update_t, spamd_tmp_t, spamd_tmp_t)
 manage_files_pattern(spamd_update_t, spamd_tmp_t, spamd_tmp_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1702854015.017:42859): avc:  denied  { sys_ptrace } for  pid=1077477 comm="pgrep" capability=19  scontext=system_u:system_r:spamd_update_t:s0 tcontext=system_u:system_r:spamd_update_t:s0 tclass=cap_userns permissive=1

Resolves: rhbz#2252484