### PR TITLE
Label /dev/iommu with iommu_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -206,6 +206,7 @@ ifdef(`distro_suse', `
 /dev/input/mice		-c	gen_context(system_u:object_r:mouse_device_t,s0)
 /dev/input/js.*		-c	gen_context(system_u:object_r:mouse_device_t,s0)
 /dev/input/uinput	-c	gen_context(system_u:object_r:event_device_t,s0)
+/dev/iommu		-c	gen_context(system_u:object_r:iommu_device_t,s0)
 
 /dev/mapper/control	-c	gen_context(system_u:object_r:lvm_control_t,s0)
 

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -177,6 +177,12 @@ type infiniband_mgmt_device_t;
 dev_node(infiniband_mgmt_device_t)
 
 #
+# Type for /dev/iommu devices
+#
+type iommu_device_t;
+dev_node(iommu_device_t)
+
+#
 # Type for /dev/kmsg
 #
 type kmsg_device_t;


### PR DESCRIPTION
The /dev/iommu framework provides an unified interface for managing I/O page tables for passthrough devices. Existing passthrough frameworks are expected to use this interface instead of continuing their ad-hoc implementations.

Resolves: RHEL-22063