### PR TITLE
Update stalld policy for bpf usage

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -19,8 +19,9 @@ files_pid_file(stalld_var_run_t)
 #
 # stalld local policy
 #
-allow stalld_t self:capability sys_nice;
-allow stalld_t self:process { fork setsched };
+allow stalld_t self:bpf { map_create map_read map_write prog_load prog_run };
+allow stalld_t self:capability { sys_nice sys_resource };
+allow stalld_t self:process { fork setsched setrlimit };
 allow stalld_t self:fifo_file rw_fifo_file_perms;
 allow stalld_t self:unix_stream_socket create_stream_socket_perms;
 


### PR DESCRIPTION
The new stalld version makes use of bpf programs to monitor run queues instead of parsing /sys/kernel/debug/sched/debug. For changing thread scheduling policies, CAP_SYS_RESOURCE is required.

Resolves: RHEL-50356