### PR TITLE
Allow qatlib set attributes of vfio device files

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -47,6 +47,7 @@ corecmd_exec_bin(qatlib_t)
 dev_create_sysfs_files(qatlib_t)
 dev_rw_sysfs(qatlib_t)
 dev_rw_vfio_dev(qatlib_t)
+dev_setattr_vfio_dev(qatlib_t)
 dev_setattr_generic_dirs(qatlib_t)
 
 domain_use_interactive_fds(qatlib_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(12/19/2023 21:25:56.400:609) : proctitle=chown :qat /dev/vfio/482 type=SYSCALL msg=audit(12/19/2023 21:25:56.400:609) : arch=x86_64 syscall=fchownat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55c94ddcdaa0 a2=0xffffffff a3=0x3d1 items=0 ppid=5723 pid=5771 auid=unset uid=root gid=qat euid=root suid=root fsuid=root egid=qat sgid=qat fsgid=qat tty=(none) ses=unset comm=chown exe=/usr/bin/chown subj=system_u:system_r:qatlib_t:s0 key=(null) type=AVC msg=audit(12/19/2023 21:25:56.400:609) : avc:  denied  { setattr } for  pid=5771 comm=chown name=482 dev="devtmpfs" ino=1901 scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:vfio_device_t:s0 tclass=chr_file permissive=0 type=PROCTITLE msg=audit(12/19/2023 21:25:56.402:610) : proctitle=chmod +060 /dev/vfio/482 type=SYSCALL msg=audit(12/19/2023 21:25:56.402:610) : arch=x86_64 syscall=fchmodat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55b21af25500 a2=0660 a3=0x0 items=0 ppid=5723 pid=5772 auid=unset uid=root gid=qat euid=root suid=root fsuid=root egid=qat sgid=qat fsgid=qat tty=(none) ses=unset comm=chmod exe=/usr/bin/chmod subj=system_u:system_r:qatlib_t:s0 key=(null) type=AVC msg=audit(12/19/2023 21:25:56.402:610) : avc:  denied  { setattr } for  pid=5772 comm=chmod name=482 dev="devtmpfs" ino=1901 scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:vfio_device_t:s0 tclass=chr_file permissive=0

Resolves: RHEL-19051