### PR TITLE
Allow abrt-dump-journal read all non_security socket files

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -570,6 +570,7 @@ tunable_policy(`deny_ptrace',`',`
 
 files_manage_non_security_dirs(abrt_dump_oops_t)
 files_manage_non_security_files(abrt_dump_oops_t)
+files_read_non_security_sock_files(abrt_dump_oops_t)
 files_map_non_security_files(abrt_dump_oops_t)
 
 fs_getattr_all_fs(abrt_dump_oops_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1719926548.159:637): avc:  denied  { getattr } for  pid=2385 comm="abrt-dump-journ" path="/run/samba/winbindd/pipe" dev="tmpfs" ino=3370 scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:object_r:winbind_var_run_t:s0 tclass=sock_file permissive=0

Resolves: rhbz#2295175