### PR TITLE
Remove all file context entries for /bin and /lib

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -1,22 +1,4 @@
 #
-# /bin
-#
-/bin					gen_context(system_u:object_r:bin_t,s0)
-/bin/.*					gen_context(system_u:object_r:bin_t,s0)
-/bin/d?ash			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/esh			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/bash			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/bash2			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/fish			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/ksh.*			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/mksh			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/mountpoint			--	gen_context(system_u:object_r:bin_t,s0)
-/bin/sash			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/tcsh			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/yash			--	gen_context(system_u:object_r:shell_exec_t,s0)
-/bin/zsh.*			--	gen_context(system_u:object_r:shell_exec_t,s0)
-
-#
 # /dev
 #
 /dev/MAKEDEV			--	gen_context(system_u:object_r:bin_t,s0)
@@ -147,31 +129,6 @@ ifdef(`distro_debian',`
 /etc/dhcp/scripts(/.*)?			gen_context(system_u:object_r:bin_t,s0)
 
 #
-# /lib
-#
-
-/lib/nut/.*			--	gen_context(system_u:object_r:bin_t,s0)
-/lib/readahead(/.*)?			gen_context(system_u:object_r:bin_t,s0)
-/lib/security/pam_krb5/pam_krb5_storetmp -- gen_context(system_u:object_r:bin_t,s0)
-/usr/lib64/security/pam_krb5/pam_krb5_cchelper	--	gen_context(system_u:object_r:bin_t,s0)
-/lib/udev/[^/]*			--	gen_context(system_u:object_r:bin_t,s0)
-/lib/udev/devices/MAKEDEV	-l	gen_context(system_u:object_r:bin_t,s0)
-/lib/udev/scsi_id		--	gen_context(system_u:object_r:bin_t,s0)
-/lib/upstart(/.*)?			gen_context(system_u:object_r:bin_t,s0)
-/lib/security/pam_krb5(/.*)?		gen_context(system_u:object_r:bin_t,s0)
-
-ifdef(`distro_gentoo',`
-/lib/dhcpcd/dhcpcd-run-hooks	--	gen_context(system_u:object_r:bin_t,s0)
-
-/lib/rcscripts/addons(/.*)?		gen_context(system_u:object_r:bin_t,s0)
-/lib/rcscripts/sh(/.*)?			gen_context(system_u:object_r:bin_t,s0)
-/lib/rcscripts/net\.modules\.d/helpers\.d/dhclient-.* -- gen_context(system_u:object_r:bin_t,s0)
-/lib/rcscripts/net\.modules\.d/helpers\.d/udhcpc-.* -- gen_context(system_u:object_r:bin_t,s0)
-')
-
-/usr/lib/erlang/erts.*/bin(/.*)?        gen_context(system_u:object_r:bin_t,s0)
-
-#
 # /opt
 #
 /opt/(.*/)?bin(/.*)?			gen_context(system_u:object_r:bin_t,s0)
@@ -239,6 +196,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/cyrus-imapd/.*	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/dotnet/dotnet	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/dpkg/.+		--	gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/erlang/erts.*/bin(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/emacsen-common/.*		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/gimp/.*/plug-ins(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/gnome-settings-daemon/.* --	gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
The /bin and /lib top level directories are now a subject of file equivalency settings, so all entries inside them are overriden by the equivalency.