### PR TITLE
Allow postfix_domain connect to postgresql over a unix socket

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -866,6 +866,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	postgresql_stream_connect(postfix_domain)
+')
+
+optional_policy(`
 	spamd_stream_connect(postfix_domain)
 	spamassassin_domtrans_client(postfix_domain)
 ')


### PR DESCRIPTION
The commit addresses the following (unrelated) AVC denials: type=AVC msg=audit(08.12.2023 10:41:54.740:21138) : avc:  denied  { write } for  pid=323918 comm=smtpd name=.s.PGSQL.5432 dev="tmpfs" ino=1174 scontext=system_u:system_r:postfix_smtpd_t:s0 tcontext=system_u:object_r:postgresql_var_run_t:s0 tclass=sock_file permissive=0 type=AVC msg=audit(1716541501.113:12346): avc:  denied  { connectto } for  pid=328734 comm="trivial-rewrite" path="/run/postgresql/.s.PGSQL.5432" scontext=system_u:system_r:postfix_master_t:s0 tcontext=system_u:system_r:postgresql_t:s0 tclass=unix_stream_socket permissive=0

Resolves: RHEL-6776