### PR TITLE
Allow fstab generator dac_read_search capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1273,7 +1273,7 @@ optional_policy(`
 #
 # systemd_fstab_generator_t 
 #
-allow systemd_fstab_generator_t self:capability dac_override;
+allow systemd_fstab_generator_t self:capability { dac_override dac_read_search };
 dev_write_sysfs_dirs(systemd_fstab_generator_t)
 
 files_read_etc_files(systemd_fstab_generator_t)


### PR DESCRIPTION
The dac_override capability has already been allowed, so it makes sense to allow dac_read_search, too, as the latter one is actually the first one checked by kernel.