### PR TITLE
Fix SELinux policy for sandbox X server to fix 'sandbox -X' command

### DIFF
--- a/policy/modules/contrib/sandboxX.te
+++ b/policy/modules/contrib/sandboxX.te
@@ -65,7 +65,10 @@ manage_fifo_files_pattern(sandbox_xserver_t, sandbox_xserver_tmpfs_t, sandbox_xs
 manage_sock_files_pattern(sandbox_xserver_t, sandbox_xserver_tmpfs_t, sandbox_xserver_tmpfs_t)
 fs_tmpfs_filetrans(sandbox_xserver_t, sandbox_xserver_tmpfs_t, { dir file lnk_file sock_file fifo_file })
 
+allow sandbox_xserver_t sandbox_xserver_tmpfs_t:file map;
+
 kernel_dontaudit_request_load_module(sandbox_xserver_t)
+kernel_read_device_sysctls(sandbox_xserver_t)
 kernel_read_system_state(sandbox_xserver_t)
 
 corecmd_exec_bin(sandbox_xserver_t)
@@ -93,6 +96,7 @@ domain_use_interactive_fds(sandbox_xserver_t)
 files_read_config_files(sandbox_xserver_t)
 files_search_home(sandbox_xserver_t)
 fs_dontaudit_rw_tmpfs_files(sandbox_xserver_t)
+fs_getattr_xattr_fs(sandbox_xserver_t)
 fs_search_auto_mountpoints(sandbox_xserver_t)
 
 miscfiles_read_fonts(sandbox_xserver_t)


### PR DESCRIPTION
Hi,

Hope you're well! I was speaking with @rhatdan and trying to make "sandbox -X" work properly. This issue occurs on Rawhide. The error I get is:

```
/usr/share/sandbox/sandboxX.sh: line 16: 810257 Aborted                 (core dumped) /usr/bin/Xwayland -terminate -dpi $DPI -retro -geometry $SCREENSIZE -decorate -displayfd 5 5>&1 2> /dev/null
```

I ran it with `setenforce 0` and it worked then. The AVC I saw immediately in the problematic run was:

```
type=AVC msg=audit(1721850176.924:703): avc: denied { search } for pid=30127 comm="Xwayland" name="dev" dev="proc" ino=24178 scontext=unconfined_u:unconfined_r:sandbox_xserver_t:s0:c149,c693 tcontext=system_u:object_r:sysctl_dev_t:s0 tclass=dir permissive=0
```

Dan says there's no problem allowing that, and that he's sure there are plenty more.

I've spoken with Dan, Lukas, Zdeněk, and Petr, and Dan suggested this implementation. 

Not tested yet.