### PR TITLE
Allow virtstoraged execute mount programs in the mount domain

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2362,6 +2362,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mount_domtrans(virtstoraged_t)
+')
+
+optional_policy(`
 	udev_domtrans(virtstoraged_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/10/2024 09:02:19.765:1406) : proctitle=/usr/bin/mount -o nodev,nosuid,noexec -t auto /dev/vdb1 /var/lib/libvirt/images/vm-mountpoint-1 type=EXECVE msg=audit(09/10/2024 09:02:19.765:1406) : argc=7 a0=/usr/bin/mount a1=-o a2=nodev,nosuid,noexec a3=-t a4=auto a5=/dev/vdb1 a6=/var/lib/libvirt/images/vm-mountpoint-1 type=SYSCALL msg=audit(09/10/2024 09:02:19.765:1406) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7fe308002410 a1=0x7fe308001f60 a2=0x7ffe9070c6a8 a3=0x0 items=1 ppid=7130 pid=7232 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=mount exe=/usr/bin/mount subj=system_u:system_r:virtstoraged_t:s0 key=(null) type=AVC msg=audit(09/10/2024 09:02:19.765:1406) : avc:  denied  { map } for  pid=7232 comm=mount path=/usr/bin/mount dev="vda3" ino=793633 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:mount_exec_t:s0 tclass=file permissive=1 type=AVC msg=audit(09/10/2024 09:02:19.765:1406) : avc:  denied  { execute_no_trans } for  pid=7232 comm=rpc-virtstorage path=/usr/bin/mount dev="vda3" ino=793633 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:mount_exec_t:s0 tclass=file permissive=1 type=AVC msg=audit(09/10/2024 09:02:19.765:1406) : avc:  denied  { execute } for  pid=7232 comm=rpc-virtstorage name=mount dev="vda3" ino=793633 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:mount_exec_t:s0 tclass=file permissive=1

Resolves: rhbz#2311178