### PR TITLE
Add policy for /usr/libexec/samba/samba-bgqd

### DIFF
--- a/policy/modules/contrib/samba.fc
+++ b/policy/modules/contrib/samba.fc
@@ -19,6 +19,7 @@
 /usr/lib/systemd/system/winbind.*   --  gen_context(system_u:object_r:samba_unit_file_t,s0)
 
 /usr/libexec/samba/rpcd_lsad	--	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
+/usr/libexec/samba/samba-bgqd	--	gen_context(system_u:object_r:samba_bgqd_exec_t,s0)
 /usr/libexec/samba/samba-dcerpcd --	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
 
 /usr/bin/net			--	gen_context(system_u:object_r:samba_net_exec_t,s0)
@@ -67,6 +68,7 @@
 
 /run/samba/winbindd(/.*)?		gen_context(system_u:object_r:winbind_var_run_t,s0)
 /run/winbindd(/.*)?			gen_context(system_u:object_r:winbind_var_run_t,s0)
+/run/samba-bgqd.pid	--	gen_context(system_u:object_r:samba_bgqd_var_run_t,s0)
 
 /var/spool/samba(/.*)?			gen_context(system_u:object_r:samba_spool_t,s0)
 

--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -1118,3 +1118,22 @@ interface(`samba_domtrans_winbind_rpcd',`
 	corecmd_search_bin($1)
 	domtrans_pattern($1, winbind_rpcd_exec_t, winbind_rpcd_t)
 ')
+
+########################################
+## <summary>
+##	Execute samba-bgqd in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed accesss.
+##	</summary>
+## </param>
+#
+interface(`samba_exec_bgqd',`
+	gen_require(`
+		type samba_bgqd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, samba_bgqd_exec_t)
+')

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -134,6 +134,13 @@ type samba_gpupdate_exec_t;
 application_domain(samba_gpupdate_t, samba_gpupdate_exec_t)
 role system_r types samba_gpupdate_t;
 
+type samba_bgqd_t;
+type samba_bgqd_exec_t;
+init_daemon_domain(samba_bgqd_t, samba_bgqd_exec_t)
+
+type samba_bgqd_var_run_t;
+files_pid_file(samba_bgqd_var_run_t)
+
 type smbcontrol_t;
 type smbcontrol_exec_t;
 application_domain(smbcontrol_t, smbcontrol_exec_t)
@@ -298,6 +305,37 @@ domtrans_pattern(winbind_rpcd_t, samba_gpupdate_exec_t, samba_gpupdate_t)
 
 optional_policy(`
 	certmonger_domtrans(samba_gpupdate_t)
+')
+
+########################################
+#
+# samba-bgqd local policy
+#
+
+permissive samba_bgqd_t;
+
+allow samba_bgqd_t self:netlink_route_socket r_netlink_socket_perms;
+allow samba_bgqd_t self:tcp_socket create_stream_socket_perms;
+allow samba_bgqd_t self:udp_socket create_socket_perms;
+allow samba_bgqd_t self:unix_dgram_socket create_socket_perms;
+
+read_files_pattern(samba_bgqd_t, samba_etc_t, samba_etc_t)
+allow samba_bgqd_t samba_log_t:dir create_dir_perms;
+manage_files_pattern(samba_bgqd_t, samba_log_t, samba_log_t)
+allow samba_bgqd_t samba_var_t:dir create_dir_perms;
+allow samba_bgqd_t samba_var_t:file map;
+manage_files_pattern(samba_bgqd_t, samba_var_t, samba_var_t)
+manage_sock_files_pattern(samba_bgqd_t, samba_var_t, samba_var_t)
+
+manage_files_pattern(samba_bgqd_t, samba_bgqd_var_run_t, samba_bgqd_var_run_t)
+files_pid_filetrans(samba_bgqd_t, samba_bgqd_var_run_t, file)
+
+kernel_dgram_send(samba_bgqd_t)
+
+corenet_tcp_connect_ipp_port(samba_bgqd_t)
+
+optional_policy(`
+	auth_read_passwd_file(samba_bgqd_t)
 ')
 
 ########################################
@@ -1332,10 +1370,13 @@ optional_policy(`
 allow smbd_t winbind_rpcd_t:process noatsecure;
 allow smbd_t winbind_rpcd_t:unix_stream_socket connectto;
 allow winbind_t winbind_rpcd_t:unix_stream_socket connectto;
+allow winbind_rpcd_t samba_bgqd_t:unix_dgram_socket sendto;
 allow winbind_rpcd_t nmbd_t:unix_dgram_socket sendto;
 allow winbind_rpcd_t smbd_t:unix_dgram_socket sendto;
 allow winbind_rpcd_t winbind_t:unix_dgram_socket sendto;
 allow winbind_rpcd_t winbind_t:unix_stream_socket connectto;
+
+allow winbind_rpcd_t samba_bgqd_var_run_t:file write_file_perms;
 
 samba_domtrans_winbind_rpcd(smbd_t)
 samba_domtrans_winbind_rpcd(winbind_t)


### PR DESCRIPTION
samba-bgqd is an helper program added in samba v4.20.2 to be spawned by smbd or spoolssd to perform jobs like updating the printer list or other management tasks asynchronously on demand. It is not intended to be called by users or administrators.