### PR TITLE
Allow nut to statfs()

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -1,4 +1,4 @@
-policy_module(nut, 1.3.1)
+policy_module(nut, 1.3.2)
 
 ########################################
 #
@@ -59,6 +59,8 @@ corenet_tcp_bind_generic_port(nut_upsd_t)
 corenet_tcp_bind_all_nodes(nut_upsd_t)
 
 fs_getattr_cgroup(nut_upsd_t)
+# NSS does a statfs() on the database to determine filesystem type
+fs_getattr_xattr_fs(nut_upsd_t)
 
 optional_policy(`
 	unconfined_stream_connect(nut_upsd_t)
@@ -101,6 +103,7 @@ term_write_all_terms(nut_upsmon_t)
 # upsmon runs shutdown, probably need a shutdown domain
 init_rw_utmp(nut_upsmon_t)
 init_telinit(nut_upsmon_t)
+fs_getattr_xattr_fs(nut_upsmon_t)
 
 
 mta_send_mail(nut_upsmon_t)


### PR DESCRIPTION
This resolves the following denials:
type=AVC msg=audit(1713892782.603:545): avc:  denied  { getattr } for  pid=46128 comm="upsd" name="/" dev="dm-1" ino=128 scontext=system_u:system_r:nut_upsd_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0 type=AVC msg=audit(1713894055.590:666): avc:  denied  { getattr } for  pid=53147 comm="shutdown" name="/" dev="dm-1" ino=128 scontext=system_u:system_r:nut_upsmon_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1