### PR TITLE
Allow initrc_t transition to passwd_t

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1339,6 +1339,10 @@ ifdef(`distro_redhat',`
 	')
 
 	optional_policy(`
+		usermanage_run_passwd(initrc_t, system_r)
+	')
+
+	optional_policy(`
 		wdmd_manage_pid_files(initrc_t)
 	')
 


### PR DESCRIPTION
Allow initrc_t transition to passwd_t when passwd and chpasswd executables or other ones labeled with passwd_exec_t are run.

Resolves: RHEL-17404