### PR TITLE
Allow thumb_t to watch and watch_reads mount_var_run_t

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -115,6 +115,10 @@ miscfiles_read_fonts(thumb_t)
 miscfiles_dontaudit_setattr_fonts_dirs(thumb_t)
 miscfiles_dontaudit_setattr_fonts_cache_dirs(thumb_t)
 
+mount_watch_pid_dirs(thumb_t)
+mount_watch_pid_files(thumb_t)
+mount_watch_reads_pid_files(thumb_t)
+
 sysnet_read_config(thumb_t)
 
 


### PR DESCRIPTION
Recent change in glib2 [1] setups watches on /run/mount directory and /run/mount/utab.lock file, but this is not allowed by the policy.

[1]: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3845

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/19/2024 05:27:32.928:414) : proctitle=/usr/lib64/tumbler-1/tumblerd type=PATH msg=audit(02/19/2024 05:27:32.928:414) : item=0 name=/run/mount/utab.lock inode=955 dev=00:18 mode=file,644 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:mount_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/19/2024 05:27:32.928:414) : arch=x86_64 syscall=inotify_add_watch success=no exit=EACCES(Permission denied) a0=0xa a1=0x7f0414006d00 a2=0x10 a3=0x7f04249b13e0 items=1 ppid=15005 pid=15039 auid=user4067 uid=user4067 gid=user4067 euid=user4067 suid=user4067 fsuid=user4067 egid=user4067 sgid=user4067 fsgid=user4067 tty=(none) ses=7 comm=gmain exe=/usr/lib64/tumbler-1/tumblerd subj=staff_u:staff_r:thumb_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/19/2024 05:27:32.928:414) : avc:  denied  { watch watch_reads } for  pid=15039 comm=gmain path=/run/mount/utab.lock dev="tmpfs" ino=955 scontext=staff_u:staff_r:thumb_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:mount_var_run_t:s0 tclass=file permissive=0

Resolves: RHEL-26073