### PR TITLE
Allow login_userdomain map files in /var

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -7923,6 +7923,24 @@ interface(`files_read_var_files',`
 
 ########################################
 ## <summary>
+##	Map and read files in the /var directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_map_read_var_files',`
+	gen_require(`
+		type var_t;
+	')
+
+	mmap_read_files_pattern($1, var_t, var_t)
+')
+
+########################################
+## <summary>
 ##	Append files in the /var directory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -135,6 +135,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	setroubleshoot_dbus_chat(user_t)
+	setroubleshoot_dbus_chat_fixit(user_t)
+')
+
+optional_policy(`
 	systemd_dbus_chat_machined(user_t)
 	systemd_read_unit_files(user_t)
 	systemd_exec_systemctl(user_t)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -398,6 +398,7 @@ corecmd_watch_bin_dirs(login_userdomain)
 dev_watch_generic_dirs(login_userdomain)
 dev_watch_video_dev(login_userdomain)
 
+files_map_read_var_files(login_userdomain)
 files_map_var_lib_files(login_userdomain)
 files_read_var_lib_symlinks(login_userdomain)
 files_watch_etc_dirs(login_userdomain)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/19/2024 16:12:10.631:242) : proctitle=/usr/libexec/DiscoverNotifier type=MMAP msg=audit(02/19/2024 16:12:10.631:242) : fd=16 flags=MAP_PRIVATE type=SYSCALL msg=audit(02/19/2024 16:12:10.631:242) : arch=x86_64 syscall=mmap success=no exit=EACCES(Permission denied) a0=0x0 a1=0xc9f9bb a2=PROT_READ a3=MAP_PRIVATE items=0 ppid=1231 pid=1993 auid=user uid=user gid=user euid=user suid=user fsuid=user egid=user sgid=user fsgid=user tty=(none) ses=5 comm=DiscoverNotifie exe=/usr/libexec/DiscoverNotifier subj=user_u:user_r:user_t:s0 key=(null) type=AVC msg=audit(02/19/2024 16:12:10.631:242) : avc:  denied  { map } for  pid=1993 comm=DiscoverNotifie path=/var/cache/swcatalog/cache/en-US-os-catalog.xb dev="vda3" ino=761212 scontext=user_u:user_r:user_t:s0 tcontext=unconfined_u:object_r:var_t:s0 tclass=file permissive=0