### PR TITLE
Declare regexes in segenxml.py as raw strings to prevent deprecation warnings

### DIFF
--- a/support/segenxml.py
+++ b/support/segenxml.py
@@ -43,7 +43,7 @@ output_dir = ""
 #	 -> ("interface", "kernel_read_system_state")
 #	"template(`base_user_template',`"
 #	 -> ("template", "base_user_template")
-INTERFACE = re.compile("^\s*(interface|template)\(`(\w*)'")
+INTERFACE = re.compile(r"^\s*(interface|template)\(`(\w*)'")
 
 # Matches either a gen_bool or a gen_tunable statement. Will give the tuple:
 #	("tunable" or "bool", name, "true" or "false")
@@ -52,7 +52,7 @@ INTERFACE = re.compile("^\s*(interface|template)\(`(\w*)'")
 #	 -> ("bool", "secure_mode", "false")
 #	"gen_tunable(allow_kerberos, false)"
 #	 -> ("tunable", "allow_kerberos", "false")
-BOOLEAN = re.compile("^\s*gen_(tunable|bool)\(\s*(\w*)\s*,\s*(true|false)\s*\)")
+BOOLEAN = re.compile(r"^\s*gen_(tunable|bool)\(\s*(\w*)\s*,\s*(true|false)\s*\)")
 
 # Matches a XML comment in the policy, which is defined as any line starting
 #  with two # and at least one character of white space. Will give the single
@@ -63,7 +63,7 @@ BOOLEAN = re.compile("^\s*gen_(tunable|bool)\(\s*(\w*)\s*,\s*(true|false)\s*\)")
 #	 -> ("<summary>")
 #	"##		The domain allowed access.	"
 #	 -> ("The domain allowed access.")
-XML_COMMENT = re.compile("^##\s+(.*?)\s*$")
+XML_COMMENT = re.compile(r"^##\s+(.*?)\s*$")
 
 
 # FUNCTIONS


### PR DESCRIPTION
CI builds generate noise for 'invalid escape sequences', e.g.:

```
/builddir/build/BUILD/selinux-policy-c4eb5c5ddbc9f4f7e8e7b907f903f1d2cfb6140a/support/segenxml.py:46: SyntaxWarning: invalid escape sequence '\s'
  INTERFACE = re.compile("^\s*(interface|template)\(`(\w*)'")
/builddir/build/BUILD/selinux-policy-c4eb5c5ddbc9f4f7e8e7b907f903f1d2cfb6140a/support/segenxml.py:55: SyntaxWarning: invalid escape sequence '\s'
  BOOLEAN = re.compile("^\s*gen_(tunable|bool)\(\s*(\w*)\s*,\s*(true|false)\s*\)")
/builddir/build/BUILD/selinux-policy-c4eb5c5ddbc9f4f7e8e7b907f903f1d2cfb6140a/support/segenxml.py:66: SyntaxWarning: invalid escape sequence '\s'
  XML_COMMENT = re.compile("^##\s+(.*?)\s*$")
```

Declaring regexes as raw strings instead should get rid of those warnings:

```
>>> import re
>>> INTERFACE = re.compile("^\s*(interface|template)\(`(\w*)'")
<stdin>:1: SyntaxWarning: invalid escape sequence '\s'
>>> INTERFACE = re.compile(r"^\s*(interface|template)\(`(\w*)'")
>>>
```