### PR TITLE
Allow numad to trace processes in user namespace

### DIFF
--- a/policy/modules/contrib/numad.te
+++ b/policy/modules/contrib/numad.te
@@ -24,6 +24,7 @@ files_pid_file(numad_var_run_t)
 #
 
 allow numad_t self:capability { ipc_owner kill sys_nice sys_ptrace } ;
+allow numad_t self:cap_userns sys_ptrace;
 allow numad_t self:fifo_file rw_fifo_file_perms;
 allow numad_t self:msgq create_msgq_perms;
 allow numad_t self:msg { send receive };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/23/2024 18:03:36.617:3479) : proctitle=/usr/bin/numad -i 15 type=SYSCALL msg=audit(04/23/2024 18:03:36.617:3479) : arch=x86_64 syscall=read success=yes exit=169 a0=0x1 a1=0x55cf0c6d4240 a2=0x400 a3=0x0 items=0 ppid=1 pid=3200 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=numad exe=/usr/bin/numad subj=system_u:system_r:numad_t:s0 key=(null) type=AVC msg=audit(04/23/2024 18:03:36.617:3479) : avc:  denied  { sys_ptrace } for  pid=3200 comm=numad capability=sys_ptrace  scontext=system_u:system_r:numad_t:s0 tcontext=system_u:system_r:numad_t:s0 tclass=cap_userns permissive=0

Resolves: RHEL-33994