### PR TITLE
Remove rule to allow users execute init with a domain transition

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1519,7 +1519,7 @@ tunable_policy(`deny_bluetooth',`',`
 	corenet_tcp_bind_xserver_port($1_t)
 	corenet_tcp_bind_generic_node($1_usertype)
 
-    init_domtrans($1_t)
+	init_exec($1_t)
     init_rw_stream_sockets($1_t)
 
 	storage_rw_fuse($1_t)


### PR DESCRIPTION
This rule exists in the userdom_unpriv_user_template() template.