### PR TITLE
Allow nfsidmap connect to systemd-homed

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -456,6 +456,8 @@ allow nfsidmap_t self:udp_socket create_socket_perms;
 
 kernel_setattr_key(nfsidmap_t)
 
+init_stream_connectto(nfsidmap_t)
+
 sysnet_read_config(nfsidmap_t)
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1715353588.747:526): avc:  denied  { connectto } for  pid=25014 comm="nfsidmap" path="/run/systemd/userdb/io.systemd.Home" scontext=system_u:system_r:nfsidmap_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2280017