### PR TITLE
Allow systemd_getty_generator_t to read and write to tty_device_t

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2251,6 +2251,7 @@ files_pid_filetrans(virtstoraged_t, virtstoraged_var_run_t, { dir file sock_file
 filetrans_pattern(virtstoraged_t, virt_var_run_t, virtstoraged_var_run_t, { file sock_file } )
 
 manage_dirs_pattern(virtstoraged_t, virt_content_t, virt_content_t)
+manage_files_pattern(virtstoraged_t, virt_content_t, virt_content_t)
 
 manage_dirs_pattern(virtstoraged_t, virt_image_t, virt_image_t)
 manage_files_pattern(virtstoraged_t, virt_image_t, virt_image_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -502,6 +502,10 @@ storage_rw_inherited_fixed_disk_dev(svirt_t)
 
 userdom_read_all_users_state(svirt_t)
 
+optional_policy(`
+	unconfined_stream_connect(svirt_t)
+')
+
 #######################################
 #
 # svirt_prot_exec local policy

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2165,6 +2165,7 @@ fs_manage_tmpfs_symlinks(virtqemud_t)
 fs_mount_tmpfs(virtqemud_t)
 fs_read_nsfs_files(virtqemud_t)
 fs_relabel_tmpfs_chr_file(virtqemud_t)
+fs_unmount_xattr_fs(virtqemud_t)
 
 seutil_read_default_contexts(virtqemud_t)
 seutil_read_file_contexts(virtqemud_t)

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -83,6 +83,7 @@ type ssh_exec_t;
 typealias ssh_t alias { user_ssh_t staff_ssh_t sysadm_ssh_t };
 typealias ssh_t alias { auditadm_ssh_t secadm_ssh_t };
 userdom_user_application_domain(ssh_t, ssh_exec_t)
+role system_r types ssh_t;
 
 type ssh_agent_exec_t;
 corecmd_executable_file(ssh_agent_exec_t)

--- a/policy/modules/system/modutils.fc
+++ b/policy/modules/system/modutils.fc
@@ -34,5 +34,6 @@ ifdef(`distro_gentoo',`
 
 /usr/lib/modules/modprobe\.conf -- 	gen_context(system_u:object_r:modules_conf_t,s0)
 
+/run/modprobe\.d(/.*)?		gen_context(system_u:object_r:modules_conf_t,s0)
 /run/tmpfiles.d/kmod.conf --	gen_context(system_u:object_r:kmod_var_run_t,s0)
 /run/tmpfiles.d/static-nodes.conf --	gen_context(system_u:object_r:kmod_var_run_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1291,7 +1291,7 @@ optional_policy(`
 
 ### getty generator
 dev_read_sysfs(systemd_getty_generator_t)
-term_open_unallocated_ttys(systemd_getty_generator_t)
+term_use_unallocated_ttys(systemd_getty_generator_t)
 
 ### gpt generator
 allow systemd_gpt_generator_t self:capability sys_rawio;


### PR DESCRIPTION
systemd getty generator can not auto-add serial getty on ttyS0 on boot without reading and writing /dev/ttyS0 (tty_device_t)

see https://github.com/systemd/systemd/blob/22b414f185827e905c81949ae8a30a7d8d3ae17c/src/getty-generator/getty-generator.c#L262

Adresses:
type=AVC msg=audit(1721035205.661:184): avc:  denied  { read write } for  pid=1669 comm="systemd-getty-g" name="ttyS0" dev="devtmpfs" ino=88 scontext=system_u:system_r:systemd_getty_generator_t:s0 tcontext=system_u:object_r:tty_device_t:s0 tclass=chr_file permissive=0