### PR TITLE
Allow updatedb connect to userdbd over a unix stream socket

### DIFF
--- a/policy/modules/contrib/slocate.te
+++ b/policy/modules/contrib/slocate.te
@@ -34,6 +34,7 @@ files_pid_filetrans(locate_t, locate_var_run_t, file, "mlocate.daily.lock")
 can_exec(locate_t, locate_exec_t)
 
 kernel_read_system_state(locate_t)
+kernel_stream_connect(locate_t)
 kernel_dontaudit_search_network_state(locate_t)
 kernel_dontaudit_search_sysctl(locate_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/11/2024 16:44:56.224:298) : proctitle=/usr/sbin/updatedb type=PATH msg=audit(07/11/2024 16:44:56.224:298) : item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=42 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(07/11/2024 16:44:56.224:298) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DynamicUser } type=SYSCALL msg=audit(07/11/2024 16:44:56.224:298) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x5 a1=0x7fff1bb9c4c0 a2=0x2d a3=0x561a49906040 items=1 ppid=1 pid=5767 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=updatedb exe=/usr/sbin/updatedb subj=system_u:system_r:locate_t:s0 key=(null) type=AVC msg=audit(07/11/2024 16:44:56.224:298) : avc:  denied  { connectto } for  pid=5767 comm=updatedb path=/systemd/userdb/io.systemd.DynamicUser scontext=system_u:system_r:locate_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0