### PR TITLE
Allow sandbox_x_client_t dbus chat with accountsd

### DIFF
--- a/policy/modules/contrib/sandboxX.te
+++ b/policy/modules/contrib/sandboxX.te
@@ -344,6 +344,10 @@ userdom_map_tmp_files(sandbox_x_client_t)
 userdom_manage_user_tmp_files(sandbox_x_client_t)
 
 optional_policy(`
+	accountsd_dbus_chat(sandbox_x_client_t)
+')
+
+optional_policy(`
 	avahi_dbus_chat(sandbox_x_client_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=USER_AVC msg=audit(05/13/2024 10:21:39.922:837) : pid=799 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:accountsd_t:s0 tcontext=staff_u:staff_r:sandbox_x_client_t:s0:c13,c243 tclass=dbus permissive=0 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'