### PR TITLE
Define context for `.mylogin.cnf`

### DIFF
--- a/policy/modules/contrib/mysql.fc
+++ b/policy/modules/contrib/mysql.fc
@@ -4,7 +4,9 @@
 # /HOME
 #
 HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
+HOME_DIR/\.mylogin\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 /root/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
+/root/\.mylogin\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 
 /usr/lib/systemd/system/mysqld.*	--	gen_context(system_u:object_r:mysqld_unit_file_t,s0)
 /usr/lib/systemd/system/mariadb.*   --  gen_context(system_u:object_r:mysqld_unit_file_t,s0)


### PR DESCRIPTION
`.mylogin.cnf` is created by `mysql_config_editor`. The file location is the current user's home directory: https://dev.mysql.com/doc/refman/9.0/en/mysql-config-editor.html.

Also opened upstream as https://github.com/SELinuxProject/refpolicy/pull/808.