### PR TITLE
Allow init_t nnp domain transition to colord_t

### DIFF
--- a/policy/modules/contrib/colord.te
+++ b/policy/modules/contrib/colord.te
@@ -17,6 +17,7 @@ type colord_t;
 type colord_exec_t;
 dbus_system_domain(colord_t, colord_exec_t)
 init_daemon_domain(colord_t, colord_exec_t)
+init_nnp_daemon_domain(colord_t)
 
 type colord_tmp_t;
 files_tmp_file(colord_tmp_t)


### PR DESCRIPTION
The permission is required in colord v1.4.7 which contains miscellaneous service sandboxing features.

The commit addresses the following AVC denial:
Jan 22 09:23:44 fedora audit[1159]: AVC avc:  denied  { nnp_transition } for  pid=1159 comm="(colord)" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:colord_t:s0 tclass=process2 permissive=0 Jan 22 09:23:44 fedora audit: SELINUX_ERR op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:colord_t:s0

Resolves: rhbz#2259679