### PR TITLE
Add port 80/udp and 443/udp to http_port_t defination

### DIFF
--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -193,7 +193,7 @@ network_port(hadoop_namenode, tcp,8020,s0)
 network_port(hddtemp, tcp,7634,s0)
 network_port(howl, tcp,5335,s0, udp,5353,s0)
 network_port(hplip, tcp,1782,s0, tcp,2207,s0, tcp,2208,s0, tcp, 8290,s0, tcp,50000,s0, tcp,50002,s0, tcp,8292,s0, tcp,9100,s0, tcp,9101,s0, tcp,9102,s0, tcp,9220,s0, tcp,9221,s0, tcp,9222,s0, tcp,9280,s0, tcp,9281,s0, tcp,9282,s0, tcp,9290,s0, tcp,9291,s0)
-network_port(http, tcp,80,s0, tcp,81,s0, tcp,443,s0, tcp,488,s0, tcp,8008,s0, tcp,8009,s0, tcp,8443,s0,tcp,9000, s0) #8443 is mod_nss default port
+network_port(http, tcp,80,s0, udp,80,s0, tcp,81,s0, tcp,443,s0, udp,443,s0, tcp,488,s0, tcp,8008,s0, tcp,8009,s0, tcp,8443,s0, tcp,9000,s0) #8443 is mod_nss default port
 network_port(http_cache, udp,3130,s0, tcp,8080,s0, tcp,8118,s0, tcp,8123,s0, tcp,10001-10010,s0) # 8118 is for privoxy
 network_port(ibm_dt_2, tcp,1792,s0, udp,1792,s0)
 network_port(intermapper, tcp,8181,s0)


### PR DESCRIPTION
According to RFC9110[1] the port 80/udp and 443/udp has been assigned to http service in IANA registery[2]. Adding those ports to the SELinux port defination should allow the http/3 services to listen on the ports.

[1]: https://www.rfc-editor.org/rfc/rfc9110.html#name-port-registration
[2]: https://www.iana.org/assignments/service-names-port-numbers/