### PR TITLE
Allow ssh_t to change role to system_r

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -83,6 +83,7 @@ type ssh_exec_t;
 typealias ssh_t alias { user_ssh_t staff_ssh_t sysadm_ssh_t };
 typealias ssh_t alias { auditadm_ssh_t secadm_ssh_t };
 userdom_user_application_domain(ssh_t, ssh_exec_t)
+role system_r types ssh_t;
 
 type ssh_agent_exec_t;
 corecmd_executable_file(ssh_agent_exec_t)


### PR DESCRIPTION
The commit addresses the following SELINUX_ERR denial: audit: SELINUX_ERR op=security_compute_sid invalid_context="system_u:system_r:ssh_t:s0" scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:ssh_exec_t:s0 tclass=process