### PR TITLE
Add stalld the bpf capability

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -21,8 +21,10 @@ files_pid_file(stalld_var_run_t)
 #
 allow stalld_t self:bpf { map_create map_read map_write prog_load prog_run };
 allow stalld_t self:capability { sys_nice sys_resource };
+allow stalld_t self:capability2 { bpf perfmon };
 allow stalld_t self:process { fork setsched setrlimit };
 allow stalld_t self:fifo_file rw_fifo_file_perms;
+allow stalld_t self:process setrlimit;
 allow stalld_t self:unix_stream_socket create_stream_socket_perms;
 
 manage_dirs_pattern(stalld_t, stalld_var_run_t, stalld_var_run_t)
@@ -43,6 +45,8 @@ domain_setpriority_all_domains(stalld_t)
 domain_use_interactive_fds(stalld_t)
 
 files_read_etc_files(stalld_t)
+
+fs_list_bpf_dirs(stalld_t)
 
 selinux_read_security_files(stalld_t)
 

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -601,6 +601,26 @@ interface(`fs_register_binary_executable_type',`
 
 ########################################
 ## <summary>
+##	List bpf directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_list_bpf_dirs',`
+	gen_require(`
+		type bpf_t;
+	')
+
+	list_dirs_pattern($1, bpf_t, bpf_t)
+	fs_search_tmpfs($1)
+	dev_search_sysfs($1)
+')
+
+########################################
+## <summary>
 ##	Manage bpf directories.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/31/2024 01:53:18.796:601) : proctitle=/usr/bin/stalld --systemd -b queue_track -p 1000000000 -r 20000 -d 3 -t 20 --foreground --pidfile /run/stalld/stalld.pid type=SYSCALL msg=audit(07/31/2024 01:53:18.796:601) : arch=x86_64 syscall=bpf success=no exit=EOPNOTSUPP(Operation not supported) a0=unknown-bpf-cmd(24) a1=0x7ffc5aec6f70 a2=0x8 a3=0x0 items=0 ppid=1 pid=3040 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stalld exe=/usr/bin/stalld subj=system_u:system_r:stalld_t:s0 key=(null) type=AVC msg=audit(07/31/2024 01:53:18.796:601) : avc:  denied  { bpf } for  pid=3040 comm=stalld capability=bpf  scontext=system_u:system_r:stalld_t:s0 tcontext=system_u:system_r:stalld_t:s0 tclass=capability2 permissive=1

Resolves: RHEL-50356