### PR TITLE
Allow virt_driver_domain connect to systemd-userdbd over a unix socket

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -306,6 +306,12 @@ type virt_dbus_exec_t, virt_file_type;
 init_daemon_domain(virt_dbus_t, virt_dbus_exec_t)
 init_nnp_daemon_domain(virt_dbus_t)
 
+# common rules for virt_driver_domain;
+
+optional_policy(`
+	systemd_userdbd_stream_connect(virt_driver_domain)
+')
+
 # virtinterfaced
 type virtinterfaced_t, virt_driver_domain;
 type virtinterfaced_exec_t, virt_driver_executable;
@@ -1993,10 +1999,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_userdbd_stream_connect(virtnodedevd_t)
-')
-
-optional_policy(`
 	udev_domtrans(virtnodedevd_t)
 	udev_read_pid_files(virtnodedevd_t)
 ')
@@ -2066,10 +2068,6 @@ userdom_read_all_users_state(virtproxyd_t)
 
 optional_policy(`
 	dnsmasq_filetrans_named_content_fromdir(virtproxyd_t, virtproxyd_var_run_t)
-')
-
-optional_policy(`
-	systemd_userdbd_stream_connect(virtproxyd_t)
 ')
 
 #######################################
@@ -2245,7 +2243,6 @@ optional_policy(`
 
 optional_policy(`
 	systemd_dbus_chat_machined(virtqemud_t)
-	systemd_userdbd_stream_connect(virtqemud_t)
 ')
 
 #######################################


### PR DESCRIPTION
Allow the permissions for the virt_driver_domain attribute instead of separate rules for individual domains which are a part of this attribute. The issue manifests when any of the drivers is configured with:

access_drivers = ["polkit"]
auth_unix_rw = "none"

Resolves: RHEL-44932