### PR TITLE
Allow rhsmcertd read, write, and map ica tmpfs files

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -162,6 +162,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ica_rw_map_tmpfs_files(rhsmcertd_t)
+')
+
+optional_policy(`
 	insights_client_read_config(rhsmcertd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1721649717.737:22248): avc: denied { read write } for pid=402528 comm="rhsmcertd-worke" name="icastats_0" dev="tmpfs" ino=64 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=unconfined_u:object_r:ica_tmpfs_t:s0 tclass=file permissive=0

Resolves: RHEL-50926