### PR TITLE
Allow keyutils-dns-resolver connect to the system log service

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -44,3 +44,7 @@ sysnet_read_config(keyutils_dns_resolver_t)
 optional_policy(`
 	avahi_stream_connect(keyutils_dns_resolver_t)
 ')
+
+optional_policy(`
+	logging_send_syslog_msg(keyutils_dns_resolver_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1712345086.525:270): avc:  denied  { read } for  pid=5751 comm="key.dns_resolve" name="log" dev="devtmpfs" ino=198 scontext=system_u:system_r:keyutils_dns_resolver_t:s0 tcontext=system_u:object_r:devlog_t:s0 tclass=lnk_file permissive=0

Resolves: rhbz#2273707