### PR TITLE
Allow certmonger read and write tpm devices (f39)

### DIFF
--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -84,6 +84,7 @@ corecmd_exec_shell(certmonger_t)
 dev_read_rand(certmonger_t)
 dev_read_urand(certmonger_t)
 dev_read_sysfs(certmonger_t)
+dev_rw_tpm(certmonger_t)
 
 domain_use_interactive_fds(certmonger_t)
 


### PR DESCRIPTION
Can be triggered by running using ipa-getcert to get a new certificate on a system with an integrated TPM device.

The commit addresses the following AVC denial:
type=AVC msg=audit(1708407186.8:1410): avc:  denied  { read write } for  pid=215523 comm="dogtag-ipa-rene" name="tpm0" dev="devtmpfs" ino=142 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:object_r:tpm_device_t:s0 tclass=chr_file permissive=0

Resolves: rhbz#2265390