### PR TITLE
Allow samba to have dac_override capability

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -286,7 +286,7 @@ optional_policy(`
 # smbd Local policy
 #
 
-allow smbd_t self:capability { chown fowner kill fsetid setgid setuid sys_chroot sys_nice sys_admin sys_resource lease  dac_read_search net_admin };
+allow smbd_t self:capability { chown fowner kill fsetid setgid setuid sys_chroot sys_nice sys_admin sys_resource lease dac_override dac_read_search net_admin };
 dontaudit smbd_t self:capability sys_tty_config;
 dontaudit smbd_t self:capability2 block_suspend;
 allow smbd_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };


### PR DESCRIPTION
Previously commit cc5d0d7c98d06866f26dd1f54b34f70fd3b531f9 removed dac_override capability from many SELinux modules. But with recent [changes](https://git.samba.org/?p=samba.git;a=commit;h=a1738e8265dd256c5a1064482a6dfccbf9ca44f1) to Samba upstream it has become necessary to have this capability to work under some special common configurations.

One among those configurations require smbd to read ACLs stored in extended attributes from security namespace which further calls for additional privileges where dac_override would be the bare minimum and least expensive capability to be acquired without becoming root. You may find slighlty more details from the discussion around the [merge request](https://gitlab.com/samba-team/samba/-/merge_requests/3434) upstream.

Therefore resurrect the dac_override capability for smbd_t to avoid the following AVC denial.

> type=AVC msg=audit(1700643404.314:3644): avc: denied { dac_override } for pid=83444 comm="smbd[192.168.12" capability=1 scontext=system_u:system_r:smbd_t:s0 tcontext=system_u:system_r:smb
d_t:s0 tclass=capability permissive=0
type=SYSCALL msg=audit(1700643404.314:3644): arch=c000003e syscall=191 success=no exit=-61 a0=7ffea4096890 a1=7f5809ce635a a2=561c6dfe9d90 a3=1000 items=1 ppid=76437 pid=83444 auid=429496
7295 uid=2001 gid=0 euid=2001 suid=0 fsuid=2001 egid=2001 sgid=0 fsgid=2001 tty=(none) ses=4294967295 comm="smbd[192.168.12" exe="/usr/sbin/smbd" subj=system_u:system_r:smbd_t:s0 key=(null)AR
CH=x86_64 SYSCALL=getxattr AUID="unset" UID="test1" GID="root" EUID="test1" SUID="root" FSUID="test1" EGID="test1" SGID="root" FSGID="test1"