### PR TITLE
Allow virtqemud manage nfs files when virt_use_nfs boolean is on

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2144,6 +2144,10 @@ tunable_policy(`virtqemud_use_execmem',`
 	allow virtqemud_t self:process { execmem execstack };
 ')
 
+tunable_policy(`virt_use_nfs',`
+	fs_manage_nfs_files(virtqemud_t)
+')
+
 optional_policy(`
 	dmidecode_domtrans(virtqemud_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1717642887.414:2031): avc:  denied  { write } for  pid=65361 comm="rpc-virtqemud" name="rhel10.qcow2" dev="0:53" ino=203153578 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:nfs_t:s0 tclass=file permissive=1 type=AVC msg=audit(1717642888.009:2035): avc:  denied  { setattr } for  pid=65362 comm="rpc-virtqemud" name="rhel10.qcow2" dev="0:53" ino=203153578 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:nfs_t:s0 tclass=file permissive=1

Resolves: RHEL-40205