### PR TITLE
Allow systemd-ssh-generator to load net-pf-40

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1366,6 +1366,7 @@ allow systemd_ssh_generator_t self:vsock_socket create;
 allow systemd_ssh_generator_t vsock_device_t:chr_file { read_chr_file_perms };
 
 dev_read_sysfs(systemd_ssh_generator_t)
+kernel_request_load_module(systemd_ssh_generator_t)
 
 optional_policy(`
 	ssh_domtrans(systemd_ssh_generator_t)


### PR DESCRIPTION
see:
https://www.freedesktop.org/software/systemd/man/devel/systemd-ssh-generator.html "systemd-ssh-generator binds a socket-activated SSH server to local AF_VSOCK"

and modinfo suggests net-pf-40 to be the kernel modules for virtual sockets

Fixes:
> Aug 22 05:17:20 localhost kernel: audit: type=1400 audit(1724303839.663:5): avc:  denied  { module_request } for  pid=593 comm="systemd-ssh-gen" kmod="net-pf-40" scontext=system_u:system_r:systemd_ssh_generator_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0