### PR TITLE
Allow coreos-installer-generator manage mdadm_conf_t files

### DIFF
--- a/policy/modules/contrib/coreos_installer.te
+++ b/policy/modules/contrib/coreos_installer.te
@@ -75,6 +75,8 @@ optional_policy(`
 ')
 
 optional_policy(`
+	raid_create_conf_dirs(coreos_installer_generator_t)
+	raid_manage_conf_files(coreos_installer_generator_t)
 	raid_filetrans_named_content(coreos_installer_generator_t)
 ')
 

--- a/policy/modules/contrib/raid.if
+++ b/policy/modules/contrib/raid.if
@@ -174,6 +174,24 @@ interface(`raid_manage_conf_files',`
 
 ########################################
 ## <summary>
+##	Create mdadm config dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`raid_create_conf_dirs',`
+	gen_require(`
+		type mdadm_conf_t;
+	')
+
+    allow $1 mdadm_conf_t:dir create_dir_perms;
+')
+
+########################################
+## <summary>
 ##	Transition to mdadm named content
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Resolves: RHEL-38614