### PR TITLE
Allow bitlbee execute generic programs in system bin directories

### DIFF
--- a/policy/modules/contrib/bitlbee.te
+++ b/policy/modules/contrib/bitlbee.te
@@ -78,6 +78,7 @@ files_pid_filetrans(bitlbee_t, bitlbee_var_run_t, { dir file sock_file })
 kernel_read_system_state(bitlbee_t)
 kernel_read_kernel_sysctls(bitlbee_t)
 
+corecmd_exec_bin(bitlbee_t)
 corecmd_exec_shell(bitlbee_t)
 
 corenet_all_recvfrom_unlabeled(bitlbee_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(06/29/2024 07:07:58.615:3442) : avc:  denied  { execute } for  pid=216683 comm=bitlbee name=gst-plugin-scanner dev="xvda4" ino=847249672 scontext=system_u:system_r:bitlbee_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=0 