### PR TITLE
Allow to create and delete socket files created by rhsm.service

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -47,6 +47,7 @@ dontaudit rhsmcertd_t self:process setfscreate;
 
 allow rhsmcertd_t self:fifo_file rw_fifo_file_perms;
 allow rhsmcertd_t self:unix_stream_socket create_stream_socket_perms;
+allow rhsmcertd_t rhsmcertd_var_run_t:sock_file manage_sock_file_perms;
 
 manage_dirs_pattern(rhsmcertd_t, rhsmcertd_config_t, rhsmcertd_config_t)
 manage_files_pattern(rhsmcertd_t, rhsmcertd_config_t, rhsmcertd_config_t)


### PR DESCRIPTION
* rhsm.service need to create socket file, when client tries to register system. SELinux blocked this.
* Issue is described in: https://github.com/fedora-selinux/selinux-policy/issues/2214
* Card ID: CCT-561