### PR TITLE
Allow journald read systemd config files and directories

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -773,6 +773,8 @@ optional_policy(`
 optional_policy(`
 	systemd_rw_bootchart_tmpfs_files(syslogd_t)
 	systemd_map_bootchart_tmpfs_files(syslogd_t)
+	systemd_list_conf_dirs(syslogd_t)
+	systemd_read_conf_files(syslogd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2947,3 +2947,41 @@ interface(`systemd_connectto_socket_proxyd_unix_sockets', `
 
 	allow $1 systemd_socket_proxyd_t:unix_stream_socket connectto;
 ')
+
+#######################################
+## <summary>
+##	List systemd config directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_list_conf_dirs', `
+	gen_require(`
+		type systemd_conf_t;
+	')
+
+	files_search_etc($1)
+	list_dirs_pattern($1, systemd_conf_t, systemd_conf_t)
+')
+
+#######################################
+## <summary>
+##	Read systemd config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_conf_files', `
+	gen_require(`
+		type systemd_conf_t;
+	')
+
+	files_search_etc($1)
+	read_files_pattern($1, systemd_conf_t, systemd_conf_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1716124222.645:387): avc:  denied  { read } for  pid=7051 comm="systemd-journal" name="journald.conf" dev="dm-0" ino=3408555 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:systemd_conf_t:s0 tclass=file permissive=0

Resolves: rhbz#2281489