### PR TITLE
Fix policy for systemd getty generator

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1304,6 +1304,7 @@ optional_policy(`
 
 ### getty generator
 dev_read_sysfs(systemd_getty_generator_t)
+init_read_state(systemd_getty_generator_t)
 term_use_unallocated_ttys(systemd_getty_generator_t)
 
 ### gpt generator

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1304,7 +1304,7 @@ optional_policy(`
 
 ### getty generator
 dev_read_sysfs(systemd_getty_generator_t)
-term_open_unallocated_ttys(systemd_getty_generator_t)
+term_use_unallocated_ttys(systemd_getty_generator_t)
 
 ### gpt generator
 allow systemd_gpt_generator_t self:capability sys_rawio;


### PR DESCRIPTION
current systemd getty generator policy breaks auto-add of ttyS0 and reading of $SYSTEMD_GETTY_AUTO from /proc/1/environ

details see commit messages 

tests/bug report see https://bugzilla.suse.com/show_bug.cgi?id=1226888