### PR TITLE
Allow setroubleshootd create and use inherited io_uring

### DIFF
--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -90,7 +90,7 @@ manage_files_pattern(setroubleshootd_t, setroubleshoot_var_run_t, setroubleshoot
 manage_sock_files_pattern(setroubleshootd_t, setroubleshoot_var_run_t, setroubleshoot_var_run_t)
 files_pid_filetrans(setroubleshootd_t, setroubleshoot_var_run_t, { file sock_file dir })
 
-
+kernel_io_uring_use(setroubleshootd_t)
 kernel_read_kernel_sysctls(setroubleshootd_t)
 kernel_read_system_state(setroubleshootd_t)
 kernel_read_net_sysctls(setroubleshootd_t)


### PR DESCRIPTION
The io_uring class is used by plocate executed by setroubleshootd.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/05/2024 11:50:06.209:990) : proctitle=locate -b \socket:[55759] type=SYSCALL msg=audit(02/05/2024 11:50:06.209:990) : arch=x86_64 syscall=mmap success=yes exit=140140076916736 a0=0x0 a1=0x2440 a2=PROT_READ|PROT_WRITE a3=MAP_SHARED|MAP_POPULATE items=0 ppid=9028 pid=9138 auid=unset uid=setroubleshoot gid=setroubleshoot euid=setroubleshoot suid=setroubleshoot fsuid=setroubleshoot egid=setroubleshoot sgid=plocate fsgid=setroubleshoot tty=(none) ses=unset comm=locate exe=/usr/bin/plocate subj=system_u:system_r:setroubleshootd_t:s0 key=(null) type=AVC msg=audit(02/05/2024 11:50:06.209:990) : avc:  denied  { read write } for  pid=9138 comm=locate path=anon_inode:[io_uring] dev="anon_inodefs" ino=61622 scontext=system_u:system_r:setroubleshootd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1 type=AVC msg=audit(02/05/2024 11:50:06.209:990) : avc:  denied  { map } for  pid=9138 comm=locate path=anon_inode:[io_uring] dev="anon_inodefs" ino=61622 scontext=system_u:system_r:setroubleshootd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1