### PR TITLE
Allow systemd-machined read the vsock device

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -503,6 +503,8 @@ kernel_dgram_send(systemd_machined_t)
 # This is a bug, but need for now.
 kernel_read_unlabeled_state(systemd_machined_t)
 
+dev_read_vsock(systemd_machined_t)
+
 domain_signal_all_domains(systemd_machined_t)
 domain_signull_all_domains(systemd_machined_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/19/2024 06:25:43.735:1439) : proctitle=/usr/lib/systemd/systemd-machined type=PATH msg=audit(06/19/2024 06:25:43.735:1439) : item=0 name=/dev/vsock inode=741 dev=00:06 mode=character,666 ouid=root ogid=root rdev=0a:7a obj=system_u:object_r:vsock_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/19/2024 06:25:43.735:1439) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f530435a150 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=61525 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-machine exe=/usr/lib/systemd/systemd-machined subj=system_u:system_r:systemd_machined_t:s0 key=(null) type=AVC msg=audit(06/19/2024 06:25:43.735:1439) : avc:  denied  { read } for  pid=61525 comm=systemd-machine name=vsock dev="devtmpfs" ino=741 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:vsock_device_t:s0 tclass=chr_file permissive=0