### PR TITLE
CI: update to actions/checkout@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       image: quay.io/fedora/fedora:rawhide
       options: --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: dnf install --nogpgcheck -y git-core checkpolicy policycoreutils-devel make m4 findutils
       - run: git clone --depth=1 https://github.com/containers/container-selinux.git /tmp/container-selinux
       - run: cp /tmp/container-selinux/container.* policy/modules/contrib


### PR DESCRIPTION
Fixes a deprecation warning:

>The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/