### PR TITLE
Update policy for rpc-virtstorage

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2339,6 +2339,7 @@ kernel_io_uring_use(virtstoraged_t)
 corecmd_exec_bin(virtstoraged_t)
 
 fs_getattr_all_fs(virtstoraged_t)
+fs_getattr_configfs_dirs(virtstoraged_t)
 
 userdom_read_user_home_content_files(virtstoraged_t)
 

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2334,12 +2334,16 @@ manage_files_pattern(virtstoraged_t, virt_var_lib_t, virt_var_lib_t)
 
 manage_lnk_files_pattern(virtstoraged_t, virt_etc_rw_t, virt_etc_rw_t)
 
+kernel_get_sysvipc_info(virtstoraged_t)
 kernel_io_uring_use(virtstoraged_t)
 
 corecmd_exec_bin(virtstoraged_t)
 
 fs_getattr_all_fs(virtstoraged_t)
 fs_getattr_configfs_dirs(virtstoraged_t)
+
+storage_raw_read_fixed_disk(virtstoraged_t)
+storage_raw_write_fixed_disk(virtstoraged_t)
 
 userdom_read_user_home_content_files(virtstoraged_t)
 
@@ -2348,7 +2352,15 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fstools_domtrans(virtstoraged_t)
+')
+
+optional_policy(`
 	lvm_domtrans(virtstoraged_t)
+')
+
+optional_policy(`
+	udev_domtrans(virtstoraged_t)
 ')
 
 #######################################

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -2064,6 +2064,24 @@ interface(`fs_dontaudit_write_configfs_dirs',`
 
 #######################################
 ## <summary>
+##	Getattr dirs on a configfs filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_getattr_configfs_dirs',`
+	gen_require(`
+		type configfs_t;
+	')
+
+	allow $1 configfs_t:dir getattr;
+')
+
+#######################################
+## <summary>
 ##	Read dirs
 ##	on a configfs filesystem.
 ## </summary>


### PR DESCRIPTION
In particular, domain transition on udev execution and r/w operations on fixed devices were allowed.

Resolves: rhbz#2305564