### PR TITLE
Allow boothd connect to systemd-userdbd over a unix socket

### DIFF
--- a/policy/modules/contrib/boothd.te
+++ b/policy/modules/contrib/boothd.te
@@ -77,5 +77,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+       systemd_userdbd_stream_connect(boothd_t)
+')
+
+optional_policy(`
 	sysnet_read_config(boothd_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(2.7.2024 15:31:59.064:1036) : proctitle=boothd daemon -c /etc/booth/booth.conf type=AVC msg=audit(07/02/24 15:31:59.064:1036) : avc:  denied  { read } for  pid=13949 comm=boothd name=userdb dev="tmpfs" ino=47 scontext=system_u:system_r:boothd_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(07/02/24 15:31:59.064:1036) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fe048ca39cf a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=0 ppid=13894 pid=13949 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=boothd exe=/usr/sbin/boothd subj=system_u:system_r:boothd_t:s0 key=(null)

Resolves: RHEL-45907