### PR TITLE
Allow gnome-software work for login_userdomain

### DIFF
--- a/policy/modules/contrib/fwupd.if
+++ b/policy/modules/contrib/fwupd.if
@@ -78,6 +78,44 @@ interface(`fwupd_search_cache',`
 
 ########################################
 ## <summary>
+##	Read fwupd cache directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fwupd_list_cache_dirs',`
+	gen_require(`
+		type fwupd_cache_t;
+	')
+
+	files_search_var($1)
+	list_dirs_pattern($1, fwupd_cache_t, fwupd_cache_t)
+')
+
+########################################
+## <summary>
+##	Watch fwupd cache directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fwupd_watch_cache_dirs',`
+	gen_require(`
+		type fwupd_cache_t;
+	')
+
+	files_search_var($1)
+	watch_dirs_pattern($1, fwupd_cache_t, fwupd_cache_t)
+')
+
+########################################
+## <summary>
 ##	Allow the specified domain to delete
 ##	fwupd cache.
 ## </summary>

--- a/policy/modules/contrib/rpm.if
+++ b/policy/modules/contrib/rpm.if
@@ -829,6 +829,24 @@ interface(`rpm_dontaudit_manage_db',`
 	dontaudit $1 rpm_var_lib_t:file map;
 ')
 
+########################################
+## <summary>
+##	Watch the RPM package database directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`rpm_watch_db_dirs',`
+	gen_require(`
+		type rpm_var_lib_t;
+	')
+
+	watch_dirs_pattern($1, rpm_var_lib_t, rpm_var_lib_t)
+')
+
 #####################################
 ## <summary>
 ##	Read rpm pid files.

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -411,6 +411,7 @@ files_watch_system_conf_dirs(login_userdomain)
 files_watch_usr_dirs(login_userdomain)
 files_watch_usr_files(login_userdomain)
 files_watch_usr_lnk_files(login_userdomain)
+files_watch_var_dirs(login_userdomain)
 files_watch_var_lib_dirs(login_userdomain)
 files_watch_var_run_dirs(login_userdomain)
 files_watch_generic_tmp_dirs(login_userdomain)
@@ -444,6 +445,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fwupd_list_cache_dirs(login_userdomain)
+	fwupd_watch_cache_dirs(login_userdomain)
+')
+
+optional_policy(`
 	gnome_exec_atspi(login_userdomain)
 	gnome_watch_generic_data_home_dirs(login_userdomain)
 	gnome_watch_home_config_dirs(login_userdomain)
@@ -469,6 +475,7 @@ optional_policy(`
 
 optional_policy(`
 	rpm_script_rw_stream_sockets(login_userdomain)
+	rpm_watch_db_dirs(login_userdomain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(06/10/2024 16:22:27.975:582) : proctitle=/usr/bin/gnome-software --gapplication-service type=PATH msg=audit(06/10/2024 16:22:27.975:582) : item=0 name=/var/cache/swcatalog/xml inode=813565 dev=fd:00 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:var_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/10/2024 16:22:27.975:582) : arch=x86_64 syscall=inotify_add_watch success=yes exit=20 a0=0x3 a1=0x7fba47705ee0 a2=0x1002fce a3=0x0 items=1 ppid=5134 pid=5295 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=(none) ses=3 comm=gnome-software exe=/usr/bin/gnome-software subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(06/10/2024 16:22:27.975:582) : avc:  denied  { watch } for  pid=5295 comm=gnome-software path=/var/cache/swcatalog/xml dev="dm-0" ino=813565 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_t:s0 tclass=dir permissive=1