### PR TITLE
Allow systemd-sleep read raw disk data

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1615,9 +1615,9 @@ fstools_rw_swap_files(systemd_sleep_t)
 
 init_search_var_lib_dirs(systemd_sleep_t)
 
-# systemd-sleep needs to getattr swap partitions
-storage_getattr_fixed_disk_dev(systemd_sleep_t)
-storage_getattr_removable_dev(systemd_sleep_t)
+# systemd-sleep needs to read swap partitions
+storage_raw_read_fixed_disk(systemd_sleep_t)
+storage_raw_read_removable_device(systemd_sleep_t)
 
 optional_policy(`
 	logging_dgram_send(systemd_sleep_t)


### PR DESCRIPTION
The commit addresses the following issue:
audit[5317]: AVC avc:  denied  { read } for  pid=5317 comm="systemd-sleep" name="dm-1" dev="devtmpfs" ino=423 scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=0 systemd-sleep[5317]: Failed to find location to hibernate to: Permission denied systemd[1]: systemd-hibernate.service: Main process exited, code=exited, status=1/FAILURE systemd[1]: systemd-hibernate.service: Failed with result 'exit-code'. systemd[1]: Failed to start systemd-hibernate.service - System Hibernate.

Resolves: rhbz#2273959