### PR TITLE
Allow staff_t use the io_uring API

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -27,6 +27,7 @@ allow staff_t self:netlink_generic_socket { create_socket_perms };
 
 corenet_ib_access_unlabeled_pkeys(staff_t)
 
+kernel_io_uring_use(staff_t)
 kernel_read_ring_buffer(staff_t)
 kernel_getattr_core_if(staff_t)
 kernel_getattr_message_if(staff_t)


### PR DESCRIPTION
Required for handling qemu disk images by a user in the staff_t domain.

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(9.5.2024 11:47:16.231:436) : proctitle=qemu-img create -qf qcow2 -F qcow2 -b /path/filename.qcow2 -o lazy type=SYSCALL msg=audit(9.5.2024 11:47:16.231:436) : arch=x86_64 syscall=io_uring_setup success=yes exit=4 a0=0x80 a1=0x7ffc49b29840 a2=0x7ffc49b29840 a3=0x4 items=0 ppid=25793 pid=25872 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=pts11 ses=3 comm=qemu-img exe=/usr/bin/qemu-img subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(9.5.2024 11:47:16.231:436) : avc:  denied  { create } for  pid=25872 comm=qemu-img anonclass=[io_uring] scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1 type=PROCTITLE msg=audit(9.5.2024 11:47:16.231:437) : proctitle=qemu-img create -qf qcow2 -F qcow2 -b /path/filename.qcow2 -o lazy type=MMAP msg=audit(9.5.2024 11:47:16.231:437) : fd=4 flags=MAP_SHARED|MAP_POPULATE type=SYSCALL msg=audit(9.5.2024 11:47:16.231:437) : arch=x86_64 syscall=mmap success=yes exit=139636585943040 a0=0x0 a1=0x1240 a2=PROT_READ|PROT_WRITE a3=MAP_SHARED|MAP_POPULATE items=0 ppid=25793 pid=25872 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=pts11 ses=3 comm=qemu-img exe=/usr/bin/qemu-img subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(9.5.2024 11:47:16.231:437) : avc:  denied  { read write } for  pid=25872 comm=qemu-img path=anon_inode:[io_uring] dev="anon_inodefs" ino=318625 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1 type=AVC msg=audit(9.5.2024 11:47:16.231:437) : avc:  denied  { map } for  pid=25872 comm=qemu-img path=anon_inode:[io_uring] dev="anon_inodefs" ino=318625 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1