### PR TITLE
Allow plymouthd read efivarfs files

### DIFF
--- a/policy/modules/contrib/plymouthd.te
+++ b/policy/modules/contrib/plymouthd.te
@@ -76,7 +76,7 @@ dev_rw_xserver_misc(plymouthd_t)
 domain_use_interactive_fds(plymouthd_t)
 
 fs_getattr_all_fs(plymouthd_t)
-fs_search_efivarfs_dirs(plymouthd_t)
+fs_read_efivarfs_files(plymouthd_t)
 
 term_getattr_pty_fs(plymouthd_t)
 term_use_all_terms(plymouthd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PATH msg=audit(1713905790.274:105): item=0 name=/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c inode=3360 dev=00:1e mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:efivarfs_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 type=AVC msg=audit(1713905790.274:105): avc:  denied  { read } for  pid=435 comm="plymouthd" name="SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" dev="efivarfs" ino=3360 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:object_r:efivarfs_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(1713905790.274:105): arch=x86_64 syscall=openat success=no exit=EACCES a0=ffffff9c a1=7f3417ba4150 a2=0 a3=0 items=1 ppid=1 pid=435 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=plymouthd exe=/usr/sbin/plymouthd subj=system_u:system_r:plymouthd_t:s0 key=(null)

Resolves: rhbz#2276729