### PR TITLE
Allow staff_t the io_uring sqpoll permission

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -23,6 +23,7 @@ gen_tunable(staff_use_svirt, false)
 #
 
 allow staff_t self:cap_userns { setpcap };
+allow staff_t self:io_uring sqpoll;
 allow staff_t self:netlink_generic_socket { create_socket_perms };
 
 corenet_ib_access_unlabeled_pkeys(staff_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10.5.2024 18:11:00.485:871) : proctitle=/opt/app type=SYSCALL msg=audit(10.5.2024 18:11:00.485:871) : arch=x86_64 syscall=io_uring_setup success=yes exit=7 a0=0x40 a1=0x7ffe85d540b0 a2=0x53 a3=0x1aa800238600 items=0 ppid=83930 pid=84132 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=(none) ses=3 comm=freetube exe=/opt/FreeTube/freetube subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(10.5.2024 18:11:00.485:871) : avc:  denied  { sqpoll } for  pid=84132 comm=freetube scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=io_uring permissive=1