### PR TITLE
Allow init_t nnp domain transition to firewalld_t

### DIFF
--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -8,6 +8,7 @@ policy_module(firewalld, 1.1.1)
 type firewalld_t;
 type firewalld_exec_t;
 init_daemon_domain(firewalld_t, firewalld_exec_t)
+init_nnp_daemon_domain(firewalld_t)
 
 type firewalld_initrc_exec_t;
 init_script_file(firewalld_initrc_exec_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/22/2024 18:40:52.987:5580) : proctitle=/usr/bin/python3 -sP /usr/sbin/firewalld --nofork --nopid type=PATH msg=audit(07/22/2024 18:40:52.987:5580) : item=2 name=/lib64/ld-linux-x86-64.so.2 inode=43227 dev=00:26 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(07/22/2024 18:40:52.987:5580) : item=1 name=/usr/bin/python3 inode=3322 dev=00:26 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:bin_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(07/22/2024 18:40:52.987:5580) : item=0 name=/usr/sbin/firewalld inode=89459 dev=00:26 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:firewalld_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(07/22/2024 18:40:52.987:5580) : argc=5 a0=/usr/bin/python3 a1=-sP a2=/usr/sbin/firewalld a3=--nofork a4=--nopid type=BPRM_FCAPS msg=audit(07/22/2024 18:40:52.987:5580) : fver=0 fp=none fi=none fe=0 old_pp=chown,dac_override,dac_read_search,fowner,fsetid,kill,setgid,setuid,setpcap,linux_immutable,net_bind_service,net_broadcast,net_admin,net_raw,ipc_lock,ipc_owner,sys_module,sys_rawio,sys_chroot,sys_ptrace,sys_pacct,sys_admin,sys_boot,sys_nice,sys_resource,sys_time,sys_tty_config,mknod,lease,audit_write,audit_control,setfcap,mac_override,mac_admin,syslog,wake_alarm,block_suspend,audit_read,perfmon,bpf,checkpoint_restore old_pi=none old_pe=chown,dac_override,dac_read_search,fowner,fsetid,kill,setgid,setuid,setpcap,linux_immutable,net_bind_service,net_broadcast,net_admin,net_raw,ipc_lock,ipc_owner,sys_module,sys_rawio,sys_chroot,sys_ptrace,sys_pacct,sys_admin,sys_boot,sys_nice,sys_resource,sys_time,sys_tty_config,mknod,lease,audit_write,audit_control,setfcap,mac_override,mac_admin,syslog,wake_alarm,block_suspend,audit_read,perfmon,bpf,checkpoint_restore old_pa=none pp=chown,dac_override,dac_read_search,fowner,fsetid,kill,setgid,setuid,setpcap,linux_immutable,net_bind_service,net_broadcast,net_admin,net_raw,ipc_lock,ipc_owner,sys_module,sys_chroot,sys_ptrace,sys_pacct,sys_admin,sys_boot,sys_nice,sys_resource,sys_tty_config,lease,audit_write,audit_control,setfcap,mac_override,mac_admin,block_suspend,audit_read,perfmon,bpf,checkpoint_restore pi=none pe=chown,dac_override,dac_read_search,fowner,fsetid,kill,setgid,setuid,setpcap,linux_immutable,net_bind_service,net_broadcast,net_admin,net_raw,ipc_lock,ipc_owner,sys_module,sys_chroot,sys_ptrace,sys_pacct,sys_admin,sys_boot,sys_nice,sys_resource,sys_tty_config,lease,audit_write,audit_control,setfcap,mac_override,mac_admin,block_suspend,audit_read,perfmon,bpf,checkpoint_restore pa=none frootid=0 type=SYSCALL msg=audit(07/22/2024 18:40:52.987:5580) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55ce64735120 a1=0x55ce644e9090 a2=0x55ce64087860 a3=0x0 items=3 ppid=1 pid=193143 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=firewalld exe=/usr/bin/python3.13 subj=system_u:system_r:init_t:s0 key=(null) type=SELINUX_ERR msg=audit(07/22/2024 18:40:52.987:5580) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:firewalld_t:s0 type=AVC msg=audit(07/22/2024 18:40:52.987:5580) : avc:  denied  { nnp_transition } for  pid=193143 comm=(irewalld) scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:firewalld_t:s0 tclass=process2 permissive=0