### PR TITLE
Allow tlp status power services

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -111,6 +111,7 @@ optional_policy(`
 	systemd_exec_systemctl(tlp_t)
 	systemd_read_unit_files(tlp_t)
 	systemd_search_unit_dirs(tlp_t)
+	systemd_status_power_services(tlp_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: Jun 27 00:27:20 hostname audit[1]: USER_AVC pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=0 gid=0 path="/usr/lib/systemd/system/power-profiles-daemon.service" cmdline="" function="mac_selinux_filter" scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:object_r:power_unit_file_t:s0 tclass=service permissive=1 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'

Resolves: rhbz#2292626