### PR TITLE
Allow NetworkManager the sys_ptrace capability in user namespace

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -79,6 +79,7 @@ init_system_domain(wpa_cli_t, wpa_cli_exec_t)
 allow NetworkManager_t self:capability { fowner chown fsetid kill setgid setuid sys_admin sys_nice dac_read_search dac_override net_admin net_raw net_bind_service ipc_lock sys_chroot };
 dontaudit NetworkManager_t self:capability sys_tty_config;
 allow NetworkManager_t self:capability2 bpf;
+allow NetworkManager_t self:cap_userns sys_ptrace;
 
 allow NetworkManager_t self:bpf { map_create map_read map_write prog_load prog_run };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/11/2024 06:47:26.478:1051) : proctitle=/usr/sbin/NetworkManager --no-daemon type=SYSCALL msg=audit(03/11/2024 06:47:26.478:1051) : arch=x86_64 syscall=read success=yes exit=185 a0=0x16 a1=0x7ffc1fa820b0 a2=0x1000 a3=0x0 items=0 ppid=1 pid=627 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=NetworkManager exe=/usr/sbin/NetworkManager subj=system_u:system_r:NetworkManager_t:s0 key=(null) type=AVC msg=audit(03/11/2024 06:47:26.478:1051) : avc:  denied  { sys_ptrace } for  pid=627 comm=NetworkManager capability=sys_ptrace  scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=cap_userns permissive=0

Resolves: RHEL-24346