### PR TITLE
Allow samba-dcerpcd to operate with ctdb

### DIFF
--- a/policy/modules/contrib/samba.fc
+++ b/policy/modules/contrib/samba.fc
@@ -19,7 +19,6 @@
 /usr/lib/systemd/system/winbind.*   --  gen_context(system_u:object_r:samba_unit_file_t,s0)
 
 /usr/libexec/samba/rpcd_lsad	--	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
-/usr/libexec/samba/samba-dcerpcd --	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
 
 /usr/bin/net			--	gen_context(system_u:object_r:samba_net_exec_t,s0)
 /usr/bin/ntlm_auth		--	gen_context(system_u:object_r:winbind_helper_exec_t,s0)


### PR DESCRIPTION
Pre-defined policies for _winbind_rpcd_t_ type added via commit 7367896085 failed to consider a clustered samba setup where communication between nodes is handled by ctdb. As a result SMB clients(smbclient, Windows and so on) are unable to browse the services available from such a cluster where _samba-dcerpcd_ is invoked on demand by _smbd_. See below for related AVC denial entries during an attempt to list the services:

> type=AVC msg=audit(1719320611.316:194102): avc: denied { write } for pid=2811143 comm="samba-dcerpcd" name="ctdbd.socket" dev="tmpfs" ino=20734 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:ctdbd_var_run_t:s0 tclass=sock_file permissive=1

> type=AVC msg=audit(1719320611.316:194102): avc: denied { connectto } for pid=2811143 comm="samba-dcerpcd" path="/run/ctdb/ctdbd.socket" scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:ctdbd_t:s0 tclass=unix_stream_socket permissive=1

> type=AVC msg=audit(1719320611.330:194103): avc: denied { getattr } for pid=2811144 comm="samba-dcerpcd" path="/run/ctdb/ctdbd.socket" dev="tmpfs" ino=20734 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:ctdbd_var_run_t:s0 tclass=sock_file permissive=1

> type=AVC msg=audit(1719320611.332:194104): avc: denied { map } for pid=2811144 comm="samba-dcerpcd" path="/var/lib/ctdb/persistent/secrets.tdb.0" dev="dm-0" ino=202466688 scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:object_r:ctdbd_var_lib_t:s0 tclass=file permissive=1

Therefore we leave _samba-dcerpcd_ installed under _/usr/libexec/samba_ with its fhs based default context type(_bin_t_) which should allow ctdb interaction in a configuration where samba is clustered.

fixes #2196 