### PR TITLE
Allow ptp4l_t request that the kernel load a kernel module

### DIFF
--- a/policy/modules/contrib/linuxptp.te
+++ b/policy/modules/contrib/linuxptp.te
@@ -177,6 +177,7 @@ corenet_udp_bind_ptp_event_port(ptp4l_t)
 corenet_udp_bind_reserved_port(ptp4l_t)
 
 kernel_read_network_state(ptp4l_t)
+kernel_request_load_module(ptp4l_t)
 
 dev_rw_realtime_clock(ptp4l_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1716862418.381:226): avc:  denied  { module_request } for  pid=13694 comm="ptp4l" kmod="netdev-eth0" scontext=system_u:system_r:ptp4l_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0 type=SYSCALL msg=audit(1716862418.381:226): arch=x86_64 syscall=ioctl success=no exit=ENODEV a0=1a a1=8933 a2=7fff83c07cb0 a3=7f73dfb5cac0 items=0 ppid=1 pid=13694 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=ptp4l exe=/usr/sbin/ptp4l subj=system_u:system_r:ptp4l_t:s0 key=(null)

Resolves: RHEL-38905