### PR TITLE
Dontaudit sulogin the checkpoint_restore capability

### DIFF
--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -214,6 +214,7 @@ optional_policy(`
 #
 
 allow sulogin_t self:capability { dac_read_search  sys_admin };
+dontaudit sulogin_t self:capability2 checkpoint_restore;
 allow sulogin_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
 allow sulogin_t self:fd use;
 allow sulogin_t self:fifo_file rw_fifo_file_perms;

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -257,10 +257,13 @@ logging_send_syslog_msg(sulogin_t)
 seutil_read_config(sulogin_t)
 seutil_read_default_contexts(sulogin_t)
 
+term_relabel_unallocated_ttys(sulogin_t)
+
 userdom_use_unpriv_users_fds(sulogin_t)
 
 userdom_search_admin_dir(sulogin_t)
 userdom_search_user_home_dirs(sulogin_t)
+userdom_relabel_user_ttys(sulogin_t)
 userdom_use_user_ptys(sulogin_t)
 
 term_use_console(sulogin_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -4728,6 +4728,25 @@ interface(`userdom_dontaudit_use_user_ttys',`
 	dontaudit $1 user_tty_device_t:chr_file rw_inherited_file_perms;
 ')
 
+#######################################
+## <summary>
+##	Relabel from and to user ttys.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_relabel_user_ttys',`
+	gen_require(`
+		type user_tty_device_t;
+	')
+
+	dev_list_all_dev_nodes($1)
+	allow $1 user_tty_device_t:chr_file relabel_chr_file_perms;
+')
+
 ########################################
 ## <summary>
 ##	Read the process state of all user domains.


### PR DESCRIPTION
The commit dontaudits the following AVC denial:
type=AVC msg=audit(1708518790.257:1208): avc:  denied  { checkpoint_restore } for  pid=220682 comm="sulogin" capability=40  scontext=system_u:system_r:sulogin_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sulogin_t:s0-s0:c0.c1023 tclass=capability2 permissive=0

Resolves: rhbz#2265391