### PR TITLE
Allow rules for confined users logged in plasma

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7622,7 +7622,7 @@ interface(`files_watch_usr_lnk_files',`
 		type usr_t;
 	')
 
-	allow $1 usr_t:file watch_lnk_file_perms;
+	allow $1 usr_t:lnk_file watch_lnk_file_perms;
 ')
 
 ########################################

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -400,6 +400,7 @@ files_map_var_lib_files(login_userdomain)
 files_read_var_lib_symlinks(login_userdomain)
 files_watch_etc_dirs(login_userdomain)
 files_watch_etc_files(login_userdomain)
+files_watch_home(login_userdomain)
 files_watch_root_dirs(login_userdomain)
 files_watch_system_conf_dirs(login_userdomain)
 files_watch_usr_dirs(login_userdomain)
@@ -438,6 +439,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gnome_exec_atspi(login_userdomain)
 	gnome_watch_generic_data_home_dirs(login_userdomain)
 	gnome_watch_home_config_dirs(login_userdomain)
 	gnome_watch_home_config_files(login_userdomain)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -375,7 +375,9 @@ optional_policy(`
 allow login_userdomain self:service status;
 allow login_userdomain self:user_namespace create;
 
+corenet_udp_bind_howl_port(login_userdomain)
 corenet_tcp_bind_xmsg_port(login_userdomain)
+corenet_udp_bind_xmsg_port(login_userdomain)
 
 create_blk_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )
 create_chr_files_pattern(login_userdomain, user_tmp_t, user_tmp_t )


### PR DESCRIPTION
Namely watch home dirs and execute gnome-atspi. Additionally, files_watch_usr_lnk_files() was updated to really use lnk_file class.

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(02/02/2024 14:26:04.277:981) : proctitle=(launcher) type=PATH msg=audit(02/02/2024 14:26:04.277:981) : item=0 name=/lib64/ld-linux-x86-64.so.2 inode=257286 dev=00:1f mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(02/02/2024 14:26:04.277:981) : argc=1 a0=/usr/libexec/at-spi-bus-launcher type=SYSCALL msg=audit(02/02/2024 14:26:04.277:981) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55ae3f19e3d0 a1=0x55ae3f19e3b0 a2=0x55ae3f19d310 a3=0x0 items=1 ppid=6578 pid=9183 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=(none) ses=16 comm=at-spi-bus-laun exe=/usr/libexec/at-spi-bus-launcher subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/02/2024 14:26:04.277:981) : avc:  denied  { map } for  pid=9183 comm=at-spi-bus-laun path=/usr/libexec/at-spi-bus-launcher dev="vda3" ino=312167 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:gnome_atspi_exec_t:s0 tclass=file permissive=1 type=AVC msg=audit(02/02/2024 14:26:04.277:981) : avc:  denied  { execute_no_trans } for  pid=9183 comm=(launcher) path=/usr/libexec/at-spi-bus-launcher dev="vda3" ino=312167 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:gnome_atspi_exec_t:s0 tclass=file permissive=1 type=AVC msg=audit(02/02/2024 14:26:04.277:981) : avc:  denied  { read open } for  pid=9183 comm=(launcher) path=/usr/libexec/at-spi-bus-launcher dev="vda3" ino=312167 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:gnome_atspi_exec_t:s0 tclass=file permissive=1

type=PROCTITLE msg=audit(02/02/2024 14:25:55.202:775) : proctitle=(systemd)
type=SYSCALL msg=audit(02/02/2024 14:25:55.202:775) : arch=x86_64 syscall=inotify_add_watch success=yes exit=2 a0=0xa a1=0x55ca691841d0 a2=0x2000d84 a3=0x7ffc1b1c7a1c items=0 ppid=1 pid=6578 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=(none) ses=16 comm=systemd exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(02/02/2024 14:25:55.202:775) : avc:  denied  { watch } for  pid=6578 comm=systemd path=/home dev="vda3" ino=256 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:home_root_t:s0 tclass=dir permissive=1

type=PROCTITLE msg=audit(02/02/2024 14:37:59.338:1081) : proctitle=/usr/libexec/kscreenlocker_greet --graceTime 5000 --ksldfd 174
type=SYSCALL msg=audit(02/02/2024 14:37:59.338:1081) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0x13 a1=0x5566154431d0 a2=0x2000fc6 a3=0x556615443250 items=0 ppid=8964 pid=10266 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=(none) ses=16 comm=kscreenlocker_g exe=/usr/libexec/kscreenlocker_greet subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(02/02/2024 14:37:59.338:1081) : avc:  denied  { watch } for  pid=10266 comm=kscreenlocker_g path=/usr/share/backgrounds/default.png dev="vda3" ino=254488 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:usr_t:s0 tclass=lnk_file permissive=0