### PR TITLE
Allow microcode create /sys/devices/system/cpu/microcode/reload

### DIFF
--- a/policy/modules/contrib/cpucontrol.te
+++ b/policy/modules/contrib/cpucontrol.te
@@ -72,6 +72,7 @@ kernel_read_system_state(cpucontrol_t)
 
 auth_use_nsswitch(cpucontrol_t)
 
+dev_create_sysfs_files(cpucontrol_t)
 dev_rw_sysfs(cpucontrol_t)
 dev_rw_cpu_microcode(cpucontrol_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/27/2024 07:12:26.337:658) : proctitle=/usr/bin/bash -efu /usr/libexec/microcode_ctl/reload_microcode type=PATH msg=audit(02/27/2024 07:12:26.337:658) : item=1 name=/sys/devices/system/cpu/microcode/reload nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(02/27/2024 07:12:26.337:658) : item=0 name=/sys/devices/system/cpu/microcode/ inode=112738 dev=00:15 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/27/2024 07:12:26.337:658) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x5640f0df42f0 a2=O_WRONLY|O_CREAT|O_TRUNC a3=0x1b6 items=2 ppid=1 pid=51594 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=reload_microcod exe=/usr/bin/bash subj=system_u:system_r:cpucontrol_t:s0 key=(null) type=AVC msg=audit(02/27/2024 07:12:26.337:658) : avc:  denied  { create } for  pid=51594 comm=reload_microcod name=reload scontext=system_u:system_r:cpucontrol_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1 type=AVC msg=audit(02/27/2024 07:12:26.337:658) : avc:  denied  { add_name } for  pid=51594 comm=reload_microcod name=reload scontext=system_u:system_r:cpucontrol_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1 type=AVC msg=audit(02/27/2024 07:12:26.337:658) : avc:  denied  { write } for  pid=51594 comm=reload_microcod name=microcode dev="sysfs" ino=112738 scontext=system_u:system_r:cpucontrol_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1

Resolves: RHEL-26821