### PR TITLE
Allow systemd-networkd write files in /var/lib/systemd/network

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -590,9 +590,10 @@ allow systemd_networkd_t self:udp_socket create_socket_perms;
 allow systemd_networkd_t self:rawip_socket create_socket_perms;
 allow systemd_networkd_t self:tun_socket { relabelfrom relabelto create_socket_perms };
 
-allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
-
 allow init_t systemd_networkd_t:netlink_route_socket create_netlink_socket_perms;
+
+allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
+create_files_pattern(systemd_networkd_t, systemd_networkd_var_lib_t, systemd_networkd_var_lib_t)
 
 manage_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 manage_lnk_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/28/2024 22:15:26.391:6401) : proctitle=/usr/lib/systemd/systemd-networkd type=PATH msg=audit(06/28/2024 22:15:26.391:6401) : item=0 name=/proc/self/fd/20 inode=2131 dev=00:25 mode=dir,755 ouid=systemd-network ogid=systemd-network rdev=00:00 obj=system_u:object_r:systemd_networkd_var_lib_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/28/2024 22:15:26.391:6401) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x7ffea97360e0 a1=W_OK a2=0x0 a3=0x0 items=1 ppid=1 pid=255124 auid=unset uid=systemd-network gid=systemd-network euid=systemd-network suid=systemd-network fsuid=systemd-network egid=systemd-network sgid=systemd-network fsgid=systemd-network tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-networkd subj=system_u:system_r:systemd_networkd_t:s0 key=(null) type=AVC msg=audit(06/28/2024 22:15:26.391:6401) : avc:  denied  { write } for  pid=255124 comm=systemd-network name=network dev="nvme0n1p4" ino=2131 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:systemd_networkd_var_lib_t:s0 tclass=dir permissive=0