### PR TITLE
Allow systemd_fstab_generator_t read tmpfs files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1280,6 +1280,7 @@ files_read_all_mountpoint_symlinks(systemd_fstab_generator_t)
 files_search_all_mountpoints(systemd_fstab_generator_t)
 
 fs_getattr_dos_dirs(systemd_fstab_generator_t)
+fs_read_tmpfs_files(systemd_fstab_generator_t)
 
 optional_policy(`
 	fstools_exec(systemd_fstab_generator_t)


### PR DESCRIPTION
Adresses:
> Apr 30 14:38:33 localhost kernel: audit: type=1400 audit(1714487912.659:8): avc:  denied  { read } for  pid=485 comm="systemd-fstab-g" name="fstab.extra" dev="tmpfs" ino=2 scontext=system_u:system_r:systemd_fstab_generator_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0

systemd-credentials allows credenials to be passed over SMBIOS. These SMBIOS values are mounted as tmpfs to /run/credentials/@system and the content is then mounted as directory via the fstab generator. Therefor the fstab generator needs to read the content of the mounted tmpfs file.

Reproducer see:
https://bugzilla.suse.com/show_bug.cgi?id=1223599#c4