### PR TITLE
Allow postfix smtpd map aliases file

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -754,6 +754,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mta_map_aliases(postfix_smtpd_t)
+')
+
+optional_policy(`
 	postgrey_stream_connect(postfix_smtpd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/16/2024 11:58:56.019:602) : proctitle=smtpd -n smtp -t inet -u -s 2 type=MMAP msg=audit(05/16/2024 11:58:56.019:602) : fd=12 flags=MAP_SHARED type=SYSCALL msg=audit(05/16/2024 11:58:56.019:602) : arch=x86_64 syscall=mmap success=yes exit=139799220453376 a0=0x0 a1=0x1000000 a2=PROT_READ a3=MAP_SHARED items=0 ppid=8078 pid=8866 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=smtpd exe=/usr/libexec/postfix/smtpd subj=system_u:system_r:postfix_smtpd_t:s0 key=(null) type=AVC msg=audit(05/16/2024 11:58:56.019:602) : avc:  denied  { map } for  pid=8866 comm=smtpd path=/etc/aliases.lmdb dev="vda2" ino=2316284 scontext=system_u:system_r:postfix_smtpd_t:s0 tcontext=system_u:object_r:etc_aliases_t:s0 tclass=file permissive=1

Resolves: RHEL-35544