### PR TITLE
Add missing sys_chroot capability to groupadd policy

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -212,7 +212,7 @@ optional_policy(`
 # Groupadd local policy
 #
 
-allow groupadd_t self:capability { dac_read_search dac_override chown fowner kill setuid sys_resource audit_write };
+allow groupadd_t self:capability { dac_read_search dac_override chown fowner kill setuid sys_resource sys_chroot audit_write };
 dontaudit groupadd_t self:capability { fsetid sys_tty_config };
 allow groupadd_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execheap execstack };
 allow groupadd_t self:process { setrlimit setfscreate };


### PR DESCRIPTION
Just like useradd, groupadd supports chroot operation, but for that to work it needs the sys_chroot capability, just like the useradd policy has (see commit 0651cc950eae4fef8e631a61b36aa3f38e72ea12).

This is one of the roadblocks in making RPM sysusers feature fully functional: https://github.com/rpm-software-management/rpm/issues/3227