### PR TITLE
Allow gpg manage rpm cache

### DIFF
--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -197,7 +197,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	rpm_read_db(gpg_t)
+	rpm_manage_cache(gpg_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Instead of reading all rpm data, gpg needs permissions to manage, but only for cache files.

The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(01/29/2024 07:58:45.089:80) : proctitle=gpg --enable-special-filenames --batch --no-sk-comments --homedir /var/cache/dnf/RHEL6421-290d60badb0765d7/pubring --status-fd 1 type=PATH msg=audit(01/29/2024 07:58:45.089:80) : item=0 name=/var/cache/dnf/RHEL6421-290d60badb0765d7/pubring/ inode=258138 dev=fd:01 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:rpm_var_cache_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0OUID="root" OGID="root" type=SYSCALL msg=audit(01/29/2024 07:58:45.089:80) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55fedc65d0e0 a2=O_WRONLY|O_CREAT|O_EXCL a3=0x1a4 items=1 ppid=1 pid=2179 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=gpg exe=/usr/bin/gpg subj=system_u:system_r:gpg_t:s0 key=(null) SYSCALL=openat AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root" type=AVC msg=audit(01/29/2024 07:58:45.089:80) : avc:  denied  { write } for  pid=2179 comm=gpg name=pubring dev="dm-1" ino=258138 scontext=system_u:system_r:gpg_t:s0 tcontext=system_u:object_r:rpm_var_cache_t:s0 tclass=dir permissive=0

Resolves: RHEL-11249