### PR TITLE
Allow svirt_tcg_t map svirt_image_t files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1037,7 +1037,7 @@ read_lnk_files_pattern(virt_domain, svirt_image_t, svirt_image_t)
 rw_chr_files_pattern(virt_domain, svirt_image_t, svirt_image_t)
 rw_blk_files_pattern(virt_domain, svirt_image_t, svirt_image_t)
 fs_hugetlbfs_filetrans(virt_domain, svirt_image_t, file)
-allow svirt_t svirt_image_t:file map;
+allow virt_domain svirt_image_t:file map;
 allow svirt_t svirt_image_t:blk_file map;
 allow svirt_t svirt_image_t:chr_file map;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1710328208.112:388): avc:  denied  { map } for  pid=3395 comm="qemu-system-aar" path="/home/username//CentOS-9-stream/username-centos-9-stream_aarch64/nvdimm-0.dev" dev="sdb4" ino=789153 scontext=system_u:system_r:svirt_tcg_t:s0:c23,c892 tcontext=system_u:object_r:svirt_image_t:s0:c23,c892 tclass=file permissive=0

Resolves: rhbz#2270027