### PR TITLE
Allow httpd work with PrivateTmp

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -1372,6 +1372,10 @@ optional_policy(`
 	')
 ')
 
+optional_policy(`
+	systemd_private_tmp(httpd_php_tmp_t)
+')
+
 ########################################
 #
 # Apache suexec local policy


### PR DESCRIPTION
In particular, assign httpd_tmp_t to the systemd_private_tmp_type attribute.

The commit addresses the following AVC denial example: type=AVC msg=audit(1705486932.024:438): avc:  denied  { remove_name } for  pid=8044 comm="(sd-rmrf)" name="test" dev="tmpfs" ino=169 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:httpd_tmp_t:s0 tclass=dir permissive=0

Resolves: rhbz#2258637