### PR TITLE
Allow mdadm get attributes of stratisd data directories

### DIFF
--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -184,6 +184,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	stratisd_data_list_dirs(mdadm_t)
+	stratisd_data_read_lnk_files(mdadm_t)
+')
+
+optional_policy(`
 	udev_read_db(mdadm_t)
 ')
 

--- a/policy/modules/contrib/stratisd.if
+++ b/policy/modules/contrib/stratisd.if
@@ -133,3 +133,21 @@ interface(`stratisd_data_read_lnk_files',`
 
 	allow $1 stratisd_data_t:lnk_file read_lnk_file_perms;
 ')
+
+########################################
+## <summary>
+##	Read stratisd data directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`stratisd_data_list_dirs',`
+	gen_require(`
+		type stratisd_data_t;
+	')
+
+	list_dirs_pattern($1, stratisd_data_t, stratisd_data_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/13/2023 03:00:49.582:354) : proctitle=/usr/sbin/mdadm --detail --no-devices --export /dev/md0 type=PATH msg=audit(12/13/2023 03:00:49.582:354) : item=0 name=stratis inode=507 dev=00:05 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:stratisd_data_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(12/13/2023 03:00:49.582:354) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=0x4 a1=0x55a2e2d8d0db a2=0x7fffd4911350 a3=0x100 items=1 ppid=17196 pid=17200 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=mdadm exe=/usr/sbin/mdadm subj=system_u:system_r:mdadm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(12/13/2023 03:00:49.582:354) : avc:  denied  { getattr } for  pid=17200 comm=mdadm path=/dev/stratis dev="devtmpfs" ino=507 scontext=system_u:system_r:mdadm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:stratisd_data_t:s0 tclass=dir permissive=0

Resolves: RHEL-19276