### PR TITLE
Allow virtqemud read virt-dbus process state

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2124,6 +2124,8 @@ read_lnk_files_pattern(virtqemud_t, svirt_t, svirt_t)
 
 manage_files_pattern(virtqemud_t, virt_content_t, virt_content_t)
 
+read_files_pattern(virtqemud_t, virt_dbus_t, virt_dbus_t)
+
 manage_files_pattern(virtqemud_t, virt_image_t, virt_image_t)
 
 manage_dirs_pattern(virtqemud_t, virt_var_lib_t, virt_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/03/2024 02:09:46.826:653) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(07/03/2024 02:09:46.826:653) : item=0 name=/proc/6531/stat inode=29798 dev=00:15 mode=file,444 ouid=libvirtdbus ogid=libvirtdbus rdev=00:00 obj=system_u:system_r:virt_dbus_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/03/2024 02:09:46.826:653) : arch=x86_64 syscall=openat success=yes exit=20 a0=AT_FDCWD a1=0x55feae213740 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=6617 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=prio-rpc-virtqe exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(07/03/2024 02:09:46.826:653) : avc:  denied  { open } for  pid=6617 comm=prio-rpc-virtqe path=/proc/6531/stat dev="proc" ino=29798 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virt_dbus_t:s0 tclass=file permissive=1 type=AVC msg=audit(07/03/2024 02:09:46.826:653) : avc:  denied  { read } for  pid=6617 comm=prio-rpc-virtqe name=stat dev="proc" ino=29798 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virt_dbus_t:s0 tclass=file permissive=1 type=AVC msg=audit(07/03/2024 02:09:46.826:653) : avc:  denied  { search } for  pid=6617 comm=prio-rpc-virtqe name=6531 dev="proc" ino=29780 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virt_dbus_t:s0 tclass=dir permissive=1

Resolves: RHEL-37822