### PR TITLE
Do not label /usr/bin/httpd with publicfile_exec_t

### DIFF
--- a/policy/modules/contrib/publicfile.fc
+++ b/policy/modules/contrib/publicfile.fc
@@ -1,5 +1,6 @@
 /usr/bin/ftpd	--	gen_context(system_u:object_r:publicfile_exec_t,s0)
-/usr/bin/httpd	--	gen_context(system_u:object_r:publicfile_exec_t,s0)
+# This entry clashes with one in apache.fc after the bin-sbin merge
+#/usr/bin/httpd	--	gen_context(system_u:object_r:publicfile_exec_t,s0)
 
 # this is the place where online content located
 # set this to suit your needs


### PR DESCRIPTION
After the bin-sbin merge, an entry for /usr/bin/httpd in publicfile.fc started to clash with another one in apache.fc.