### PR TITLE
Allow opafm create NFS files and directories

### DIFF
--- a/policy/modules/contrib/opafm.te
+++ b/policy/modules/contrib/opafm.te
@@ -47,7 +47,9 @@ dev_rw_infiniband_mgmt_dev(opafm_t)
 dev_list_sysfs(opafm_t)
 dev_read_sysfs(opafm_t)
 
-fs_search_nfs(opafm_t)
+fs_create_nfs_dirs(opafm_t)
+fs_create_nfs_files(opafm_t)
+fs_write_nfs_files(opafm_t)
 
 libs_exec_lib_files(opafm_t)
 

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -4330,6 +4330,46 @@ interface(`fs_rw_rpc_sockets',`
 
 ########################################
 ## <summary>
+##	Create directories on a NFS filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_create_nfs_dirs',`
+	gen_require(`
+		type nfs_t;
+	')
+
+	fs_search_auto_mountpoints($1)
+	create_dirs_pattern($1, nfs_t, nfs_t)
+')
+
+########################################
+## <summary>
+##	Create files on a NFS filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`fs_create_nfs_files',`
+	gen_require(`
+		type nfs_t;
+	')
+
+	fs_search_auto_mountpoints($1)
+	create_files_pattern($1, nfs_t, nfs_t)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete directories
 ##	on a NFS filesystem.
 ## </summary>


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(20.2.2024 03:14:09.354:524) : avc:  denied  { write } for  pid=57860 comm=sm name=/ dev="0:45" ino=4299124166 scontext=system_u:system_r:opafm_t:s0 tcontext=system_u:object_r:nfs_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(20.2.2024 03:14:09.354:524) : arch=x86_64 syscall=mkdir success=no exit=EACCES(Operace zamítnuta) a0=0x55a0b1ee4c00 a1=0644 a2=0xfffffffffffffef8 a3=0x0 items=0 ppid=57810 pid=57860 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sm exe=/usr/lib/opa-fm/runtime/sm subj=system_u:system_r:opafm_t:s0 key=(null)

Resolves: RHEL-17820