### PR TITLE
Allow locate stream connect to systemd-userdbd

### DIFF
--- a/policy/modules/contrib/slocate.te
+++ b/policy/modules/contrib/slocate.te
@@ -36,6 +36,7 @@ can_exec(locate_t, locate_exec_t)
 kernel_read_system_state(locate_t)
 kernel_dontaudit_search_network_state(locate_t)
 kernel_dontaudit_search_sysctl(locate_t)
+kernel_stream_connect(locate_t)
 
 corecmd_exec_bin(locate_t)
 corecmd_exec_shell(locate_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1720899391.878:361): avc:  denied  { connectto } for  pid=25089 comm="updatedb" path="/systemd/userdb/io.systemd.DynamicUser" scontext=system_u:system_r:locate_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=1 type=SYSCALL msg=audit(1720899391.878:361): arch=x86_64 syscall=connect success=yes exit=0 a0=5 a1=7ffffc356d20 a2=2d a3=4 items=1 ppid=1 pid=25089 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=updatedb exe=/usr/sbin/updatedb subj=system_u:system_r:locate_t:s0 key=(null) type=PATH msg=audit(1720899391.878:361): item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=48 dev=00:1b mode=0140666 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: rhbz#2297731