### PR TITLE
ci: Adjust Cockpit test plans

### DIFF
--- a/plans/cockpit.fmf
+++ b/plans/cockpit.fmf
@@ -14,17 +14,17 @@ discover:
 execute:
     how: tmt
 
-/basic:
-    summary: Run tests for basic packages
+/main:
+    summary: Non-storage tests
     discover+:
-        test: /test/browser/basic
+        test: /test/browser/main
 
-/network:
-    summary: Run tests for cockpit-networkmanager
+/storage-basic:
+    summary: Basic storage tests
     discover+:
-        test: /test/browser/network
+        test: /test/browser/storage-basic
 
-/optional:
-    summary: Run tests for optional packages
+/storage-extra:
+    summary: More expensive storage tests (LVM, LUKS, Anaconda)
     discover+:
-        test: /test/browser/optional
+        test: /test/browser/storage-extra


### PR DESCRIPTION
Cockpit recently reorganized its fmf test plans to better balance the test durations [1]. Follow suit.

It would be really nice to have https://github.com/teemtee/tmt/issues/1770 to avoid this duplication..

https://github.com/cockpit-project/cockpit/commit/18814b60c97cbbba