### PR TITLE
Allow NetworkManager_dispatcher_t send SIGKILL to plugins

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -571,6 +571,8 @@ allow NetworkManager_dispatcher_ddclient_t self:unix_dgram_socket { create_socke
 allow NetworkManager_dispatcher_tlp_t self:unix_dgram_socket { create_socket_perms sendto };
 allow NetworkManager_dispatcher_custom_t self:unix_dgram_socket { create_socket_perms sendto };
 
+allow NetworkManager_dispatcher_t networkmanager_dispatcher_plugin:process sigkill;
+
 allow NetworkManager_dispatcher_t NetworkManager_unit_file_t:file getattr;
 allow NetworkManager_dispatcher_cloud_t NetworkManager_unit_file_t:file getattr;
 allow NetworkManager_dispatcher_cloud_t NetworkManager_unit_file_t:service { start status stop };


### PR DESCRIPTION
Allow NetworkManager_dispatcher_t send the SIGKILL signal to nm-dispatcher plugins which are a part of the
networkmanager_dispatcher_plugin attribute.

The commit addresses the following AVC denial:
type=AVC msg=audit(1718350338.265:319): avc:  denied  { sigkill } for  pid=1790 comm="nm-dispatcher" scontext=system_u:system_r:NetworkManager_dispatcher_t:s0 tcontext=system_u:system_r:NetworkManager_dispatcher_custom_t:s0 tclass=process permissive=0

Resolves: rhbz#2292370