### PR TITLE
Allow systemd-timedated get the timemaster service status

### DIFF
--- a/policy/modules/contrib/linuxptp.if
+++ b/policy/modules/contrib/linuxptp.if
@@ -158,3 +158,21 @@ interface(`phc2sys_rw_shm',`
 	read_lnk_files_pattern($1, timemaster_tmpfs_t, timemaster_tmpfs_t)
 	fs_search_tmpfs($1)
 ')
+
+#######################################
+## <summary>
+##	Get timemaster services status
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`timemaster_service_status',`
+	gen_require(`
+		type timemaster_unit_file_t;
+	')
+
+	allow $1 timemaster_unit_file_t:service status;
+')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1116,6 +1116,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	timemaster_service_status(systemd_timedated_t)
+')
+
+optional_policy(`
 	xserver_manage_config(systemd_timedated_t)
     xserver_read_state_xdm(systemd_timedated_t)
 ')


### PR DESCRIPTION
Resolves: RHEL-25978