### PR TITLE
Allow key.dns_resolve set attributes on the kernel key ring

### DIFF
--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -42,6 +42,7 @@ allow keyutils_dns_resolver_t self:unix_dgram_socket create_socket_perms;
 
 kernel_read_key(keyutils_dns_resolver_t)
 kernel_view_key(keyutils_dns_resolver_t)
+kernel_setattr_key(keyutils_dns_resolver_t)
 
 init_search_pid_dirs(keyutils_dns_resolver_t)
 sysnet_read_config(keyutils_dns_resolver_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/15/2024 12:29:00.759:330) : proctitle=key.dns_resolver 935646915 type=SYSCALL msg=audit(06/15/2024 12:29:00.759:330) : arch=x86_64 syscall=keyctl success=yes exit=0 a0=0xf a1=0x37c4d6c3 a2=0x5 a3=0x55d974fca2b4 items=0 ppid=96 pid=3219 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=key.dns_resolve exe=/usr/sbin/key.dns_resolver subj=system_u:system_r:keyutils_dns_resolver_t:s0 key=(null) type=AVC msg=audit(06/15/2024 12:29:00.759:330) : avc:  denied  { setattr } for  pid=3219 comm=key.dns_resolve scontext=system_u:system_r:keyutils_dns_resolver_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=key permissive=0

Resolves: rhbz#2272646