### PR TITLE
Allow virt_driver_domain read virtd-lxc files in /proc

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -308,6 +308,8 @@ init_nnp_daemon_domain(virt_dbus_t)
 
 # common rules for virt_driver_domain;
 
+read_files_pattern(virt_driver_domain, virtd_lxc_t, virtd_lxc_t)
+
 optional_policy(`
 	systemd_userdbd_stream_connect(virt_driver_domain)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(08/06/2024 14:41:27.583:6417) : proctitle=/usr/sbin/virtstoraged --timeout 120 type=PATH msg=audit(08/06/2024 14:41:27.583:6417) : item=0 name=/proc/217624/stat inode=356144 dev=00:16 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:virtd_lxc_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/06/2024 14:41:27.583:6417) : arch=x86_64 syscall=openat success=yes exit=18 a0=AT_FDCWD a1=0x55ff3ad9d390 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=218059 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtstorage exe=/usr/sbin/virtstoraged subj=system_u:system_r:virtstoraged_t:s0 key=(null) type=AVC msg=audit(08/06/2024 14:41:27.583:6417) : avc:  denied  { open } for  pid=218059 comm=rpc-virtstorage path=/proc/217624/stat dev="proc" ino=356144 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:system_r:virtd_lxc_t:s0 tclass=file permissive=1 type=AVC msg=audit(08/06/2024 14:41:27.583:6417) : avc:  denied  { read } for  pid=218059 comm=rpc-virtstorage name=stat dev="proc" ino=356144 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:system_r:virtd_lxc_t:s0 tclass=file permissive=1 type=AVC msg=audit(08/06/2024 14:41:27.583:6417) : avc:  denied  { search } for  pid=218059 comm=rpc-virtstorage name=217624 dev="proc" ino=357519 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:system_r:virtd_lxc_t:s0 tclass=dir permissive=1