### PR TITLE
Revert to permissive for coreos-installer & bootupd

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -15,6 +15,8 @@ systemd_unit_file(bootupd_unit_file_t)
 type bootupd_var_run_t;
 files_pid_file(bootupd_var_run_t)
 
+permissive bootupd_t;
+
 ########################################
 #
 # bootupd local policy

--- a/policy/modules/contrib/coreos_installer.te
+++ b/policy/modules/contrib/coreos_installer.te
@@ -39,6 +39,8 @@ files_type(coreos_sulogin_force_generator_unit_file_t)
 type coreos_installer_var_run_t;
 files_pid_file(coreos_installer_var_run_t)
 
+permissive coreos_installer_t;
+
 ########################################
 #
 # coreos_installer local policy


### PR DESCRIPTION
Temporarily revert to permissive for those domains so that we have time to fix the issues that we missed earlier.

---

Revert "Remove permissive domain for bootupd_t"

This reverts commit 0cbc7da8130fd7cf030ab61f68a3eb449a8d6391.

---

Revert "Remove permissive domain for coreos_installer_t"

This reverts commit cd99e90ef9fc952ac9925a9f42befc9bd14ea5e4.