### PR TITLE
Allow alsa get attributes filesystems with extended attributes (f38)

### DIFF
--- a/policy/modules/contrib/alsa.te
+++ b/policy/modules/contrib/alsa.te
@@ -88,6 +88,8 @@ dev_write_sound(alsa_t)
 
 files_search_var_lib(alsa_t)
 
+fs_getattr_xattr_fs(alsa_t)
+
 modutils_domtrans_kmod(alsa_t)
 
 term_dontaudit_use_console(alsa_t)

--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -44,3 +44,7 @@ sysnet_read_config(keyutils_dns_resolver_t)
 optional_policy(`
 	avahi_stream_connect(keyutils_dns_resolver_t)
 ')
+
+optional_policy(`
+	logging_send_syslog_msg(keyutils_dns_resolver_t)
+')

--- a/policy/modules/contrib/modemmanager.te
+++ b/policy/modules/contrib/modemmanager.te
@@ -20,7 +20,7 @@ systemd_unit_file(modemmanager_unit_file_t)
 # Local policy
 #
 
-dontaudit modemmanager_t self:process { setpgid };
+dontaudit modemmanager_t self:process { execmem setpgid };
 allow modemmanager_t self:capability { dac_read_search dac_override net_admin sys_admin sys_tty_config };
 allow modemmanager_t self:process { getsched signal };
 allow modemmanager_t self:fifo_file rw_fifo_file_perms;

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -481,7 +481,9 @@ tunable_policy(`samba_domain_controller',`
 
 tunable_policy(`samba_enable_home_dirs',`
 	userdom_manage_user_home_content(smbd_t)
+	userdom_watch_user_home_dirs(smbd_t)
 	userdom_manage_user_home_content(winbind_rpcd_t)
+	userdom_watch_user_home_dirs(winbind_rpcd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1700102760.194:134): avc:  denied  { getattr } for  pid=1349 comm="rm" name="/" dev="dm-0" ino=2 scontext=system_u:system_r:alsa_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0

Resolves: rhbz#2249960