### PR TITLE
Fix ras-mc-ctl.service (rasdaemon)

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -31,7 +31,7 @@ kernel_read_system_state(rasdaemon_t)
 kernel_manage_debugfs(rasdaemon_t)
 
 dev_read_raw_memory(rasdaemon_t)
-dev_read_sysfs(rasdaemon_t)
+dev_rw_sysfs(rasdaemon_t)
 dev_read_urand(rasdaemon_t)
 dev_rw_cpu_microcode(rasdaemon_t)
 
@@ -42,7 +42,13 @@ fs_manage_tracefs_dirs(rasdaemon_t)
 fs_mount_tracefs(rasdaemon_t)
 fs_unmount_tracefs(rasdaemon_t)
 
-modutils_dontaudit_exec_kmod(rasdaemon_t) # more info here #1030277
+# In rasdaemon 0.8.0, ras-mc-ctl tries to find modprobe, exits with error
+# code if fails, but never actually uses it. While it should be fixed in
+# rasdaemon, it seems to be safe to just allow it to find the binary.
+gen_require(`
+	type kmod_exec_t;
+')
+allow rasdaemon_t kmod_exec_t:file getattr;
 
 auth_use_nsswitch(rasdaemon_t)
 


### PR DESCRIPTION
ras-mc-ctl.service fails to start when in Enforcing mode:

	# systemctl status ras-mc-ctl.service
	× ras-mc-ctl.service - Initialize EDAC v3.0.0 Drivers For Machine Hardware
		 Loaded: loaded (/usr/lib/systemd/system/ras-mc-ctl.service; enabled; preset: disabled)
		Drop-In: /usr/lib/systemd/system/service.d
				 └─10-timeout-abort.conf
		 Active: failed (Result: exit-code) since Sat 2024-03-02 12:12:11 +05; 1s ago
	   Duration: 16min 7.651s
		Process: 19995 ExecStart=/usr/sbin/ras-mc-ctl --register-labels (code=exited, status=1/FAILURE)
	   Main PID: 19995 (code=exited, status=1/FAILURE)
			CPU: 28ms

	Mar 02 12:12:11 im-desktop.local systemd[1]: Starting ras-mc-ctl.service - Initialize EDAC v3.0.0 Drivers For Machine Hardware...
	Mar 02 12:12:11 im-desktop.local systemd[1]: ras-mc-ctl.service: Main process exited, code=exited, status=1/FAILURE
	Mar 02 12:12:11 im-desktop.local systemd[1]: ras-mc-ctl.service: Failed with result 'exit-code'.
	Mar 02 12:12:11 im-desktop.local systemd[1]: Failed to start ras-mc-ctl.service - Initialize EDAC v3.0.0 Drivers For Machine Hardware.

audit.log shows following error when in Permissive mode:

	type=AVC msg=audit(1709359272.102:3163): avc:  denied  { write } for  pid=15841 comm="ras-mc-ctl" name="dimm_label" dev="sysfs" ino=53742 scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1

Those are two separate problems:

1) `modutils_dontaudit_exec_kmod(rasdaemon_t)` prevents ras-mc-ctl from
   finding modprobe binary at https://github.com/mchehab/rasdaemon/blob/v0.8.0/util/ras-mc-ctl.in#L42
   It also suppresses all audit events about this.

2) There is no write access for /sys/. It is required to write DIMM
   labels in /sys/devices/system/edac/mc/.

Resolves: rhbz#1836861
Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2054
Resolves: https://github.com/mchehab/rasdaemon/issues/79