### PR TITLE
Allow dhcpc read /run/netns files

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -181,6 +181,7 @@ miscfiles_read_generic_certs(dhcpc_t)
 
 modutils_run_kmod(dhcpc_t, dhcpc_roles)
 
+sysnet_read_ifconfig_run_files(dhcpc_t)
 sysnet_run_ifconfig(dhcpc_t, dhcpc_roles)
 
 userdom_stream_connect(dhcpc_t)


### PR DESCRIPTION
The commit addresses the following AVC denial which appears every time the service is restarted:

type=PROCTITLE msg=audit(03/15/2024 10:52:30.995:633) : proctitle=/usr/sbin/dhcpcd -q --nobackground
type=PATH msg=audit(03/15/2024 10:52:30.995:633) : item=0 name=/var/run/netns inode=1401 dev=00:19 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:ifconfig_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(03/15/2024 10:52:30.995:633) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55d4418543ae a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=2900 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=dhcpcd exe=/usr/sbin/dhcpcd subj=system_u:system_r:dhcpc_t:s0 key=(null)
type=AVC msg=audit(03/15/2024 10:52:30.995:633) : avc:  denied  { read } for  pid=2900 comm=dhcpcd name=netns dev="tmpfs" ino=1401 scontext=system_u:system_r:dhcpc_t:s0 tcontext=unconfined_u:object_r:ifconfig_var_run_t:s0 tclass=dir permissive=0

Resolves: rhbz#2269708