### PR TITLE
Add support for systemd-homed

### DIFF
--- a/dist/targeted/modules.conf
+++ b/dist/targeted/modules.conf
@@ -3077,3 +3077,10 @@ afterburn = module
 # sap
 #
 sap = module
+
+# Layer: system
+# Module: systemd-homed
+#
+# Policy for systemd-homed
+#
+systemd-homed = module

--- a/policy/modules/contrib/colord.te
+++ b/policy/modules/contrib/colord.te
@@ -100,6 +100,7 @@ domain_use_interactive_fds(colord_t)
 files_list_mnt(colord_t)
 files_watch_usr_dirs(colord_t)
 files_map_var_lib_files(colord_t)
+files_mmap_isid_files(colord_t)
 files_read_var_lib_files(colord_t)
 
 fs_getattr_all_fs(colord_t)

--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -229,6 +229,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_homed_write_pipes(system_dbusd_t)
 	systemd_status_systemd_services(system_dbusd_t)
 	systemd_use_fds_logind(system_dbusd_t)
 	systemd_write_inherited_logind_sessions_pipes(system_dbusd_t)

--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -126,6 +126,10 @@ optional_policy(`
 	')
 
 	optional_policy(`
+		systemd_homed_dbus_chat(policykit_t)
+	')
+	
+	optional_policy(`
 		rhsmcertd_dbus_chat(policykit_t)
 	')
 

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2280,6 +2280,7 @@ optional_policy(`
 
 optional_policy(`
 	systemd_dbus_chat_machined(virtqemud_t)
+	systemd_homed_stream_connect(virtqemud_t)
 ')
 
 optional_policy(`

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -4850,6 +4850,25 @@ interface(`files_manage_isid_type_dirs',`
 
 ########################################
 ## <summary>
+##	Map files on new filesystems
+##	that have not yet been labeled.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_mmap_isid_files',`
+	gen_require(`
+		type unlabeled_t;
+	')
+
+	allow $1 unlabeled_t:file { getattr map };
+')
+
+########################################
+## <summary>
 ##	Mount a filesystem on a directory on new filesystems
 ##	that has not yet been labeled.
 ## </summary>
@@ -5247,6 +5266,24 @@ interface(`files_create_home_dir',`
 	')
 
 	create_dirs_pattern($1, home_root_t, home_root_t)
+')
+
+########################################
+## <summary>
+## 	Delete /home directories
+## </summary>
+## <param name="domain">
+## 	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`files_delete_home_dir',`
+	gen_require(`
+		type home_root_t;
+	')
+
+	delete_dirs_pattern($1, home_root_t, home_root_t)
 ')
 
 ########################################

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -1155,6 +1155,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+    systemd_homed_write_pid_sock_files(xdm_t)
+    systemd_homed_write_pipes(xdm_t)
+    systemd_homed_dbus_chat(xdm_t)
+')
+
+optional_policy(`
 	telepathy_exec(xdm_t)
 ')
 

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -572,6 +572,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_homed_stream_connect(nsswitch_domain)
 	systemd_userdbd_stream_connect(nsswitch_domain)
 	systemd_machined_stream_connect(nsswitch_domain)
 ')

--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -21,6 +21,24 @@ interface(`fstools_domtrans',`
 
 ########################################
 ## <summary>
+##	NNP Transition to fstools.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`fstools_nnp_domtrans',`
+	gen_require(`
+		type fsadm_t;
+	')
+	allow $1 fsadm_t:process2 nnp_transition;
+
+')
+
+########################################
+## <summary>
 ##	Execute fs tools in the fstools domain, and
 ##	allow the specified role the fs tools domain.
 ## </summary>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -815,6 +815,7 @@ optional_policy(`
 	optional_policy(`
 		devicekit_dbus_chat_power(init_t)
 	')
+
 ')
 
 optional_policy(`
@@ -877,6 +878,11 @@ optional_policy(`
 	stratisd_data_read_lnk_files(init_t)
 ')
 
+optional_policy(`
+	systemd_homed_dbus_chat(init_t)
+	systemd_homed_write_pipes(init_t)
+')
+	
 optional_policy(`
 	systemd_filetrans_named_content(init_t)
     systemd_write_inhibit_pipes(init_t)

--- a/policy/modules/system/systemd-homed.fc
+++ b/policy/modules/system/systemd-homed.fc
@@ -1,0 +1,22 @@
+#
+# homed file context
+#
+
+/run/systemd/home/(.+)\.dont-suspend                      -p  gen_context(system_u:object_r:systemd_homed_runtime_pipe_t,s0)
+/run/systemd/home/notify                                  -s  gen_context(system_u:object_r:systemd_homed_runtime_socket_t,s0)
+/run/systemd/home                                         -d  gen_context(system_u:object_r:systemd_homed_runtime_dir_t,s0)
+/run/systemd/user-home-mount                              -d  gen_context(system_u:object_r:systemd_homed_runtime_work_dir_t,s0)
+
+/usr/lib/systemd/systemd-homed                            --  gen_context(system_u:object_r:systemd_homed_exec_t,s0)
+/usr/lib/systemd/systemd-homework                         --  gen_context(system_u:object_r:systemd_homework_exec_t,s0)
+/usr/lib/systemd/system/systemd-homed-activate\.service   --  gen_context(system_u:object_r:systemd_homed_unit_file_t,s0)
+/usr/lib/systemd/system/systemd-homed\.service            --  gen_context(system_u:object_r:systemd_homed_unit_file_t,s0)
+
+/var/lib/systemd/home/(.+)\.identity                      --  gen_context(system_u:object_r:systemd_homed_record_t,s0)
+/var/lib/systemd/home/local\.private                      --  gen_context(system_u:object_r:systemd_homed_record_t,s0)
+/var/lib/systemd/home/(.+)\.public                        --  gen_context(system_u:object_r:systemd_homed_record_t,s0)
+/var/lib/systemd/home/local\.public                       --  gen_context(system_u:object_r:systemd_homed_record_t,s0)
+/var/lib/systemd/home                                     -d  gen_context(system_u:object_r:systemd_homed_library_dir_t,s0)
+
+HOME_DIR/\.identity                                       --  gen_context(system_u:object_r:systemd_homed_record_t,s0)
+HOME_ROOT/(.+)\.home                                      --  gen_context(system_u:object_r:systemd_homed_crypto_luks_t,s0)

--- a/policy/modules/system/systemd-homed.if
+++ b/policy/modules/system/systemd-homed.if
@@ -1,0 +1,80 @@
+## <summary>SELinux policy for systemd-homed components</summary>
+
+########################################
+## <summary>
+##	Send and receive messages from
+##	systemd homed over dbus.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_homed_dbus_chat',`
+	gen_require(`
+		type systemd_homed_t;
+		class dbus send_msg;
+	')
+
+	allow $1 systemd_homed_t:dbus send_msg;
+	allow systemd_homed_t $1:dbus send_msg;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to connect to
+##	systemd homed with a unix socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_homed_stream_connect',`
+	gen_require(`
+		type systemd_homed_t;
+	')
+
+	allow $1 systemd_homed_t:unix_stream_socket connectto;
+')
+
+#######################################
+## <summary>
+##	Write to systemd_homed PID socket files.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`systemd_homed_write_pid_sock_files',`
+    gen_require(`
+        type systemd_homed_runtime_dir_t;
+        type systemd_homed_runtime_socket_t;
+    ')
+
+	write_sock_files_pattern($1, systemd_homed_runtime_dir_t, systemd_homed_runtime_socket_t)
+')
+
+######################################
+## <summary>
+##	Write systemd homed pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_homed_write_pipes',`
+	gen_require(`
+		type systemd_homed_runtime_dir_t;
+		type systemd_homed_runtime_pipe_t;
+	')
+
+	write_fifo_files_pattern($1, systemd_homed_runtime_dir_t, systemd_homed_runtime_pipe_t)
+')
+

--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -1,0 +1,251 @@
+policy_module(systemd-homed, 0.2.0)
+########################################
+#
+# Declarations
+#
+
+type systemd_homed_t;
+type systemd_homed_exec_t;
+init_daemon_domain(systemd_homed_t, systemd_homed_exec_t)
+init_nnp_daemon_domain(systemd_homed_t)
+
+type systemd_homework_t;
+type systemd_homework_exec_t;
+domain_type(systemd_homework_t)
+domain_entry_file(systemd_homework_t, systemd_homework_exec_t)
+role system_r types systemd_homework_t;
+
+type systemd_homed_crypto_luks_t;
+userdom_user_home_content(systemd_homed_crypto_luks_t)
+
+type systemd_homed_library_dir_t;
+files_type(systemd_homed_library_dir_t)
+
+type systemd_homed_record_t;
+files_auth_file(systemd_homed_record_t)
+
+type systemd_homed_runtime_dir_t;
+files_pid_file(systemd_homed_runtime_dir_t)
+
+type systemd_homed_runtime_pipe_t;
+files_pid_file(systemd_homed_runtime_pipe_t)
+
+type systemd_homed_runtime_socket_t;
+files_pid_file(systemd_homed_runtime_socket_t)
+
+type systemd_homed_runtime_work_dir_t;
+files_pid_file(systemd_homed_runtime_work_dir_t)
+files_mountpoint(systemd_homed_runtime_work_dir_t)
+
+type systemd_homed_tmpfs_t;
+files_tmpfs_file(systemd_homed_tmpfs_t)
+
+type systemd_homed_unit_file_t;
+systemd_unit_file(systemd_homed_unit_file_t)
+
+#######################################
+#
+# systemd_homed local policy
+#
+
+allow systemd_homed_t self:capability { sys_admin sys_resource dac_override dac_read_search setuid setgid };
+allow systemd_homed_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow systemd_homed_t self:unix_dgram_socket create_socket_perms;
+
+domtrans_pattern(systemd_homed_t, systemd_homework_exec_t, systemd_homework_t)
+allow systemd_homed_t systemd_homework_t:process2 nnp_transition;
+
+# homed.conf
+files_read_config_files(systemd_homed_t)
+init_read_pid_files(systemd_homed_t)
+libs_read_lib_files(systemd_homed_t)
+
+# /home
+files_watch_home(systemd_homed_t)
+files_search_home(systemd_homed_t)
+
+# unlabeled home directories
+files_manage_isid_type_dirs(systemd_homed_t)
+files_manage_isid_type_files(systemd_homed_t)
+
+# /var/lib/systemd/home
+manage_files_pattern(systemd_homed_t, systemd_homed_library_dir_t, systemd_homed_record_t)
+init_var_lib_filetrans(systemd_homed_t, systemd_homed_library_dir_t, dir, "home")
+filetrans_pattern(systemd_homed_t, systemd_homed_library_dir_t, systemd_homed_record_t, file)
+
+# /run/systemd/home
+create_dirs_pattern(systemd_homed_t, init_var_run_t, systemd_homed_runtime_dir_t)
+init_pid_filetrans(systemd_homed_t, systemd_homed_runtime_dir_t, dir, "home")
+
+# /run/systemd/home/*.dont-suspend
+manage_fifo_files_pattern(systemd_homed_t, systemd_homed_runtime_dir_t, systemd_homed_runtime_pipe_t)
+filetrans_pattern(systemd_homed_t, systemd_homed_runtime_dir_t, systemd_homed_runtime_pipe_t, fifo_file)
+
+# /run/systemd/home/notify
+create_sock_files_pattern(systemd_homed_t, systemd_homed_runtime_dir_t, systemd_homed_runtime_socket_t)
+delete_sock_files_pattern(systemd_homed_t, systemd_homed_runtime_dir_t, systemd_homed_runtime_socket_t)
+filetrans_pattern(systemd_homed_t, systemd_homed_runtime_dir_t, systemd_homed_runtime_socket_t, sock_file, "notify")
+
+rw_files_pattern(systemd_homed_t, systemd_homed_tmpfs_t, systemd_homed_tmpfs_t)
+fs_tmpfs_filetrans(systemd_homed_t, systemd_homed_tmpfs_t, file)
+
+kernel_dgram_send(systemd_homed_t)
+kernel_read_system_state(systemd_homed_t)
+
+dev_getattr_generic_blk_files(systemd_homed_t)
+dev_read_sysfs(systemd_homed_t)
+
+fs_getattr_cgroup(systemd_homed_t)
+fs_getattr_xattr_fs(systemd_homed_t)
+fs_search_cgroup_dirs(systemd_homed_t)
+fs_write_cgroup_files(systemd_homed_t)
+
+storage_getattr_fixed_disk_dev(systemd_homed_t)
+storage_raw_read_removable_device(systemd_homed_t)
+
+optional_policy(`
+    auth_use_nsswitch(systemd_homed_t)
+')
+
+optional_policy(`
+    container_runtime_read_tmpfs_files(systemd_homed_t)
+')
+
+optional_policy(`
+    dbus_connect_system_bus(systemd_homed_t)
+')
+
+optional_policy(`
+    logging_send_syslog_msg(systemd_homed_t)
+')
+
+optional_policy(`
+    miscfiles_read_all_certs(systemd_homed_t)
+')
+
+optional_policy(`
+    mta_getattr_spool(systemd_homed_t)
+')
+
+optional_policy(`
+    systemd_manage_userdbd_runtime_sock_files(systemd_homed_t)
+')
+
+optional_policy(`
+    udev_manage_pid_files(systemd_homed_t)
+')
+
+optional_policy(`
+   # labeled home directories
+   userdom_home_manager(systemd_homed_t)
+   userdom_manage_home_role(system_r, systemd_homed_t)
+')
+
+optional_policy(`
+   usermanage_read_crack_db(systemd_homed_t)
+')
+
+#######################################
+#
+# systemd_homework local policy
+#
+
+allow systemd_homework_t self:cap_userns { sys_admin sys_ptrace  };
+allow systemd_homework_t self:capability { chown fowner fsetid setfcap dac_override dac_read_search setuid setgid sys_admin sys_resource };
+allow systemd_homework_t self:file mounton;
+allow systemd_homework_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow systemd_homework_t self:process { setsched getsched };
+allow systemd_homework_t self:sem create_sem_perms;
+allow systemd_homework_t self:unix_dgram_socket create_socket_perms;
+allow systemd_homework_t self:user_namespace create;
+allow systemd_homework_t systemd_homed_t:unix_dgram_socket sendto;
+
+# /home
+files_create_home_dir(systemd_homework_t)
+files_delete_home_dir(systemd_homework_t)
+files_search_home(systemd_homework_t)
+files_home_filetrans(systemd_homework_t, systemd_homed_crypto_luks_t, file)
+
+# unlabeled home directories
+files_manage_isid_type_dirs(systemd_homework_t)
+files_manage_isid_type_files(systemd_homework_t)
+files_mounton_isid(systemd_homework_t)
+
+# /run/systemd/home/notify
+write_sock_files_pattern(systemd_homework_t, systemd_homed_runtime_dir_t, systemd_homed_runtime_socket_t)
+
+# /run/systemd/user-home-mount
+create_dirs_pattern(systemd_homework_t, init_var_run_t, systemd_homed_runtime_work_dir_t)
+read_files_pattern(systemd_homework_t, systemd_homed_runtime_work_dir_t, systemd_homed_record_t)
+delete_files_pattern(systemd_homework_t, systemd_homed_runtime_work_dir_t, systemd_homed_record_t)
+init_pid_filetrans(systemd_homework_t, systemd_homed_runtime_work_dir_t, dir, "user-home-mount")
+
+rw_files_pattern(systemd_homework_t, systemd_homed_tmpfs_t, systemd_homed_tmpfs_t)
+
+files_mounton_all_mountpoints(systemd_homework_t)
+
+kernel_dgram_send(systemd_homework_t)
+kernel_get_sysvipc_info(systemd_homework_t)
+kernel_read_fs_sysctls(systemd_homework_t)
+kernel_read_system_state(systemd_homework_t)
+kernel_request_load_module(systemd_homework_t)
+
+corecmd_exec_shell(systemd_homework_t)
+
+dev_getattr_fs(systemd_homework_t)
+dev_read_rand(systemd_homework_t)
+dev_read_sysfs(systemd_homework_t)
+dev_rw_generic_usb_dev(systemd_homework_t)
+dev_rw_loop_control(systemd_homework_t)
+dev_rw_lvm_control(systemd_homework_t)
+dev_watch_generic_dirs(systemd_homework_t)
+
+domain_manage_all_domains_keyrings(systemd_homework_t)
+
+fs_all_mount_fs_perms_xattr_fs(systemd_homework_t)
+fs_getattr_cgroup(systemd_homework_t)
+fs_read_nsfs_files(systemd_homework_t)
+fs_relabelfrom_xattr_fs(systemd_homework_t)
+fs_search_all(systemd_homework_t)
+
+fsadm_manage_pid(systemd_homework_t)
+
+init_read_state(systemd_homework_t)
+init_rw_stream_sockets(systemd_homework_t)
+
+storage_raw_read_removable_device(systemd_homework_t)
+storage_rw_inherited_removable_device(systemd_homework_t)
+storage_manage_fixed_disk(systemd_homework_t)
+
+optional_policy(`
+    auth_read_passwd_file(systemd_homework_t)
+')
+
+optional_policy(`
+    fstools_domtrans(systemd_homework_t)
+    fstools_nnp_domtrans(systemd_homework_t)
+')
+
+optional_policy(`
+    lvm_manage_var_run(systemd_homework_t)
+')
+
+optional_policy(`
+    logging_send_syslog_msg(systemd_homework_t)
+')
+
+optional_policy(`
+    miscfiles_read_all_certs(systemd_homework_t)
+')
+
+optional_policy(`
+    udev_read_pid_files(systemd_homework_t)
+    udev_search_pids(systemd_homework_t)
+')
+
+optional_policy(`
+    # labeled home directories
+    userdom_home_filetrans_user_home_dir(systemd_homework_t)
+    userdom_home_manager(systemd_homework_t)
+    userdom_manage_home_role(system_r, systemd_homework_t)
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1769,6 +1769,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_homed_dbus_chat(systemd_sleep_t)
+')
+
+optional_policy(`
 	tlp_domtrans(systemd_sleep_t)
 	tlp_filetrans_named_content(systemd_sleep_t)
 ')

--- a/policy/modules/system/userdomain.fc
+++ b/policy/modules/system/userdomain.fc
@@ -1,3 +1,4 @@
+HOME_ROOT/(.+)\.homedir	--  gen_context(system_u:object_r:user_home_dir_t,s0)
 HOME_DIR	-d	gen_context(system_u:object_r:user_home_dir_t,s0-mls_systemhigh)
 HOME_DIR	-l	gen_context(system_u:object_r:user_home_dir_t,s0-mls_systemhigh)
 HOME_DIR/.+		gen_context(system_u:object_r:user_home_t,s0)


### PR DESCRIPTION
### Testing 

Enable homed features on Fedora
```sh
sudo authselect enable-feature \
    with-systemd-homed
```
```sh
sudo systemctl enable --now \
    systemd-homed
```
Relabel homed context
```sh
sudo restorecon -v \
    /usr/lib/systemd/systemd-homed \
    /usr/lib/systemd/systemd-homework \
    /usr/lib/systemd/system/systemd-homed-activate.service \
    /usr/lib/systemd/system/systemd-homed.service \
    /var/lib/systemd/home/
```
Create a testuser for homed
```sh
sudo homectl create testuser
```