### PR TITLE
Allow krb5kdc_t map krb5kdc_principal_t files

### DIFF
--- a/policy/modules/contrib/kerberos.te
+++ b/policy/modules/contrib/kerberos.te
@@ -242,7 +242,7 @@ allow krb5kdc_t krb5kdc_lock_t:file { rw_file_perms setattr_file_perms };
 allow krb5kdc_t krb5kdc_log_t:file manage_file_perms;
 logging_log_filetrans(krb5kdc_t, krb5kdc_log_t, file)
 
-allow krb5kdc_t krb5kdc_principal_t:file rw_file_perms;
+allow krb5kdc_t krb5kdc_principal_t:file mmap_rw_file_perms;
 
 manage_dirs_pattern(krb5kdc_t, krb5kdc_tmp_t, krb5kdc_tmp_t)
 manage_files_pattern(krb5kdc_t, krb5kdc_tmp_t, krb5kdc_tmp_t)


### PR DESCRIPTION
The krb5kdc daemon now uses LMDB database format and since it uses the mmap() syscall on the files, it also requires the map SELinux permission.

The commit addresses the following AVC denial:
type=AVC msg=audit(1708536086.456:512): avc:  denied  { map } for  pid=1677 comm="krb5kdc" path="/var/kerberos/krb5kdc/principal.mdb-lock" dev="vda2" ino=262184 scontext=system_u:system_r:krb5kdc_t:s0 tcontext=unconfined_u:object_r:krb5kdc_principal_t:s0 tclass=file permissive=1

Resolves: rhbz#2265378