### PR TITLE
Allow virtqemud read vm sysctls

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2087,6 +2087,7 @@ read_files_pattern(virtqemud_t, virtproxyd_t, virtproxyd_t)
 kernel_io_uring_use(virtqemud_t)
 kernel_read_all_proc(virtqemud_t)
 kernel_read_network_state_symlinks(virtqemud_t)
+kernel_read_vm_sysctls(virtqemud_t)
 kernel_request_load_module(virtqemud_t)
 
 corecmd_exec_bin(virtqemud_t)


### PR DESCRIPTION
Required by qemu-system-ppc on the ppc64le architecture.

The commit addresses the following AVC denial:
type=AVC msg=audit(1716962750.427:216): avc:  denied  { read } for  pid=3074 comm="qemu-system-ppc" name="max_map_count" dev="proc" ino=53342 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:sysctl_vm_t:s0 tclass=file permissive=1

Resolves: rhbz#2283792