### PR TITLE
Add support for libvirt hooks (f40)

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -570,6 +570,7 @@ tunable_policy(`deny_ptrace',`',`
 
 files_manage_non_security_dirs(abrt_dump_oops_t)
 files_manage_non_security_files(abrt_dump_oops_t)
+files_read_non_security_sock_files(abrt_dump_oops_t)
 files_map_non_security_files(abrt_dump_oops_t)
 
 fs_getattr_all_fs(abrt_dump_oops_t)

--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -758,6 +758,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mysql_read_config(postfix_smtpd_t)
+')
+
+optional_policy(`
 	postgrey_stream_connect(postfix_smtpd_t)
 ')
 

--- a/policy/modules/contrib/slocate.te
+++ b/policy/modules/contrib/slocate.te
@@ -36,6 +36,7 @@ can_exec(locate_t, locate_exec_t)
 kernel_read_system_state(locate_t)
 kernel_dontaudit_search_network_state(locate_t)
 kernel_dontaudit_search_sysctl(locate_t)
+kernel_stream_connect(locate_t)
 
 corecmd_exec_bin(locate_t)
 corecmd_exec_shell(locate_t)

--- a/policy/modules/contrib/virt.fc
+++ b/policy/modules/contrib/virt.fc
@@ -13,6 +13,7 @@ HOME_DIR/\.local/share/libvirt/boot(/.*)?	gen_context(system_u:object_r:svirt_ho
 /etc/libvirt/virtlogd\.conf	--	gen_context(system_u:object_r:virtlogd_etc_t,s0)
 /etc/libvirt/[^/]*		--	gen_context(system_u:object_r:virt_etc_t,s0)
 /etc/libvirt/[^/]*		-d	gen_context(system_u:object_r:virt_etc_rw_t,s0)
+/etc/libvirt/hooks(/.*)?		gen_context(system_u:object_r:virt_hook_t,s0)
 /etc/libvirt/.*/.*			gen_context(system_u:object_r:virt_etc_rw_t,s0)
 /etc/rc\.d/init\.d/libvirtd	--	gen_context(system_u:object_r:virtd_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/virtlogd	--	gen_context(system_u:object_r:virtlogd_initrc_exec_t,s0)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -157,6 +157,13 @@ gen_tunable(virt_sandbox_use_all_caps, true)
 ## </desc>
 gen_tunable(virt_lockd_blk_devs, false)
 
+## <desc>
+## <p>
+## Allow virt daemons run unconfined hooks
+## </p>
+## </desc>
+gen_tunable(virt_hooks_unconfined, false)
+
 gen_require(`
     class passwd rootok;
     class passwd passwd;
@@ -202,6 +209,11 @@ files_config_file(virt_etc_t)
 
 type virt_etc_rw_t, virt_file_type;
 files_type(virt_etc_rw_t)
+
+type virt_hook_t, virt_file_type;
+type virt_hook_unconfined_t;
+role system_r types virt_hook_unconfined_t;
+application_domain(virt_hook_unconfined_t, virt_hook_t)
 
 type virt_home_t, virt_file_type;
 userdom_user_home_content(virt_home_t)
@@ -1903,6 +1915,10 @@ dev_rw_sysfs(virtnetworkd_t)
 sysnet_domtrans_ifconfig(virtnetworkd_t)
 sysnet_read_config(virtnetworkd_t)
 
+tunable_policy(`virt_hooks_unconfined',`
+	domtrans_pattern(virtnetworkd_t, virt_hook_t, virt_hook_unconfined_t)
+')
+
 optional_policy(`
 	dnsmasq_create_pid_dirs(virtnetworkd_t)
 	dnsmasq_domtrans(virtnetworkd_t)
@@ -2405,3 +2421,12 @@ read_files_pattern(svirt_sandbox_domain, container_ro_file_t, container_ro_file_
 read_lnk_files_pattern(svirt_sandbox_domain, container_ro_file_t, container_ro_file_t)
 allow svirt_sandbox_domain container_ro_file_t:file execmod;
 can_exec(svirt_sandbox_domain, container_ro_file_t)
+
+########################################
+#
+# Policy for libvirt hooks
+#
+
+optional_policy(`
+	unconfined_domain(virt_hook_unconfined_t)
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1916,6 +1916,7 @@ sysnet_domtrans_ifconfig(virtnetworkd_t)
 sysnet_read_config(virtnetworkd_t)
 
 tunable_policy(`virt_hooks_unconfined',`
+	corecmd_exec_shell(virtnetworkd_t)
 	domtrans_pattern(virtnetworkd_t, virt_hook_t, virt_hook_unconfined_t)
 ')
 

--- a/policy/modules/contrib/wireshark.if
+++ b/policy/modules/contrib/wireshark.if
@@ -30,7 +30,7 @@ interface(`wireshark_role',`
 	ps_process_pattern($2, wireshark_t)
 
 	allow $2 { wireshark_tmp_t wireshark_home_t wireshark_tmpfs_t }:dir { manage_dir_perms relabel_dir_perms };
-	allow $2 { wireshark_tmp_t wireshark_home_t wireshark_tmpfs_t }:file { manage_file_perms relabel_file_perms };
+	allow $2 { wireshark_tmp_t wireshark_home_t wireshark_tmpfs_t }:file { manage_file_perms map relabel_file_perms };
 	allow $2 { wireshark_home_t wireshark_tmpfs_t }:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
 	allow $2 wireshark_tmpfs_t:sock_file { manage_sock_file_perms relabel_sock_file_perms };
 	allow $2 wireshark_tmpfs_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };

--- a/policy/modules/contrib/wireshark.te
+++ b/policy/modules/contrib/wireshark.te
@@ -61,6 +61,7 @@ manage_lnk_files_pattern(wireshark_t, wireshark_tmpfs_t, wireshark_tmpfs_t)
 manage_sock_files_pattern(wireshark_t, wireshark_tmpfs_t, wireshark_tmpfs_t)
 manage_fifo_files_pattern(wireshark_t, wireshark_tmpfs_t, wireshark_tmpfs_t)
 fs_tmpfs_filetrans(wireshark_t, wireshark_tmpfs_t, { dir file lnk_file sock_file fifo_file })
+allow wireshark_t wireshark_tmpfs_t:file map;
 
 can_exec(wireshark_t, wireshark_exec_t)
 
@@ -111,12 +112,15 @@ tunable_policy(`deny_bluetooth',`',`
 ')
 
 optional_policy(`
-    dbus_session_bus_client(wireshark_t)
+	dbus_session_bus_client(wireshark_t)
+	dbus_write_session_tmp_sock_files(wireshark_t)
 ')
 
 optional_policy(`
-    gnome_create_home_config_dirs(wireshark_t)
-    gnome_manage_home_config(wireshark_t)
+	gnome_create_home_config_dirs(wireshark_t)
+	gnome_manage_home_config(wireshark_t)
+	gnome_read_generic_cache_files(wireshark_t)
+	gnome_write_generic_cache_files(wireshark_t)
 ')
 
 optional_policy(`
@@ -127,4 +131,5 @@ optional_policy(`
 optional_policy(`
 	xserver_user_x_domain_template(wireshark, wireshark_t, wireshark_tmpfs_t)
 	xserver_create_xdm_tmp_sockets(wireshark_t)
+	xserver_map_user_fonts(wireshark_t)
 ')

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -96,6 +96,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 
 /var/lib/machines(/.*)?			gen_context(system_u:object_r:systemd_machined_var_lib_t,s0)
 /var/lib/systemd/coredump(/.*)?		gen_context(system_u:object_r:systemd_coredump_var_lib_t,s0)
+/var/lib/systemd/network(/.*)?         gen_context(system_u:object_r:systemd_networkd_var_lib_t,s0)
 /var/lib/systemd/pstore(/.*)?         gen_context(system_u:object_r:systemd_pstore_var_lib_t,s0)
 /var/lib/systemd/rfkill(/.*)?         gen_context(system_u:object_r:systemd_rfkill_var_lib_t,s0)
 /var/lib/systemd/linger(/.*)?  		gen_context(system_u:object_r:systemd_logind_var_lib_t,mls_systemhigh)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -580,6 +580,9 @@ allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
 
 allow init_t systemd_networkd_t:netlink_route_socket create_netlink_socket_perms;
 
+allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
+create_files_pattern(systemd_networkd_t, systemd_networkd_var_lib_t, systemd_networkd_var_lib_t)
+
 manage_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 manage_lnk_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 manage_sock_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -79,6 +79,9 @@ init_nnp_daemon_domain(systemd_networkd_t)
 type systemd_networkd_unit_file_t;
 systemd_unit_file(systemd_networkd_unit_file_t)
 
+type systemd_networkd_var_lib_t;
+files_type(systemd_networkd_var_lib_t)
+
 type systemd_networkd_var_run_t;
 files_pid_file(systemd_networkd_var_run_t)
 files_mountpoint(systemd_networkd_var_run_t)
@@ -573,6 +576,8 @@ allow systemd_networkd_t self:udp_socket create_socket_perms;
 allow systemd_networkd_t self:rawip_socket create_socket_perms;
 allow systemd_networkd_t self:tun_socket { relabelfrom relabelto create_socket_perms };
 
+allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
+
 allow init_t systemd_networkd_t:netlink_route_socket create_netlink_socket_perms;
 
 manage_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
@@ -602,15 +607,13 @@ fs_write_cgroup_files(systemd_networkd_t)
 dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)
 
-logging_send_syslog_msg(systemd_networkd_t)
+init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "netif")
 
 sysnet_manage_config(systemd_networkd_t)
 sysnet_manage_config_dirs(systemd_networkd_t)
 
 systemd_dbus_chat_hostnamed(systemd_networkd_t)
 systemd_read_efivarfs(systemd_networkd_t)
-
-init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "netif")
 
 optional_policy(`
     dbus_system_bus_client(systemd_networkd_t)
@@ -620,6 +623,10 @@ optional_policy(`
     dbus_read_pid_files(systemd_networkd_t)
     dbus_read_pid_sock_files(systemd_networkd_t)
     systemd_dbus_chat_logind(systemd_networkd_t)
+')
+
+optional_policy(`
+	logging_send_syslog_msg(systemd_networkd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Beginning with libvirt 0.8.0, specific events on a host system will trigger custom scripts located in /etc/libvirt/hooks. These scripts will be executed in the virt_hook_unconfined_t domain only when the virt_hooks_unconfined boolean, which is off by default, is turned on.

Links:
https://www.libvirt.org/hooks.html Hooks for specific system management

Resolves: rhbz#2276917