### PR TITLE
Allow abrt-dump-journal-core connect to systemd-machined

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -594,6 +594,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_machined_stream_connect(abrt_dump_oops_t)
 	systemd_userdbd_stream_connect(abrt_dump_oops_t)
 ')
 


### PR DESCRIPTION
abrt-dump-journal-core was allowed to connect to systemd-machined over a unix socket.

The commit addresses the following AVC denial and 2 related ones: type=AVC msg=audit(1714352016.324:249): avc:  denied  { connectto } for  pid=2471 comm="abrt-dump-journ" path="/run/systemd/userdb/io.systemd.Machine" scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2277658