### PR TITLE
Allow virtnetworkd exec shell when virt_hooks_unconfined is on

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1924,6 +1924,7 @@ sysnet_domtrans_ifconfig(virtnetworkd_t)
 sysnet_read_config(virtnetworkd_t)
 
 tunable_policy(`virt_hooks_unconfined',`
+	corecmd_exec_shell(virtnetworkd_t)
 	domtrans_pattern(virtnetworkd_t, virt_hook_t, virt_hook_unconfined_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/03/2024 02:49:51.051:177) : proctitle=/usr/sbin/virtnetworkd --timeout 120 type=SYSCALL msg=audit(07/03/2024 02:49:51.051:177) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x7f6d90010b90 a1=0x7f6d900170c0 a2=0x7f6d90017630 a3=0x7f6d90000b90 items=0 ppid=1325 pid=1346 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=daemon-init exe=/usr/sbin/virtnetworkd subj=system_u:system_r:virtnetworkd_t:s0 key=(null) type=AVC msg=audit(07/03/2024 02:49:51.051:177) : avc:  denied  { execute } for  pid=1346 comm=daemon-init name=bash dev="vda2" ino=4449649 scontext=system_u:system_r:virtnetworkd_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0

Resolves: RHEL-41168