### PR TITLE
Allow systemd-sleep set attributes of efivarfs files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1597,6 +1597,7 @@ dev_rw_sysfs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
 
 fs_create_efivarfs_files(systemd_sleep_t)
+fs_setattr_efivarfs_files(systemd_sleep_t)
 fs_rw_efivarfs_files(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1703311625.363:336): avc:  denied  { setattr } for  pid=3817 comm="systemd-sleep" path="/sys/firmware/efi/efivars/HibernateLocation-8cf2644b-4b0b-428f-9387-6d876050dc67" dev="efivarfs" ino=510 scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:object_r:efivarfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2255693