### PR TITLE
Allow abrt-dump-journal-core connect to systemd-homed

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -576,6 +576,8 @@ fs_getattr_all_fs(abrt_dump_oops_t)
 fs_list_pstorefs(abrt_dump_oops_t)
 fs_getattr_nsfs_files(abrt_dump_oops_t)
 
+init_stream_connectto(abrt_dump_oops_t)
+
 selinux_compute_create_context(abrt_dump_oops_t)
 
 logging_read_generic_logs(abrt_dump_oops_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
audit: type=1400 audit(1713982589.922:18417): avc:  denied  { connectto } for  pid=175324 comm="abrt-dump-journ" path="/run/systemd/userdb/io.systemd.Home" scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=0