### PR TITLE
Update bootupd policy for unmounted ESP case

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -20,7 +20,7 @@ files_pid_file(bootupd_var_run_t)
 # bootupd local policy
 #
 allow bootupd_t self:capability { setgid setuid };
-allow bootupd_t self:process { fork setpgid };
+allow bootupd_t self:process { fork setfscreate setpgid };
 allow bootupd_t self:fifo_file rw_fifo_file_perms;
 allow bootupd_t self:unix_dgram_socket create_socket_perms;
 allow bootupd_t self:unix_stream_socket create_stream_socket_perms;
@@ -45,6 +45,8 @@ fs_getattr_all_fs(bootupd_t)
 fs_manage_dos_dirs(bootupd_t)
 fs_manage_dos_files(bootupd_t)
 fs_search_efivarfs_dirs(bootupd_t)
+
+storage_getattr_fixed_disk_dev(bootupd_t)
 
 optional_policy(`
 	bootloader_domtrans(bootupd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1725385838.182:370): avc:  denied  { getattr } for  pid=3034 comm="bootupctl" path="/dev/vda1" dev="devtmpfs" ino=311 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1 type=AVC msg=audit(1725385843.983:373): avc:  denied  { setfscreate } for  pid=3046 comm="cp" scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:system_r:bootupd_t:s0 tclass=process permissive=1