### PR TITLE
Allow l2tpd_t access to netlink and sysfs

### DIFF
--- a/policy/modules/contrib/l2tp.te
+++ b/policy/modules/contrib/l2tp.te
@@ -31,6 +31,7 @@ allow l2tpd_t self:process signal_perms;
 allow l2tpd_t self:fifo_file rw_fifo_file_perms;
 allow l2tpd_t self:netlink_generic_socket create_socket_perms;
 allow l2tpd_t self:netlink_socket create_socket_perms;
+allow l2tpd_t self:netlink_generic_socket create_socket_perms;
 allow l2tpd_t self:rawip_socket create_socket_perms;
 allow l2tpd_t self:socket create_socket_perms;
 allow l2tpd_t self:tcp_socket { accept listen };
@@ -78,6 +79,7 @@ kernel_request_load_module(l2tpd_t)
 corecmd_exec_bin(l2tpd_t)
 
 dev_read_urand(l2tpd_t)
+dev_read_sysfs(l2tpd_t)
 
 term_setattr_generic_ptys(l2tpd_t)
 term_use_generic_ptys(l2tpd_t)


### PR DESCRIPTION
The go-l2tp kl2tpd daemon used by NetworkManager-l2tp uses netlink_generic_socket and sysfs.

This change addresses the following AVC denials:

type=AVC msg=audit(1721045130.932:277): avc:  denied  { read } for  pid=3560 comm="kl2tpd" name="hpage_pmd_size" dev="sysfs" ino=1261 scontext=system_u:system_r:l2tpd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(1721045130.932:278): avc:  denied  { open } for  pid=3560 comm="kl2tpd" path="/sys/kernel/mm/transparent_hugepage/hpage_pmd_size" dev="sysfs" ino=1261 scontext=system_u:system_r:l2tpd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
type=AVC msg=audit(1721045130.942:279): avc:  denied  { create } for  pid=3560 comm="kl2tpd" scontext=system_u:system_r:l2tpd_t:s0 tcontext=system_u:system_r:l2tpd_t:s0 tclass=netlink_generic_socket permissive=1
type=AVC msg=audit(1721045130.942:280): avc:  denied  { getopt } for  pid=3560 comm="kl2tpd" scontext=system_u:system_r:l2tpd_t:s0 tcontext=system_u:system_r:l2tpd_t:s0 tclass=netlink_generic_socket permissive=1
type=AVC msg=audit(1721045130.942:281): avc:  denied  { bind } for  pid=3560 comm="kl2tpd" scontext=system_u:system_r:l2tpd_t:s0 tcontext=system_u:system_r:l2tpd_t:s0 tclass=netlink_generic_socket permissive=1
type=AVC msg=audit(1721045130.942:282): avc:  denied  { getattr } for  pid=3560 comm="kl2tpd" scontext=system_u:system_r:l2tpd_t:s0 tcontext=system_u:system_r:l2tpd_t:s0 tclass=netlink_generic_socket permissive=1

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2259