### PR TITLE
Allow libvirt-dbus stream connect to virtlxcd

### DIFF
--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -398,6 +398,24 @@ interface(`virt_rw_stream_sockets_svirt',`
 	allow $1 svirt_t:unix_stream_socket { getopt read setopt write };
 ')
 
+#######################################
+## <summary>
+##	Connect to lxc process over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_stream_connect_lxc',`
+	gen_require(`
+		type virtd_lxc_t, virt_lxc_var_run_t;
+	')
+
+	stream_connect_pattern($1, virt_lxc_var_run_t, virt_lxc_var_run_t, virtd_lxc_t)
+')
+
 ########################################
 ## <summary>
 ##	Allow domain to attach to virt TUN devices

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2499,6 +2499,7 @@ allow virt_dbus_t virt_var_run_t:sock_file write_sock_file_perms;
 allow virt_dbus_t virtproxyd_t:unix_stream_socket connectto;
 allow virt_dbus_t virtqemud_t:unix_stream_socket connectto;
 allow virt_dbus_t virtqemud_var_run_t:sock_file write;
+virt_stream_connect_lxc(virt_dbus_t)
 
 kernel_read_proc_files(virt_dbus_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/01/2024 03:51:07.320:1414) : proctitle=/usr/sbin/libvirt-dbus --system type=PATH msg=audit(08/01/2024 03:51:07.320:1414) : item=0 name=/var/run/libvirt/virtlxcd-sock inode=2230 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:virt_lxc_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(08/01/2024 03:51:07.320:1414) : saddr={ saddr_fam=local path=/var/run/libvirt/virtlxcd-sock } type=SYSCALL msg=audit(08/01/2024 03:51:07.320:1414) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x7 a1=0x7ffb5fdff400 a2=0x6e a3=0x7ffb540026a0 items=1 ppid=1 pid=5324 auid=unset uid=libvirtdbus gid=libvirtdbus euid=libvirtdbus suid=libvirtdbus fsuid=libvirtdbus egid=libvirtdbus sgid=libvirtdbus fsgid=libvirtdbus tty=(none) ses=unset comm=pool-libvirt-db exe=/usr/sbin/libvirt-dbus subj=system_u:system_r:virt_dbus_t:s0 key=(null) type=AVC msg=audit(08/01/2024 03:51:07.320:1414) : avc:  denied  { connectto } for  pid=5324 comm=pool-libvirt-db path=/run/libvirt/virtlxcd-sock scontext=system_u:system_r:virt_dbus_t:s0 tcontext=system_u:system_r:virtd_lxc_t:s0 tclass=unix_stream_socket permissive=1 type=AVC msg=audit(08/01/2024 03:51:07.320:1414) : avc:  denied  { write } for  pid=5324 comm=pool-libvirt-db name=virtlxcd-sock dev="tmpfs" ino=2230 scontext=system_u:system_r:virt_dbus_t:s0 tcontext=system_u:object_r:virt_lxc_var_run_t:s0 tclass=sock_file permissive=1

Resolves: rhbz#2302209