### PR TITLE
Allow systemd_domain read systemd_conf_t dirs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1394,6 +1394,7 @@ allow systemd_domain self:process { setfscreate signal_perms };
 allow systemd_domain self:unix_dgram_socket { create_socket_perms sendto };
 dontaudit systemd_domain self:capability net_admin;
 
+list_dirs_pattern(systemd_domain, systemd_conf_t, systemd_conf_t)
 read_files_pattern(systemd_domain, systemd_conf_t, systemd_conf_t)
 read_lnk_files_pattern(systemd_domain, systemd_conf_t, systemd_conf_t)
 


### PR DESCRIPTION
With the 98d767358ccf ("Label systemd configuration files with systemd_conf_t") commit, new file type was introduced for systemd configuration files and read access was allowed to systemd_domain for files and symlinks and search for directories. Since this commit, also dir read permissions are allowed.

The commit addresses the following AVC denial:
type=AVC msg=audit(05/18/2024 13:05:44.500:53) : avc:  denied  { read } for  pid=727 comm=systemd-resolve name=resolved.conf.d dev="dm-0" ino=715865 scontext=system_u:system_r:systemd_resolved_t:s0 tcontext=system_u:object_r:systemd_conf_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(05/18/2024 13:05:44.500:53) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=0x7 a1=0x7f554f13a438 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=727 auid=unset uid=systemd-resolve gid=systemd-resolve euid=systemd-resolve suid=systemd-resolve fsuid=systemd-resolve egid=systemd-resolve sgid=systemd-resolve fsgid=systemd-resolve tty=(none) ses=unset comm=systemd-resolve exe=/usr/lib/systemd/systemd-resolved subj=system_u:system_r:systemd_resolved_t:s0 key=(null) type=PATH msg=audit(05/18/2024 13:05:44.500:53) : item=0 name=. inode=715865 dev=fd:00 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_conf_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0