### PR TITLE
Allow bluetooth devices work with alsa

### DIFF
--- a/policy/modules/contrib/bluetooth.te
+++ b/policy/modules/contrib/bluetooth.te
@@ -124,6 +124,8 @@ corenet_udp_sendrecv_all_ports(bluetooth_t)
 dev_rw_sysfs(bluetooth_t)
 dev_rw_usbfs(bluetooth_t)
 dev_rw_generic_usb_dev(bluetooth_t)
+dev_read_sound(bluetooth_t)
+dev_write_sound(bluetooth_t)
 dev_read_urand(bluetooth_t)
 dev_rw_input_dev(bluetooth_t)
 dev_rw_wireless(bluetooth_t)
@@ -153,6 +155,10 @@ userdom_dontaudit_search_user_home_dirs(bluetooth_t)
 # machine-info
 systemd_hostnamed_read_config(bluetooth_t)
 systemd_dbus_chat_hostnamed(bluetooth_t)
+
+optional_policy(`
+	alsa_read_lib(bluetooth_t)
+')
 
 optional_policy(`
 	dbus_system_bus_client(bluetooth_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=AVC msg=audit(1702496797.273:128): avc:  denied  { search } for  pid=1387 comm="bluetoothd" name="alsa" dev="nvme1n1p2" ino=141177 scontext=system_u:system_r:bluetooth_t:s0 tcontext=system_u:object_r:alsa_var_lib_t:s0 tclass=dir permissive=1 type=SYSCALL msg=audit(1702496797.273:128): arch=x86_64 syscall=access success=no exit=ENOENT a0=56394639e0f0 a1=4 a2=0 a3=7c items=1 ppid=1 pid=1387 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=bluetoothd exe=/usr/libexec/bluetooth/bluetoothd subj=system_u:system_r:bluetooth_t:s0 key=(null)

type=AVC msg=audit(1702496797.274:129): avc:  denied  { read write } for  pid=1387 comm="bluetoothd" name="seq" dev="devtmpfs" ino=745 scontext=system_u:system_r:bluetooth_t:s0 tcontext=system_u:object_r:sound_device_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1702496797.274:129): avc:  denied  { open } for  pid=1387 comm="bluetoothd" path="/dev/snd/seq" dev="devtmpfs" ino=745 scontext=system_u:system_r:bluetooth_t:s0 tcontext=system_u:object_r:sound_device_t:s0 tclass=chr_file permissive=1
type=SYSCALL msg=audit(1702496797.274:129): arch=x86_64 syscall=openat success=yes exit=ETXTBSY a0=ffffff9c a1=7f28825ca24d a2=80002 a3=0 items=1 ppid=1 pid=1387 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=bluetoothd exe=/usr/libexec/bluetooth/bluetoothd subj=system_u:system_r:bluetooth_t:s0 key=(null)
type=CWD msg=audit(1702496797.274:129): cwd=/
type=PATH msg=audit(1702496797.274:129): item=0 name=/dev/snd/seq inode=745 dev=00:05 mode=020660 ouid=0 ogid=63 rdev=74:01 obj=system_u:object_r:sound_device_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: rhbz#2254422