### PR TITLE
Label /usr/bin/ntfsck with fsadm_exec_t

### DIFF
--- a/policy/modules/system/fstools.fc
+++ b/policy/modules/system/fstools.fc
@@ -36,6 +36,7 @@
 /usr/bin/mkraid	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 /usr/bin/mkreiserfs	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 /usr/bin/mkudffs	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+/usr/bin/ntfsck	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 /usr/bin/parted	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 /usr/bin/partprobe	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 /usr/bin/partx		--	gen_context(system_u:object_r:fsadm_exec_t,s0)


### PR DESCRIPTION
Can be executed e.g. by systemd-fstab-generator:
type=AVC msg=audit(1716626415.385:479): avc:  denied  { execute } for  pid=11286 comm="systemd-fstab-g" name="ntfsck" dev="nvme0n1p5" ino=1106075 scontext=system_u:system_r:systemd_fstab_generator_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=0

Resolves: rhbz#2283187