### PR TITLE
Dontaudit subscription manager setfscreate and read file contexts

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -43,6 +43,7 @@ files_type(cloud_what_var_cache_t)
 
 allow rhsmcertd_t self:capability { fowner kill sys_nice };
 allow rhsmcertd_t self:process { signal_perms setsched };
+dontaudit rhsmcertd_t self:process setfscreate;
 
 allow rhsmcertd_t self:fifo_file rw_fifo_file_perms;
 allow rhsmcertd_t self:unix_stream_socket create_stream_socket_perms;
@@ -183,6 +184,10 @@ optional_policy(`
 
 optional_policy(`
     rtas_errd_rw_lock(rhsmcertd_t)
+')
+
+optional_policy(`
+	seutil_dontaudit_read_file_contexts(rhsmcertd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
These permissions are requested when libdnf is loaded, but subscription-manager does not actually need them.

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(01/15/2024 11:21:17.704:345) : proctitle=/usr/libexec/platform-python /usr/libexec/rhsm-package-profile-uploader --force-upload type=PATH msg=audit(01/15/2024 11:21:17.704:345) : item=0 name=/etc/selinux/targeted/contexts/files/file_contexts.subs_dist nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/15/2024 11:21:17.704:345) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x556739b81090 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=663 pid=5746 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-package-pr exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:rhsmcertd_t:s0 key=(null) type=AVC msg=audit(01/15/2024 11:21:17.704:345) : avc:  denied  { search } for  pid=5746 comm=rhsm-package-pr name=contexts dev="vda1" ino=4128398 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:default_context_t:s0 tclass=dir permissive=0

type=PROCTITLE msg=audit(01/15/2024 11:21:17.704:346) : proctitle=/usr/libexec/platform-python /usr/libexec/rhsm-package-profile-uploader --force-upload
type=SYSCALL msg=audit(01/15/2024 11:21:17.704:346) : arch=x86_64 syscall=write success=no exit=EACCES(Permission denied) a0=0x6 a1=0x0 a2=0x0 a3=0x0 items=0 ppid=663 pid=5746 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-package-pr exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)
type=AVC msg=audit(01/15/2024 11:21:17.704:346) : avc:  denied  { setfscreate } for  pid=5746 comm=rhsm-package-pr scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:system_r:rhsmcertd_t:s0 tclass=process permissive=0

Resolves: RHEL-21639