### PR TITLE
Allow su domains write login records

### DIFF
--- a/policy/modules/admin/su.if
+++ b/policy/modules/admin/su.if
@@ -80,6 +80,7 @@ template(`su_restricted_domain_template', `
 	auth_dontaudit_read_shadow($1_su_t)
 	auth_use_nsswitch($1_su_t)
 	auth_rw_faillog($1_su_t)
+	auth_write_login_records($1_su_t)
 
 	domain_use_interactive_fds($1_su_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=SYSCALL msg=audit(12/31/1969 19:00:08.000:0)  : arch=unknown-elf-type(x86_64) syscall=read success=no exit=EACCES(Permission denied) a0=0x0xffffff9c a1=0x0x7fa86f9fea59 a2=0xO_WRONLY a3=0x0x0 items=1 ppid=44644 pid=44645 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=1 comm=su exe=/usr/bin/su subj=staff_u:sysadm_r:sysadm_su_t:s0-s0:c0.c1023 key=perm_access type=PATH msg=audit(12/31/1969 19:00:08.000:0)  : item=0 name=/var/log/wtmp inode=25 dev=08:0a mode=000,000 664 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:wtmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=AVC msg=audit(12/31/1969 19:00:08.000:0)  : avc: denied { write }  for pid=44645 comm=su name=wtmp dev="sda10" ino=25 scontext=staff_u:sysadm_r:sysadm_su_t:s0-s0:c0.c1023 tcontext=system_u:object_r:wtmp_t:s0 tclass=file permissive=0

Resolves: RHEL-2606