### PR TITLE
Update afterburn file transition policy

### DIFF
--- a/policy/modules/contrib/afterburn.te
+++ b/policy/modules/contrib/afterburn.te
@@ -26,7 +26,7 @@ allow afterburn_t self:unix_dgram_socket create_socket_perms;
 
 allow afterburn_t afterburn_runtime_t:dir manage_dir_perms;
 manage_files_pattern(afterburn_t, afterburn_runtime_t, afterburn_runtime_t)
-files_pid_filetrans(afterburn_t, afterburn_runtime_t, dir)
+files_pid_filetrans(afterburn_t, afterburn_runtime_t, dir, "metadata")
 
 kernel_dgram_send(afterburn_t)
 kernel_read_all_proc(afterburn_t)


### PR DESCRIPTION
Update afterburn policy to contain the /run/metadata dir name in the file transition rule.