### PR TITLE
Allow system_cronjob_t dbus chat with avahi_t

### DIFF
--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -574,6 +574,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	avahi_dbus_chat(system_cronjob_t)
+')
+
+optional_policy(`
 	bind_read_config(system_cronjob_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(04/10/2024 03:09:01.517:310) : pid=553 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:avahi_t:s0 tcontext=system_u:system_r:system_cronjob_t:s0-s0:c0.c1023 tclass=dbus permissive=1 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'

Resolves: RHEL-32290