### PR TITLE
Allow wdmd read hardware state information

### DIFF
--- a/policy/modules/contrib/wdmd.te
+++ b/policy/modules/contrib/wdmd.te
@@ -42,7 +42,7 @@ kernel_read_system_state(wdmd_t)
 corecmd_exec_bin(wdmd_t)
 corecmd_exec_shell(wdmd_t)
 
-dev_list_sysfs(wdmd_t)
+dev_read_sysfs(wdmd_t)
 dev_read_watchdog(wdmd_t)
 dev_write_watchdog(wdmd_t)
 


### PR DESCRIPTION
The previous 12885bb7c8fa ("Allow wdmd list the contents of the sysfs directories") commit was not sufficient as apart from reading the /sys/class/watchdog/watchdog0 symlink, reading the /sys/class/watchdog/watchdog0/identity file is also needed.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/26/2024 09:44:20.607:565) : proctitle=/usr/sbin/wdmd --probe type=PATH msg=audit(02/26/2024 09:44:20.607:565) : item=0 name=/sys/class/watchdog/watchdog0/identity inode=14577 dev=00:14 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/26/2024 09:44:20.607:565) : arch=s390x syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x3ffde0f91a8 a2=O_RDONLY a3=0x0 items=1 ppid=46918 pid=46920 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=wdmd exe=/usr/sbin/wdmd subj=system_u:system_r:wdmd_t:s0 key=(null) type=AVC msg=audit(02/26/2024 09:44:20.607:565) : avc:  denied  { open } for  pid=46920 comm=wdmd path=/sys/devices/virtual/watchdog/watchdog0/identity dev="sysfs" ino=14577 scontext=system_u:system_r:wdmd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1 type=AVC msg=audit(02/26/2024 09:44:20.607:565) : avc:  denied  { read } for  pid=46920 comm=wdmd name=identity dev="sysfs" ino=14577 scontext=system_u:system_r:wdmd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1 type=AVC msg=audit(02/26/2024 09:44:20.607:565) : avc:  denied  { read } for  pid=46920 comm=wdmd name=watchdog0 dev="sysfs" ino=14575 scontext=system_u:system_r:wdmd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=lnk_file permissive=1

Resolves: RHEL-26663