### PR TITLE
Differentiate between staff and sysadm when executing crontab with sudo

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -117,10 +117,6 @@ template(`sudo_role_template',`
 	optional_policy(`
 		usermanage_domtrans_passwd($1_sudo_t)
 	')
-
-	optional_policy(`
-		crontab_domtrans($1_sudo_t)
-	')
 ')
 
 ########################################

--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -1097,3 +1097,21 @@ interface(`crontab_domtrans',`
 
 	domtrans_pattern($1, crontab_exec_t, crontab_t)
 ')
+
+########################################
+## <summary>
+##	Execute crontab in the admin crontab domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`crontab_admin_domtrans',`
+	gen_require(`
+		type crontab_exec_t, admin_crontab_t;
+	')
+
+	domtrans_pattern($1, crontab_exec_t, admin_crontab_t)
+')

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -322,6 +322,9 @@ optional_policy(`
 
 optional_policy(`
 	sudo_role_template(staff, staff_r, staff_t)
+	optional_policy(`
+		crontab_domtrans(staff_sudo_t)
+	')
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -607,6 +607,9 @@ optional_policy(`
 
 optional_policy(`
 	sudo_role_template(sysadm, sysadm_r, sysadm_t)
+	optional_policy(`
+		crontab_admin_domtrans(sysadm_sudo_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
Addresses the following error:
    type=PROCTITLE msg=audit(02/16/2024 05:30:44.450:614) : proctitle=sudo -u user30731 crontab -r
    type=PATH msg=audit(02/16/2024 05:30:44.450:614) : item=0 name=/bin/crontab inode=589204 dev=fd:00 mode=file,suid,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:crontab_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
    type=CWD msg=audit(02/16/2024 05:30:44.450:614) : cwd=/home/user30731
    type=SYSCALL msg=audit(02/16/2024 05:30:44.450:614) : arch=ppc64le syscall=execve success=no exit=EACCES(Permission denied) a0=0x10034c28b18 a1=0x10034c19408 a2=0x10034c119a0 a3=0x10034c119a0 items=1 ppid=31112 pid=31113 auid=user30731 uid=user30731 gid=user30731 euid=user30731 suid=user30731 fsuid=user30731 egid=user30731 sgid=user30731 fsgid=user30731 tty=pts2 ses=12 comm=sudo exe=/usr/bin/sudo subj=sysadm_u:sysadm_r:sysadm_sudo_t:s0-s0:c0.c1023 key=(null)
    type=SELINUX_ERR msg=audit(02/16/2024 05:30:44.450:614) : op=security_compute_sid invalid_context=sysadm_u:sysadm_r:crontab_t:s0-s0:c0.c1023 scontext=sysadm_u:sysadm_r:sysadm_sudo_t:s0-s0:c0.c1023 tcontext=system_u:object_r:crontab_exec_t:s0 tclass=process