### PR TITLE
Allow systemd_cryptsetup_generator_t to write kmsg

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1275,6 +1275,7 @@ allow systemd_generator systemd_unit_file_type:lnk_file getattr_lnk_file_perms;
 fs_getattr_cgroup(systemd_generator)
 fs_search_cgroup_dirs(systemd_generator)
 kernel_read_proc_files(systemd_generator)
+dev_write_kmsg(systemd_generator)
 
 ### Rules for individual systemd generator domains
 
@@ -1289,7 +1290,6 @@ allow systemd_fstab_generator_t self:capability { dac_override dac_read_search }
 
 create_lnk_files_pattern(systemd_fstab_generator_t, systemd_unit_file_type, systemd_unit_file_type)
 
-dev_write_kmsg(systemd_fstab_generator_t)
 dev_write_sysfs_dirs(systemd_fstab_generator_t)
 
 files_getattr_all_dirs(systemd_fstab_generator_t)
@@ -1313,7 +1313,6 @@ dontaudit systemd_gpt_generator_t self:capability sys_admin;
 allow systemd_gpt_generator_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 dev_read_sysfs(systemd_gpt_generator_t)
-dev_write_kmsg(systemd_gpt_generator_t)
 dev_read_rand(systemd_gpt_generator_t)
 
 files_list_boot(systemd_gpt_generator_t)
@@ -1369,7 +1368,6 @@ filetrans_pattern(systemd_zram_generator_t, systemd_unit_file_t, systemd_zram_ge
 
 dev_create_sysfs_files(systemd_zram_generator_t)
 dev_rw_sysfs(systemd_zram_generator_t)
-dev_write_kmsg(systemd_zram_generator_t)
 
 # for systemd-detect-virt - needs to be confined
 corecmd_exec_bin(systemd_zram_generator_t)


### PR DESCRIPTION
Addresses:
```
type=AVC msg=audit(1721045161.675:334): avc:  denied  { write } for  pid=1662 comm="systemd-cryptse" name="kmsg" dev="devtmpfs" ino=10 scontext=system_u:system_r:systemd_cryptsetup_generator_t:s0 tcontext=system_u:object_r:kmsg_device_t:s0 tclass=chr_file permissive=0
```

Reproducer:
https://openqa.opensuse.org/tests/4341371#downloads
encrypt during install, then `systemctl daemon-reload`

it might be better to allow this for all generators? idk
see: https://www.freedesktop.org/software/systemd/man/latest/systemd.generator.html
`Since syslog(3) is not available (see above), log messages have to be written to /dev/kmsg instead.`