### PR TITLE
Allow login_userdomain execute systemd-tmpfiles in the caller domain

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -760,7 +760,7 @@ interface(`systemd_exec_sysctl',`
 
 #######################################
 ## <summary>
-##  Allow a domain to execute systemd-sysctl in the caller domain.
+##  Allow a domain to execute systemd-tmpfiles in the caller domain.
 ## </summary>
 ## <param name="domain">
 ## <summary>

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -467,6 +467,7 @@ optional_policy(`
 	systemd_machined_watch_pid_dirs(login_userdomain)
 	systemd_passwd_watch_pid_dirs(login_userdomain)
 	systemd_resolved_watch_pid_dirs(login_userdomain)
+	systemd_tmpfiles_exec(login_userdomain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/17/2024 03:27:20.756:432) : proctitle=(tmpfiles) type=PATH msg=audit(06/17/2024 03:27:20.756:432) : item=0 name=/proc/self/fd/3 inode=6849180 dev=fd:01 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_tmpfiles_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/17/2024 03:27:20.756:432) : arch=x86_64 syscall=access success=yes exit=0 a0=0x7ffe7e9bbad0 a1=X_OK a2=0x0 a3=0x3 items=1 ppid=5020 pid=5028 auid=staff-user uid=staff-user gid=staff-user euid=staff-user suid=staff-user fsuid=staff-user egid=staff-user sgid=staff-user fsgid=staff-user tty=(none) ses=11 comm=(tmpfiles) exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(06/17/2024 03:27:20.756:432) : avc:  denied  { execute } for  pid=5028 comm=(tmpfiles) name=systemd-tmpfiles dev="vda1" ino=6849180 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_tmpfiles_exec_t:s0 tclass=file permissive=1

Resolves: RHEL-40374