### PR TITLE
Allow request-key execute scripts

### DIFF
--- a/policy/modules/contrib/keyutils.fc
+++ b/policy/modules/contrib/keyutils.fc
@@ -1,2 +1,3 @@
 /usr/bin/request-key	--	gen_context(system_u:object_r:keyutils_request_exec_t,s0)
 /usr/bin/key\.dns_resolver	--	gen_context(system_u:object_r:keyutils_dns_resolver_exec_t,s0)
+/usr/share/keyutils/request-key-debug.sh	--	gen_context(system_u:object_r:keyutils_request_exec_t,s0)

--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -19,6 +19,8 @@ role system_r types keyutils_dns_resolver_t;
 ### policy for the keyutils_request_t domain
 allow keyutils_request_t self:unix_dgram_socket create_socket_perms;
 
+corecmd_exec_bin(keyutils_request_t)
+
 domain_read_view_all_domains_keyrings(keyutils_request_t)
 
 optional_policy(`


### PR DESCRIPTION
Label /usr/share/keyutils/request-key-debug.sh with keyutils_request_exec_t. Allow keyutils_request_t exwecute generic programs in bin directories.

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(05/28/2024 09:18:47.166:361) : proctitle=/sbin/request-key create 281154719 0 0 0 0 343574427 type=AVC msg=audit(05/28/2024 09:18:47.166:361) : avc: denied { execute } for pid=442722 comm=request-key name=request-key-debug.sh dev="dm-0" ino=101086371 scontext=system_u:system_r:keyutils_request_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(05/28/2024 09:18:47.166:361) : arch=aarch64 syscall=execve success=no exit=EACCES(Permission denied) a0=0xaaaaac102070 a1=0xffffd189f468 a2=0xffffd189ffa0 a3=0x32 items=0 ppid=236323 pid=442722 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=request-key exe=/usr/sbin/request-key subj=system_u:system_r:keyutils_request_t:s0 key=(null) type=EXECVE msg=audit(05/28/2024 09:18:47.166:361) : argc=8 a0=/sbin/request-key a1=create a2=281154719 a3=0 a4=0 a5=0 a6=0 a7=343574427

type=PROCTITLE msg=audit(06/05/2024 14:51:26.400:981) : proctitle=/sbin/request-key create 389140661 0 0 216799752 0 607636618
type=AVC msg=audit(06/05/2024 14:51:26.400:981) : avc:  denied  { execute } for  pid=432485 comm=request-key name=keyctl dev="dm-0" ino=67117479 scontext=system_u:system_r:keyutils_request_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(06/05/2024 14:51:26.400:981) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x559a4a5f60e0 a1=0x7ffec05ef480 a2=0x7ffec05eff00 a3=0x559a5a11c010 items=0 ppid=102371 pid=432485 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=request-key exe=/usr/sbin/request-key subj=system_u:system_r:keyutils_request_t:s0 key=(null)

Resolves: RHEL-38920