### PR TITLE
Allow sshd_keygen_t connect to userdbd over a unix stream socket

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -524,6 +524,7 @@ allow sshd_keygen_t sshd_key_t:file manage_file_perms;
 
 kernel_read_system_state(sshd_keygen_t)
 kernel_dontaudit_request_load_module(sshd_keygen_t)
+kernel_stream_connect(sshd_keygen_t)
 
 corecmd_exec_bin(sshd_keygen_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/12/24 17:09:43.094:29) : proctitle=/usr/bin/chgrp ssh_keys /etc/ssh/ssh_host_ed25519_key type=SYSCALL msg=audit(07/12/24 17:09:43.094:29) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x4 a1=0x7ffceeb2ebe0 a2=0x2d a3=0x0 items=0 ppid=1704 pid=1733 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=chgrp exe=/usr/bin/chgrp subj=system_u:system_r:sshd_keygen_t:s0 key=(null) type=AVC msg=audit(07/12/24 17:09:43.094:29) : avc:  denied  { connectto } for  pid=1733 comm=chgrp path=/run/systemd/userdb/io.systemd.DynamicUser scontext=system_u:system_r:sshd_keygen_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=1

Resolves: RHEL-47033