### PR TITLE
Label /etc/mdevctl.d with mdevctl_conf_t

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2009,6 +2009,8 @@ dev_write_sysfs_dirs(virtnodedevd_t)
 
 files_map_var_lib_files(virtnodedevd_t)
 files_watch_etc_dirs(virtnodedevd_t)
+files_etc_filetrans_mdevctl_conf(virtnodedevd_t)
+files_manage_mdevctl_conf_files(virtnodedevd_t)
 
 miscfiles_read_hwdata(virtnodedevd_t)
 

--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -60,6 +60,7 @@ ifdef(`distro_suse',`
 /etc/nologin.*		--	gen_context(system_u:object_r:etc_runtime_t,s0)
 /etc/securetty  	--  	gen_context(system_u:object_r:etc_runtime_t,s0)
 
+/etc/mdevctl\.d(/.*)		gen_context(system_u:object_r:mdevctl_conf_t,s0)
 /etc/sysctl\.conf(\.old)?               --      gen_context(system_u:object_r:system_conf_t,s0)
 /etc/sysconfig/ebtables.*				--      gen_context(system_u:object_r:system_conf_t,s0)
 /etc/sysconfig/ip6?tables.*             --      gen_context(system_u:object_r:system_conf_t,s0)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6030,6 +6030,43 @@ interface(`files_read_world_readable_sockets',`
 
 #######################################
 ## <summary>
+##	Manage mdevctl configuration files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_manage_mdevctl_conf_files',`
+	gen_require(`
+		type mdevctl_conf_t;
+	')
+
+	files_search_etc(mdevctl_conf_t)
+	manage_files_pattern($1, mdevctl_conf_t, mdevctl_conf_t)
+')
+
+###################################
+## <summary>
+##	Create /etc/mdevctl.d with the correct type
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_etc_filetrans_mdevctl_conf',`
+	gen_require(`
+		type etc_t, mdevctl_conf_t;
+	')
+
+	filetrans_pattern($1, etc_t, mdevctl_conf_t, dir, "mdevctl.d")
+')
+
+#######################################
+## <summary>
 ##  Read manageable system configuration files in /etc
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/files.te
+++ b/policy/modules/kernel/files.te
@@ -80,6 +80,9 @@ files_ro_base_file(system_conf_t)
 # compatibility aliases for removed type:
 typealias system_conf_t alias iptables_conf_t;
 
+# mdevctl_conf_t is a type for files in /etc/mdevctl.d
+type mdevctl_conf_t, configfile;
+
 # system_db_t is a new type of various
 # db files.
 type system_db_t;


### PR DESCRIPTION
Allow virtnodedevd create /etc/mdevctl.d with a file transition and manage mdevctl_conf_t files.

Resolves: RHEL-39893