### PR TITLE
Allow journalctl_t read filesystem sysctls

### DIFF
--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -24,6 +24,7 @@ allow journalctl_t self:process { fork setrlimit signal_perms };
 allow journalctl_t self:fifo_file manage_fifo_file_perms;
 allow journalctl_t self:unix_stream_socket create_stream_socket_perms;
 
+kernel_read_fs_sysctls(journalctl_t)
 kernel_read_system_state(journalctl_t)
 
 corecmd_exec_bin(journalctl_t)


### PR DESCRIPTION
This permission is required for journalctl run by confined users in the user_r, staff_r, or sysadm_r roles.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(6.3.2024 08:45:58.914:3044) : proctitle=(pager) type=PATH msg=audit(6.3.2024 08:45:58.914:3044) : item=0 name=/proc/sys/fs/nr_open inode=7329 dev=00:16 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_fs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(6.3.2024 08:45:58.914:3044) : arch=x86_64 syscall=openat success=yes exit=36 a0=AT_FDCWD a1=0x7f18a1f1b0e0 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=467120 pid=467121 auid=user uid=user gid=user euid=user suid=user fsuid=user egid=user sgid=user fsgid=user tty=pts13 ses=7 comm=(pager) exe=/usr/bin/journalctl subj=staff_u:staff_r:journalctl_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(6.3.2024 08:45:58.914:3044) : avc:  denied  { open } for  pid=467121 comm=(pager) path=/proc/sys/fs/nr_open dev="proc" ino=7329 scontext=staff_u:staff_r:journalctl_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_fs_t:s0 tclass=file permissive=1 type=AVC msg=audit(6.3.2024 08:45:58.914:3044) : avc:  denied  { read } for  pid=467121 comm=(pager) name=nr_open dev="proc" ino=7329 scontext=staff_u:staff_r:journalctl_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_fs_t:s0 tclass=file permissive=1