### PR TITLE
Allow pulseaudio map its runtime files

### DIFF
--- a/policy/modules/contrib/pulseaudio.te
+++ b/policy/modules/contrib/pulseaudio.te
@@ -59,6 +59,7 @@ manage_files_pattern(pulseaudio_t, pulseaudio_var_lib_t, pulseaudio_var_lib_t)
 manage_lnk_files_pattern(pulseaudio_t, pulseaudio_var_lib_t, pulseaudio_var_lib_t)
 files_var_lib_filetrans(pulseaudio_t, pulseaudio_var_lib_t, { dir file })
 
+allow pulseaudio_t pulseaudio_var_run_t:file map;
 manage_dirs_pattern(pulseaudio_t, pulseaudio_var_run_t, pulseaudio_var_run_t)
 manage_files_pattern(pulseaudio_t, pulseaudio_var_run_t, pulseaudio_var_run_t)
 manage_sock_files_pattern(pulseaudio_t, pulseaudio_var_run_t, pulseaudio_var_run_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(06/02/2024 21:36:11.313:861) : avc:  denied  { map } for  pid=831 comm=alsa-sink-USB A path=/run/pulse/orcexec.Tw9Ifn (deleted) dev="tmpfs" ino=2349 scontext=system_u:system_r:pulseaudio_t:s0 tcontext=system_u:object_r:pulseaudio_var_run_t:s0 tclass=file permissive=0

Resolves: rhbz#2290363