### PR TITLE
Modify sudo_role_template() to allow getpgid

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -54,6 +54,7 @@ template(`sudo_role_template',`
 	allow $1_sudo_t $1_sudo_tmp_t:file manage_file_perms;
 	files_tmp_filetrans($1_sudo_t, $1_sudo_tmp_t, file)
 
+	allow $1_sudo_t $3:process getpgid;
 	allow $1_sudo_t $3:dir search_dir_perms;;
 	allow $1_sudo_t $3:file read_file_perms;;
 	allow $1_sudo_t $3:key search;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/04/2024 14:15:38.342:337) : proctitle=sudo -i type=SYSCALL msg=audit(03/04/2024 14:15:38.342:337) : arch=x86_64 syscall=getpgid success=no exit=EACCES(Permission denied) a0=0x1062 a1=0x31e a2=0x0 a3=0x8 items=0 ppid=3187 pid=4256 auid=staff uid=staff gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=7 comm=sudo exe=/usr/bin/sudo subj=staff_u:staff_r:staff_sudo_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(03/04/2024 14:15:38.342:337) : avc:  denied  { getpgid } for  pid=4256 comm=sudo scontext=staff_u:staff_r:staff_sudo_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=process permissive=0