### PR TITLE
dontaudit execmem for modemmanager

### DIFF
--- a/policy/modules/contrib/modemmanager.te
+++ b/policy/modules/contrib/modemmanager.te
@@ -20,7 +20,7 @@ systemd_unit_file(modemmanager_unit_file_t)
 # Local policy
 #
 
-dontaudit modemmanager_t self:process { setpgid };
+dontaudit modemmanager_t self:process { execmem setpgid };
 allow modemmanager_t self:capability { dac_read_search dac_override net_admin sys_admin sys_tty_config };
 allow modemmanager_t self:process { getsched signal };
 allow modemmanager_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
Calls to g_regex_match_full can use a JIT to improve performance, but that requests execmem. Perfomance isn't priority here, so we don't allow this. Fixes
https://bugzilla.redhat.com/show_bug.cgi?id=2149946 https://bugzilla.suse.com/show_bug.cgi?id=1219363