### PR TITLE
Update policy for haproxyd

### DIFF
--- a/policy/modules/contrib/rhcs.if
+++ b/policy/modules/contrib/rhcs.if
@@ -39,6 +39,7 @@ template(`rhcs_domain_template',`
 	# Local policy
 	#
 
+	allow $1_t $1_tmpfs_t:file map;
 	manage_dirs_pattern($1_t, $1_tmpfs_t, $1_tmpfs_t)
 	manage_files_pattern($1_t, $1_tmpfs_t, $1_tmpfs_t)
 	fs_tmpfs_filetrans($1_t, $1_tmpfs_t, { dir file })

--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -657,6 +657,7 @@ manage_sock_files_pattern(haproxy_t, haproxy_var_lib_t, haproxy_var_lib_t)
 files_var_lib_filetrans(haproxy_t, haproxy_var_lib_t, { dir file lnk_file })
 
 kernel_read_network_state(haproxy_t)
+kernel_read_state(haproxy_t)
 
 can_exec(haproxy_t, haproxy_exec_t)
 


### PR DESCRIPTION
Allow haproxy_t read kernel threads state.
Update rhcs_domain_template to include the map files permission in addition to managing them.

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(06/12/2024 07:13:19.407:542) : proctitle=/usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -f /etc/haproxy/conf.d -c -q type=MMAP msg=audit(06/12/2024 07:13:19.407:542) : fd=3 flags=MAP_SHARED type=SYSCALL msg=audit(06/12/2024 07:13:19.407:542) : arch=x86_64 syscall=mmap success=yes exit=139859595870208 a0=0x0 a1=0x10000 a2=PROT_READ|PROT_WRITE a3=MAP_SHARED items=0 ppid=1 pid=21251 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=haproxy exe=/usr/sbin/haproxy subj=system_u:system_r:haproxy_t:s0 key=(null) type=AVC msg=audit(06/12/2024 07:13:19.407:542) : avc:  denied  { map } for  pid=21251 comm=haproxy path=/dev/shm/haproxy_startup_logs_21251 (deleted) dev="tmpfs" ino=10 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:haproxy_tmpfs_t:s0 tclass=file permissive=1

type=PROCTITLE msg=audit(06/12/2024 07:13:19.428:543) : proctitle=/usr/sbin/haproxy -Ws -f /etc/haproxy/haproxy.cfg -f /etc/haproxy/conf.d -p /run/haproxy.pid
type=PATH msg=audit(06/12/2024 07:13:19.428:543) : item=0 name=/proc/2/status inode=26102 dev=00:15 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:kernel_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(06/12/2024 07:13:19.428:543) : arch=x86_64 syscall=openat success=yes exit=6 a0=AT_FDCWD a1=0x564c0fadb330 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=21254 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=haproxy exe=/usr/sbin/haproxy subj=system_u:system_r:haproxy_t:s0 key=(null)
type=AVC msg=audit(06/12/2024 07:13:19.428:543) : avc:  denied  { open } for  pid=21254 comm=haproxy path=/proc/2/status dev="proc" ino=26102 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=file permissive=1
type=AVC msg=audit(06/12/2024 07:13:19.428:543) : avc:  denied  { read } for  pid=21254 comm=haproxy name=status dev="proc" ino=26102 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=file permissive=1
type=AVC msg=audit(06/12/2024 07:13:19.428:543) : avc:  denied  { search } for  pid=21254 comm=haproxy name=2 dev="proc" ino=2084 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=dir permissive=1

Resolves: RHEL-40877