### PR TITLE
Allow virtqemud relabelfrom also for file and sock_file

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2108,7 +2108,7 @@ allow virtqemud_t self:tcp_socket create_socket_perms;
 allow virtqemud_t self:tun_socket create;
 allow virtqemud_t self:udp_socket { connect create getattr };
 
-allow virtqemud_t qemu_var_run_t:dir relabelfrom;
+allow virtqemud_t qemu_var_run_t:{ dir file sock_file } relabelfrom;
 
 allow virtqemud_t svirt_t:process { getattr setsched signal signull transition };
 allow virtqemud_t svirt_t:unix_stream_socket { connectto create_stream_socket_perms };


### PR DESCRIPTION
So far, virtqemud was allowed relabelfrom qemu_var_run_t for the dir class only.  This commit allows it also for the file and sock_file classes.