### PR TITLE
Declare ports 80/udp and 443/udp as http for HTTP/3 (QUIC)

### DIFF
--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -193,7 +193,7 @@ network_port(hadoop_namenode, tcp,8020,s0)
 network_port(hddtemp, tcp,7634,s0)
 network_port(howl, tcp,5335,s0, udp,5353,s0)
 network_port(hplip, tcp,1782,s0, tcp,2207,s0, tcp,2208,s0, tcp, 8290,s0, tcp,50000,s0, tcp,50002,s0, tcp,8292,s0, tcp,9100,s0, tcp,9101,s0, tcp,9102,s0, tcp,9220,s0, tcp,9221,s0, tcp,9222,s0, tcp,9280,s0, tcp,9281,s0, tcp,9282,s0, tcp,9290,s0, tcp,9291,s0)
-network_port(http, tcp,80,s0, tcp,81,s0, tcp,443,s0, tcp,488,s0, tcp,8008,s0, tcp,8009,s0, tcp,8443,s0,tcp,9000, s0) #8443 is mod_nss default port
+network_port(http, tcp,80,s0, udp,80,s0, tcp,81,s0, tcp,443,s0, udp,443,s0, tcp,488,s0, tcp,8008,s0, tcp,8009,s0, tcp,8443,s0,tcp,9000, s0) #8443 is mod_nss default port
 network_port(http_cache, udp,3130,s0, tcp,8080,s0, tcp,8118,s0, tcp,8123,s0, tcp,10001-10010,s0) # 8118 is for privoxy
 network_port(ibm_dt_2, tcp,1792,s0, udp,1792,s0)
 network_port(intermapper, tcp,8181,s0)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1714750445.928:337): avc:  denied  { name_bind } for  pid=9687 comm="nginx" src=443 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:reserved_port_t:s0 tclass=udp_socket permissive=1

Resolves: rhbz#2278979