### PR TITLE
Remove duplicate entries in /run

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -193,14 +193,6 @@ ifdef(`distro_redhat',`
 /rhev/[^/]*/.*			gen_context(system_u:object_r:mnt_t,s0)
 ')
 
-#
-# /run
-#
-/run			-d	gen_context(system_u:object_r:var_run_t,s0-mls_systemhigh)
-/run/.*				gen_context(system_u:object_r:var_run_t,s0)
-/run/.*\.*pid			<<none>>
-/run/lock(/.*)?			gen_context(system_u:object_r:var_lock_t,s0)
-
 /sandbox(/.*)?                  gen_context(system_u:object_r:tmp_t,s0)
 #
 # /selinux
@@ -317,8 +309,6 @@ ifndef(`distro_redhat',`
 /var/run/.*			gen_context(system_u:object_r:var_run_t,s0)
 /var/run/.*\.*pid		<<none>>
 /var/run/lock/.*		<<none>>
-
-/run/cockpit/motd	--	gen_context(system_u:object_r:etc_t,s0)
 
 /var/spool(/.*)?		gen_context(system_u:object_r:var_spool_t,s0)
 /var/spool/postfix/etc(/.*)?	gen_context(system_u:object_r:etc_t,s0)

--- a/policy/modules/system/mount.fc
+++ b/policy/modules/system/mount.fc
@@ -3,7 +3,6 @@
 /bin/umount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 
 /dev/\.mount(/.*)?			gen_context(system_u:object_r:mount_var_run_t,s0)
-/run/mount(/.*)?			gen_context(system_u:object_r:mount_var_run_t,s0)
 
 /sbin/mount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)
 /sbin/umount.*			--	gen_context(system_u:object_r:mount_exec_t,s0)


### PR DESCRIPTION
Currently, entries for the /run filesystem are derived from /var/run entries by "/run = /var/run" equivalency.