### PR TITLE
Allow systemd-ssh-generator read sysctl files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1365,6 +1365,8 @@ init_exec_script_files(systemd_rc_local_generator_t)
 allow systemd_ssh_generator_t self:vsock_socket create;
 allow systemd_ssh_generator_t vsock_device_t:chr_file { read_chr_file_perms };
 
+kernel_read_sysctl(systemd_ssh_generator_t)
+
 dev_read_sysfs(systemd_ssh_generator_t)
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
[    8.111974] audit: type=1400 audit(1724677759.011:4): avc:  denied  { read } for  pid=1358 comm="systemd-ssh-gen" name="sysinfo" dev="proc" ino=4026531945 scontext=system_u:system_r:systemd_ssh_generator_t:s0 tcontext=system_u:object_r:sysctl_t:s0 tclass=file permissive=0

Resolves: rhbz#2308177