### PR TITLE
Add interfaces for watching and reading ifconfig_var_run_t

### DIFF
--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1225,6 +1225,44 @@ interface(`sysnet_manage_ifconfig_run',`
 	manage_lnk_files_pattern($1, ifconfig_var_run_t, ifconfig_var_run_t)
 ')
 
+######################################
+## <summary>
+##	Watch ifconfig_var_run_t directories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_watch_ifconfig_run_dirs',`
+	gen_require(`
+		type ifconfig_var_run_t;
+	')
+
+	watch_dirs_pattern($1, ifconfig_var_run_t, ifconfig_var_run_t)
+')
+
+########################################
+## <summary>
+##	Read ifconfig_var_run_t files and link files
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_read_ifconfig_run_files',`
+	gen_require(`
+		type ifconfig_var_run_t;
+	')
+
+	list_dirs_pattern($1, ifconfig_var_run_t, ifconfig_var_run_t)
+	read_files_pattern($1, ifconfig_var_run_t, ifconfig_var_run_t)
+	read_lnk_files_pattern($1, ifconfig_var_run_t, ifconfig_var_run_t)
+')
+
 ########################################
 ## <summary>
 ##	Transition to sysnet ifconfig named content


### PR DESCRIPTION
Required by frr.
https://gitlab.com/redhat/centos-stream/rpms/frr/-/merge_requests/24

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>

Resolves: RHEL-39408