### PR TITLE
Allow systemd-hostnamed shut down nscd

### DIFF
--- a/policy/modules/contrib/nscd.if
+++ b/policy/modules/contrib/nscd.if
@@ -340,6 +340,25 @@ interface(`nscd_systemctl',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain shut down nscd.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`nscd_shutdown',`
+	gen_require(`
+		type nscd_t;
+		class nscd admin;
+	')
+
+	allow $1 nscd_t:nscd admin;
+')
+
+########################################
+## <summary>
 ##	All of the rules required to administrate 
 ##	an nscd environment
 ## </summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -994,6 +994,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	nscd_shutdown(systemd_hostnamed_t)
+')
+
+optional_policy(`
 	udev_read_pid_files(systemd_hostnamed_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(06/24/2024 17:45:24.258:695) : pid=42475 uid=nscd auid=unset ses=unset subj=system_u:system_r:nscd_t:s0 msg='avc: denied { admin } for scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:system_r:nscd_t:s0 tclass=nscd permissive=0 exe=/usr/sbin/nscd sauid=nscd hostname=? addr=? terminal=?'

Resolves: RHEL-45033