### PR TITLE
Change fs_dontaudit_write_cgroup_files() to apply to cgroup_t

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -943,10 +943,10 @@ interface(`fs_write_cgroup_files', `
 #
 interface(`fs_dontaudit_write_cgroup_files',`
 	gen_require(`
-		attribute cgroup_type;
+		type cgroup_t;
 	')
 
-	dontaudit $1 cgroup_type:file write_file_perms;
+	dontaudit $1 cgroup_t:file write_file_perms;
 ')
 
 ########################################


### PR DESCRIPTION
The fs_dontaudit_write_cgroup_files() interface was changed to apply to cgroup_t instead of cgroup_type. This changes the effect of the 9a3beb7ba7c0 ("Dontaudit domain write cgroup files") commit not to dontaudit other types like cgroup_memory_pressure_t.