### PR TITLE
Allow samba use the io_uring API

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -391,6 +391,7 @@ allow smbd_t winbind_t:process { signal signull };
 
 kernel_getattr_core_if(smbd_t)
 kernel_getattr_message_if(smbd_t)
+kernel_io_uring_use(smbd_t)
 kernel_read_network_state(smbd_t)
 kernel_read_net_sysctls(smbd_t)
 kernel_read_fs_sysctls(smbd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=AVC msg=audit(08/25/2024 22:56:47.375:253) : avc:  denied  { create } for  pid=1244 comm=smbd[127.0.0.1] anonclass=[io_uring] scontext=system_u:system_r:smbd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1

Resolves: rhbz#2307812