### PR TITLE
Allow sysadm_t run systemd-nsresourced bpf programs

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -259,7 +259,6 @@ optional_policy(`
         systemd_dbus_chat_timedated(sysadm_t)
         systemd_dbus_chat_hostnamed(sysadm_t)
         systemd_dbus_chat_localed(sysadm_t)
-        systemd_hwdb_mmap_config(sysadm_t)
     ')
 
 	optional_policy(`
@@ -621,9 +620,11 @@ optional_policy(`
 	systemd_passwd_agent_run(sysadm_t, sysadm_r)
 	systemd_config_all_services(sysadm_t)
 	systemd_dbus_chat_machined(sysadm_t)
+        systemd_hwdb_mmap_config(sysadm_t)
 	systemd_manage_all_unit_files(sysadm_t)
 	systemd_manage_all_unit_lnk_files(sysadm_t)
 	systemd_manage_unit_dirs(sysadm_t)
+	systemd_nsresourced_prog_run_bpf(sysadm_t)
 	systemd_login_status(sysadm_t)
 	systemd_login_reboot(sysadm_t)
 	systemd_login_halt(sysadm_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -3044,3 +3044,21 @@ interface(`systemd_nsresourced_runtime_filetrans',`
 
 	filetrans_pattern($1, init_var_run_t, systemd_nsresourced_runtime_t, file, "io.systemd.NamespaceResource")
 ')
+
+########################################
+## <summary>
+##	Allow caller domain to run bpf on systemd-nsresourced.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_nsresourced_prog_run_bpf',`
+	gen_require(`
+		type systemd_nsresourced_runtime_t;
+	')
+
+    allow $1 systemd_nsresourced_runtime_t:bpf { map_read map_write prog_run };
+')


### PR DESCRIPTION
The systemd_nsresourced_prog_run_bpf() interface was added. The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/19/2024 21:19:30.819:6470) : proctitle=perf record -o /dev/null echo test type=SYSCALL msg=audit(06/19/2024 21:19:30.819:6470) : arch=x86_64 syscall=bpf success=no exit=EACCES(Permission denied) a0=BPF_PROG_GET_FD_BY_ID a1=0x7ffc7b65dd10 a2=0xc a3=0x30 items=0 ppid=170615 pid=170616 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=121 comm=perf exe=/usr/bin/perf subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(06/19/2024 21:19:30.819:6470) : avc:  denied  { prog_run } for  pid=170616 comm=perf scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:systemd_nsresourced_t:s0 tclass=bpf permissive=0