### PR TITLE
Allow system dbusd service status systemd services

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -229,6 +229,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_status_systemd_services(system_dbusd_t)
 	systemd_use_fds_logind(system_dbusd_t)
 	systemd_write_inherited_logind_sessions_pipes(system_dbusd_t)
 	systemd_write_inhibit_pipes(system_dbusd_t)


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: Apr 14 03:33:32 hostname audit[1]: USER_AVC pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=0 gid=81 path="/usr/lib/systemd/system/systemd-logind.service" cmdline="/usr/bin/dbus-broker-launch --scope system --audit" function="reply_unit_path" scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=service permissive=0 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'