### PR TITLE
Dontaudit getty and plymouth the checkpoint_restore capability (f38)

### DIFF
--- a/policy/modules/contrib/plymouthd.te
+++ b/policy/modules/contrib/plymouthd.te
@@ -34,6 +34,7 @@ files_pid_file(plymouthd_var_run_t)
 allow plymouthd_t self:capability { sys_admin sys_chroot sys_tty_config };
 allow plymouthd_t self:capability2 { block_suspend bpf };
 dontaudit plymouthd_t self:capability{ dac_read_search   };
+dontaudit plymouthd_t self:capability2 checkpoint_restore;
 allow plymouthd_t self:process { signal getsched };
 allow plymouthd_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow plymouthd_t self:fifo_file rw_fifo_file_perms;

--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -30,9 +30,11 @@ kernel_load_module(wireguard_t)
 kernel_request_load_module(wireguard_t)
 kernel_rw_net_sysctls(wireguard_t)
 kernel_search_debugfs(wireguard_t)
+kernel_read_proc_files(wireguard_t)
 
 corecmd_exec_bin(wireguard_t)
 
+dev_read_sysfs(wireguard_t)
 dev_write_kmsg(wireguard_t)
 
 domain_use_interactive_fds(wireguard_t)
@@ -48,6 +50,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	firewalld_dbus_chat(wireguard_t)
+')
+
+optional_policy(`
 	iptables_domtrans(wireguard_t)
 ')
 
@@ -56,6 +62,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	miscfiles_read_generic_certs(wireguard_t)
 	miscfiles_read_localization(wireguard_t)
 ')
 

--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -46,6 +46,7 @@ ifdef(`enable_mls',`
 # Use capabilities.
 allow getty_t self:capability { dac_read_search  dac_override chown setgid sys_resource sys_tty_config fowner fsetid };
 dontaudit getty_t self:capability sys_tty_config;
+dontaudit getty_t self:capability2 checkpoint_restore;
 allow getty_t self:process { getpgid setpgid getsession signal_perms };
 allow getty_t self:fifo_file rw_fifo_file_perms;
 

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -151,6 +151,8 @@ auth_filetrans_auth_home_content(userdomain)
 
 files_dontaudit_manage_boot_files(unpriv_userdomain)
 
+fs_getattr_nsfs_files(userdomain)
+
 mount_dontaudit_write_mount_pid(unpriv_userdomain)
 mount_entry_type(unpriv_userdomain)
 


### PR DESCRIPTION
The capability CAP_CHECKPOINT_RESTORE was introduced to allow non-root users to checkpoint and restore processes as non-root with CRIU. Since the "tty: allow TIOCSLCKTRMIOS with CAP_CHECKPOINT_RESTORE" (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e0f25b8992345aa5f113da2815f5add98738c611) kernel commit, the same capability check is used in the tty kernel driver. Since there is a fallback check for the CAP_SYS_ADMIN capability, CAP_CHECKPOINT_RESTORE can be dontaudited for getty_t and plymouthd_t.

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(01/29/2024 13:52:21.033:258) : proctitle=/sbin/agetty -o -p -- \u --noclear - linux type=SYSCALL msg=audit(01/29/2024 13:52:21.033:258) : arch=x86_64 syscall=ioctl success=yes exit=0 a0=0x0 a1=0x5457 a2=0x7fff99415720 a3=0x8 items=0 ppid=1 pid=2720 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=tty2 ses=unset comm=agetty exe=/usr/sbin/agetty subj=system_u:system_r:getty_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(01/29/2024 13:52:21.033:258) : avc:  denied  { checkpoint_restore } for  pid=2720 comm=agetty capability=checkpoint_restore  scontext=system_u:system_r:getty_t:s0-s0:c0.c1023 tcontext=system_u:system_r:getty_t:s0-s0:c0.c1023 tclass=capability2 permissive=0

type=PROCTITLE msg=audit(01/29/2024 13:53:22.553:465) : proctitle=/usr/sbin/plymouthd --mode=shutdown --attach-to-session
type=SYSCALL msg=audit(01/29/2024 13:53:22.553:465) : arch=x86_64 syscall=ioctl success=yes exit=0 a0=0x7 a1=0x5457 a2=0x7ffc2e51b680 a3=0x10 items=0 ppid=1 pid=4208 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=plymouthd exe=/usr/sbin/plymouthd subj=system_u:system_r:plymouthd_t:s0 key=(null)
type=AVC msg=audit(01/29/2024 13:53:22.553:465) : avc:  denied  { checkpoint_restore } for  pid=4208 comm=plymouthd capability=checkpoint_restore  scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:system_r:plymouthd_t:s0 tclass=capability2 permissive=0

Resolves: rhbz#2259622