### PR TITLE
Label /usr/lib/node_modules/npm/bin with bin_t

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -256,6 +256,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/netsaint/plugins(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/news/bin(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/NetworkManager/nm\-.*	--	gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/node_modules/npm/bin(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/nspluginwrapper/np.*	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/ocf(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/portage/bin(/.*)?	gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
The current state is the usr_t label for actual executables:

  $ ls -lZ /usr/bin/npm /usr/lib/node_modules/npm/bin/npm-cli.js
lrwxrwxrwx. 1 root root system_u:object_r:bin_t:s0 38 Mar  5 07:14 /usr/bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js -rwxr-xr-x. 1 root root system_u:object_r:lib_t:s0 50 Aug  9  2023 /usr/lib/node_modules/npm/bin/npm-cli.js

Resolves: RHEL-36587