### PR TITLE
Allow dhcpcd use unix_stream_socket

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -77,6 +77,7 @@ allow dhcpc_t self:netlink_generic_socket create_socket_perms;
 allow dhcpc_t self:netlink_route_socket { create_socket_perms nlmsg_read nlmsg_write };
 allow dhcpc_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow dhcpc_t self:unix_dgram_socket sendto;
+allow dhcpc_t self:unix_stream_socket connectto;
 
 allow dhcpc_t dhcp_etc_t:dir list_dir_perms;
 read_lnk_files_pattern(dhcpc_t, dhcp_etc_t, dhcp_etc_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
AVC avc:  denied  { connectto } for  pid=769 comm="dhcpcd" path="/run/dhcpcd/eth0-4.unpriv.sock" scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:system_r:dhcpc_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2270461