### PR TITLE
Ensure dbus communication is allowed bidirectionally

### DIFF
--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -131,6 +131,7 @@ interface(`cron_role',`
 		dbus_stub(cronjob_t)
 
 		allow cronjob_t $2_t:dbus send_msg;
+		allow $2_t cronjob_t:dbus send_msg;
 	')		
 ')
 
@@ -213,6 +214,7 @@ interface(`cron_unconfined_role',`
 
 		dbus_stub(unconfined_cronjob_t)
 		allow unconfined_cronjob_t $2_t:dbus send_msg;
+		allow $2_t unconfined_cronjob_t:dbus send_msg;
 	')
 ')
 
@@ -307,6 +309,7 @@ interface(`cron_admin_role',`
 		dbus_stub(admin_cronjob_t)
 
 		allow cronjob_t $2_t:dbus send_msg;
+		allow $2_t cronjob_t:dbus send_msg;
 	')		
 ')
 

--- a/policy/modules/contrib/dbus.if
+++ b/policy/modules/contrib/dbus.if
@@ -91,7 +91,9 @@ template(`dbus_role_template',`
 
 	# SE-DBus specific permissions
 	allow { dbusd_unconfined $3 } $1_dbusd_t:dbus { send_msg acquire_svc };
+	allow $1_dbusd_t { dbusd_unconfined $3 }:dbus send_msg;
 	allow $3 system_dbusd_t:dbus { send_msg acquire_svc };
+	allow system_dbusd_t $3:dbus send_msg;
 
     # Permissions for dbus-broker running with systemd user sessions
     allow $3 $1_dbusd_t:process { noatsecure rlimitinh siginh };
@@ -157,7 +159,8 @@ interface(`dbus_system_bus_client',`
 	')
 
 	# SE-DBus specific permissions
-	allow $1 { system_dbusd_t self }:dbus send_msg;
+	allow $1 self:dbus send_msg;
+	allow $1 { system_dbusd_t dbusd_unconfined }:dbus send_msg;
 	allow { system_dbusd_t dbusd_unconfined } $1:dbus send_msg;
 
 	read_files_pattern($1, system_dbusd_var_lib_t, system_dbusd_var_lib_t)
@@ -222,7 +225,9 @@ interface(`dbus_session_bus_client',`
 	')
 
 	# SE-DBus specific permissions
-	allow $1 { session_bus_type self }:dbus send_msg;
+	allow $1 self:dbus send_msg;
+	allow $1 session_bus_type:dbus send_msg;
+	allow session_bus_type $1:dbus send_msg;
 
 	# For connecting to the bus
 	allow $1 session_bus_type:unix_stream_socket connectto;

--- a/policy/modules/contrib/vmtools.if
+++ b/policy/modules/contrib/vmtools.if
@@ -140,4 +140,5 @@ interface(`vmtools_unconfined_dbus_chat',`
 	')
 
 	allow $1 vmtools_unconfined_t:dbus send_msg;
+	allow vmtools_unconfined_t $1:dbus send_msg;
 ')

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2020,6 +2020,7 @@ interface(`init_dbus_send_script',`
 	')
 
 	allow $1 initrc_t:dbus send_msg;
+	allow initrc_t $1:dbus send_msg;
 ')
 
 ########################################

--- a/policy/modules/system/lvm.if
+++ b/policy/modules/system/lvm.if
@@ -503,8 +503,8 @@ interface(`lvm_dbus_send_msg',`
 		type lvm_t;
 		class dbus send_msg;
 	')
-    allow $1 lvm_t:dbus send_msg;
-
+	allow $1 lvm_t:dbus send_msg;
+	allow lvm_t $1:dbus send_msg;
 ')
 
 ########################################

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -5001,6 +5001,7 @@ interface(`userdom_dbus_send_all_users',`
 	')
 
 	allow $1 userdomain:dbus send_msg;
+	allow userdomain $1:dbus send_msg;
 	ps_process_pattern($1, userdomain)
 ')
 


### PR DESCRIPTION
In some interfaces, only one-way communication over dbus is allowed. This is not correct, it may result in timeouting the dbus request or response and possibly also make the service, which uses dbus communication, fail.