### PR TITLE
Allow virtqemud the kill capability in user namespace

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2032,6 +2032,7 @@ optional_policy(`
 allow virtqemud_t self:bpf { map_create map_read map_write prog_load prog_run };
 allow virtqemud_t self:capability { audit_write chown dac_override dac_read_search fowner fsetid kill net_admin setgid setuid sys_admin sys_chroot sys_ptrace sys_rawio };
 allow virtqemud_t self:capability2 { bpf perfmon };
+allow virtqemud_t self:cap_userns kill;
 
 allow virtqemud_t self:netlink_audit_socket { nlmsg_relay read write };
 allow virtqemud_t self:process { setcap setexec setrlimit setsched setsockcreate };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/25/24 16:59:25.633:96419) : proctitle=/usr/sbin/virtqemud --timeout 120 type=AVC msg=audit(06/25/24 16:59:25.633:96419) : avc:  denied  { kill } for  pid=1630689 comm=qemu-event capability=kill  scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=cap_userns permissive=1 type=SYSCALL msg=audit(06/25/24 16:59:25.633:96419) : arch=x86_64 syscall=kill success=yes exit=0 a0=0x18f8e8 a1=SIGTERM a2=0x7f013af4862b a3=0xc8 items=0 ppid=1 pid=1630689 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=qemu-event exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null)

Resolves: RHEL-44996