### PR TITLE
Allow qatlib connect to systemd-machined over a unix socket

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -40,6 +40,7 @@ files_pid_filetrans(qatlib_t, qatlib_var_run_t, { dir file sock_file } )
 kernel_load_module(qatlib_t)
 kernel_read_proc_files(qatlib_t)
 kernel_request_load_module(qatlib_t)
+kernel_search_debugfs(qatlib_t)
 kernel_stream_connect(qatlib_t)
 
 corecmd_exec_shell(qatlib_t)

--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -82,5 +82,6 @@ optional_policy(`
 
 optional_policy(`
 	systemd_search_unit_dirs(qatlib_t)
+	systemd_machined_stream_connect(qatlib_t)
 	systemd_userdbd_stream_connect(qatlib_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1725307496.795:489): avc:  denied  { connectto } for  pid=5096 comm="chown" path="/run/systemd/userdb/io.systemd.Machine" scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=unix_stream_socket permissive=0