### PR TITLE
init: attempt to port boolean init_create_mountpoints

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -855,6 +855,24 @@ interface(`files_search_non_security_dirs',`
 
 ########################################
 ## <summary>
+##	Create non-security directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_create_non_security_dirs',`
+	gen_require(`
+		attribute non_security_file_type;
+	')
+
+	create_dirs_pattern($1, non_security_file_type, non_security_file_type)
+')
+
+########################################
+## <summary>
 ##	Get the attributes of all files.
 ## </summary>
 ## <param name="domain">
@@ -1273,6 +1291,46 @@ interface(`files_relabel_non_security_files',`
 
 	# satisfy the assertions:
 	seutil_relabelto_bin_policy($1)
+')
+
+########################################
+## <summary>
+##	Write all non-security files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_write_non_security_files',`
+	gen_require(`
+		attribute non_security_file_type;
+	')
+
+	write_files_pattern($1, non_security_file_type, non_security_file_type)
+	read_lnk_files_pattern($1, non_security_file_type, non_security_file_type)
+')
+
+########################################
+## <summary>
+##	Create all non-security files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`files_create_non_security_files',`
+	gen_require(`
+		attribute non_security_file_type;
+	')
+
+	create_files_pattern($1, non_security_file_type, non_security_file_type)
+	read_lnk_files_pattern($1, non_security_file_type, non_security_file_type)
 ')
 
 ########################################

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -1818,6 +1818,42 @@ interface(`kernel_dontaudit_list_all_proc',`
 
 ########################################
 ## <summary>
+##	Write systemd mountpoint files except proc entries.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_write_non_proc_init_mountpoint_files',`
+	gen_require(`
+		attribute proc_type;
+	')
+
+	init_write_mountpoint_files($1, -proc_type)
+')
+
+########################################
+## <summary>
+##	Create systemd mountpoint files except proc entries.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_create_non_proc_init_mountpoint_files',`
+	gen_require(`
+		attribute proc_type;
+	')
+
+	init_create_mountpoint_files($1, -proc_type)
+')
+
+########################################
+## <summary>
 ##	Allow attempts to read all proc types.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -818,6 +818,54 @@ interface(`init_named_socket_activation',`
 
 ########################################
 ## <summary>
+##	Write systemd mountpoint files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="exception_types" optional="true">
+##	<summary>
+##	The types to be excluded.  Each type or attribute
+##	must be negated by the caller.
+##	</summary>
+## </param>
+#
+interface(`init_write_mountpoint_files',`
+	gen_require(`
+		attribute init_mountpoint_type;
+	')
+
+	allow $1 { init_mountpoint_type $2 }:file write_file_perms;
+')
+
+########################################
+## <summary>
+##	Create systemd mountpoint files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="exception_types" optional="true">
+##	<summary>
+##	The types to be excluded.  Each type or attribute
+##	must be negated by the caller.
+##	</summary>
+## </param>
+#
+interface(`init_create_mountpoint_files',`
+	gen_require(`
+		attribute init_mountpoint_type;
+	')
+
+	allow $1 { init_mountpoint_type $2 }:file create_file_perms;
+')
+
+########################################
+## <summary>
 ##	Connect to init with a unix socket.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -53,6 +53,13 @@ gen_tunable(init_create_dirs, true)
 
 ## <desc>
 ## <p>
+## Enable systemd to create mountpoints.
+## </p>
+## </desc>
+gen_tunable(init_create_mountpoints, false)
+
+## <desc>
+## <p>
 ## Allow init audit_control capability
 ## </p>
 ## </desc>
@@ -582,6 +589,22 @@ tunable_policy(`init_create_dirs',`
     files_create_non_security_dirs(init_t)
     files_mounton_non_security(init_t)
     files_setattr_non_security_dirs(init_t)
+')
+
+tunable_policy(`init_create_mountpoints',`
+    allow init_t init_mountpoint_type:dir { create_dir_perms add_entry_dir_perms };
+    allow init_t init_mountpoint_type:fifo_file create_fifo_file_perms;
+    allow init_t init_mountpoint_type:sock_file create_sock_file_perms;
+    allow init_t init_mountpoint_type:lnk_file create_lnk_file_perms;
+
+    kernel_write_non_proc_init_mountpoint_files(init_t)
+    kernel_create_non_proc_init_mountpoint_files(init_t)
+')
+
+tunable_policy(`init_create_mountpoints && init_create_dirs',`
+    files_create_non_security_dirs(init_t)
+    files_create_non_security_files(init_t)
+    files_write_non_security_files(init_t)
 ')
 
 tunable_policy(`init_audit_control',`


### PR DESCRIPTION
Attempt to port over https://github.com/SELinuxProject/refpolicy/commit/3265c15c30029db523bb082b3e81cd56ab41fb8e

This is my rather naive attempt to get this into the fedora branch of selinux-policy.