### PR TITLE
Allow login_userdomain delete session dbusd tmp socket files

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -433,6 +433,7 @@ optional_policy(`
 
 optional_policy(`
 	dbus_create_session_tmp_sock_files(login_userdomain)
+	dbus_delete_session_tmp_sock_files(login_userdomain)
 	dbus_write_session_tmp_sock_files(login_userdomain)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/24/2024 21:14:21.706:7485) : proctitle=(systemd) type=PATH msg=audit(01/24/2024 21:14:21.706:7485) : item=1 name=/run/user/1002/bus inode=35 dev=00:36 mode=socket,666 ouid=user12424 ogid=user12424 rdev=00:00 obj=staff_u:object_r:session_dbusd_tmp_t:s0 nametype=DELETE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(01/24/2024 21:14:21.706:7485) : item=0 name=/run/user/1002/ inode=1 dev=00:36 mode=dir,700 ouid=user12424 ogid=user12424 rdev=00:00 obj=staff_u:object_r:user_tmp_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/24/2024 21:14:21.706:7485) : arch=x86_64 syscall=unlink success=no exit=EACCES(Permission denied) a0=0x55f03a905302 a1=0x55f03a937ea0 a2=0x55f56590dc97 a3=0x55f03a937eb0 items=2 ppid=1 pid=144007 auid=user12424 uid=user12424 gid=user12424 euid=user12424 suid=user12424 fsuid=user12424 egid=user12424 sgid=user12424 fsgid=user12424 tty=(none) ses=37 comm=systemd exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(01/24/2024 21:14:21.706:7485) : avc:  denied  { unlink } for  pid=144007 comm=systemd name=bus dev="tmpfs" ino=35 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:session_dbusd_tmp_t:s0 tclass=sock_file permissive=0