### PR TITLE
Allow qemu-ga read vmsysctls

### DIFF
--- a/policy/modules/contrib/virt_supplementary.te
+++ b/policy/modules/contrib/virt_supplementary.te
@@ -183,6 +183,7 @@ logging_log_filetrans(virt_qemu_ga_t, virt_qemu_ga_log_t, { dir file })
 kernel_read_system_state(virt_qemu_ga_t)
 kernel_read_network_state(virt_qemu_ga_t)
 kernel_rw_kernel_sysctl(virt_qemu_ga_t)
+kernel_read_vm_sysctls(virt_qemu_ga_t)
 
 corecmd_exec_shell(virt_qemu_ga_t)
 corecmd_exec_bin(virt_qemu_ga_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/05/2024 08:35:35.512:92) : proctitle=/usr/bin/qemu-ga --method=virtio-serial --path=/dev/virtio-ports/org.qemu.guest_agent.0 --allow-rpcs=guest-sync-delimited,guest- type=PATH msg=audit(04/05/2024 08:35:35.512:92) : item=0 name=/proc/sys/vm/max_map_count inode=19121 dev=00:16 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_vm_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/05/2024 08:35:35.512:92) : arch=aarch64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0xaaaae899c318 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=1448 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=qemu-ga exe=/usr/bin/qemu-ga subj=system_u:system_r:virt_qemu_ga_t:s0 key=(null) type=AVC msg=audit(04/05/2024 08:35:35.512:92) : avc:  denied  { open } for  pid=1448 comm=qemu-ga path=/proc/sys/vm/max_map_count dev="proc" ino=19121 scontext=system_u:system_r:virt_qemu_ga_t:s0 tcontext=system_u:object_r:sysctl_vm_t:s0 tclass=file permissive=1 type=AVC msg=audit(04/05/2024 08:35:35.512:92) : avc:  denied  { read } for  pid=1448 comm=qemu-ga name=max_map_count dev="proc" ino=19121 scontext=system_u:system_r:virt_qemu_ga_t:s0 tcontext=system_u:object_r:sysctl_vm_t:s0 tclass=file permissive=1

Resolves: RHEL-31892