### PR TITLE
Allow sbd to trace processes in user namespace

### DIFF
--- a/policy/modules/contrib/sbd.te
+++ b/policy/modules/contrib/sbd.te
@@ -23,6 +23,7 @@ userdom_user_tmpfs_file(sbd_tmpfs_t)
 # sbd local policy
 #
 allow sbd_t self:capability { dac_read_search dac_override ipc_lock kill sys_boot sys_nice sys_ptrace sys_admin};
+allow sbd_t self:cap_userns sys_ptrace;
 allow sbd_t self:process { fork setsched signal_perms };
 allow sbd_t self:fifo_file rw_fifo_file_perms;
 allow sbd_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/04/2024 14:19:23.844:821) : proctitle=/usr/sbin/sbd query-watchdog type=SYSCALL msg=audit(06/04/2024 14:19:23.844:821) : arch=x86_64 syscall=readlink success=no exit=EACCES(Permission denied) a0=0x7ffcb67f3b10 a1=0x7ffcb67f3900 a2=0xff a3=0x7fb806bb13e0 items=0 ppid=55785 pid=55786 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sbd exe=/usr/sbin/sbd subj=system_u:system_r:sbd_t:s0 key=(null) type=AVC msg=audit(1717503563.844:821): avc:  denied  { sys_ptrace } for  pid=55786 comm="sbd" capability=19  scontext=system_u:system_r:sbd_t:s0 tcontext=system_u:system_r:sbd_t:s0 tclass=cap_userns permissive=0

Resolves: RHEL-39989