### PR TITLE
Allow systemd-pstore send a message to syslogd over a unix domain

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1771,6 +1771,10 @@ fs_read_pstore_files(systemd_pstore_t)
 
 init_search_var_lib_dirs(systemd_pstore_t)
 
+optional_policy(`
+	logging_dgram_send(systemd_pstore_t)
+')
+
 ########################################
 #
 # systemd_mountfsd local policy


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/24/2024 18:32:36.742:2420) : proctitle=/usr/lib/systemd/systemd-pstore type=PATH msg=audit(06/24/2024 18:32:36.742:2420) : item=0 name=/run/systemd/journal/socket inode=35 dev=00:17 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:syslogd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(06/24/2024 18:32:36.742:2420) : saddr={ saddr_fam=local path=/run/systemd/journal/socket } type=SYSCALL msg=audit(06/24/2024 18:32:36.742:2420) : arch=aarch64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x3 a1=0xffffdeae4f18 a2=0x1e a3=0xffa5ef950020 items=1 ppid=1 pid=288863 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-pstore exe=/usr/lib/systemd/systemd-pstore subj=system_u:system_r:systemd_pstore_t:s0 key=(null) type=AVC msg=audit(06/24/2024 18:32:36.742:2420) : avc:  denied  { sendto } for  pid=288863 comm=systemd-pstore path=/run/systemd/journal/socket scontext=system_u:system_r:systemd_pstore_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: RHEL-45528