### PR TITLE
Update policy for awstats scripts

### DIFF
--- a/policy/modules/contrib/awstats.if
+++ b/policy/modules/contrib/awstats.if
@@ -36,6 +36,25 @@ interface(`awstats_rw_pipes',`
 
 ########################################
 ## <summary>
+##	Execute the awstats scripts in the awstats scripts domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`awstats_domtrans_script',`
+	gen_require(`
+		type awstats_script_t, awstats_script_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, awstats_script_exec_t, awstats_script_t)
+')
+
+########################################
+## <summary>
 ##	Execute awstats cgi scripts in the caller domain. (Deprecated)
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/awstats.te
+++ b/policy/modules/contrib/awstats.te
@@ -41,7 +41,7 @@ files_tmp_filetrans(awstats_t, awstats_tmp_t, { dir file })
 
 manage_files_pattern(awstats_t, awstats_var_lib_t, awstats_var_lib_t)
 
-allow awstats_t { awstats_content_t  awstats_script_exec_t }:dir search_dir_perms;
+allow awstats_t { awstats_content_t  awstats_script_exec_t }:dir list_dir_perms;
 
 can_exec(awstats_t, { awstats_exec_t awstats_script_exec_t })
 

--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -243,6 +243,7 @@ optional_policy(`
 
 optional_policy(`
 	awstats_domtrans(logrotate_t)
+	awstats_domtrans_script(logrotate_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow allow awstats_t list directories labeled awstats_content_t or awstats_script_exec_t.
Allow logrotate domain transition on awstats scripts execution.

The commit addresses the following AVC denials:
type=AVC msg=audit(1713888061.568:5491): avc:  denied  { read } for  pid=434128 comm="awstats.pl" name="cgi-bin" dev="dm-0" ino=51656323 scontext=system_u:system_r:awstats_t:s0-s0:c0.c1023 tcontext=system_u:object_r:awstats_script_exec_t:s0 tclass=dir permissive=0 type=AVC msg=audit(1713852008.371:5064): avc:  denied  { read } for  pid=404945 comm="sh" name="awstats.pl" dev="dm-0" ino=51656326 scontext=system_u:system_r:logrotate_t:s0 tcontext=system_u:object_r:awstats_script_exec_t:s0 tclass=file permissive=0