### PR TITLE
systemd: allow systemd_notify_t to send data to kernel_t datagram sockets

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -800,6 +800,13 @@ allow systemd_notify_t self:fifo_file rw_fifo_file_perms;
 allow systemd_notify_t self:unix_stream_socket create_stream_socket_perms;
 allow systemd_notify_t self:unix_dgram_socket create_socket_perms;
 
+# FIXME: this is required because of systemd's notify socket is created while
+# in the initramfs, hence as kernel_t. Once SELinux permits relabeling socket
+# objects created before the policy is loaded, this should be removed and
+# systemd fixed to relabel the socket appropriately.
+# Tracked by [systemd PR](https://github.com/systemd/systemd/pull/31336).
+allow systemd_notify_t kernel_t:unix_dgram_socket sendto;
+
 dev_write_kmsg(systemd_notify_t)
 
 domain_use_interactive_fds(systemd_notify_t)


### PR DESCRIPTION
This is required because of systemd's notify socket is created while in the initramfs, hence as `kernel_t`.
Once SELinux permits relabeling socket objects created before the policy is loaded, this should be removed and _systemd_ fixed to relabel the socket appropriately.
Tracked by [systemd PR](https://github.com/systemd/systemd/pull/31336).