### PR TITLE
Allow wireguard work with firewall-cmd

### DIFF
--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -30,9 +30,11 @@ kernel_load_module(wireguard_t)
 kernel_request_load_module(wireguard_t)
 kernel_rw_net_sysctls(wireguard_t)
 kernel_search_debugfs(wireguard_t)
+kernel_read_proc_files(wireguard_t)
 
 corecmd_exec_bin(wireguard_t)
 
+dev_read_sysfs(wireguard_t)
 dev_write_kmsg(wireguard_t)
 
 domain_use_interactive_fds(wireguard_t)
@@ -48,6 +50,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	firewalld_dbus_chat(wireguard_t)
+')
+
+optional_policy(`
 	iptables_domtrans(wireguard_t)
 ')
 
@@ -56,6 +62,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	miscfiles_read_generic_certs(wireguard_t)
 	miscfiles_read_localization(wireguard_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denials:
audit[5106]: AVC avc:  denied  { search } for  pid=5106 comm="firewall-cmd" name="pki" dev="sda1" ino=393252 scontext=system_u:system_r:wireguard_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=0 audit[5106]: AVC avc:  denied  { read } for  pid=5106 comm="firewall-cmd" name="possible" dev="sysfs" ino=42 scontext=system_u:system_r:wireguard_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0 audit[5106]: AVC avc:  denied  { read } for  pid=5106 comm="firewall-cmd" name="stat" dev="proc" ino=4026532026 scontext=system_u:system_r:wireguard_t:s0 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=0 audit[333]: USER_AVC pid=333 uid=81 auid=zzz ses=zzz subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:wireguard_t:s0 tcontext=system_u:system_r:firewalld_t:s0 tclass=dbus permissive=0 exe="/usr/bin/dbus-broker" sauid=81 hostname=? addr=? terminal=?'

Resolves: rhbz#2255572