### PR TITLE
Allow ip the setexec permission

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -315,7 +315,7 @@ optional_policy(`
 allow ifconfig_t self:bpf { prog_load prog_run };
 allow ifconfig_t self:capability { net_raw net_admin sys_admin sys_tty_config };
 allow ifconfig_t self:capability2 { bpf perfmon };
-allow ifconfig_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execheap execstack };
+allow ifconfig_t self:process ~{ ptrace setcurrent setfscreate setrlimit execmem execheap execstack };
 allow ifconfig_t self:fd use;
 allow ifconfig_t self:fifo_file rw_fifo_file_perms;
 allow ifconfig_t self:sock_file read_sock_file_perms;


### PR DESCRIPTION
This permission is required for ip-vrf to be able to set security context using setexecfilecon(3).

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/14/2024 05:11:03.557:807) : proctitle=/usr/sbin/ip vrf exec vrf1 /usr/bin/sleep 3600 type=SYSCALL msg=audit(06/14/2024 05:11:03.557:807) : arch=x86_64 syscall=write success=yes exit=32 a0=0x4 a1=0x55cb385f46e0 a2=0x20 a3=0x55cb385f4010 items=0 ppid=1 pid=19201 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ip exe=/usr/sbin/ip subj=system_u:system_r:ifconfig_t:s0 key=(null) type=AVC msg=audit(06/14/2024 05:11:03.557:807) : avc:  denied  { setexec } for  pid=19201 comm=ip scontext=system_u:system_r:ifconfig_t:s0 tcontext=system_u:system_r:ifconfig_t:s0 tclass=process permissive=1

Resolves: rhbz#41182