### PR TITLE
Allow additional services read and write z90crypt device

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -691,6 +691,4 @@ optional_policy(`
 allow abrt_domain abrt_var_run_t:sock_file write_sock_file_perms;
 allow abrt_domain abrt_var_run_t:unix_stream_socket connectto;
 
-dev_rw_crypto(abrt_domain)
-
 files_read_etc_files(abrt_domain)

--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -635,7 +635,6 @@ tunable_policy(`httpd_graceful_shutdown',`
 dev_read_sysfs(httpd_t)
 dev_read_rand(httpd_t)
 dev_read_urand(httpd_t)
-dev_rw_crypto(httpd_t)
 dev_rw_zero(httpd_t)
 
 files_dontaudit_write_all_mountpoints(httpd_t)
@@ -1877,7 +1876,6 @@ tunable_policy(`httpd_use_openstack',`
 
 optional_policy(`
     tunable_policy(`httpd_use_opencryptoki',`
-        dev_rw_crypto(httpd_passwd_t)
         pkcs_manage_lock(httpd_passwd_t)
     ')
 ')

--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -162,7 +162,6 @@ corenet_udp_bind_all_ephemeral_ports(named_t)
 dev_read_sysfs(named_t)
 dev_read_rand(named_t)
 dev_read_urand(named_t)
-dev_rw_crypto(named_t)
 dev_dontaudit_write_urand(named_t)
 
 domain_use_interactive_fds(named_t)

--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -82,7 +82,6 @@ corecmd_exec_shell(firewalld_t)
 
 dev_read_urand(firewalld_t)
 dev_read_sysfs(firewalld_t)
-dev_rw_crypto(firewalld_t)
 
 domain_use_interactive_fds(firewalld_t)
 domain_obj_id_change_exemption(firewalld_t)

--- a/policy/modules/contrib/gssproxy.te
+++ b/policy/modules/contrib/gssproxy.te
@@ -56,7 +56,6 @@ auth_use_nsswitch(gssproxy_t)
 dev_read_rand(gssproxy_t)
 dev_read_urand(gssproxy_t)
 dev_read_sysfs(gssproxy_t)
-dev_rw_crypto(gssproxy_t)
 
 logging_send_syslog_msg(gssproxy_t)
 

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -198,7 +198,6 @@ dev_read_rand(NetworkManager_t)
 dev_read_urand(NetworkManager_t)
 dev_dontaudit_getattr_generic_blk_files(NetworkManager_t)
 dev_getattr_all_chr_files(NetworkManager_t)
-dev_rw_crypto(NetworkManager_t)
 dev_rw_wireless(NetworkManager_t)
 
 fs_getattr_all_fs(NetworkManager_t)

--- a/policy/modules/contrib/pkcs.if
+++ b/policy/modules/contrib/pkcs.if
@@ -222,8 +222,6 @@ interface(`pkcs_use_opencryptoki',`
 
     corenet_tcp_connect_tcs_port($1)
 
-    dev_rw_crypto($1)
-
     pkcs_getattr_exec_files($1)
     pkcs_manage_lock($1)
     pkcs_rw_shm($1)

--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -167,8 +167,6 @@ kernel_signal(rpcd_t)
 
 corecmd_exec_bin(rpcd_t)
 
-dev_rw_crypto(rpcd_t)
-
 files_manage_mounttab(rpcd_t)
 files_getattr_all_dirs(rpcd_t)
 

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -119,7 +119,6 @@ corecmd_exec_bin(sssd_t)
 
 dev_read_urand(sssd_t)
 dev_read_sysfs(sssd_t)
-dev_rw_crypto(sssd_t)
 
 domain_read_all_domains_state(sssd_t)
 domain_obj_id_change_exemption(sssd_t)

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -163,6 +163,9 @@ dev_getattr_sysfs_fs(domain)
 # Allow all domains to read /dev/urandom. It is needed by all apps/services
 # linked to libgcrypt. There is no harm to allow it by default.
 dev_read_urand(domain)
+# The access to /dev/z90crypto is a feature of openssl 3.2, so any domain
+# using some of openssl libraries needs it
+dev_rw_crypto(domain)
 
 # list the root directory
 files_list_root(domain)

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -272,8 +272,6 @@ template(`ssh_server_template',`
 	# for sshd subsystems, such as sftp-server.
 	corecmd_getattr_bin_files($1_t)
 
-	dev_rw_crypto($1_t)
-
 	domain_interactive_fd($1_t)
 	domain_dyntrans_type($1_t)
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -577,7 +577,6 @@ fs_search_auto_mountpoints(ssh_keygen_t)
 dev_read_sysfs(ssh_keygen_t)
 dev_read_rand(ssh_keygen_t)
 dev_read_urand(ssh_keygen_t)
-dev_rw_crypto(ssh_keygen_t)
 
 term_dontaudit_use_console(ssh_keygen_t)
 
@@ -639,8 +638,6 @@ logging_send_audit_msgs(sshd_sandbox_t)
 allow sshd_t sshd_net_t:process signal;
 
 allow sshd_net_t self:process setrlimit;
-
-dev_rw_crypto(sshd_net_t)
 
 init_ioctl_stream_sockets(sshd_net_t)
 init_rw_tcp_sockets(sshd_net_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -287,7 +287,6 @@ dev_rw_generic_chr_files(init_t)
 dev_filetrans_all_named_dev(init_t)
 dev_write_watchdog(init_t)
 dev_rw_inherited_input_dev(init_t)
-dev_rw_crypto(init_t)
 dev_rw_dri(init_t)
 dev_rw_tpm(init_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -328,7 +328,6 @@ dev_getattr_all_blk_files(systemd_logind_t)
 dev_rw_sysfs(systemd_logind_t)
 dev_rw_input_dev(systemd_logind_t)
 dev_rw_dri(systemd_logind_t)
-dev_rw_crypto(systemd_logind_t)
 dev_setattr_all_chr_files(systemd_logind_t)
 dev_setattr_dri_dev(systemd_logind_t)
 dev_setattr_generic_usb_dev(systemd_logind_t)
@@ -955,7 +954,6 @@ kernel_read_sysctl(systemd_hostnamed_t)
 dev_read_vsock(systemd_hostnamed_t)
 dev_write_kmsg(systemd_hostnamed_t)
 dev_read_sysfs(systemd_hostnamed_t)
-dev_rw_crypto(systemd_hostnamed_t)
 
 fs_read_xenfs_files(systemd_hostnamed_t)
 
@@ -1174,7 +1172,6 @@ kernel_write_security_state(systemd_sysctl_t)
 files_read_system_conf_files(systemd_sysctl_t)
 
 dev_write_kmsg(systemd_sysctl_t)
-dev_rw_crypto(systemd_sysctl_t)
 
 domain_use_interactive_fds(systemd_sysctl_t)
 
@@ -1252,7 +1249,6 @@ systemd_read_efivarfs(systemd_hwdb_t)
 ### Common rules for systemd generators
 allow systemd_generator self:unix_dgram_socket { create_socket_perms sendto };
 
-dev_rw_crypto(systemd_generator)
 dev_write_kmsg(systemd_generator)
 fs_getattr_cgroup(systemd_generator)
 fs_search_cgroup_dirs(systemd_generator)


### PR DESCRIPTION
This is a follow-up to the 01507d2fe7c6 ("Allow various services read and write z90crypt device) commit. In this batch, the following services were allowed r/w access to the crypt device:

- systemd-coredump

Resolves: rhbz#2283367