### PR TITLE
Allow unix dgram sendto between exim processes

### DIFF
--- a/policy/modules/contrib/exim.te
+++ b/policy/modules/contrib/exim.te
@@ -75,6 +75,7 @@ ifdef(`distro_debian',`
 allow exim_t self:capability { chown dac_read_search dac_override fowner setuid setgid sys_resource };
 allow exim_t self:process { setrlimit setpgid };
 allow exim_t self:fifo_file rw_fifo_file_perms;
+allow exim_t self:unix_dgram_socket sendto;
 allow exim_t self:unix_stream_socket { accept listen };
 allow exim_t self:tcp_socket { accept listen };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/14/2024 13:24:32.626:977) : proctitle=/usr/sbin/exim -bd -q1h type=SOCKADDR msg=audit(01/14/2024 13:24:32.626:977) : saddr={ saddr_fam=local path=/var/spool/exim/exim_daemon_notify } type=SYSCALL msg=audit(01/14/2024 13:24:32.626:977) : arch=x86_64 syscall=sendto success=no exit=EACCES(Permission denied) a0=0x3 a1=0x55fa5b7e21f8 a2=0x11 a3=0x0 items=0 ppid=185680 pid=185770 auid=unset uid=exim gid=exim euid=exim suid=exim fsuid=exim egid=exim sgid=exim fsgid=exim tty=(none) ses=unset comm=exim exe=/usr/sbin/exim subj=system_u:system_r:exim_t:s0 key=(null) type=AVC msg=audit(01/14/2024 13:24:32.626:977) : avc:  denied  { sendto } for  pid=185770 comm=exim path=/var/spool/exim/exim_daemon_notify scontext=system_u:system_r:exim_t:s0 tcontext=system_u:system_r:exim_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: RHEL-21903