### PR TITLE
Allow samba-dcerpcd work with ctdb cluster

### DIFF
--- a/policy/modules/contrib/ctdb.if
+++ b/policy/modules/contrib/ctdb.if
@@ -172,6 +172,25 @@ interface(`ctdbd_read_lib_files',`
 
 ########################################
 ## <summary>
+##	Map ctdbd lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ctdbd_map_lib_files',`
+	gen_require(`
+		type ctdbd_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	allow $1 ctdbd_var_lib_t:file map;
+')
+
+########################################
+## <summary>
 ##	Manage ctdbd lib files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1262,6 +1262,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ctdbd_stream_connect(winbind_rpcd_t)
+	ctdbd_map_lib_files(winbind_rpcd_t)
+')
+
+optional_policy(`
 	cups_read_config(winbind_rpcd_t)
 	cups_stream_connect(winbind_rpcd_t)
 ')


### PR DESCRIPTION
ctdb is Clustered Database based on Samba's Trivial Database (TDB). In a clustered Samba setup, /usr/libexec/samba/samba-dcerpcd, when invoked on demand to list the services available from a server, needs to be allowed to connect to the ctdbd service over a unix socket and map its database files.

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2196