### PR TITLE
Revert "Allow svirt read virtqemud fifo files"

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -489,7 +489,6 @@ allow svirt_t virtlogd_t:fifo_file write;
 allow svirt_t virtlogd_t:unix_stream_socket connectto;
 
 allow svirt_t virtqemud_t:tun_socket attach_queue;
-allow svirt_t virtqemud_t:fifo_file read;
 allow svirt_t virtqemud_var_run_t:file write;
 
 read_files_pattern(svirt_t, virtqemud_t, virtqemud_t)


### PR DESCRIPTION
This reverts commit 6c412b200d601c87816a744891ba31021d969458 as the denial actually is for the swtpm command:
    type=AVC msg=audit(1718761275.391:3532): avc:  denied  { read } for  pid=41418 comm="swtpm" path="pipe:[128958]" dev="pipefs" ino=128958 scontext=system_u:system_r:svirt_t:s0:c127,c890 tcontext=system_u:system_r:virtqemud_t:s0 tclass=fifo_file permissive=0

which changed when a transition was defined to the swtpm_t domain.