### PR TITLE
nova: Fix duplicate declarations

### DIFF
--- a/policy/modules/contrib/nova.te
+++ b/policy/modules/contrib/nova.te
@@ -184,10 +184,6 @@ optional_policy(`
 	lvm_domtrans(nova_domain)
 ')
 
-optional_policy(`
-	lvm_domtrans(nova_domain)
-')
-
 #######################################
 #
 # nova sudo domain local policy


### PR DESCRIPTION
lvm_domtrans is called twice with the exactly same usage.