### PR TITLE
Update bootupd policy

### DIFF
--- a/policy/modules/contrib/bootupd.fc
+++ b/policy/modules/contrib/bootupd.fc
@@ -4,4 +4,5 @@
 /usr/lib/systemd/system/bootupd\.service	--	gen_context(system_u:object_r:bootupd_unit_file_t,s0)
 /usr/lib/systemd/system/bootupd\.socket		--	gen_context(system_u:object_r:bootupd_unit_file_t,s0)
 
+/run/bootupd-lock			--	gen_context(system_u:object_r:bootupd_var_run_t,s0)
 /run/bootupd\.sock			-s	gen_context(system_u:object_r:bootupd_var_run_t,s0)

--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -25,10 +25,19 @@ allow bootupd_t self:fifo_file rw_fifo_file_perms;
 allow bootupd_t self:unix_dgram_socket create_socket_perms;
 allow bootupd_t self:unix_stream_socket create_stream_socket_perms;
 
+manage_files_pattern(bootupd_t, bootupd_var_run_t, bootupd_var_run_t)
+manage_sock_files_pattern(bootupd_t, bootupd_var_run_t, bootupd_var_run_t)
+files_pid_filetrans(bootupd_t, bootupd_var_run_t, { file sock_file })
+
 kernel_dgram_send(bootupd_t)
+
+corecmd_exec_bin(bootupd_t)
+
+dev_read_sysfs(bootupd_t)
 
 domain_use_interactive_fds(bootupd_t)
 
+files_create_boot_dirs(bootupd_t)
 files_read_etc_files(bootupd_t)
 
 fs_getattr_all_fs(bootupd_t)
@@ -36,5 +45,22 @@ fs_search_dos(bootupd_t)
 fs_search_efivarfs_dirs(bootupd_t)
 
 optional_policy(`
+	bootloader_domtrans(bootupd_t)
+')
+
+optional_policy(`
+	miscfiles_read_certs(bootupd_t)
 	miscfiles_read_localization(bootupd_t)
+')
+
+optional_policy(`
+	mount_domtrans(bootupd_t)
+')
+
+optional_policy(`
+	udev_domtrans(bootupd_t)
+')
+
+optional_policy(`
+	userdom_use_inherited_user_ptys(bootupd_t)
 ')


### PR DESCRIPTION
Label /run/bootupd-lock with bootupd_var_run_t.
Allow bootupd manage files in /boot.
Allow bootupd execute generic executables.
Allow bootupd execute bootloader, mount, udev with a transition. Allow bootupd read generic certificates.
Allow bootupd read sysfs files.

Resolves: rhbz#2300306