### PR TITLE
Use better escape method for "interface"

### DIFF
--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -166,7 +166,7 @@ template(`virt_driver_template',`
 
 	# This sequence of quotation marks is needed to prevent "interface"
 	# from being interpreted as a keyword and further parsed by m4 macros
-	filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, "``interface''")
+	filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, ``"interface"'')
 	filetrans_pattern($1, virt_var_run_t, virtnodedevd_var_run_t, dir, "nodedev")
 	filetrans_pattern($1, virt_var_run_t, virtnwfilterd_var_run_t, dir, "nwfilter")
 	filetrans_pattern($1, virt_var_run_t, virtsecretd_var_run_t, dir, "secrets")


### PR DESCRIPTION
Fixes commit c7e8af00ef03 ("Escape "interface" as a file name in a virt filetrans pattern")

For a context see https://github.com/SELinuxProject/selint/pull/291 and https://lore.kernel.org/selinux/20240827113150.1843304-1-lautrbach@redhat.com/T/#u

