### PR TITLE
Remove fc entry for /usr/bin/pump

### DIFF
--- a/policy/modules/system/sysnetwork.fc
+++ b/policy/modules/system/sysnetwork.fc
@@ -54,7 +54,6 @@ ifdef(`distro_redhat',`
 /usr/bin/ipx_internal_net --	gen_context(system_u:object_r:ifconfig_exec_t,s0)
 /usr/bin/iwconfig	--	gen_context(system_u:object_r:ifconfig_exec_t,s0)
 /usr/bin/mii-tool	--	gen_context(system_u:object_r:ifconfig_exec_t,s0)
-/usr/bin/pump		--	gen_context(system_u:object_r:dhcpc_exec_t,s0)
 /usr/bin/tc		--	gen_context(system_u:object_r:ifconfig_exec_t,s0)
 
 #


### PR DESCRIPTION
The dhcpc_exec_t type was assigned to /usr/bin/pump because it was a part of the pump ("configure network interface via BOOTP or DHCP protocol") package which is not available in Fedora any longer. This clashes with the same binary name from the distcc ("Distributed C/C++ compilation") package where no private type is needed.

Resolves: rhbz#2312044