### PR TITLE
Allow systemd domains watch system dbus pid socket files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -505,6 +505,7 @@ optional_policy(`
 	dbus_connect_system_bus(systemd_machined_t)
 	dbus_system_bus_client(systemd_machined_t)
 	dbus_watch_pid_dir_path(systemd_machined_t)
+	dbus_watch_pid_sock_files(systemd_machined_t)
 ')
 
 optional_policy(`
@@ -595,6 +596,7 @@ optional_policy(`
     dbus_system_bus_client(systemd_networkd_t)
     dbus_connect_system_bus(systemd_networkd_t)
 	dbus_watch_pid_dir_path(systemd_networkd_t)
+	dbus_watch_pid_sock_files(systemd_networkd_t)
     dbus_read_pid_files(systemd_networkd_t)
     dbus_read_pid_sock_files(systemd_networkd_t)
     systemd_dbus_chat_logind(systemd_networkd_t)
@@ -929,6 +931,7 @@ optional_policy(`
         dbus_system_bus_client(systemd_hostnamed_t)
         dbus_connect_system_bus(systemd_hostnamed_t)
 	dbus_watch_pid_dir_path(systemd_hostnamed_t)
+	dbus_watch_pid_sock_files(systemd_hostnamed_t)
 
 	optional_policy(`
 		init_dbus_chat_script(systemd_hostnamed_t)


### PR DESCRIPTION
With the 569208d534 commit ("Allow systemd services watch dbusd pid directory and its parents"), 5 systemd domains were allowed to watch /run/dbus and all its parents in path, but only 2 of the domains were already allowed to watch the "/run/dbus/system_bus_socket" socket file. This commit adds the socket file watch rule also for the rest of the domains: systemd_machined_t, systemd_networkd_t, systemd_hostnamed_t.

The commit addresses the following AVC denial:
Jan 08 11:52:41 fedora audit[374]: AVC avc:  denied  { watch } for  pid=374 comm="systemd-network" path="/run/dbus/system_bus_socket" dev="tmpfs" ino=143 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:system_dbusd_var_run_t:s0 tclass=sock_file permissive=1

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/1991