### PR TITLE
Allow create memory.pressure files with cgroup_memory_pressure_t

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -336,6 +336,7 @@ files_watch_non_security_files(init_t)
 files_watch_non_security_lnk_files(init_t)
 
 fs_cgroup_filetrans_memory_pressure(init_t)
+fs_mounton_cgroup(init_t)
 fs_read_efivarfs_files(init_t)
 fs_setattr_efivarfs_files(init_t)
 fs_read_nfsd_files(init_t)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -417,6 +417,7 @@ files_watch_var_run_dirs(login_userdomain)
 files_watch_generic_tmp_dirs(login_userdomain)
 
 fs_create_cgroup_files(login_userdomain)
+fs_cgroup_filetrans_memory_pressure(login_userdomain)
 fs_watch_cgroup_files(login_userdomain)
 
 libs_watch_lib_dirs(login_userdomain)


### PR DESCRIPTION
In particular, this permission was allowed to syslogd_t and systemd_domain.