### PR TITLE
Fix typo in systemd_nsresourced_prog_run_bpf()

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -3057,8 +3057,8 @@ interface(`systemd_nsresourced_runtime_filetrans',`
 #
 interface(`systemd_nsresourced_prog_run_bpf',`
 	gen_require(`
-		type systemd_nsresourced_runtime_t;
+		type systemd_nsresourced_t;
 	')
 
-    allow $1 systemd_nsresourced_runtime_t:bpf { map_read map_write prog_run };
+    allow $1 systemd_nsresourced_t:bpf { map_read map_write prog_run };
 ')


### PR DESCRIPTION
Instead the proper systemd_nsresourced_t domain,
systemd_nsresourced_runtime_t was used in the interface body.