### PR TITLE
Allow sysadm_t to create PF_KEY sockets

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -15,6 +15,7 @@ allow sysadm_t self:netlink_generic_socket create_socket_perms;
 allow sysadm_t self:tipc_socket create_socket_perms;
 allow sysadm_t self:sctp_socket create_socket_perms;
 allow sysadm_t self:rawip_socket create_socket_perms;
+allow sysadm_t self:key_socket create_socket_perms;
 
 allow sysadm_t self:system all_system_perms;
 


### PR DESCRIPTION
This is needed to run selinux-testsuite as sysadm_t starting with: https://github.com/SELinuxProject/selinux-testsuite/commit/a9e631f0f1d5b11756a62679e8da073b3cc85b13