### PR TITLE
fix hibernate on btrfs swapfile (F40)

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1591,7 +1591,8 @@ systemd_read_efivarfs(systemd_userdbd_t)
 # systemd_sleep local policy
 #
 
-allow systemd_sleep_t self:capability { linux_immutable sys_resource };
+# systemd-sleep wants cap_sys_admin to check btrfs swapfile offset (https://github.com/systemd/systemd/pull/29382)
+allow systemd_sleep_t self:capability { linux_immutable sys_resource sys_admin };
 # systemd-sleep needs to set timer for suspend-then-hibernate
 allow systemd_sleep_t self:capability2 wake_alarm;
 dontaudit systemd_sleep_t self:capability sys_ptrace;


### PR DESCRIPTION
- https://github.com/systemd/systemd/pull/29382 double-checks the configured resume offset of the swapfile
- this needs CAP_SYS_ADMIN for [BTRFS_IOC_TREE_SEARCH](https://btrfs.readthedocs.io/en/latest/btrfs-ioctl.html)
- stopped working in Fedora 40 beta