### PR TITLE
Dontaudit rpmdb attempts to connect to sssd over a unix stream socket

### DIFF
--- a/policy/modules/contrib/rpm.te
+++ b/policy/modules/contrib/rpm.te
@@ -293,6 +293,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_dontaudit_stream_connect(rpmdb_t)
+')
+
+optional_policy(`
 	userdom_read_admin_home_files(rpmdb_t)
 ')
 


### PR DESCRIPTION
This is just a follow-up on this existing rule:
auth_dontaudit_read_passwd(rpmdb_t)
The /usr/lib/rpm/rpmdb_migrate script does not seem to require user id.

The commit addresses the following AVC denial:
type=AVC msg=audit(1707219993.399:46): avc:  denied  { write } for  pid=1007 comm="rpmdb_migrate" name="nss" dev="sde4" ino=1623381 scontext=system_u:system_r:rpmdb_t:s0 tcontext=unconfined_u:object_r:sssd_var_lib_t:s0 tclass=sock_file permissive=1

Resolves: rhbz#2262977