### PR TITLE
Dontaudit domain write cgroup files

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -184,6 +184,7 @@ files_dontaudit_map_all_dirs(domain)
 files_dontaudit_execute_all_sockets(domain)
 
 fs_dontaudit_map_all_dirs(domain)
+fs_dontaudit_write_cgroup_files(domain)
 
 # All executables should be able to search the directory they are in
 corecmd_search_bin(domain)

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -933,6 +933,24 @@ interface(`fs_write_cgroup_files', `
 
 ########################################
 ## <summary>
+##	Do not audit attempts to write cgroup files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_write_cgroup_files',`
+	gen_require(`
+		attribute cgroup_type;
+	')
+
+	dontaudit $1 cgroup_type:file write_file_perms;
+')
+
+########################################
+## <summary>
 ##	Read and write cgroup files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This rule is added to prevent from reporting bugs since there currently is not a clear way how to address the problem how to allow domains write to
/sys/fs/cgroup/system.slice/servicename.service/memory.pressure, but not give the write access completely to the cgroup filesystem.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2294402