### PR TITLE
Allow utempter_t use ptmx

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -413,7 +413,7 @@ term_getattr_all_ttys(utempter_t)
 term_getattr_all_ptys(utempter_t)
 term_dontaudit_use_all_ttys(utempter_t)
 term_dontaudit_use_all_ptys(utempter_t)
-term_dontaudit_use_ptmx(utempter_t)
+term_use_ptmx(utempter_t)
 
 auth_use_nsswitch(utempter_t)
 


### PR DESCRIPTION
This permission is required when a confined user runs tlog-rec to record a terminal session.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/12/2024 10:57:55.073:386) : proctitle=/usr/libexec/utempter/utempter add type=PATH msg=audit(02/12/2024 10:57:55.073:386) : item=0 name=/lib64/ld-linux-x86-64.so.2 inode=16817307 dev=fd:00 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(02/12/2024 10:57:55.073:386) : argc=2 a0=/usr/libexec/utempter/utempter a1=add type=SYSCALL msg=audit(02/12/2024 10:57:55.073:386) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7ff2467eceb0 a1=0x7ffcd6caddb0 a2=0x7ffcd6cae4d8 a3=0x7ff247d9d980 items=1 ppid=37949 pid=37951 auid=staff uid=root gid=root euid=root suid=root fsuid=root egid=utmp sgid=utmp fsgid=utmp tty=pts0 ses=8 comm=utempter exe=/usr/libexec/utempter/utempter subj=staff_u:sysadm_r:utempter_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/12/2024 10:57:55.073:386) : avc:  denied  { read write } for  pid=37951 comm=utempter path=/dev/ptmx dev="devtmpfs" ino=1114 scontext=staff_u:sysadm_r:utempter_t:s0-s0:c0.c1023 tcontext=system_u:object_r:ptmx_t:s0 tclass=chr_file permissive=0

Resolves: RHEL-24946