### PR TITLE
systemd: allow sys_admin capability for systemd_notify_t

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -793,7 +793,7 @@ optional_policy(`
 #
 # systemd_notify local policy
 #
-allow systemd_notify_t self:capability chown;
+allow systemd_notify_t self:capability { chown sys_admin };
 allow systemd_notify_t self:process { fork setfscreate setsockcreate };
 
 allow systemd_notify_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
See [RHEL-25605 - AVCs "sys_admin" when executing systemd-notify from a service unit](https://issues.redhat.com/browse/RHEL-25701).