### PR TITLE
Fix speech-dispatcherd.service denials 

### DIFF
--- a/policy/modules/contrib/speech-dispatcher.fc
+++ b/policy/modules/contrib/speech-dispatcher.fc
@@ -1,3 +1,5 @@
+HOME_DIR/\.cache/speech-dispatcher(/.*)?	gen_context(system_u:object_r:speech_dispatcher_home_t,s0)
+
 /usr/bin/speech-dispatcher		--	gen_context(system_u:object_r:speech_dispatcher_exec_t,s0)
 
 /usr/lib/systemd/system/speech-dispatcherd.service		--	gen_context(system_u:object_r:speech_dispatcher_unit_file_t,s0)

--- a/policy/modules/contrib/speech-dispatcher.fc
+++ b/policy/modules/contrib/speech-dispatcher.fc
@@ -3,5 +3,6 @@ HOME_DIR/\.cache/speech-dispatcher(/.*)?	gen_context(system_u:object_r:speech_di
 /usr/bin/speech-dispatcher		--	gen_context(system_u:object_r:speech_dispatcher_exec_t,s0)
 
 /usr/lib/systemd/system/speech-dispatcherd.service		--	gen_context(system_u:object_r:speech_dispatcher_unit_file_t,s0)
+/usr/lib/speech-dispatcher-modules(/.*)?    gen_context(system_u:object_r:speech_dispatcher_modules_t,s0)
 
 /var/log/speech-dispatcher(/.*)?		gen_context(system_u:object_r:speech_dispatcher_log_t,s0)

--- a/policy/modules/contrib/speech-dispatcher.te
+++ b/policy/modules/contrib/speech-dispatcher.te
@@ -2,6 +2,7 @@ policy_module(speech-dispatcher, 1.0.0)
 
 gen_require(`
     type cache_home_t;
+    type ephemeral_port_t;
 ')
 
 ########################################
@@ -36,6 +37,9 @@ type speech_dispatcher_tmpfs_t;
 typealias speech_dispatcher_tmpfs_t alias speech-dispatcher_tmpfs_t;
 files_tmpfs_file(speech_dispatcher_tmpfs_t)
 
+type speech_dispatcher_modules_t;
+files_type(speech_dispatcher_modules_t)
+
 ########################################
 #
 # speech-dispatcher local policy
@@ -48,6 +52,8 @@ allow speech_dispatcher_t self:unix_stream_socket create_stream_socket_perms;
 allow speech_dispatcher_t self:tcp_socket create_socket_perms;
 allow speech_dispatcher_t speech_dispatcher_home_t:file create_file_perms;
 allow speech_dispatcher_t speech_dispatcher_home_t:dir create_dir_perms;
+allow speech_dispatcher_t ephemeral_port_t:tcp_socket name_connect;
+corecmd_exec_shell(speech_dispatcher_t)
 
 manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
 manage_files_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
@@ -65,6 +71,12 @@ manage_fifo_files_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_
 userdom_filetrans_home_content(speech_dispatcher_t,speech_dispatcher_home_t, dir, ".cache/speech-dispatcher")
 userdom_filetrans_home_content(speech_dispatcher_t,speech_dispatcher_home_t, dir, ".config/speech-dispatcher")
 filetrans_pattern(speech_dispatcher_t, cache_home_t, speech_dispatcher_home_t, dir, "speech-dispatcher")
+
+exec_files_pattern(speech_dispatcher_t, speech_dispatcher_modules_t, speech_dispatcher_modules_t)
+read_lnk_files_pattern(speech_dispatcher_t, speech_dispatcher_modules_t, speech_dispatcher_modules_t)
+manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_modules_t, speech_dispatcher_modules_t)
+
+manage_sock_files_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
 
 kernel_read_system_state(speech_dispatcher_t)
 

--- a/policy/modules/contrib/speech-dispatcher.te
+++ b/policy/modules/contrib/speech-dispatcher.te
@@ -1,5 +1,9 @@
 policy_module(speech-dispatcher, 1.0.0)
 
+gen_require(`
+    type cache_home_t;
+')
+
 ########################################
 #
 # Declarations
@@ -42,6 +46,8 @@ allow speech_dispatcher_t self:process signal_perms;
 allow speech_dispatcher_t self:fifo_file rw_fifo_file_perms;
 allow speech_dispatcher_t self:unix_stream_socket create_stream_socket_perms;
 allow speech_dispatcher_t self:tcp_socket create_socket_perms;
+allow speech_dispatcher_t speech_dispatcher_home_t:file create_file_perms;
+allow speech_dispatcher_t speech_dispatcher_home_t:dir create_dir_perms;
 
 manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
 manage_files_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
@@ -56,7 +62,9 @@ fs_tmpfs_filetrans(speech_dispatcher_t, speech_dispatcher_tmpfs_t, { file })
 manage_files_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
 manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
 manage_fifo_files_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
-userdom_filetrans_home_content(speech_dispatcher_t,speech_dispatcher_home_t, dir, ".speech-dispatcher")
+userdom_filetrans_home_content(speech_dispatcher_t,speech_dispatcher_home_t, dir, ".cache/speech-dispatcher")
+userdom_filetrans_home_content(speech_dispatcher_t,speech_dispatcher_home_t, dir, ".config/speech-dispatcher")
+filetrans_pattern(speech_dispatcher_t, cache_home_t, speech_dispatcher_home_t, dir, "speech-dispatcher")
 
 kernel_read_system_state(speech_dispatcher_t)
 


### PR DESCRIPTION
When systemctl start speech-dispatcherd.service, the following AVC denial occurs：

1.  speech-dispatcher working directory changes, causing AVC rejection. 
```
type=AVC msg=audit(1713942006.045:1230): avc:  denied  { create } for  pid=12672 comm="speech-dispatch" name="speech-dispatcher" scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:cache_home_t:s0 tclass=dir permissive=0
type=SERVICE_START msg=audit(1713942006.053:1232): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=speech-dispatcherd comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=failed'^]UID="root" AUID="unset"
```


2.  bash command, tcp port connection, and speech dispatcher-modules access are denied.

The audit.log is as follows:
```
239:type=AVC msg=audit(1714149641.307:1053): avc:  denied  { execute } for  pid=6920 comm="speech-dispatch" name="bash" dev="dm-0" ino=16782846 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
240:type=AVC msg=audit(1714149641.308:1054): avc:  denied  { execute } for  pid=6921 comm="speech-dispatch" name="bash" dev="dm-0" ino=16782846 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
241:type=AVC msg=audit(1714149641.308:1055): avc:  denied  { name_connect } for  pid=6909 comm="speech-dispatch" dest=59125 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:ephemeral_port_t:s0 tclass=tcp_socket permissive=0
242:type=AVC msg=audit(1714149641.310:1056): avc:  denied  { execute } for  pid=6922 comm="speech-dispatch" name="bash" dev="dm-0" ino=16782846 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
243:type=AVC msg=audit(1714149641.311:1057): avc:  denied  { execute } for  pid=6923 comm="speech-dispatch" name="bash" dev="dm-0" ino=16782846 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
244:type=AVC msg=audit(1714149641.313:1058): avc:  denied  { execute_no_trans } for  pid=6924 comm="speech-dispatch" path="/usr/lib64/speech-dispatcher-modules/sd_cicero" dev="dm-0" ino=34460340 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:lib_t:s0 tclass=file permissive=0
245:type=AVC msg=audit(1714149641.317:1059): avc:  denied  { execute_no_trans } for  pid=6925 comm="speech-dispatch" path="/usr/lib64/speech-dispatcher-modules/sd_espeak-ng" dev="dm-0" ino=34566660 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:lib_t:s0 tclass=file permissive=0
246:type=AVC msg=audit(1714149641.321:1060): avc:  denied  { execute_no_trans } for  pid=6926 comm="speech-dispatch" path="/usr/lib64/speech-dispatcher-modules/sd_espeak-ng" dev="dm-0" ino=34566660 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:lib_t:s0 tclass=file permissive=0
247:type=AVC msg=audit(1714149641.324:1061): avc:  denied  { execute_no_trans } for  pid=6927 comm="speech-dispatch" path="/usr/lib64/speech-dispatcher-modules/sd_dummy" dev="dm-0" ino=34460341 scontext=system_u:system_r:speech_dispatcher_t:s0 tcontext=system_u:object_r:lib_t:s0 tclass=file permissive=0
```

Related discussion: https://github.com/fedora-selinux/selinux-policy/issues/2100
