### PR TITLE
Label /run/coreos-installer-reboot with coreos_installer_var_run_t

### DIFF
--- a/policy/modules/contrib/coreos_installer.fc
+++ b/policy/modules/contrib/coreos_installer.fc
@@ -5,3 +5,5 @@
 
 /usr/lib/systemd/system-generators/coreos-installer-generator	--	gen_context(system_u:object_r:coreos_installer_exec_t,s0)
 /usr/lib/systemd/system/coreos-installer.*			--	gen_context(system_u:object_r:coreos_installer_unit_file_t,s0)
+
+/run/coreos-installer-reboot	--	gen_context(system_u:object_r:coreos_installer_var_run_t,s0)

--- a/policy/modules/contrib/coreos_installer.te
+++ b/policy/modules/contrib/coreos_installer.te
@@ -12,6 +12,9 @@ init_daemon_domain(coreos_installer_t, coreos_installer_exec_t)
 type coreos_installer_unit_file_t;
 systemd_unit_file(coreos_installer_unit_file_t)
 
+type coreos_installer_var_run_t;
+files_pid_file(coreos_installer_var_run_t)
+
 ########################################
 #
 # coreos_installer local policy
@@ -20,6 +23,9 @@ allow coreos_installer_t self:capability { setgid setuid sys_admin };
 allow coreos_installer_t self:process { fork setpgid };
 allow coreos_installer_t self:fifo_file rw_fifo_file_perms;
 allow coreos_installer_t self:unix_stream_socket create_stream_socket_perms;
+
+allow coreos_installer_t coreos_installer_var_run_t:file manage_file_perms;
+files_pid_filetrans(coreos_installer_t, coreos_installer_var_run_t, file)
 
 kernel_read_proc_files(coreos_installer_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denials:
audit: type=1400 audit(1720804444.438:7): avc:  denied  { write } for  pid=891 comm="touch" name="/" dev="tmpfs" ino=1 scontext=system_u:system_r:coreos_installer_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=1 audit: type=1400 audit(1720804444.440:8): avc:  denied  { add_name } for  pid=891 comm="touch" name="coreos-installer-reboot" scontext=system_u:system_r:coreos_installer_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=1 audit: type=1400 audit(1720804444.442:9): avc:  denied  { create } for  pid=891 comm="touch" name="coreos-installer-reboot" scontext=system_u:system_r:coreos_installer_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=1 audit: type=1400 audit(1720804444.444:10): avc:  denied  { write open } for  pid=891 comm="touch" path="/run/coreos-installer-reboot" dev="tmpfs" ino=525 scontext=system_u:system_r:coreos_installer_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=1

Resolves: RHEL-38614