### PR TITLE
postfix: allow qmgr to delete mails in bounce/ directory

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -632,13 +632,13 @@ manage_files_pattern(postfix_qmgr_t, postfix_spool_t, postfix_spool_t)
 manage_lnk_files_pattern(postfix_qmgr_t, postfix_spool_t, postfix_spool_t)
 files_spool_filetrans(postfix_qmgr_t, postfix_spool_t, dir)
 
-allow postfix_qmgr_t postfix_spool_bounce_t:dir list_dir_perms;
-allow postfix_qmgr_t postfix_spool_bounce_t:file read_file_perms;
-allow postfix_qmgr_t postfix_spool_bounce_t:lnk_file read_lnk_file_perms;
-
 manage_files_pattern(postfix_qmgr_t, postfix_spool_maildrop_t, postfix_spool_maildrop_t)
 manage_dirs_pattern(postfix_qmgr_t, postfix_spool_maildrop_t, postfix_spool_maildrop_t)
 allow postfix_qmgr_t postfix_spool_maildrop_t:lnk_file read_lnk_file_perms;
+
+manage_dirs_pattern(postfix_qmgr_t, postfix_spool_bounce_t, postfix_spool_bounce_t)
+manage_files_pattern(postfix_qmgr_t, postfix_spool_bounce_t, postfix_spool_bounce_t)
+manage_lnk_files_pattern(postfix_qmgr_t, postfix_spool_bounce_t, postfix_spool_bounce_t)
 
 corecmd_exec_bin(postfix_qmgr_t)
 


### PR DESCRIPTION
See [RHEL-30271 - postfix qmgr cannot delete mails in bounce/ directory](https://issues.redhat.com/browse/RHEL-30271).

### AVC:
~~~
... type=PROCTITLE msg=...: proctitle=qmgr-l-tunix-u
... type=PATH msg=...: item=1 name=bounce/E40A741281B ... obj=system_u:object_r:postfix_spool_bounce_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
... type=PATH msg=...: item=0 name=bounce/ ... obj=system_u:object_r:postfix_spool_bounce_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
... type=CWD msg=...: cwd=/var/spool/postfix
... type=SYSCALL msg=...: arch=c000003e syscall=87 success=no exit=-13 ... comm=qmgr exe=/usr/libexec/postfix/qmgr subj=system_u:system_r:postfix_qmgr_t:s0 key=(null)
... type=AVC msg=...: avc:  denied  { write } for  pid=2012444 comm=qmgr name=bounce ... scontext=system_u:system_r:postfix_qmgr_t:s0 tcontext=system_u:object_r:postfix_spool_bounce_t:s0 tclass=dir permissive=0
~~~