### PR TITLE
Allow various services read and write z90crypt device

### DIFF
--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -162,6 +162,7 @@ corenet_udp_bind_all_ephemeral_ports(named_t)
 dev_read_sysfs(named_t)
 dev_read_rand(named_t)
 dev_read_urand(named_t)
+dev_rw_crypto(named_t)
 dev_dontaudit_write_urand(named_t)
 
 domain_use_interactive_fds(named_t)

--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -167,6 +167,8 @@ kernel_signal(rpcd_t)
 
 corecmd_exec_bin(rpcd_t)
 
+dev_rw_crypto(rpcd_t)
+
 files_manage_mounttab(rpcd_t)
 files_getattr_all_dirs(rpcd_t)
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -576,6 +576,7 @@ fs_search_auto_mountpoints(ssh_keygen_t)
 dev_read_sysfs(ssh_keygen_t)
 dev_read_rand(ssh_keygen_t)
 dev_read_urand(ssh_keygen_t)
+dev_rw_crypto(ssh_keygen_t)
 
 term_dontaudit_use_console(ssh_keygen_t)
 

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -287,6 +287,7 @@ dev_rw_generic_chr_files(init_t)
 dev_filetrans_all_named_dev(init_t)
 dev_write_watchdog(init_t)
 dev_rw_inherited_input_dev(init_t)
+dev_rw_crypto(init_t)
 dev_rw_dri(init_t)
 dev_rw_tpm(init_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -299,6 +299,7 @@ dev_getattr_all_blk_files(systemd_logind_t)
 dev_rw_sysfs(systemd_logind_t)
 dev_rw_input_dev(systemd_logind_t)
 dev_rw_dri(systemd_logind_t)
+dev_rw_crypto(systemd_logind_t)
 dev_setattr_all_chr_files(systemd_logind_t)
 dev_setattr_dri_dev(systemd_logind_t)
 dev_setattr_generic_usb_dev(systemd_logind_t)
@@ -921,6 +922,7 @@ kernel_read_sysctl(systemd_hostnamed_t)
 
 dev_write_kmsg(systemd_hostnamed_t)
 dev_read_sysfs(systemd_hostnamed_t)
+dev_rw_crypto(systemd_hostnamed_t)
 
 fs_read_xenfs_files(systemd_hostnamed_t)
 
@@ -1139,6 +1141,7 @@ kernel_write_security_state(systemd_sysctl_t)
 files_read_system_conf_files(systemd_sysctl_t)
 
 dev_write_kmsg(systemd_sysctl_t)
+dev_rw_crypto(systemd_sysctl_t)
 
 domain_use_interactive_fds(systemd_sysctl_t)
 
@@ -1214,6 +1217,8 @@ systemd_read_efivarfs(systemd_hwdb_t)
 allow systemd_generator self:unix_dgram_socket { create_socket_perms sendto };
 
 kernel_dgram_send(systemd_generator)
+
+dev_rw_crypto(systemd_generator)
 
 fs_getattr_all_fs(systemd_generator)
 fs_search_all(systemd_generator)


### PR DESCRIPTION
This permission is required on s390x systems with the Crypto Express adapter card. The z90crypt device driver acts as the interface to the PCI cryptography hardware and performs asynchronous encryption operations (RSA) as used during the SSL handshake.

In this commit, services executing the following executables were allowed the access:
- /usr/bin/ssh-keygen
- /usr/bin/systemctl
- /usr/sbin/sm-notify
- /usr/lib/systemd/systemd-executor
- /usr/lib/systemd/systemd-hostnamed
- /usr/lib/systemd/systemd-random-seed
- /usr/lib/systemd/systemd-update-utmp
- /usr/lib/systemd/systemd-user-sessions
- /usr/lib/systemd/systemd-user-runtime-dir

Resolves: RHEL-33361