### PR TITLE
Allow unconfined_service_t transition to passwd_t

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -21,6 +21,7 @@ corecmd_bin_entry_type(unconfined_service_t)
 corecmd_shell_entry_type(unconfined_service_t)
 
 init_use_notify(unconfined_service_t)
+usermanage_run_passwd(unconfined_service_t, system_r)
 
 optional_policy(`
 	rpm_transition_script(unconfined_service_t, system_r)


### PR DESCRIPTION
Allow unconfined_service_t transition to passwd_t when passwd and chpasswd executables or other ones labeled with passwd_exec_t are run, similar to already existing rule for unconfined_t.