### PR TITLE
Allow sssd create and use io_uring

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -102,6 +102,7 @@ manage_files_pattern(sssd_t, sssd_var_run_t, sssd_var_run_t)
 manage_sock_files_pattern(sssd_t, sssd_var_run_t, sssd_var_run_t)
 files_pid_filetrans(sssd_t, sssd_var_run_t, { file dir sock_file })
 
+kernel_io_uring_use(sssd_t)
 kernel_read_network_state(sssd_t)
 kernel_read_system_state(sssd_t)
 kernel_request_load_module(sssd_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:
avc:  denied  { create } for  pid=879 comm="nsupdate" anonclass=[io_uring] scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1 avc:  denied  { map } for  pid=879 comm="nsupdate" path="anon_inode:[io_uring]" dev="anon_inodefs" ino=11274 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1 avc:  denied  { read write } for  pid=879 comm="nsupdate" path="anon_inode:[io_uring]" dev="anon_inodefs" ino=11274 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1

Resolves: rhbz#2276937