### PR TITLE
Allow chronyd-restricted read its key files

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -208,6 +208,8 @@ allow chronyd_restricted_t self:tcp_socket create_stream_socket_perms;
 allow chronyd_restricted_t self:udp_socket create_socket_perms;
 allow chronyd_restricted_t self:unix_dgram_socket create_socket_perms;
 
+allow chronyd_restricted_t chronyd_keys_t:file read_file_perms;
+
 manage_files_pattern(chronyd_restricted_t, chronyd_var_lib_t, chronyd_var_lib_t)
 
 allow chronyd_restricted_t chronyd_var_log_t:dir getattr_dir_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1706021857.079:1326): avc:  denied  { read } for  pid=25023 comm="chronyd" name="chrony.keys" dev="xvda4" ino=17299976 scontext=system_u:system_r:chronyd_restricted_t:s0 tcontext=system_u:object_r:chronyd_keys_t:s0 tclass=file permissive=0

Resolves: RHEL-18219