### PR TITLE
Allow boothd connect to kernel over a unix socket

### DIFF
--- a/policy/modules/contrib/boothd.te
+++ b/policy/modules/contrib/boothd.te
@@ -43,6 +43,7 @@ files_pid_filetrans(boothd_t, boothd_var_run_t, { dir file} )
 manage_dirs_pattern(boothd_t, boothd_var_lib_t, boothd_var_lib_t)
 
 kernel_dgram_send(boothd_t)
+kernel_stream_connect(boothd_t)
 
 corecmd_exec_bin(boothd_t)
 corecmd_exec_shell(boothd_t)


### PR DESCRIPTION
It actually allows boothd connect to systemd-userdbd over a unix socket when the socket is still labeled as kernel_t.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/09/2024 15:21:42.512:2513) : proctitle=/usr/sbin/boothd daemon -S -c /etc/booth/booth.conf type=PATH msg=audit(09/09/2024 15:21:42.512:2513) : item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=43 dev=00:1b mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(09/09/2024 15:21:42.512:2513) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DynamicUser } type=SYSCALL msg=audit(09/09/2024 15:21:42.512:2513) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x4 a1=0x7fff90ca7ec0 a2=0x2d a3=0x55fe78f35430 items=1 ppid=1 pid=61596 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=boothd exe=/usr/sbin/boothd subj=system_u:system_r:boothd_t:s0 key=(null) type=AVC msg=audit(09/09/2024 15:21:42.512:2513) : avc:  denied  { connectto } for  pid=61596 comm=boothd path=/systemd/userdb/io.systemd.DynamicUser scontext=system_u:system_r:boothd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0

Resolves: RHEL-45907