### PR TITLE
Allow nut-upsmon read systemd-logind session files

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -105,10 +105,7 @@ init_rw_utmp(nut_upsmon_t)
 init_telinit(nut_upsmon_t)
 fs_getattr_xattr_fs(nut_upsmon_t)
 
-
 mta_send_mail(nut_upsmon_t)
-
-systemd_start_power_services(nut_upsmon_t)
 
 optional_policy(`
 	shutdown_domtrans(nut_upsmon_t)
@@ -117,6 +114,11 @@ optional_policy(`
 optional_policy(`
 	dbus_system_bus_client(nut_upsmon_t)
 	systemd_dbus_chat_logind(nut_upsmon_t)
+')
+
+optional_policy(`
+	systemd_read_logind_sessions_files(nut_upsmon_t)
+	systemd_start_power_services(nut_upsmon_t)
 ')
 
 ########################################


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=AVC msg=audit(08/25/24 15:08:31.976:201) : avc:  denied  { read } for  pid=6543 comm=wall name=sessions dev="tmpfs" ino=1257 scontext=system_u:system_r:nut_upsmon_t:s0 tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=dir permissive=1

Resolves: rhbz#2297933