### PR TITLE
Add logging_watch_all_log_dirs() and logging_watch_all_log_files()

### DIFF
--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -1224,6 +1224,42 @@ interface(`logging_manage_all_logs',`
 
 #######################################
 ## <summary>
+##	Watch all log directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_watch_all_log_dirs',`
+	gen_require(`
+		attribute logfile;
+	')
+
+	allow $1 logfile:dir { search_dir_perms watch_dir_perms };
+')
+
+#######################################
+## <summary>
+##	Watch all log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_watch_all_log_files',`
+	gen_require(`
+		attribute logfile;
+	')
+
+	allow $1 logfile:file watch_file_perms;
+')
+
+#######################################
+## <summary>
 ##	Watch all directories in the path for log directories.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Add logging_watch_all_log_dirs() and logging_watch_all_log_files() interfaces to watch all directories or files with the type matching the logfile attribute.

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2048