### PR TITLE
Allow setsebool_t relabel selinux data files

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -572,9 +572,16 @@ optional_policy(`
 #
 # setsebool local policy
 #
+allow setsebool_t file_context_t:file { relabelfrom relabelto };
+allow setsebool_t selinux_config_t:file { relabelfrom relabelto };
+allow setsebool_t semanage_store_t:dir { relabelfrom relabelto };
+allow setsebool_t semanage_store_t:file { relabelfrom relabelto };
+
+seutil_relabelto_bin_policy(setsebool_t)
 seutil_semanage_policy(setsebool_t)
 selinux_set_all_booleans(setsebool_t)
 
+domain_obj_id_change_exemption(setsebool_t)
 init_dontaudit_use_fds(setsebool_t)
 
 # Bug in semanage


### PR DESCRIPTION
Since the "libsemanage: Preserve file context and ownership in policy store" commit [1], libsemanage ensures that ownership and also SELinux context of policy data files are correct.

This requires additional permissions for setsebool_t when there is a process transition for the setsebool command defined, such as when executed from an rpm scriptlet.

Assigning to the following attributes is also needed:
- can_change_object_identity because it actually is the user part of the context which is being fixed; role part is not a subject of constraint violation rules
- can_relabelto_binary_policy to be able to modify the policy store context (neverallow rule)

[1] https://github.com/SELinuxProject/selinux/commit/d96f27bf7cb9

Resolves: RHEL-55414