### PR TITLE
Allow postfix_domain map postfix_etc_t files

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -814,6 +814,7 @@ allow postfix_domain postfix_master_t:unix_dgram_socket sendto;
 allow postfix_domain postfix_master_t:file read;
 allow postfix_domain postfix_etc_t:dir list_dir_perms;
 read_files_pattern(postfix_domain, postfix_etc_t, postfix_etc_t)
+allow postfix_domain postfix_etc_t:file map;
 read_lnk_files_pattern(postfix_domain, postfix_etc_t, postfix_etc_t)
 
 allow postfix_domain postfix_exec_t:file { mmap_file_perms lock };


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(07/04/2024 11:31:46.789:700) : proctitle=cleanup -z -t unix -u type=SYSCALL msg=audit(07/04/2024 11:31:46.789:700) : arch=x86_64 syscall=mmap success=yes exit=140271979331584 a0=0x0 a1=0x1000000 a2=PROT_READ a3=MAP_SHARED items=0 ppid=9793 pid=9906 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=cleanup exe=/usr/libexec/postfix/cleanup subj=system_u:system_r:postfix_cleanup_t:s0 key=(null) type=AVC msg=audit(07/04/2024 11:31:46.789:700) : avc:  denied  { map } for  pid=9906 comm=cleanup path=/etc/postfix/virtual.lmdb dev="vda2" ino=31457426 scontext=system_u:system_r:postfix_cleanup_t:s0 tcontext=unconfined_u:object_r:postfix_etc_t:s0 tclass=file permissive=1

Resolves: RHEL-46332