### PR TITLE
Allow init to delete daemorundir

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -940,6 +940,8 @@ can_exec(initrc_t, init_script_file_type)
 
 create_dirs_pattern(initrc_t, daemonrundir, daemonrundir)
 setattr_dirs_pattern(initrc_t, daemonrundir, daemonrundir)
+del_entry_dirs_pattern(initrc_t, daemonrundir, daemonrundir)
+delete_dirs_pattern(initrc_t, daemonrundir, daemonrundir)
 
 domtrans_pattern(init_run_all_scripts_domain, initrc_exec_t, initrc_t)
 


### PR DESCRIPTION
When a service specifies a runtime directory in its systemd service file with the `RuntimeDirectory=` property, systemd will take care of creating and deleting it.

From the docs[1]: "In case of RuntimeDirectory= the innermost subdirectories are removed when the unit is stopped.".

Allow init to delete such directories, otherwise the following definition is not enough:
```
type foo_var_run_t;
files_base_file(foo_var_run_t)
init_daemon_run_dir(foo_var_run_t, "foo")
```

Right now there are no issues because management permissions are granted to init via `files_pid_file(foo_var_run_t)` which is commonly used.

[1] https://www.freedesktop.org/software/systemd/man/255/systemd.exec.html#RuntimeDirectory=