### PR TITLE
Allow rngd read and write generic usb devices

### DIFF
--- a/policy/modules/contrib/rngd.te
+++ b/policy/modules/contrib/rngd.te
@@ -46,6 +46,7 @@ auth_use_nsswitch(rngd_t)
 
 dev_read_rand(rngd_t)
 dev_read_urand(rngd_t)
+dev_rw_generic_usb_dev(rngd_t)
 dev_rw_tpm(rngd_t)
 dev_write_rand(rngd_t)
 dev_read_sysfs(rngd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1720074976.413:170): avc:  denied  { read write } for  pid=1914 comm="rngd" name="012" dev="devtmpfs" ino=533 scontext=system_u:system_r:rngd_t:s0 tcontext=system_u:object_r:usb_device_t:s0 tclass=chr_file permissive=0 type=SYSCALL msg=audit(1720074976.413:170): arch=x86_64 syscall=openat success=no exit=EACCES a0=ffffff9c a1=7ffd075886d0 a2=80002 a3=0 items=1 ppid=1 pid=1914 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=rngd exe=/usr/sbin/rngd subj=system_u:system_r:rngd_t:s0 key=(null) type=PATH msg=audit(1720074976.413:170): item=0 name=/dev/bus/usb/001/012 inode=533 dev=00:06 mode=020664 ouid=0 ogid=990 rdev=bd:0b obj=system_u:object_r:usb_device_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: rhbz#1892399