### PR TITLE
Update bootupd policy for the removing-state-file test

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -39,9 +39,11 @@ domain_use_interactive_fds(bootupd_t)
 
 files_create_boot_dirs(bootupd_t)
 files_read_etc_files(bootupd_t)
+files_manage_boot_files(bootupd_t)
 
 fs_getattr_all_fs(bootupd_t)
-fs_search_dos(bootupd_t)
+fs_manage_dos_dirs(bootupd_t)
+fs_manage_dos_files(bootupd_t)
 fs_search_efivarfs_dirs(bootupd_t)
 
 optional_policy(`


### PR DESCRIPTION
How to reproduce:
Install a Fedora Silverblue 41 system
run sudo rm /boot/bootupd-state.json
run sudo bootupctl update

The commit addresses the following AVC denial example: type=AVC msg=audit(1725290040.770:431): avc:  denied  { open } for  pid=4524 comm="bootupctl" path="/boot/efi/EFI/BOOT/BOOTIA32.EFI" dev="vda1" ino=142 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:dosfs_t:s0 tclass=file permissive=1

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2334