### PR TITLE
Label systemd configuration files with systemd_conf_t

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -100,6 +100,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/inhibit(/.*)?	gen_context(system_u:object_r:systemd_logind_inhibit_var_run_t,s0)
 /run/systemd/ask-password-block(/.*)?	gen_context(system_u:object_r:systemd_passwd_var_run_t,s0)
 /run/systemd/ask-password(/.*)?	gen_context(system_u:object_r:systemd_passwd_var_run_t,s0)
+/run/systemd/machine(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines.lock	--	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -4,6 +4,10 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 
 /etc/.*hostname.*	--	gen_context(system_u:object_r:hostname_etc_t,s0)
 /etc/machine-info	--	gen_context(system_u:object_r:hostname_etc_t,s0)
+/etc/systemd/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
+/etc/systemd/.+\.conf\.d	-d	gen_context(system_u:object_r:systemd_conf_t,s0)
+/etc/systemd/.+\.conf\.d/.+\.conf --	gen_context(system_u:object_r:systemd_conf_t,s0)
+/etc/systemd/.+\.conf\.d/.+\.conf -l	gen_context(system_u:object_r:systemd_conf_t,s0)
 /etc/udev/.*hwdb.*	--	gen_context(system_u:object_r:systemd_hwdb_etc_t,s0)
 
 /bin/systemd-notify				--		gen_context(system_u:object_r:systemd_notify_exec_t,s0)
@@ -19,6 +23,10 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/bin/systemd-tty-ask-password-agent		--		gen_context(system_u:object_r:systemd_passwd_agent_exec_t,s0)
 /usr/bin/systemd-hwdb		--	gen_context(system_u:object_r:systemd_hwdb_exec_t,s0)
 
+/usr/lib/systemd/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
+/usr/lib/systemd/.+\.conf\.d	-d	gen_context(system_u:object_r:systemd_conf_t,s0)
+/usr/lib/systemd/.+\.conf\.d/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
+/usr/lib/systemd/.+\.conf\.d/.+\.conf	-l	gen_context(system_u:object_r:systemd_conf_t,s0)
 /usr/lib/systemd/systemd-bootchart	--	gen_context(system_u:object_r:systemd_bootchart_exec_t,s0)
 
 /usr/lib/systemd/systemd-initctl	--	gen_context(system_u:object_r:systemd_initctl_exec_t,s0)
@@ -89,6 +97,10 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/resolv.*   --   gen_context(system_u:object_r:lib_t,s0)
 /usr/var/lib/random-seed 	gen_context(system_u:object_r:random_seed_t,mls_systemhigh)
 
+/run/systemd/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
+/run/systemd/.+\.conf\.d	-d	gen_context(system_u:object_r:systemd_conf_t,s0)
+/run/systemd/.+\.conf\.d/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
+/run/systemd/.+\.conf\.d/.+\.conf	-l	gen_context(system_u:object_r:systemd_conf_t,s0)
 /run/.*nologin.*		gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /run/systemd/default-hostname	--	gen_context(system_u:object_r:hostname_etc_t,s0)
 /run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -919,6 +919,7 @@ kernel_dgram_send(systemd_hostnamed_t)
 kernel_read_xen_state(systemd_hostnamed_t)
 kernel_read_sysctl(systemd_hostnamed_t)
 
+dev_read_vsock(systemd_hostnamed_t)
 dev_write_kmsg(systemd_hostnamed_t)
 dev_read_sysfs(systemd_hostnamed_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -35,6 +35,9 @@ read_files_pattern(systemd_read_efivarfs_type, init_var_run_t, init_var_run_t)
 systemd_domain_template(systemd_logger)
 systemd_domain_template(systemd_logind)
 
+type systemd_conf_t;
+files_config_file(systemd_conf_t)
+
 # /run/systemd/sessions
 type systemd_logind_sessions_t;
 files_pid_file(systemd_logind_sessions_t)
@@ -1385,6 +1388,9 @@ optional_policy(`
 allow systemd_domain self:process { setfscreate signal_perms };
 allow systemd_domain self:unix_dgram_socket { create_socket_perms sendto };
 dontaudit systemd_domain self:capability net_admin;
+
+read_files_pattern(systemd_domain, systemd_conf_t, systemd_conf_t)
+read_lnk_files_pattern(systemd_domain, systemd_conf_t, systemd_conf_t)
 
 dev_read_urand(systemd_domain)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -462,6 +462,7 @@ manage_dirs_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_mach
 manage_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 manage_lnk_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 init_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, dir, "machines")
+init_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, dir, "machine")
 
 manage_dirs_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
 manage_files_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_machined_var_lib_t)


### PR DESCRIPTION
The systemd_conf_t type was added as default file context for files with the .conf suffix and .conf.d directories in /etc/systemd, /run/systemd, and /usr/lib/systemd.
The /usr/local/lib/systemd directory is covered by file equivalency. The systemd_domain attribute was allowed read access to these files.

Refer to https://github.com/systemd/systemd/blob/main/NEWS CHANGES WITH 256-rc1:
General Changes and New Features:

        * Various programs will now attempt to load the main configuration file
          from locations below /usr/lib/, /usr/local/lib/, and /run/, not just
          below /etc/. For example, systemd-logind will look for
          /etc/systemd/logind.conf, /run/systemd/logind.conf,
          /usr/local/lib/systemd/logind.conf, and /usr/lib/systemd/logind.conf,
          and use the first file that is found.  This means that the search
          logic for the main config file and for drop-ins is now the same.

Resolves: rhbz#2279923