### PR TITLE
Dontaudit systemd-coredump sys_admin capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1194,6 +1194,7 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # setgid setuid - to set own credentials to match the dumped process credentials
 # setpcap - to drop capabilities
 allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_ptrace };
+dontaudit systemd_coredump_t self:capability sys_admin;
 allow systemd_coredump_t self:cap_userns { dac_read_search dac_override sys_admin sys_ptrace };
 
 # To set its capability set


### PR DESCRIPTION
Systemd uses the "trusted.delegate" and "user.delegate" extended attributes to indicate coredumps can be forwarded. The capability check is raised on the cg_is_delegated() library call when forward_coredump_to_container() and can_forward_coredump() is called, because the SYS_ADMIN capability is needed to access attributes in the "trusted" namespace, but preferred way actually is to use the attribute in the "user" namespace.

cgroup_delegate_xattr_apply()
/* Indicate on the cgroup whether delegation is on, via an xattr. This is best-effort, as old kernels
 * and even later 'user.*' xattrs. We started setting this field when 'trusted.*' was added, and
 * given this is now pretty much API, let's continue to support that. But also set 'user.*' as well,
 * since it is readable by any user, not just CAP_SYS_ADMIN.  (...) */

Systemd changes with 255
* A new option CoredumpReceive= can be set for service and scope units, together with Delegate=yes, to make systemd-coredump on the host forward core files from processes crashing inside the delegated CGroup subtree to systemd-coredump running in the container. option /