### PR TITLE
Allow selinux-relabel-generator create units dir

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -823,6 +823,9 @@ kernel_read_proc_files(selinux_autorelabel_generator_t)
 # src:ln, selinuxenabled, cat
 corecmd_exec_bin(selinux_autorelabel_generator_t)
 
+# src:mkdir -p "$earlydir/selinux-autorelabel.service.d"
+init_pid_filetrans(selinux_autorelabel_generator_t, selinux_autorelabel_generator_unit_file_t, dir)
+
 optional_policy(`
 	# src:#!/bin/bash
 	auth_dontaudit_read_passwd_file(selinux_autorelabel_generator_t)
@@ -839,7 +842,6 @@ optional_policy(`
 	# src:ln -sf "$unitdir/selinux-autorelabel.target" "$earlydir/default.target"
 	systemd_create_unit_file_lnk(selinux_autorelabel_generator_t)
 
-        # src:mkdir -p "$earlydir/selinux-autorelabel.service.d"
 	# src:cat > "$earlydir/selinux-autorelabel.service.d/tty.conf" <<EOF
 	allow selinux_autorelabel_generator_t selinux_autorelabel_generator_unit_file_t:dir manage_dir_perms;
 	allow selinux_autorelabel_generator_t selinux_autorelabel_generator_unit_file_t:file manage_file_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/29/2024 06:24:29.406:1290) : proctitle=mkdir -p /run/systemd/generator.early selinux-autorelabel.service.d type=PATH msg=audit(04/29/2024 06:24:29.406:1290) : item=1 name=generator.early nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(04/29/2024 06:24:29.406:1290) : item=0 name=/run/systemd inode=2 dev=00:1b mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/29/2024 06:24:29.406:1290) : arch=x86_64 syscall=mkdir success=no exit=EACCES(Permission denied) a0=0x7fffd60f0e59 a1=0777 a2=0x7fffd60ef2b0 a3=0x555587e0c274 items=2 ppid=57153 pid=57171 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=mkdir exe=/usr/bin/mkdir subj=system_u:system_r:selinux_autorelabel_generator_t:s0 key=(null) type=AVC msg=audit(04/29/2024 06:24:29.406:1290) : avc:  denied  { write } for  pid=57171 comm=mkdir name=systemd dev="tmpfs" ino=2 scontext=system_u:system_r:selinux_autorelabel_generator_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0