### PR TITLE
Allow virt_driver_domain dbus chat with policykit

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1838,6 +1838,10 @@ optional_policy(`
 	policykit_dbus_chat(virt_driver_domain)
 ')
 
+optional_policy(`
+	unconfined_read_files(virt_driver_domain)
+')
+
 #######################################
 #
 # virtinterfaced local policy

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1831,6 +1831,15 @@ tunable_policy(`virt_sandbox_use_audit',`
 
 #######################################
 #
+# virt_driver_domain local policy (common rules)
+#
+
+optional_policy(`
+	policykit_dbus_chat(virt_driver_domain)
+')
+
+#######################################
+#
 # virtinterfaced local policy
 #
 allow virtinterfaced_t self:tcp_socket create_stream_socket_perms;


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(06/10/2024 07:35:27.376:681) : pid=551 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:virtnetworkd_t:s0 tcontext=system_u:system_r:policykit_t:s0 tclass=dbus permissive=0 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'

Resolves: RHEL-40346