### PR TITLE
Allow systemd_gpt_generator to getattr on DOS directories

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1325,6 +1325,7 @@ files_list_tmp(systemd_gpt_generator_t)
 files_list_usr(systemd_gpt_generator_t)
 files_list_var(systemd_gpt_generator_t)
 
+fs_getattr_dos_dirs(systemd_gpt_generator_t)
 fs_mount_tmpfs(systemd_gpt_generator_t)
 
 mls_file_read_to_clearance(systemd_gpt_generator_t)


### PR DESCRIPTION
Fixes #2266

systemd-gpt-auto-generator accesses /boot to figure out whether it should mount the XBOOTLDR or ESP partition there so it should be allowed to access /boot.