### PR TITLE
Label /usr/bin/noping and /usr/bin/oping with ping_exec_t

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -7,6 +7,7 @@
 /usr/bin/lft		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/mtr		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
 /usr/bin/nmap		--	gen_context(system_u:object_r:traceroute_exec_t,s0)
+/usr/bin/n?oping 	--	gen_context(system_u:object_r:ping_exec_t,s0)
 /usr/bin/ping.* 	--	gen_context(system_u:object_r:ping_exec_t,s0)
 /usr/bin/send_arp	--	gen_context(system_u:object_r:ping_exec_t,s0)
 /usr/bin/tcpdump	--	gen_context(system_u:object_r:netutils_exec_t,s0)


### PR DESCRIPTION
These commands are provided by the liboping package.

Resolves: rhbz#2305961