### PR TITLE
Allow virt_dbus_t connect to virtqemud_t over a unix stream socket

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2447,6 +2447,7 @@ allow virt_dbus_t virt_var_run_t:sock_file write_sock_file_perms;
 
 # ipc to other virt domains
 allow virt_dbus_t virtproxyd_t:unix_stream_socket connectto;
+allow virt_dbus_t virtqemud_t:unix_stream_socket connectto;
 allow virt_dbus_t virtqemud_var_run_t:sock_file write;
 
 kernel_read_proc_files(virt_dbus_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/03/2024 02:09:46.794:651) : proctitle=/usr/sbin/libvirt-dbus --system type=SYSCALL msg=audit(07/03/2024 02:09:46.794:651) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x7 a1=0x7fd023dff4a0 a2=0x6e a3=0x7fd018006960 items=0 ppid=1 pid=6531 auid=unset uid=libvirtdbus gid=libvirtdbus euid=libvirtdbus suid=libvirtdbus fsuid=libvirtdbus egid=libvirtdbus sgid=libvirtdbus fsgid=libvirtdbus tty=(none) ses=unset comm=pool-libvirt-db exe=/usr/sbin/libvirt-dbus subj=system_u:system_r:virt_dbus_t:s0 key=(null) type=AVC msg=audit(07/03/2024 02:09:46.794:651) : avc:  denied  { connectto } for  pid=6531 comm=pool-libvirt-db path=/run/libvirt/virtqemud-sock scontext=system_u:system_r:virt_dbus_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=unix_stream_socket permissive=1

Resolves: RHEL-37822