### PR TITLE
Allow systemd (PID 1) manage systemd conf files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -569,6 +569,7 @@ optional_policy(`
     systemd_allow_mount_dir(init_t)
     systemd_allow_create_mount_dir(init_t)
     systemd_hostnamed_delete_config(init_t)
+	systemd_manage_conf_files(init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2987,6 +2987,25 @@ interface(`systemd_read_conf_files', `
 
 #######################################
 ## <summary>
+##	Manage systemd config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_manage_conf_files', `
+	gen_require(`
+		type systemd_conf_t;
+	')
+
+	files_search_etc($1)
+	manage_files_pattern($1, systemd_conf_t, systemd_conf_t)
+')
+
+#######################################
+## <summary>
 ##	Allow the specified domain to connect to
 ##	systemd-nsresourced over a unix socket.
 ## </summary>


### PR DESCRIPTION
Denials are triggered when "systemctl set-property --runtime" is used.

The commit addresses the following AVC denial:
type=AVC msg=audit(06/03/2024 05:40:08.117:543) : avc:  denied  { create } for  pid=1 comm=systemd name=.#50-CPUQuota.conf02880077955bce25 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_conf_t:s0 tclass=file permissive=0

Resolves: rhbz#2284157