### PR TITLE
Add support for libvirt hooks

### DIFF
--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -13,6 +13,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?	gen_context(system_u:object_r:svirt_ho
 /etc/libvirt/virtlogd\.conf	--	gen_context(system_u:object_r:virtlogd_etc_t,s0)
 /etc/libvirt/[^/]*		--	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/libvirt/[^/]*		-d	gen_context(system_u:object_r:virt_etc_rw_t,s0)
+/etc/libvirt/hooks(/.*)?		gen_context(system_u:object_r:virt_hook_t,s0)
 /etc/libvirt/.*/.*			gen_context(system_u:object_r:virt_etc_rw_t,s0)
 /etc/rc\.d/init\.d/libvirtd	--	gen_context(system_u:object_r:virtd_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/virtlogd	--	gen_context(system_u:object_r:virtlogd_initrc_exec_t,s0)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -157,6 +157,13 @@ gen_tunable(virt_sandbox_use_all_caps, true)
 ## </desc>
 gen_tunable(virt_lockd_blk_devs, false)
 
+## <desc>
+## <p>
+## Allow virt daemons run unconfined hooks
+## </p>
+## </desc>
+gen_tunable(virt_hooks_unconfined, false)
+
 gen_require(`
     class passwd rootok;
     class passwd passwd;
@@ -202,6 +209,11 @@ files_config_file(virt_etc_t)
 
 type virt_etc_rw_t, virt_file_type;
 files_type(virt_etc_rw_t)
+
+type virt_hook_t, virt_file_type;
+type virt_hook_unconfined_t;
+role system_r types virt_hook_unconfined_t;
+application_domain(virt_hook_unconfined_t, virt_hook_t)
 
 type virt_home_t, virt_file_type;
 userdom_user_home_content(virt_home_t)
@@ -1907,6 +1919,10 @@ dev_rw_sysfs(virtnetworkd_t)
 sysnet_domtrans_ifconfig(virtnetworkd_t)
 sysnet_read_config(virtnetworkd_t)
 
+tunable_policy(`virt_hooks_unconfined',`
+	domtrans_pattern(virtnetworkd_t, virt_hook_t, virt_hook_unconfined_t)
+')
+
 optional_policy(`
 	dnsmasq_create_pid_dirs(virtnetworkd_t)
 	dnsmasq_domtrans(virtnetworkd_t)
@@ -2413,3 +2429,12 @@ read_files_pattern(svirt_sandbox_domain, container_ro_file_t, container_ro_file_
 read_lnk_files_pattern(svirt_sandbox_domain, container_ro_file_t, container_ro_file_t)
 allow svirt_sandbox_domain container_ro_file_t:file execmod;
 can_exec(svirt_sandbox_domain, container_ro_file_t)
+
+########################################
+#
+# Policy for libvirt hooks
+#
+
+optional_policy(`
+	unconfined_domain(virt_hook_unconfined_t)
+')


### PR DESCRIPTION
Beginning with libvirt 0.8.0, specific events on a host system will trigger custom scripts located in /etc/libvirt/hooks. These scripts will be executed in the virt_hook_unconfined_t domain only when the virt_hooks_unconfined boolean, which is off by default, is turned on.

Links:
https://www.libvirt.org/hooks.html Hooks for specific system management