### PR TITLE
Allow load_policy read and write generic ptys

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -208,6 +208,7 @@ selinux_load_policy(load_policy_t)
 selinux_set_all_booleans(load_policy_t)
 
 term_use_console(load_policy_t)
+term_use_generic_ptys(load_policy_t)
 term_list_ptys(load_policy_t)
 term_write_unallocated_ttys(load_policy_t)
 


### PR DESCRIPTION
This permission is required when user in the sysadm role executes "load_policy --help" in a pty terminal.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/02/2024 14:32:51.308:1070) : proctitle=load_policy --help type=PATH msg=audit(02/02/2024 14:32:51.308:1070) : item=0 name=/lib64/ld-linux-x86-64.so.2 inode=257286 dev=00:1f mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(02/02/2024 14:32:51.308:1070) : argc=2 a0=load_policy a1=--help type=SYSCALL msg=audit(02/02/2024 14:32:51.308:1070) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x5565827f9eb0 a1=0x5565827fa230 a2=0x5565827dd390 a3=0x5565827fa230 items=1 ppid=10176 pid=10237 auid=staff uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=16 comm=load_policy exe=/usr/sbin/load_policy subj=staff_u:sysadm_r:load_policy_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/02/2024 14:32:51.308:1070) : avc:  denied  { read write } for  pid=10237 comm=load_policy path=/dev/pts/3 dev="devpts" ino=6 scontext=staff_u:sysadm_r:load_policy_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:devpts_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2262392