### PR TITLE
Label /dev/mmcblk0rpmb character device with removable_device_t

### DIFF
--- a/policy/modules/kernel/storage.fc
+++ b/policy/modules/kernel/storage.fc
@@ -32,6 +32,7 @@
 /dev/megaraid_sas_ioctl_node -c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/megadev.*		-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/mmcblk.*		-b	gen_context(system_u:object_r:removable_device_t,s0)
+/dev/mmcblk[0-9]+rpmb	-c	gen_context(system_u:object_r:removable_device_t,s0)
 /dev/mspblk.*		-b	gen_context(system_u:object_r:removable_device_t,s0)
 /dev/mtd.*		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/mtd.*		-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)


### PR DESCRIPTION
So far, only /dev/mmcblk.* block devices were assigned that label. This commit adds the label for character device for the RPMB (Replay Protected Memory Block) standard.