### PR TITLE
Allow xdm_t to watch and watch_reads mount_var_run_t

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -740,6 +740,10 @@ miscfiles_read_hwdata(xdm_t)
 miscfiles_map_generic_certs(xdm_t)
 miscfiles_read_certs(xdm_t)
 
+mount_watch_pid_dirs(xdm_t)
+mount_watch_pid_files(xdm_t)
+mount_watch_reads_pid_files(xdm_t)
+
 systemd_write_inhibit_pipes(xdm_t)
 systemd_dbus_chat_localed(xdm_t)
 systemd_dbus_chat_hostnamed(xdm_t)


### PR DESCRIPTION
Recent change in glib2 [1] setups watches on /run/mount directory and /run/mount/utab.lock file, but this is not allowed by the policy.

[1]: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3845

Addresses these AVCs:

time->Thu Feb 15 09:11:58 2024
type=PROCTITLE msg=audit(1708006318.189:118): proctitle="/usr/bin/gnome-shell" type=SYSCALL msg=audit(1708006318.189:118): arch=c000003e syscall=254 success=no exit=-13 a0=33 a1=7f1094005e30 a2=40000100 a3=7f10a1bb13e0 items=0 ppid=1847 pid=1855 auid=4294967295 uid=42 gid=42 euid=42 suid=42 fsuid=42 egid=42 sgid=42 fsgid=42 tty=tty1 ses=4294967295 comm="gmain" exe="/usr/bin/gnome-shell" subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(1708006318.189:118): avc:  denied  { watch } for  pid=1855 comm="gmain" path="/run/mount" dev="tmpfs" ino=100 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:mount_var_run_t:s0 tclass=dir permissive=0 ----
time->Thu Feb 15 09:33:17 2024
type=PROCTITLE msg=audit(1708007597.939:190): proctitle="/usr/bin/gnome-shell" type=SYSCALL msg=audit(1708007597.939:190): arch=c000003e syscall=254 success=no exit=-13 a0=33 a1=7f2a1c005bb0 a2=10 a3=7f2a297b13e0 items=0 ppid=5128 pid=5136 auid=4294967295 uid=42 gid=42 euid=42 suid=42 fsuid=42 egid=42 sgid=42 fsgid=42 tty=tty1 ses=4294967295 comm="gmain" exe="/usr/bin/gnome-shell" subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(1708007597.939:190): avc:  denied  { watch watch_reads } for  pid=5136 comm="gmain" path="/run/mount/utab.lock" dev="tmpfs" ino=1602 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:mount_var_run_t:s0 tclass=file permissive=0

Resolves: RHEL-24841