### PR TITLE
Allow dhcpcd the kill capability

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -60,7 +60,7 @@ ifdef(`distro_debian',`
 #
 # DHCP client local policy
 #
-allow dhcpc_t self:capability { dac_read_search fsetid net_admin net_raw net_bind_service setgid setpcap setuid sys_chroot sys_nice sys_resource sys_tty_config };
+allow dhcpc_t self:capability { dac_read_search fsetid kill net_admin net_raw net_bind_service setgid setpcap setuid sys_chroot sys_nice sys_resource sys_tty_config };
 dontaudit dhcpc_t self:capability sys_admin;
 # for access("/etc/bashrc", X_OK) on Red Hat
 dontaudit dhcpc_t self:capability { dac_read_search sys_module };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(27.6.2024 18:45:35.616:596) : proctitle=dhcpcd -k type=AVC msg=audit(06/27/24 18:45:35.616:596) : avc:  denied  { kill } for  pid=2677 comm=dhcpcd capability=kill  scontext=unconfined_u:system_r:dhcpc_t:s0-s0:c0.c1023 tcontext=unconfined_u:system_r:dhcpc_t:s0-s0:c0.c1023 tclass=capability permissive=0 type=SYSCALL msg=audit(06/27/24 18:45:35.616:596) : arch=x86_64 syscall=kill success=no exit=EPERM(Operation not permitted) a0=0xa50 a1=SIGALRM a2=0x0 a3=0x4000 items=0 ppid=1941 pid=2677 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=5 comm=dhcpcd exe=/usr/sbin/dhcpcd subj=unconfined_u:system_r:dhcpc_t:s0-s0:c0.c1023 key=(null)

Resolves: rhbz#2294614