### PR TITLE
Allow setroubleshootd get attributes of all sysctls

### DIFF
--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -90,6 +90,7 @@ manage_files_pattern(setroubleshootd_t, setroubleshoot_var_run_t, setroubleshoot
 manage_sock_files_pattern(setroubleshootd_t, setroubleshoot_var_run_t, setroubleshoot_var_run_t)
 files_pid_filetrans(setroubleshootd_t, setroubleshoot_var_run_t, { file sock_file dir })
 
+kernel_getattr_all_sysctls(setroubleshootd_t)
 kernel_io_uring_use(setroubleshootd_t)
 kernel_read_kernel_sysctls(setroubleshootd_t)
 kernel_read_system_state(setroubleshootd_t)

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -2608,6 +2608,24 @@ interface(`kernel_mounton_systemd_ProtectKernelTunables',`
 
 ########################################
 ## <summary>
+##	Get the attributes of all sysctls.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_getattr_all_sysctls',`
+	gen_require(`
+		attribute sysctl_type;
+	')
+
+	allow $1 sysctl_type:file getattr;
+')
+
+########################################
+## <summary>
 ##	Allow caller to read all sysctls.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/24/2024 20:21:11.708:1626) : proctitle=/usr/bin/python3 -Es /usr/sbin/setroubleshootd -f type=PATH msg=audit(04/24/2024 20:21:11.708:1626) : item=0 name=/proc/sys/vm/max_map_count inode=137784 dev=00:14 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_vm_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/24/2024 20:21:11.708:1626) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f799d8a8ad0 a2=0x7f799d881050 a3=0x0 items=1 ppid=1 pid=65298 auid=unset uid=setroubleshoot gid=setroubleshoot euid=setroubleshoot suid=setroubleshoot fsuid=setroubleshoot egid=setroubleshoot sgid=setroubleshoot fsgid=setroubleshoot tty=(none) ses=unset comm=setroubleshootd exe=/usr/bin/python3.9 subj=system_u:system_r:setroubleshootd_t:s0 key=(null) type=AVC msg=audit(04/24/2024 20:21:11.708:1626) : avc:  denied  { getattr } for  pid=65298 comm=setroubleshootd path=/proc/sys/vm/max_map_count dev="proc" ino=137784 scontext=system_u:system_r:setroubleshootd_t:s0 tcontext=system_u:object_r:sysctl_vm_t:s0 tclass=file permissive=0

Resolves: RHEL-34078