### PR TITLE
Allow timemaster write to sysfs files

### DIFF
--- a/policy/modules/contrib/linuxptp.te
+++ b/policy/modules/contrib/linuxptp.te
@@ -67,6 +67,8 @@ corenet_udp_bind_generic_node(timemaster_t)
 corenet_udp_bind_ntp_port(timemaster_t)
 
 dev_read_urand(timemaster_t)
+dev_list_sysfs(timemaster_t)
+dev_write_sysfs(timemaster_t)
 
 logging_send_syslog_msg(timemaster_t)
 

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5123,7 +5123,26 @@ interface(`dev_read_sysfs',`
 
 ########################################
 ## <summary>
-##	Allow caller to modify hardware state information.
+##	Allow caller to write to sysfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_write_sysfs',`
+	gen_require(`
+		type sysfs_t;
+	')
+
+	write_files_pattern($1, sysfs_t, sysfs_t)
+	read_lnk_files_pattern($1, sysfs_t, sysfs_t)
+')
+
+########################################
+## <summary>
+##	Allow caller to r/w to sysfs files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>


### PR DESCRIPTION
Timemaster has a new functionality to configure virtual clocks by writing to files in /sys.

The commit addresses the following AVC denials:
type=AVC msg=audit(1710170769.424:453): avc:  denied  { read } for  pid=18663 comm="timemaster" name="ptp0" dev="sysfs" ino=30545 scontext=system_u:system_r:timemaster_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=lnk_file permissive=1 type=AVC msg=audit(1710170769.424:453): avc:  denied  { write } for  pid=18663 comm="timemaster" name="n_vclocks" dev="sysfs" ino=30557 scontext=system_u:system_r:timemaster_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1 type=AVC msg=audit(1710170769.441:457): avc:  denied  { read } for  pid=19357 comm="timemaster" name="ptp0" dev="sysfs" ino=30541 scontext=system_u:system_r:timemaster_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1

Resolves: RHEL-28777