### PR TITLE
Allow fido services connect to postgres database

### DIFF
--- a/policy/modules/contrib/fdo.te
+++ b/policy/modules/contrib/fdo.te
@@ -81,7 +81,7 @@ manage_dirs_pattern(fdo_t, fdo_var_t, fdo_var_t)
 manage_files_pattern(fdo_t, fdo_var_t, fdo_var_t)
 files_var_filetrans(fdo_t, fdo_var_t, { file dir })
 
-read_files_pattern(fdo_t, fdo_var_lib_t, fdo_var_lib_t)
+manage_files_pattern(fdo_t, fdo_var_lib_t, fdo_var_lib_t)
 files_var_lib_filetrans(fdo_t, fdo_var_lib_t, { file dir })
 
 kernel_get_sysvipc_info(fdo_t)
@@ -96,6 +96,7 @@ corenet_tcp_bind_http_cache_port(fdo_t)
 corenet_tcp_connect_http_cache_port(fdo_t)
 corenet_tcp_bind_http_port(fdo_t)
 corenet_tcp_connect_http_port(fdo_t)
+corenet_tcp_connect_postgresql_port(fdo_t)
 corenet_tcp_bind_transproxy_port(fdo_t)
 corenet_tcp_connect_transproxy_port(fdo_t)
 corenet_tcp_bind_us_cli_port(fdo_t)
@@ -121,6 +122,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	kerberos_search_keytab(fdo_t)
+')
+
+optional_policy(`
 	lvm_domtrans(fdo_t)
 	lvm_manage_var_run(fdo_t)
 	lvm_var_run_filetrans(fdo_t)
@@ -135,6 +140,10 @@ optional_policy(`
 	ssh_basic_client_template(fdo, fdo_t, system_r)
 	ssh_create_home_dirs(fdo_t)
 	ssh_filetrans_home_content(fdo_t)
+')
+
+optional_policy(`
+	sssd_run_stream_connect(fdo_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/kerberos.if
+++ b/policy/modules/contrib/kerberos.if
@@ -184,6 +184,26 @@ interface(`kerberos_rw_config',`
 
 ########################################
 ## <summary>
+##	Search the kerberos keys directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`kerberos_search_keytab',`
+	gen_require(`
+		type krb5_keytab_t;
+	')
+
+	files_search_etc($1)
+	allow $1 krb5_keytab_t:dir search_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Read the kerberos key table.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial and subsequently raised ones: type=PROCTITLE msg=audit(03/12/2024 00:43:15.243:1724) : proctitle=/usr/libexec/fdo/fdo-rendezvous-server type=SYSCALL msg=audit(03/12/2024 00:43:15.243:1724) : arch=x86_64 syscall=connect success=no exit=EINPROGRESS(Operation now in progress) a0=0xa a1=0x7f3bd0009e60 a2=0x10 a3=0x7f3be1d9b100 items=0 ppid=1 pid=24579 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=r2d2-worker-0 exe=/usr/libexec/fdo/fdo-rendezvous-server subj=system_u:system_r:fdo_t:s0 key=(null) type=AVC msg=audit(03/12/2024 00:43:15.243:1724) : avc:  denied  { name_connect } for  pid=24579 comm=r2d2-worker-0 dest=5432 scontext=system_u:system_r:fdo_t:s0 tcontext=system_u:object_r:postgresql_port_t:s0 tclass=tcp_socket permissive=1