### PR TITLE
Set correct label on /etc/pki/pki-tomcat/kra

### DIFF
--- a/policy/modules/contrib/pki.fc
+++ b/policy/modules/contrib/pki.fc
@@ -1,5 +1,6 @@
 /etc/pki/pki-tomcat(/.*)?		gen_context(system_u:object_r:pki_tomcat_etc_rw_t,s0)
 /etc/pki/pki-tomcat/ca(/.*)?		gen_context(system_u:object_r:pki_tomcat_cert_t,s0)
+/etc/pki/pki-tomcat/kra(/.*)?		gen_context(system_u:object_r:pki_tomcat_cert_t,s0)
 /var/lib/pki/pki-tomcat(/.*)?       	gen_context(system_u:object_r:pki_tomcat_var_lib_t,s0)
 /var/run/pki/tomcat(/.*)?		gen_context(system_u:object_r:pki_tomcat_var_run_t,s0)
 /var/log/pki/pki-tomcat(/.*)?		gen_context(system_u:object_r:pki_tomcat_log_t,s0)


### PR DESCRIPTION
Allows certmonger to modify files within the kra subsystem directory as it can already do within the ca subsystem directory.

https://bugzilla.redhat.com/show_bug.cgi?id=2166441