### PR TITLE
Allow abrt-dump-journal-core connect to winbindd

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -592,6 +592,10 @@ logging_watch_journal_dir(abrt_dump_oops_t)
 init_read_var_lib_files(abrt_dump_oops_t)
 
 optional_policy(`
+	samba_stream_connect_winbind(abrt_dump_oops_t)
+')
+
+optional_policy(`
     sssd_read_public_files(abrt_dump_oops_t)
     sssd_stream_connect(abrt_dump_oops_t)
 ')


### PR DESCRIPTION
abrt-dump-journal-core was allowed to connect to winbindd over a unix socket.

The commit addresses the following AVC denials:
type=AVC msg=audit(1722370583.663:53756): avc:  denied  { connectto } for  pid=2385 comm="abrt-dump-journ" path="/run/samba/winbindd/pipe" scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:system_r:winbind_t:s0 tclass=unix_stream_socket permissive=1 type=AVC msg=audit(1722370583.663:53755): avc:  denied  { write } for  pid=2385 comm="abrt-dump-journ" name="pipe" dev="tmpfs" ino=3370 scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:object_r:winbind_var_run_t:s0 tclass=sock_file permissive=1

Resolves: rhbz#2301815