### PR TITLE
Allow ip command write to ipsec's logs

### DIFF
--- a/policy/modules/system/ipsec.if
+++ b/policy/modules/system/ipsec.if
@@ -170,6 +170,25 @@ interface(`ipsec_getattr_key_sockets',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain to write to ipsec's log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ipsec_write_log',`
+	gen_require(`
+		type ipsec_log_t;
+	')
+
+	logging_search_logs($1)
+	write_files_pattern($1, ipsec_log_t, ipsec_log_t)
+')
+
+########################################
+## <summary>
 ##	Execute the IPSEC management program in the caller domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -479,6 +479,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ipsec_write_log(ifconfig_t)
 	ipsec_write_pid(ifconfig_t)
 	ipsec_setcontext_default_spd(ifconfig_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/14/2024 10:14:06.297:1211) : proctitle=ip -4 -o route get 10.0.184.146 from 10.0.186.202 type=EXECVE msg=audit(06/14/2024 10:14:06.297:1211) : argc=8 a0=ip a1=-4 a2=-o a3=route a4=get a5=10.0.184.146 a6=from a7=10.0.186.202 type=SYSCALL msg=audit(06/14/2024 10:14:06.297:1211) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x5639dc028d90 a1=0x5639dc029600 a2=0x5639dc09ad30 a3=0x3 items=0 ppid=18684 pid=18685 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ip exe=/usr/sbin/ip subj=system_u:system_r:ifconfig_t:s0 key=(null) type=AVC msg=audit(06/14/2024 10:14:06.297:1211) : avc:  denied  { write } for  pid=18685 comm=ip path=/var/log/pluto.log dev="vda2" ino=6293439 scontext=system_u:system_r:ifconfig_t:s0 tcontext=system_u:object_r:ipsec_log_t:s0 tclass=file permissive=0

Resolves: RHEL-41222