### PR TITLE
Label samba certificates with samba_cert_t

### DIFF
--- a/policy/modules/contrib/samba.fc
+++ b/policy/modules/contrib/samba.fc
@@ -43,6 +43,9 @@
 
 /var/lib/samba(/.*)?			gen_context(system_u:object_r:samba_var_t,s0)
 /var/lib/samba/winbindd_privileged(/.*)? gen_context(system_u:object_r:winbind_var_run_t,s0)
+/var/lib/samba/certs(/.*)?		gen_context(system_u:object_r:samba_cert_t,s0)
+/var/lib/samba/private/certs(/.*)?	gen_context(system_u:object_r:samba_cert_t,s0)
+
 
 /var/log/samba(/.*)?			gen_context(system_u:object_r:samba_log_t,s0)
 

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -126,6 +126,9 @@ files_type(samba_spool_t)
 type samba_var_t;
 files_type(samba_var_t)
 
+type samba_cert_t;
+miscfiles_cert_type(samba_cert_t)
+
 type samba_gpupdate_t;
 type samba_gpupdate_exec_t;
 application_domain(samba_gpupdate_t, samba_gpupdate_exec_t)


### PR DESCRIPTION
Certificates are downloaded into /var/lib/samba/certs and certificate keys into /var/lib/samba/private/certs.

Resolves: RHEL-25724