### PR TITLE
Allow abrt-dump-journal-core connect to systemd-userdbd over a unix s…

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -594,6 +594,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_userdbd_stream_connect(abrt_dump_oops_t)
+')
+
+optional_policy(`
 	xserver_exec(abrt_dump_oops_t)
 ')
 


### PR DESCRIPTION
…ocket

The commit addresses the following AVC denial and 2 related ones: type=PROCTITLE msg=audit(02/25/2024 23:20:22.981:1367) : proctitle=/usr/bin/abrt-dump-journal-core -D -T -f -e type=PATH msg=audit(02/25/2024 23:20:22.981:1367) : item=0 name=/run/systemd/userdb/io.systemd.DropIn inode=907 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(02/25/2024 23:20:22.981:1367) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DropIn } type=SYSCALL msg=audit(02/25/2024 23:20:22.981:1367) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x3a a1=0x7fffd87b9910 a2=0x28 a3=0x559c798649e0 items=1 ppid=1 pid=1503 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=abrt-dump-journ exe=/usr/bin/abrt-dump-journal-core subj=system_u:system_r:abrt_dump_oops_t:s0 key=(null) type=AVC msg=audit(02/25/2024 23:20:22.981:1367) : avc:  denied  { connectto } for  pid=1503 comm=abrt-dump-journ path=/run/systemd/userdb/io.systemd.Multiplexer scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:system_r:systemd_userdbd_t:s0 tclass=unix_stream_socket permissive=1

Resolves: rhbz#2265927