### PR TITLE
Allow cgred_t to get attributes of cgroup filesystems

### DIFF
--- a/policy/modules/contrib/cgroup.te
+++ b/policy/modules/contrib/cgroup.te
@@ -105,6 +105,7 @@ files_getattr_all_files(cgred_t)
 files_getattr_all_sockets(cgred_t)
 files_read_all_symlinks(cgred_t)
 
+fs_getattr_cgroup(cgred_t)
 fs_manage_cgroup_dirs(cgred_t)
 fs_manage_cgroup_files(cgred_t)
 


### PR DESCRIPTION
Need to allow cgred_t to get attributes of cgroup filesystems as libcgroup package adds support for systemd.


FYI, below is the denial this commit addresses:

type=AVC msg=audit(1704959348.276:880): avc:  denied  { getattr } for  pid=4938 comm="cgrulesengd" name="/" dev="cgroup" ino=1 scontext=system_u:system_r:cgred_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=filesystem permissive=0


This is observed with libcgroup v3.1.0, which added support for systemd:

https://github.com/libcgroup/libcgroup/tree/release-3.1