### PR TITLE
Allow tpm2 generator setfscreate

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1347,6 +1347,7 @@ allow systemd_sysv_generator_t self:process setfscreate;
 init_read_script_files(systemd_sysv_generator_t)
 
 ### tpm2 generator
+allow systemd_tpm2_generator_t self:process setfscreate;
 dev_list_sysfs(systemd_tpm2_generator_t)
 
 ### zram generator


### PR DESCRIPTION
The commit addresses the following AVC denial:
Jun 05 06:43:02 kernel: audit: type=1400 audit(1717584182.445:7): avc:  denied  { setfscreate } for  pid=1042 comm="systemd-tpm2-ge" scontext=system_u:system_r:systemd_tpm2_generator_t:s0 tcontext=system_u:system_r:systemd_tpm2_generator_t:s0 tclass=process permissive=0

Resolves: rhbz#2290515