### PR TITLE
Allow syslogd_t nnp_transition to syslogd_unconfined_script_t

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -119,6 +119,7 @@ type syslogd_unconfined_script_exec_t;
 role system_r types syslogd_unconfined_script_t;
 application_domain(syslogd_unconfined_script_t, syslogd_unconfined_script_exec_t)
 domtrans_pattern(syslogd_t, syslogd_unconfined_script_exec_t, syslogd_unconfined_script_t)
+allow syslogd_t syslogd_unconfined_script_t:process2 nnp_transition;
 
 type syslogd_tmp_t;
 files_tmp_file(syslogd_tmp_t)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -42,6 +42,13 @@ gen_tunable(logging_syslogd_use_tty, true)
 ## </desc>
 gen_tunable(logging_syslogd_run_nagios_plugins, false)
 
+## <desc>
+## <p>
+## Allow syslog to run unconfined scripts
+## </p>
+## </desc>
+gen_tunable(logging_syslogd_run_unconfined, false)
+
 attribute logfile;
 
 type auditctl_t;
@@ -118,8 +125,6 @@ type syslogd_unconfined_script_t;
 type syslogd_unconfined_script_exec_t;
 role system_r types syslogd_unconfined_script_t;
 application_domain(syslogd_unconfined_script_t, syslogd_unconfined_script_exec_t)
-domtrans_pattern(syslogd_t, syslogd_unconfined_script_exec_t, syslogd_unconfined_script_t)
-allow syslogd_t syslogd_unconfined_script_t:process2 nnp_transition;
 
 type syslogd_tmp_t;
 files_tmp_file(syslogd_tmp_t)
@@ -814,7 +819,13 @@ logging_stream_connect_syslog(syslog_client_type)
 # syslogd_unconfined_script_t local policy
 #
 
+tunable_policy(`logging_syslogd_run_unconfined',`
+	domtrans_pattern(syslogd_t, syslogd_unconfined_script_exec_t, syslogd_unconfined_script_t)
+	allow syslogd_t syslogd_unconfined_script_t:process2 nnp_transition;
+',`
+	can_exec(syslogd_t, syslogd_unconfined_script_exec_t)
+')
+
 optional_policy(`
 	unconfined_domain(syslogd_unconfined_script_t)
-
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(01/09/2024 05:11:04.592:9926) : avc:  denied  { nnp_transition } for  pid=538886 comm=rs:main Q:Reg scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_unconfined_script_t:s0 tclass=process2 permissive=0 type=SELINUX_ERR msg=audit(01/09/2024 05:11:04.592:9926) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:syslogd_t:s0 newcontext=system_u:system_r:syslogd_unconfined_script_t:s0 type=SYSCALL msg=audit(01/09/2024 05:11:04.592:9926) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x559639ba78b0 a1=0x0 a2=0x559639b81a90 a3=0x8 items=3 ppid=538750 pid=538886 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=log_rotate.sh exe=/usr/bin/bash subj=system_u:system_r:syslogd_t:s0 key=(null) type=BPRM_FCAPS msg=audit(01/09/2024 05:11:04.592:9926) : fver=0 fp=none fi=none fe=0 old_pp=chown,dac_override,setgid,setuid,net_bind_service,net_admin,net_raw,ipc_lock,sys_chroot,sys_admin,sys_resource,lease,syslog,block_suspend old_pi=none old_pe=chown,dac_override,setgid,setuid,net_bind_service,net_admin,net_raw,ipc_lock,sys_chroot,sys_admin,sys_resource,lease,syslog,block_suspend old_pa=none pp=dac_override pi=none pe=dac_override pa=none frootid=0 type=EXECVE msg=audit(01/09/2024 05:11:04.592:9926) : argc=2 a0=/bin/bash a1=/usr/libexec/rsyslog/log_rotate.sh type=PATH msg=audit(01/09/2024 05:11:04.592:9926) : item=0 name=/usr/libexec/rsyslog/log_rotate.sh inode=8964850 dev=fd:00 mode=file,755 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:syslogd_unconfined_script_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(01/09/2024 05:11:04.592:9926) : item=1 name=/bin/bash inode=25167901 dev=fd:00 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:shell_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(01/09/2024 05:11:04.592:9926) : item=2 name=/lib64/ld-linux-x86-64.so.2 inode=404 dev=fd:00 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: RHEL-11174