### PR TITLE
Allow systemd-networkd list /var/lib/systemd/network

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -97,6 +97,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 
 /var/lib/machines(/.*)?			gen_context(system_u:object_r:systemd_machined_var_lib_t,s0)
 /var/lib/systemd/coredump(/.*)?		gen_context(system_u:object_r:systemd_coredump_var_lib_t,s0)
+/var/lib/systemd/network(/.*)?         gen_context(system_u:object_r:systemd_networkd_var_lib_t,s0)
 /var/lib/systemd/pstore(/.*)?         gen_context(system_u:object_r:systemd_pstore_var_lib_t,s0)
 /var/lib/systemd/rfkill(/.*)?         gen_context(system_u:object_r:systemd_rfkill_var_lib_t,s0)
 /var/lib/systemd/linger(/.*)?  		gen_context(system_u:object_r:systemd_logind_var_lib_t,mls_systemhigh)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -79,6 +79,9 @@ init_nnp_daemon_domain(systemd_networkd_t)
 type systemd_networkd_unit_file_t;
 systemd_unit_file(systemd_networkd_unit_file_t)
 
+type systemd_networkd_var_lib_t;
+files_type(systemd_networkd_var_lib_t)
+
 type systemd_networkd_var_run_t;
 files_pid_file(systemd_networkd_var_run_t)
 files_mountpoint(systemd_networkd_var_run_t)
@@ -587,6 +590,8 @@ allow systemd_networkd_t self:udp_socket create_socket_perms;
 allow systemd_networkd_t self:rawip_socket create_socket_perms;
 allow systemd_networkd_t self:tun_socket { relabelfrom relabelto create_socket_perms };
 
+allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
+
 allow init_t systemd_networkd_t:netlink_route_socket create_netlink_socket_perms;
 
 manage_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
@@ -616,15 +621,13 @@ fs_cgroup_write_memory_pressure(systemd_networkd_t)
 dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)
 
-logging_send_syslog_msg(systemd_networkd_t)
+init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "netif")
 
 sysnet_manage_config(systemd_networkd_t)
 sysnet_manage_config_dirs(systemd_networkd_t)
 
 systemd_dbus_chat_hostnamed(systemd_networkd_t)
 systemd_read_efivarfs(systemd_networkd_t)
-
-init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "netif")
 
 optional_policy(`
     dbus_system_bus_client(systemd_networkd_t)
@@ -634,6 +637,10 @@ optional_policy(`
     dbus_read_pid_files(systemd_networkd_t)
     dbus_read_pid_sock_files(systemd_networkd_t)
     systemd_dbus_chat_logind(systemd_networkd_t)
+')
+
+optional_policy(`
+	logging_send_syslog_msg(systemd_networkd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Label /var/lib/systemd/network with systemd_networkd_var_lib_t and allow systemd-networkd access to it.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/29/2024 06:24:24.614:1151) : proctitle=/usr/lib/systemd/systemd-networkd type=SYSCALL msg=audit(04/29/2024 06:24:24.614:1151) : arch=x86_64 syscall=recvmsg success=yes exit=81 a0=0x18 a1=0x7ffdd79c0540 a2=MSG_DONTWAIT|MSG_CMSG_CLOEXEC a3=0x10 items=0 ppid=1 pid=55118 auid=unset uid=systemd-network gid=systemd-network euid=systemd-network suid=systemd-network fsuid=systemd-network egid=systemd-network sgid=systemd-network fsgid=systemd-network tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-networkd subj=system_u:system_r:systemd_networkd_t:s0 key=(null) type=AVC msg=audit(04/29/2024 06:24:24.614:1151) : avc:  denied  { read } for  pid=55118 comm=systemd-network path=/var/lib/systemd/network dev="vda4" ino=26714 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:init_var_lib_t:s0 tclass=dir permissive=0