### PR TITLE
Update the auth_dontaudit_read_passwd_file() interface

### DIFF
--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2306,7 +2306,7 @@ interface(`auth_dontaudit_read_passwd_file',`
 		type passwd_file_t;
 	')
 
-	dontaudit $1 passwd_file_t:file { open read };
+	dontaudit $1 passwd_file_t:file { getattr open read };
 ')
 
 ########################################


### PR DESCRIPTION
Include getattr permission in the auth_dontaudit_read_passwd_file() interface. This denial manifests only in permissive mode.

The commit addresses the following AVC denial:
avc: denied { getattr } for pid=79656 comm="selinux-autorel" path="/etc/passwd" dev="dm-0" ino=17705170 scontext=system_u:system_r:selinux_autorelabel_generator_t:s0 tcontext=system_u:object_r:passwd_file_t:s0 tclass=file permissive=1

Resolves: rhbz#2275266