### PR TITLE
Allow conntrackd_t to use bpf capability2

### DIFF
--- a/policy/modules/contrib/conntrackd.te
+++ b/policy/modules/contrib/conntrackd.te
@@ -34,6 +34,7 @@ files_lock_file(conntrackd_var_lock_t)
 #
 
 allow conntrackd_t self:capability { sys_nice net_admin };
+allow conntrackd_t self:capability2 { bpf };
 allow conntrackd_t self:netlink_route_socket rw_netlink_socket_perms;
 allow conntrackd_t self:netlink_netfilter_socket create_socket_perms;
 allow conntrackd_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
When conntrackd filters packets using kernelspace filter, it needs the capability to do so efficiently.

Addresses following AVC denials:
type=AVC msg=audit(01/22/2024 12:46:49.999:248) : avc:  denied  { bpf } for  pid=1927 comm=conntrackd capability=bpf  scontext=system_u:system_r:conntrackd_t:s0 tcontext=system_u:system_r:conntrackd_t:s0 tclass=capability2 permissive=0

Resolves: RHEL-22277