### PR TITLE
Allow rshim get options of the netlink class for KOBJECT_UEVENT family

### DIFF
--- a/policy/modules/contrib/rshim.te
+++ b/policy/modules/contrib/rshim.te
@@ -22,6 +22,7 @@ allow rshim_t self:netlink_kobject_uevent_socket { bind create getattr setopt };
 allow rshim_t self:process { fork };
 allow rshim_t self:system module_load;
 allow rshim_t self:unix_stream_socket create_stream_socket_perms;
+allow rshim_t self:netlink_kobject_uevent_socket getopt;
 
 kernel_read_proc_files(rshim_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/12/2024 04:46:00.275:586) : proctitle=/usr/sbin/rshim type=SYSCALL msg=audit(06/12/2024 04:46:00.275:586) : arch=x86_64 syscall=getsockopt success=no exit=EACCES(Permission denied) a0=0x6 a1=SOL_SOCKET a2=SO_RCVBUF a3=0x7ffc2b7fbd6c items=0 ppid=1 pid=18142 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rshim exe=/usr/sbin/rshim subj=system_u:system_r:rshim_t:s0 key=(null) type=AVC msg=audit(06/12/2024 04:46:00.275:586) : avc:  denied  { getopt } for  pid=18142 comm=rshim scontext=system_u:system_r:rshim_t:s0 tcontext=system_u:system_r:rshim_t:s0 tclass=netlink_kobject_uevent_socket permissive=0

Resolves: RHEL-40859