### PR TITLE
Allow samba-dcerpcd read public files

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1272,6 +1272,7 @@ optional_policy(`
 
 optional_policy(`
 	miscfiles_read_generic_certs(winbind_rpcd_t)
+	miscfiles_read_public_files(winbind_rpcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1704134675.693:18923): avc:  denied  { read write } for  pid=3960899 comm="samba-dcerpcd" path=2F7372762F70726976646174612F4D6F6E65792F47544C2F54617865732042442F42696E676E696E6720546178657320323032322D323032332E6F6473 dev="dm-2" ino=3146018 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:public_content_rw_t:s0 tclass=file permissive=0

Related: rhbz#2122904