### PR TITLE
Allow userdomain get attributes of files on an nsfs filesystem

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -151,6 +151,8 @@ auth_filetrans_auth_home_content(userdomain)
 
 files_dontaudit_manage_boot_files(unpriv_userdomain)
 
+fs_getattr_nsfs_files(userdomain)
+
 mount_dontaudit_write_mount_pid(unpriv_userdomain)
 mount_entry_type(unpriv_userdomain)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(22.2.2024 23:42:03.003:742) : proctitle=pstree type=PATH msg=audit(22.2.2024 23:42:03.003:742) : item=0 name=/proc/4139/ns/cgroup inode=4026531835 dev=00:04 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:nsfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(22.2.2024 23:42:03.003:742) : arch=x86_64 syscall=newfstatat success=yes exit=0 a0=AT_FDCWD a1=0x7ffc200aed00 a2=0x7ffc200aed40 a3=0x0 items=1 ppid=7788 pid=55219 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=pts13 ses=7 comm=pstree exe=/usr/bin/pstree subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(22.2.2024 23:42:03.003:742) : avc:  denied  { getattr } for  pid=55219 comm=pstree path=cgroup:[4026531835] dev="nsfs" ino=4026531835 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=1