### PR TITLE
Update fstab and cryptsetup generators

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1286,11 +1286,13 @@ init_read_state(systemd_generator)
 fs_read_efivarfs_files(systemd_bless_boot_generator_t)
 
 ### cryptsetup generator
-allow systemd_cryptsetup_generator_t systemd_fstab_generator_unit_file_t:file rw_file_perms;
+manage_dirs_pattern(systemd_cryptsetup_generator_t, systemd_fstab_generator_unit_file_t, systemd_fstab_generator_unit_file_t)
+manage_files_pattern(systemd_cryptsetup_generator_t, systemd_fstab_generator_unit_file_t, systemd_fstab_generator_unit_file_t)
 
 ### fstab generator
 allow systemd_fstab_generator_t self:capability { dac_override dac_read_search };
-allow systemd_fstab_generator_t systemd_cryptsetup_generator_unit_file_t:file rw_file_perms;
+manage_dirs_pattern(systemd_fstab_generator_t, systemd_cryptsetup_generator_unit_file_t, systemd_cryptsetup_generator_unit_file_t)
+manage_files_pattern(systemd_fstab_generator_t, systemd_cryptsetup_generator_unit_file_t, systemd_cryptsetup_generator_unit_file_t)
 
 create_lnk_files_pattern(systemd_fstab_generator_t, systemd_unit_file_type, systemd_unit_file_type)
 


### PR DESCRIPTION
Allow fstab manage cryptsetup generator's unit files and dirs and vice versa.

The commit addresses the following AVC denial:
type=AVC msg=audit(1722073651.126:597): avc:  denied  { write } for  pid=7236 comm="systemd-cryptse" name="dev-mapper-luks\x2d6a64436f\x2d49f1\x2d4a78\x2dbae4\x2dba5a914ba31d.device.d" dev="tmpfs" ino=4382 scontext=system_u:system_r:systemd_cryptsetup_generator_t:s0 tcontext=system_u:object_r:systemd_fstab_generator_unit_file_t:s0 tclass=dir permissive=0

Resolves: rhbz#2300244