### PR TITLE
Add support for secretmem anon inode

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -131,6 +131,7 @@ allow domain self:shm create_shm_perms;
 
 kernel_userfaultfd_domtrans(domain)
 kernel_io_uring_domtrans(domain)
+kernel_secretmem_domtrans(domain)
 
 kernel_getattr_proc(domain)
 kernel_read_proc_symlinks(domain)
@@ -305,6 +306,7 @@ allow unconfined_domain_type domain:perf_event rw_inherited_perf_event_perms;
 kernel_manage_perf_event(unconfined_domain_type)
 kernel_userfaultfd_use(unconfined_domain_type)
 kernel_io_uring_use(unconfined_domain_type)
+kernel_secretmem_use(unconfined_domain_type)
 
 corenet_filetrans_all_named_dev(named_filetrans_domain)
 

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4610,3 +4610,37 @@ interface(`kernel_io_uring_use',`
 	kernel_io_uring_use_inherited($1)
 	allow $1 io_uring_t:anon_inode create;
 ')
+
+########################################
+## <summary>
+##	Set up type transition for secretmem anon inodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to receive the type transition.
+##	</summary>
+## </param>
+#
+interface(`kernel_secretmem_domtrans',`
+	gen_require(`
+		type secretmem_t;
+	')
+	type_transition $1 self:anon_inode secretmem_t "[secretmem]";
+')
+
+########################################
+## <summary>
+##	Allow the domain to use the secretmem API.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_secretmem_use',`
+	gen_require(`
+		type secretmem_t;
+	')
+	allow $1 secretmem_t:anon_inode create;
+')

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -237,6 +237,7 @@ neverallow * unlabeled_t:file entrypoint;
 # anon_inode types
 type userfaultfd_t;
 type io_uring_t;
+type secretmem_t;
 
 # These initial sids are no longer used, and can be removed:
 sid any_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)


### PR DESCRIPTION
Commit 65b9e0bdceb7e6adbe308f9a591b103cba6986ef implements proper support for anon inodes, however it does not implement support for secretmem anon inode.

This patch adds type transition, so [secretmem] anon inode is always created with secretmem_t type. It also adds an interface allowing create permission on secretmem_t and allows unconfined_domain_type to use it.

Addresses the following AVCs:
type=PROCTITLE msg=audit(03/27/2024 02:54:00.035:4382) : proctitle=stress-ng-resources [run] type=SYSCALL msg=audit(03/27/2024 02:54:00.035:4382) : arch=x86_64 syscall=memfd_secret success=no exit=EACCES(Permission denied) a0=0x0 a1=0x0 a2=0x0 a3=0x0 items=0 ppid=2072 pid=5294 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=4 comm=stress-ng-resou exe=/usr/bin/stress-ng subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(03/27/2024 02:54:00.035:4382) : avc:  denied  { create } for  pid=5294 comm=stress-ng-resou anonclass=[secretmem] scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:unconfined_t:s0 tclass=anon_inode permissive=0

Resolves: rhbz#2270895