### PR TITLE
Allow rasdaemon write access to sysfs

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -31,9 +31,9 @@ kernel_read_system_state(rasdaemon_t)
 kernel_manage_debugfs(rasdaemon_t)
 
 dev_read_raw_memory(rasdaemon_t)
-dev_read_sysfs(rasdaemon_t)
 dev_read_urand(rasdaemon_t)
 dev_rw_cpu_microcode(rasdaemon_t)
+dev_rw_sysfs(rasdaemon_t)
 
 corecmd_exec_bin(rasdaemon_t)
 


### PR DESCRIPTION
Error message in rasdaemon:
Aug 23 09:38:48 localhost rasdaemon[17117]: rasdaemon: Kernel does not support page offline interface

Fixes:
----
time->Fri Aug 23 09:38:48 2024
type=AVC msg=audit(1724398728.627:998): avc:  denied  { write } for  pid=17117 comm="rasdaemon" name="soft_offline_page" dev="sysfs" ino=46 scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

see: https://bugzilla.suse.com/show_bug.cgi?id=1229587