### PR TITLE
Allow rsyslog read systemd-logind session files

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -776,6 +776,7 @@ optional_policy(`
 	systemd_map_bootchart_tmpfs_files(syslogd_t)
 	systemd_list_conf_dirs(syslogd_t)
 	systemd_read_conf_files(syslogd_t)
+	systemd_read_logind_sessions_files(syslogd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(06/05/24 15:29:15.928:614) : avc:  denied  { read } for  pid=1776 comm=rs:main Q:Reg name=sessions dev="tmpfs" ino=842 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(06/05/24 15:29:15.928:614) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f99cbff6970 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=0 ppid=1 pid=1776 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rs:main Q:Reg exe=/usr/sbin/rsyslogd subj=system_u:system_r:syslogd_t:s0 key=(null)

Resolves: RHEL-40961