### PR TITLE
Update ssh_role_template()

### DIFF
--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -399,6 +399,7 @@ template(`ssh_role_template',`
 
 	# for ssh-agent user service
 	allow $3 $1_ssh_agent_t:unix_stream_socket create_stream_socket_perms;
+	allow $1_ssh_agent_t $3:unix_stream_socket rw_socket_perms;
 
 	# Allow the user shell to signal the ssh program.
 	allow $3 $1_ssh_agent_t:process signal_perms;


### PR DESCRIPTION
Update ssh_role_template() to allow user ssh agent type (e.g. staff_ssh_agent_t) IPC with user type (e.g. staff_t) over a unix stream socket. The other way of communication was already allowed.

The commit addresses the following AVC denial:
Feb 05 11:36:24 fedora audit[5067]: AVC avc:  denied  { read write } for  pid=5067 comm="ssh-agent" path="socket:[38159]" dev="sockfs" ino=38159 scontext=staff_u:staff_r:staff_ssh_agent_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0