### PR TITLE
Allow smbd_t to watch user_home_dir_t if samba_enable_home_dirs is on

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -481,7 +481,9 @@ tunable_policy(`samba_domain_controller',`
 
 tunable_policy(`samba_enable_home_dirs',`
 	userdom_manage_user_home_content(smbd_t)
+	userdom_watch_user_home_dirs(smbd_t)
 	userdom_manage_user_home_content(winbind_rpcd_t)
+	userdom_watch_user_home_dirs(winbind_rpcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
When samba is allowed to access home directory, it sometimes needs to add watch on the whole home directory to respond to watch requests from clients (for example from Windows).

Addresses the following denial:
type=AVC msg=audit(1705933921.682:202): avc:  denied  { watch } for pid=11956 comm="smbd-notifyd" path="/home/test" dev="vda4" ino=912095 scontext=system_u:system_r:smbd_t:s0 tcontext=unconfined_u:object_r:user_home_dir_t:s0 tclass=dir permissive=0

Resolves: RHEL-14735