### PR TITLE
Allow abrt_t nnp domain transition to abrtd_t

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -379,6 +379,7 @@ optional_policy(`
 allow abrt_handle_event_t self:fifo_file rw_fifo_file_perms;
 
 tunable_policy(`abrt_handle_event',`
+	allow abrt_t abrt_handle_event_t:process2 nnp_transition;
 	domtrans_pattern(abrt_t, abrt_handle_event_exec_t, abrt_handle_event_t)
 ',`
 	can_exec(abrt_t, abrt_handle_event_exec_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1707891301.250:735): avc:  denied  { nnp_transition } for  pid=18455 comm="abrt-server" scontext=system_u:system_r:abrt_t:s0-s0:c0.c1023 tcontext=system_u:system_r:abrt_handle_event_t:s0-s0:c0.c1023 tclass=process2 permissive=0

Resolves: rhbz#2264143