### PR TITLE
Allow bootupd search efivarfs dirs

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -35,6 +35,7 @@ files_read_etc_files(bootupd_t)
 
 fs_getattr_all_fs(bootupd_t)
 fs_search_dos(bootupd_t)
+fs_search_efivarfs_dirs(bootupd_t)
 
 optional_policy(`
 	miscfiles_read_localization(bootupd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(05/13/2024 20:55:09.250:500) : proctitle=/usr/libexec/bootupd daemon -v
type=PATH msg=audit(05/13/2024 20:55:09.250:500) : item=0 name=/sys/firmware/efi/efivars/LoaderInfo-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(05/13/2024 20:55:09.250:500) : arch=aarch64 syscall=statx success=no exit=ENOENT(No such file or directory) a0=0xffffffffffffff9c a1=0xffffd11a0668 a2=0x0 a3=0xfff items=1 ppid=1 pid=56333 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=bootupd exe=/usr/libexec/bootupd subj=system_u:system_r:bootupd_t:s0 key=(null)
type=AVC msg=audit(05/13/2024 20:55:09.250:500) : avc:  denied  { search } for  pid=56333 comm=bootupd name=/ dev="efivarfs" ino=1336 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:efivarfs_t:s0 tclass=dir permissive=1

Resolves: RHEL-36289