### PR TITLE
Allow linuxptp configure phc2sys and chronyd over a unix domain socket

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -170,6 +170,7 @@ optional_policy(`
 optional_policy(`
     timemaster_stream_connect(chronyd_t)
     timemaster_read_pid_files(chronyd_t)
+    timemaster_manage_pid_sock_files(chronyd_t)
     timemaster_rw_shm(chronyd_t)
 ')
 

--- a/policy/modules/contrib/linuxptp.if
+++ b/policy/modules/contrib/linuxptp.if
@@ -77,6 +77,24 @@ interface(`timemaster_read_pid_files',`
 
 ########################################
 ## <summary>
+##	Manage timemaster pid files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`timemaster_manage_pid_sock_files',`
+	gen_require(`
+		type timemaster_var_run_t;
+	')
+
+	manage_sock_files_pattern($1, timemaster_var_run_t, timemaster_var_run_t)
+')
+
+########################################
+## <summary>
 ## Read and write timemaster shared memory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/linuxptp.te
+++ b/policy/modules/contrib/linuxptp.te
@@ -78,6 +78,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	chronyd_dgram_send(timemaster_t)
 	chronyd_domtrans(timemaster_t)
 	chronyd_rw_shm(timemaster_t)
 ')
@@ -129,6 +130,7 @@ dev_rw_realtime_clock(phc2sys_t)
 logging_send_syslog_msg(phc2sys_t)
 
 optional_policy(`
+	chronyd_dgram_send(phc2sys_t)
 	chronyd_rw_shm(phc2sys_t)
 ')
 
@@ -150,6 +152,7 @@ optional_policy(`
 #
 
 allow ptp4l_t self:fifo_file rw_fifo_file_perms;
+allow ptp4l_t self:netlink_generic_socket create_socket_perms;
 allow ptp4l_t self:packet_socket create_socket_perms;
 allow ptp4l_t self:unix_stream_socket create_stream_socket_perms;
 allow ptp4l_t self:shm create_shm_perms;
@@ -184,6 +187,7 @@ logging_send_syslog_msg(ptp4l_t)
 userdom_users_dgram_send(ptp4l_t)
 
 optional_policy(`
+	chronyd_dgram_send(ptp4l_t)
 	chronyd_rw_shm(ptp4l_t)
 ')
 


### PR DESCRIPTION
For phc2sys and chronyd configuration, linuxptp since v4.2 uses unix domain socket instead of shared memory segment with predictable address. This requires to be backed by appropriate SELinux policy changes.

The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(02/29/2024 13:33:47.174:396) : proctitle=/usr/sbin/chronyd -n -f /var/run/timemaster/chrony.conf type=PATH msg=audit(02/29/2024 13:33:47.174:396) : item=1 name=/var/run/timemaster/chrony.SOCK0 inode=125930 dev=00:18 mode=socket,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:timemaster_var_run_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(02/29/2024 13:33:47.174:396) : item=0 name=/var/run/timemaster/ inode=71605 dev=00:18 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:timemaster_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(02/29/2024 13:33:47.174:396) : saddr={ saddr_fam=local path=/var/run/timemaster/chrony.SOCK0 } type=SYSCALL msg=audit(02/29/2024 13:33:47.174:396) : arch=x86_64 syscall=bind success=yes exit=0 a0=0x4 a1=0x7ffdb7fdb0f0 a2=0x6e a3=0x55630dab7640 items=2 ppid=96180 pid=96181 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=chronyd exe=/usr/sbin/chronyd subj=system_u:system_r:chronyd_t:s0 key=(null) type=AVC msg=audit(02/29/2024 13:33:47.174:396) : avc:  denied  { create } for  pid=96181 comm=chronyd name=chrony.SOCK0 scontext=system_u:system_r:chronyd_t:s0 tcontext=system_u:object_r:timemaster_var_run_t:s0 tclass=sock_file permissive=1 type=AVC msg=audit(02/29/2024 13:33:47.174:396) : avc:  denied  { add_name } for  pid=96181 comm=chronyd name=chrony.SOCK0 scontext=system_u:system_r:chronyd_t:s0 tcontext=system_u:object_r:timemaster_var_run_t:s0 tclass=dir permissive=1 type=AVC msg=audit(02/29/2024 13:33:47.174:396) : avc:  denied  { write } for  pid=96181 comm=chronyd name=timemaster dev="tmpfs" ino=71605 scontext=system_u:system_r:chronyd_t:s0 tcontext=system_u:object_r:timemaster_var_run_t:s0 tclass=dir permissive=1

Resolves: RHEL-26660