### PR TITLE
Allow init and systemd-logind to inherit fds from sshd

### DIFF
--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -482,6 +482,24 @@ interface(`ssh_signull',`
 
 ########################################
 ## <summary>
+##	Use fds from sshd processes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ssh_fd_use',`
+	gen_require(`
+		type sshd_t;
+	')
+
+	allow $1 sshd_t:fd use;
+')
+
+########################################
+## <summary>
 ##	Read a ssh server unnamed pipe.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -859,6 +859,9 @@ optional_policy(`
 optional_policy(`
 	ssh_getattr_server_keys(init_t)
 	ssh_create_vsock_socket(init_t)
+	# needed after systemd commit 76f2191d8eb5 ("logind:
+	# introduce CreateSessionWithPIDFD()")
+	ssh_fd_use(init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -481,6 +481,12 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# needed after systemd commit 76f2191d8eb5 ("logind:
+	# introduce CreateSessionWithPIDFD()")
+	ssh_fd_use(systemd_logind_t)
+')
+
+optional_policy(`
 	# It links /run/user/$USER/X11/display to /tmp/.X11-unix/X* sock_file
 	xserver_search_xdm_tmp_dirs(systemd_logind_t)
 ')


### PR DESCRIPTION
This is required by systemd since commit 76f2191d8eb5 ("logind: introduce CreateSessionWithPIDFD()") when domain_fd_use is turned off.

Otherwise trying to SSH into the system will hang for two minutes until the timeout triggers a fallback and the SSH session is finally created.

---

I hit this when running selinux-testsuite, which flips `domain_fd_use` on and off. Please backport this also to F40 & F41 (F39 doesn't need it, as there is still an older systemd version).