### PR TITLE
Allow thumb_t map dri devices

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -77,6 +77,7 @@ corecmd_exec_shell(thumb_t)
 corenet_tcp_connect_xserver_port(thumb_t)
 corenet_dontaudit_tcp_connect_all_ports(thumb_t)
 
+dev_map_dri(thumb_t)
 dev_read_sysfs(thumb_t)
 dev_read_urand(thumb_t)
 dev_dontaudit_rw_dri(thumb_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1710140836.332:583): avc:  denied  { map } for  pid=1093967 comm="gst-plugin-scan" path="/dev/dri/renderD128" dev="devtmpfs" ino=458 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:object_r:dri_device_t:s0 tclass=chr_file permissive=1

Resolves: rhbz#2268960