### PR TITLE
Allow wdmd list the contents of the sysfs directories

### DIFF
--- a/policy/modules/contrib/wdmd.te
+++ b/policy/modules/contrib/wdmd.te
@@ -42,6 +42,7 @@ kernel_read_system_state(wdmd_t)
 corecmd_exec_bin(wdmd_t)
 corecmd_exec_shell(wdmd_t)
 
+dev_list_sysfs(wdmd_t)
 dev_read_watchdog(wdmd_t)
 dev_write_watchdog(wdmd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/23/2024 23:59:13.212:1911) : proctitle=/usr/sbin/wdmd --probe type=PATH msg=audit(02/23/2024 23:59:13.212:1911) : item=0 name=/sys/class/watchdog/watchdog0/identity nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(02/23/2024 23:59:13.212:1911) : cwd=/ type=SYSCALL msg=audit(02/23/2024 23:59:13.212:1911) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffce5f5ed10 a2=O_RDONLY a3=0x0 items=1 ppid=182355 pid=182356 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=wdmd exe=/usr/sbin/wdmd subj=system_u:system_r:wdmd_t:s0 key=(null) type=AVC msg=audit(02/23/2024 23:59:13.212:1911) : avc:  denied  { read } for  pid=182356 comm=wdmd name=watchdog0 dev="sysfs" ino=22335 scontext=system_u:system_r:wdmd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=lnk_file permissive=0

Resolves: RHEL-26663