### PR TITLE
policy: support pidfs

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -169,6 +169,11 @@ type oprofilefs_t;
 fs_type(oprofilefs_t)
 genfscon oprofilefs / gen_context(system_u:object_r:oprofilefs_t,s0)
 
+type pidfs_t;
+fs_type(pidfs_t)
+files_mountpoint(pidfs_t)
+genfscon pidfs_t / gen_context(system_u:object_r:pidfs_t,s0)
+
 type pstore_t alias pstorefs_t;
 fs_type(pstore_t)
 files_mountpoint(pstore_t)


### PR DESCRIPTION
pidfds are ported to a tiny in-kernel filesystem that is not mountable in userspace. This is comparable to sockfs, pipefs, nsfs, or anon_inodefs to name a few examples.

Before pidfs it wasn't possible for selinux to manage them because they didn't go through LSM hooks. We can now start doing that. But if we do it right away we'd get permission errors.

pidfds are used in systemd, dbus, LXC, polkit etc. and they currently start failing because selinux denies pidfs:

Feb 23 12:09:58 fed1 audit[353]: AVC avc:  denied  { read write open } for  pid=353 comm="systemd-userdbd" path="pidfd:[709]" dev="pidfs" ino=709 scontext=system_u:system_r:systemd_userdbd_t:>