### PR TITLE
Update keyutils policy

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -18,10 +18,13 @@ role system_r types keyutils_dns_resolver_t;
 
 ### policy for the keyutils_request_t domain
 allow keyutils_request_t self:unix_dgram_socket create_socket_perms;
+allow keyutils_request_t keyutils_request_exec_t:file execute_no_trans;
 
 corecmd_exec_bin(keyutils_request_t)
 
 domain_read_view_all_domains_keyrings(keyutils_request_t)
+
+init_write_key(keyutils_request_t)
 
 optional_policy(`
 	init_search_pid_dirs(keyutils_request_t)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1483,7 +1483,7 @@ interface(`init_write_key',`
 		type init_t;
 	')
 
-	allow $1 init_t:key read;
+	allow $1 init_t:key write;
 ')
 
 ########################################


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(07/15/2024 01:21:56.776:355) : proctitle=keyctl negate 294692574 30 387041071 type=AVC msg=audit(07/15/2024 01:21:56.776:355) : avc:  denied  { write } for  pid=443261 comm=keyctl scontext=system_u:system_r:keyutils_request_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=key permissive=0 type=SYSCALL msg=audit(07/15/2024 01:21:56.776:355) : arch=aarch64 syscall=keyctl success=no exit=EACCES(Permission denied) a0=0xd a1=0x1190a6de a2=0x1e a3=0x1711c72f items=0 ppid=362608 pid=443261 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=keyctl exe=/usr/bin/keyctl subj=system_u:system_r:keyutils_request_t:s0 key=(null) type=EXECVE msg=audit(07/15/2024 01:21:56.776:355) : argc=8 a0=keyctl a1=negate a2=294692574 a3=30 a4=387041071 a5=HOME=/ a6=PATH=/sbin:/bin:/usr/sbin:/usr/bin a7=/bin/keyctl type=PROCTITLE msg=audit(07/15/2024 01:21:56.806:356) : proctitle=keyctl negate 111528792 30 387041071 type=AVC msg=audit(07/15/2024 01:21:56.806:356) : avc:  denied  { write } for  pid=443270 comm=keyctl scontext=system_u:system_r:keyutils_request_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=key permissive=0 type=SYSCALL msg=audit(07/15/2024 01:21:56.806:356) : arch=aarch64 syscall=keyctl success=no exit=EACCES(Permission denied) a0=0xd a1=0x6a5cb58 a2=0x1e a3=0x1711c72f items=0 ppid=362608 pid=443270 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=keyctl exe=/usr/bin/keyctl subj=system_u:system_r:keyutils_request_t:s0 key=(null) type=EXECVE msg=audit(07/15/2024 01:21:56.806:356) : argc=8 a0=keyctl a1=negate a2=111528792 a3=30 a4=387041071 a5=HOME=/ a6=PATH=/sbin:/bin:/usr/sbin:/usr/bin a7=/bin/keyctl

Resolves: RHEL-38920