### PR TITLE
Allow sysadm user the secretmem API

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -27,6 +27,7 @@ kernel_manage_perf_event(sysadm_t)
 kernel_prog_run_bpf(sysadm_t)
 kernel_read_fs_sysctls(sysadm_t)
 kernel_read_all_proc(sysadm_t)
+kernel_secretmem_use(sysadm_t)
 kernel_unconfined(sysadm_t)
 
 auth_manage_shadow(sysadm_t)


### PR DESCRIPTION
This is a follow-up commit to 41c4218e835a0 ("Add support for secretmem anon inode") which allowed the permission to unconfined domain types only.

Note: Pages allocated with this method can never be swapped out of the physical memory and the system hibernation is blocked as long as any file descriptor created with this method exists, so this permission should be allowed to a very limited set of domains only.

Resolves: rhbz#2270895