### PR TITLE
Allow certmonger read network sysctls (f38)

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -58,6 +58,7 @@ files_tmp_filetrans(certmonger_t, certmonger_tmp_t, { file dir })
 allow certmonger_t certmonger_tmp_t:file map;
 
 kernel_read_kernel_sysctls(certmonger_t)
+kernel_read_net_sysctls(certmonger_t)
 kernel_read_system_state(certmonger_t)
 kernel_read_network_state(certmonger_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1691844984.141:222): avc:  denied  { search } for  pid=1513 comm="dogtag-ipa-ca-r" name="net" dev="proc" ino=2356 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: rhbz#2231732