### PR TITLE
Label /var/lib/systemd/sleep with systemd_sleep_var_lib_t

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -101,6 +101,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/lib/systemd/pstore(/.*)?         gen_context(system_u:object_r:systemd_pstore_var_lib_t,s0)
 /var/lib/systemd/rfkill(/.*)?         gen_context(system_u:object_r:systemd_rfkill_var_lib_t,s0)
 /var/lib/systemd/linger(/.*)?  		gen_context(system_u:object_r:systemd_logind_var_lib_t,mls_systemhigh)
+/var/lib/systemd/sleep(/.*)? 		gen_context(system_u:object_r:systemd_sleep_var_lib_t,s0)
 /var/lib/systemd/timesync(/.*)? 		gen_context(system_u:object_r:systemd_timedated_var_lib_t,s0)
 /var/lib/private/systemd/journal-upload(/.*)?		gen_context(system_u:object_r:systemd_journal_upload_var_lib_t,s0)
 /var/lib/private/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_lib_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -262,6 +262,8 @@ type systemd_userdbd_runtime_t;
 files_pid_file(systemd_userdbd_runtime_t)
 
 systemd_domain_template(systemd_sleep)
+type systemd_sleep_var_lib_t;
+files_type(systemd_sleep_var_lib_t)
 
 systemd_domain_template(systemd_pstore)
 type systemd_pstore_var_lib_t;
@@ -1720,6 +1722,8 @@ allow systemd_sleep_t self:capability2 wake_alarm;
 dontaudit systemd_sleep_t self:capability sys_ptrace;
 
 allow systemd_sleep_t systemd_unit_file_t:service { start stop };
+
+manage_files_pattern(systemd_sleep_t, systemd_sleep_var_lib_t, systemd_sleep_var_lib_t)
 
 kernel_dgram_send(systemd_sleep_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1722809012.514:3265): avc:  denied  { create } for  pid=646810 comm="systemd-sleep" name="battery_discharge_percentage_rate_per_hour" scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:object_r:init_var_lib_t:s0 tclass=file permissive=0

Resolves: rhbz#2302750