### PR TITLE
Allow setroubleshootd execute sendmail with a domain transition

### DIFF
--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -195,6 +195,10 @@ optional_policy(`
 	rpm_use_script_fds(setroubleshootd_t)
 ')
 
+optional_policy(`
+	sendmail_domtrans(setroubleshootd_t)
+')
+
 ########################################
 #
 # setroubleshoot_fixit local policy


### PR DESCRIPTION
The commit addresses the following AVC denial:
Jun 09 15:55:50 myserver.com audit[5494]: AVC avc:  denied  { execute } for  pid=5494 comm="setroubleshootd" name="sendmail.postfix" dev="sda1" ino=27246 scontext=system_u:system_r:setroubleshootd_t:s0 tcontext=system_u:object_r:sendmail_exec_t:s0 tclass=file permissive=1

Resolves: rhbz#2291090