### PR TITLE
Allow alsa get attributes filesystems with extended attributes

### DIFF
--- a/policy/modules/contrib/alsa.te
+++ b/policy/modules/contrib/alsa.te
@@ -88,6 +88,8 @@ dev_write_sound(alsa_t)
 
 files_search_var_lib(alsa_t)
 
+fs_getattr_xattr_fs(alsa_t)
+
 modutils_domtrans_kmod(alsa_t)
 
 term_dontaudit_use_console(alsa_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1700102760.194:134): avc:  denied  { getattr } for  pid=1349 comm="rm" name="/" dev="dm-0" ino=2 scontext=system_u:system_r:alsa_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0

Resolves: rhbz#2249960