### PR TITLE
Allow init_t nnp domain transition to abrtd_t

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -38,6 +38,7 @@ roleattribute system_r abrt_helper_roles;
 
 abrt_basic_types_template(abrt)
 init_daemon_domain(abrt_t, abrt_exec_t)
+init_nnp_daemon_domain(abrt_t)
 
 type abrt_initrc_exec_t;
 init_script_file(abrt_initrc_exec_t)


### PR DESCRIPTION
The permission is required in abrt v2.17.2 which contains miscellaneous service sandboxing features.

The commit addresses the following AVC denial:
Feb 05 14:39:14 fedora audit[729]: AVC avc:  denied  { nnp_transition } for  pid=729 comm="(abrtd)" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:abrt_t:s0-s0:c0.c1023 tclass=process2 permissive=0 Feb 05 14:39:14 fedora audit: SELINUX_ERR op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:abrt_t:s0-s0:c0.c1023

Resolves: rhbz#2263210