### PR TITLE
Allow systemd-networkd manage its runtime socket files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -558,6 +558,7 @@ allow init_t systemd_networkd_t:netlink_route_socket create_netlink_socket_perms
 
 manage_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 manage_lnk_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
+manage_sock_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 manage_dirs_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 
 kernel_dgram_send(systemd_networkd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/22/2024 06:21:29.729:1150) : proctitle=/usr/lib/systemd/systemd-networkd type=PATH msg=audit(01/22/2024 06:21:29.729:1150) : item=1 name=/run/systemd/netif/io.systemd.Network nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(01/22/2024 06:21:29.729:1150) : item=0 name=/run/systemd/netif/ inode=1543 dev=00:1a mode=dir,755 ouid=systemd-network ogid=systemd-network rdev=00:00 obj=system_u:object_r:systemd_networkd_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(01/22/2024 06:21:29.729:1150) : saddr={ saddr_fam=local path=/run/systemd/netif/io.systemd.Network } type=SYSCALL msg=audit(01/22/2024 06:21:29.729:1150) : arch=x86_64 syscall=bind success=no exit=EACCES(Permission denied) a0=0xb a1=0x7ffe6c667700 a2=0x28 a3=0x50 items=2 ppid=1 pid=49658 auid=unset uid=systemd-network gid=systemd-network euid=systemd-network suid=systemd-network fsuid=systemd-network egid=systemd-network sgid=systemd-network fsgid=systemd-network tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-networkd subj=system_u:system_r:systemd_networkd_t:s0 key=(null) type=AVC msg=audit(01/22/2024 06:21:29.729:1150) : avc:  denied  { create } for  pid=49658 comm=systemd-network name=io.systemd.Network scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:systemd_networkd_var_run_t:s0 tclass=sock_file permissive=0