### PR TITLE
Allow gpg_t get attributes of login_userdomain stream

### DIFF
--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -205,6 +205,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	userdom_getattr_stream_userdomain(gpg_t)
+')
+
+optional_policy(`
 	xserver_use_xdm_fds(gpg_t)
 	xserver_rw_xdm_pipes(gpg_t)
 ')

--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -110,7 +110,7 @@ files_tmp_filetrans(gpg_t, gpg_agent_tmp_t, { dir file })
 allow gpg_t gpg_agent_tmp_t:file map;
 can_exec(gpg_t, gpg_agent_tmp_t)
 
-allow gpg_t gpg_secret_t:dir { create_dir_perms watch_dir_perms };
+allow gpg_t gpg_secret_t:dir { create_dir_perms setattr_dir_perms watch_dir_perms };
 manage_sock_files_pattern(gpg_t, gpg_secret_t, gpg_secret_t)
 manage_files_pattern(gpg_t, gpg_secret_t, gpg_secret_t)
 manage_lnk_files_pattern(gpg_t, gpg_secret_t, gpg_secret_t)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -6758,6 +6758,24 @@ interface(`userdom_login_userdomain',`
 
 ########################################
 ## <summary>
+##	Get attributes of login_userdomain stream.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_getattr_stream_userdomain',`
+	gen_require(`
+		attribute login_userdomain;
+	')
+
+	allow $1 login_userdomain:unix_stream_socket getattr;
+')
+
+########################################
+## <summary>
 ##	Append to login_userdomain stream.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11.7.2024 16:45:16.781:1311) : proctitle=gpgsm --logger-fd 96 --server type=SYSCALL msg=audit(11.7.2024 16:45:16.781:1311) : arch=x86_64 syscall=fstat success=yes exit=0 a0=0x62 a1=0x7ffe67ad0fa0 a2=0x0 a3=0x7fc80a53dfe0 items=0 ppid=2327 pid=180599 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=(none) ses=3 comm=gpgsm exe=/usr/bin/gpgsm subj=staff_u:staff_r:gpg_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(11.7.2024 16:45:16.781:1311) : avc:  denied  { getattr } for  pid=180599 comm=gpgsm path=socket:[1692132] dev="sockfs" ino=1692132 scontext=staff_u:staff_r:gpg_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1