### PR TITLE
Make mdevctl_conf_t member of the files_type attribute

### DIFF
--- a/policy/modules/kernel/files.te
+++ b/policy/modules/kernel/files.te
@@ -82,6 +82,7 @@ typealias system_conf_t alias iptables_conf_t;
 
 # mdevctl_conf_t is a type for files in /etc/mdevctl.d
 type mdevctl_conf_t, configfile;
+files_type(mdevctl_conf_t)
 
 # system_db_t is a new type of various
 # db files.


### PR DESCRIPTION
In the 1d355565faf commit ("Label /etc/mdevctl.d with mdevctl_conf_t"), a new file type defined, but it was not made a part of the file_type attribute.

Resolves: rhbz#2311359