### PR TITLE
Allow collectd to trace processes in user namespace

### DIFF
--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -44,6 +44,7 @@ files_tmp_file(collectd_script_tmp_t)
 #
 
 allow collectd_t self:capability { ipc_lock net_raw net_admin sys_nice sys_ptrace dac_read_search  setuid setgid };
+allow collectd_t self:cap_userns sys_ptrace;
 allow collectd_t self:process { getsched setsched signal };
 allow collectd_t self:fifo_file rw_fifo_file_perms;
 allow collectd_t self:packet_socket { create_socket_perms map };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/14/2024 05:47:14.491:7864) : proctitle=/usr/sbin/collectd type=SYSCALL msg=audit(05/14/2024 05:47:14.491:7864) : arch=x86_64 syscall=read success=yes exit=177 a0=0x7 a1=0x7fc5ec000d70 a2=0x400 a3=0x0 items=0 ppid=1 pid=866907 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=reader#0 exe=/usr/sbin/collectd subj=system_u:system_r:collectd_t:s0 key=(null) type=AVC msg=audit(05/14/2024 05:47:14.491:7864) : avc:  denied  { sys_ptrace } for  pid=866907 comm=reader#0 capability=sys_ptrace  scontext=system_u:system_r:collectd_t:s0 tcontext=system_u:system_r:collectd_t:s0 tclass=cap_userns permissive=0

Resolves: RHEL-36293