### PR TITLE
Fixes for domain_fd_use=0

### DIFF
--- a/policy/modules/contrib/anaconda.if
+++ b/policy/modules/contrib/anaconda.if
@@ -167,3 +167,21 @@ interface(`anaconda_create_unix_stream_sockets',`
 
 	allow $1 install_t:unix_stream_socket create_stream_socket_perms;
 ')
+
+########################################
+## <summary>
+##	Use file descriptors from the install domain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`anaconda_fd_use',`
+	gen_require(`
+		type install_t;
+	')
+
+	allow $1 install_t:fd use;
+')

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -602,6 +602,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# This is needed purely for rpm-ostree (after --apply-live).
+	# It should be removed when/if it gets its own policy.
+	anaconda_fd_use(domain)
+')
+
+optional_policy(`
 	# A workaround to handle additional permissions check
 	# introduced as an involuntary result of a kernel change
 	automount_write_pipes(domain)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -805,6 +805,7 @@ optional_policy(`
     dbus_manage_session_tmp_dirs(init_t)
 	dbus_read_pid_sock_files(init_t)
 	dbus_watch_pid_sock_files(init_t)
+	dbus_use_system_bus_fds(init_t)
 
 	optional_policy(`
 		devicekit_dbus_chat_power(init_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -399,6 +399,7 @@ logging_manage_audit_config(init_t)
 logging_create_syslog_netlink_audit_socket(init_t)
 logging_write_var_log_dirs(init_t)
 logging_manage_var_log_symlinks(init_t)
+logging_fd_use(init_t)
 
 seutil_read_config(init_t)
 seutil_read_login_config(init_t)

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -1806,3 +1806,21 @@ interface(`logging_dgram_send',`
 
 	allow $1 syslogd_t:unix_dgram_socket sendto;
 ')
+
+#######################################
+## <summary>
+##	Use file descriptors from syslogd.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_fd_use',`
+	gen_require(`
+		type syslogd_t;
+	')
+
+	allow $1 syslogd_t:fd use;
+')


### PR DESCRIPTION
All of this needs to be allowed when the `domain_fd_use` boolean is turned off.

BTW, we should consider disabling the boolean by default instead of hiding these issues.