### PR TITLE
Allow logwatch read logind sessions files

### DIFF
--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -182,6 +182,11 @@ optional_policy(`
 	samba_read_share_files(logwatch_t)
 ')
 
+optional_policy(`
+	systemd_read_logind_sessions_files(logwatch_t)
+')
+
+
 ########################################
 #
 # Mail local policy

--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -209,6 +209,8 @@ dev_read_rand(logwatch_mail_t)
 dev_read_urand(logwatch_mail_t)
 dev_read_sysfs(logwatch_mail_t)
 
+init_rw_stream_sockets(logwatch_mail_t)
+
 logging_read_all_logs(logwatch_mail_t)
 
 mta_read_home(logwatch_mail_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/20/2024 10:36:55.005:657) : proctitle=uptime type=PATH msg=audit(03/20/2024 10:36:55.005:657) : item=0 name=/run/systemd/sessions/ inode=81 dev=00:1a mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_logind_sessions_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/20/2024 10:36:55.005:657) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f18e19bb970 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=2011 pid=2012 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=uptime exe=/usr/bin/uptime subj=system_u:system_r:logwatch_t:s0 key=(null) type=AVC msg=audit(03/20/2024 10:36:55.005:657) : avc:  denied  { read } for  pid=2012 comm=uptime name=sessions dev="tmpfs" ino=81 scontext=system_u:system_r:logwatch_t:s0 tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=dir permissive=0

Resolves: rhbz#2270484