### PR TITLE
Allow virtqemud domain transition on passt execution

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2226,6 +2226,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	passt_domtrans(virtqemud_t)
+')
+
+optional_policy(`
 	policykit_dbus_chat(virtqemud_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(1.7.2024 11:36:30.545:199) : proctitle=/usr/sbin/virtqemud --timeout 120 type=SYSCALL msg=audit(1.7.2024 11:36:30.545:199) : arch=x86_64 syscall=access success=yes exit=0 a0=0x7fa70c048e89 a1=X_OK a2=0x8 a3=0x0 items=0 ppid=1 pid=2816 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(1.7.2024 11:36:30.545:199) : avc:  denied  { execute } for  pid=2816 comm=rpc-virtqemud name=passt dev="dm-0" ino=67446255 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:passt_exec_t:s0 tclass=file permissive=1

Resolves: RHEL-45464