### PR TITLE
Allow dbus-broker rear/write inherited user ttys

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -249,6 +249,7 @@ optional_policy(`
 
 optional_policy(`
 	userdom_rw_stream(system_dbusd_t)
+	userdom_use_inherited_user_ttys(system_dbusd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This permission is required to allow systemd-run start a transient unit over D-Bus on a serial console.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/29/24 11:09:59.878:348) : proctitle=dbus-broker --log 4 --controller 9 --machine-id 010dea9d856a4caf9801faa7f613bcf3 --max-bytes 536870912 --max-fds 4096 --max-matc type=SYSCALL msg=audit(04/29/24 11:09:59.878:348) : arch=x86_64 syscall=recvmsg success=yes exit=576 a0=0x2e a1=0x7ffddaff68a0 a2=MSG_DONTWAIT|MSG_CMSG_CLOEXEC a3=0x55ced19b6b00 items=0 ppid=772 pid=791 auid=unset uid=dbus gid=dbus euid=dbus suid=dbus fsuid=dbus egid=dbus sgid=dbus fsgid=dbus tty=(none) ses=unset comm=dbus-broker exe=/usr/bin/dbus-broker subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(04/29/24 11:09:59.878:348) : avc:  denied  { read write } for  pid=791 comm=dbus-broker path=/dev/tty1 dev="devtmpfs" ino=20 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_tty_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2277599