### PR TITLE
Remove virt_use_glusterd tunable

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -42,13 +42,6 @@ gen_tunable(virt_use_fusefs, false)
 
 ## <desc>
 ## <p>
-## Allow confined virtual guests to use glusterd
-## </p>
-## </desc>
-gen_tunable(virt_use_glusterd, false)
-
-## <desc>
-## <p>
 ## Allow sandbox containers to share apache content
 ## </p>
 ## </desc>
@@ -1179,12 +1172,6 @@ tunable_policy(`virt_use_usb',`
 	fs_manage_dos_dirs(virt_domain)
 	fs_manage_dos_files(virt_domain)
 	udev_read_db(virt_domain)
-')
-
-optional_policy(`
-	tunable_policy(`virt_use_glusterd',`
-		glusterd_manage_pid(virt_domain)
-	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
Remove the declaration of the virt_use_glusterd
(Allow confined virtual guests to use glusterd) tunable and all references to it.
glusterd-selinux does not seem to refer to it either.

Resolves: RHEL-18975