### PR TITLE
Allow postfix-smtpd read mysql config files

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -758,6 +758,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mysql_read_config(postfix_smtpd_t)
+')
+
+optional_policy(`
 	postgrey_stream_connect(postfix_smtpd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=AVC msg=audit(07/11/2024 01:30:01.035:4609) : avc:  denied  { read } for  pid=129400 comm=smtpd name=my.cnf dev="vda5" ino=67157645 scontext=system_u:system_r:postfix_smtpd_t:s0 tcontext=system_u:object_r:mysqld_etc_t:s0 tclass=file permissive=1 type=AVC msg=audit(07/11/2024 01:30:01.035:4610) : avc:  denied  { open } for  pid=129400 comm=smtpd path=/etc/my.cnf dev="vda5" ino=67157645 scontext=system_u:system_r:postfix_smtpd_t:s0 tcontext=system_u:object_r:mysqld_etc_t:s0 tclass=file permissive=1

Resolves: rhbz#2255775