### PR TITLE
Allow polkit status systemd services

### DIFF
--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -152,6 +152,7 @@ optional_policy(`
 	systemd_read_logind_sessions_files(policykit_t)
 	systemd_login_list_pid_dirs(policykit_t)
 	systemd_login_read_pid_files(policykit_t)
+	systemd_status_systemd_services(policykit_t)
 ')
 
 ########################################


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(1705928748.141:203): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=114 gid=114 path="/usr/lib/systemd/system/user@.service" cmdline="/usr/lib/polkit-1/polkitd --no-debug" function="method_get_unit_by_pidfd" scontext=system_u:system_r:policykit_t:s0 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=service permissive=0 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'