### PR TITLE
Allow unprivileged user watch /run/systemd

### DIFF
--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -42,6 +42,7 @@ seutil_read_module_store(user_t)
 
 init_dbus_chat(user_t)
 init_status(user_t)
+init_watch_pid_dir(user_t)
 
 mount_signal(user_t)
 mount_run_ecryptmount(user_t, user_r)


### PR DESCRIPTION
This is similar to commit 8b480be6082b ("Allow staff use watch /run/systemd"), just for user_t.

The commit addresses the following AVC denial:
type=AVC msg=audit(1725791489.845:352): avc:  denied  { watch } for  pid=5967 comm="cockpit-bridge" path="/run/systemd" dev="tmpfs" ino=2 scontext=user_u:user_r:user_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0

Resolves: rhbz#2310648