### PR TITLE
Synchronize with 'mysql-selinux' upstream

### DIFF
--- a/policy/modules/contrib/mysql.fc
+++ b/policy/modules/contrib/mysql.fc
@@ -48,7 +48,7 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 # /var
 #
 /var/lib/mysql(-files|-keyring)?(/.*)?		gen_context(system_u:object_r:mysqld_db_t,s0)
-/var/lib/mysql/mysql\.sock -s	gen_context(system_u:object_r:mysqld_var_run_t,s0)
+/var/lib/mysql/mysql(x)?\.sock -s	gen_context(system_u:object_r:mysqld_var_run_t,s0)
 
 /var/log/mariadb(/.*)?	gen_context(system_u:object_r:mysqld_log_t,s0)
 /var/log/mysql(/.*)?	gen_context(system_u:object_r:mysqld_log_t,s0)

--- a/policy/modules/contrib/mysql.fc
+++ b/policy/modules/contrib/mysql.fc
@@ -44,6 +44,8 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 
 /usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
+/usr/bin/mariadb-backup	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+
 #
 # /var
 #

--- a/policy/modules/contrib/mysql.te
+++ b/policy/modules/contrib/mysql.te
@@ -76,6 +76,9 @@ allow mysqld_t self:unix_stream_socket create_stream_socket_perms;
 allow mysqld_t self:tcp_socket create_stream_socket_perms;
 allow mysqld_t self:udp_socket create_socket_perms;
 
+kernel_read_network_state(mysqld_t)
+kernel_read_net_sysctls(mysqld_t)
+
 manage_dirs_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)
 manage_files_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)
 manage_sock_files_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)

--- a/policy/modules/contrib/mysql.te
+++ b/policy/modules/contrib/mysql.te
@@ -251,6 +251,7 @@ mysql_write_log(mysqld_safe_t)
 
 optional_policy(`
 	hostname_exec(mysqld_safe_t)
+	hostname_exec(mysqld_t)
 ')
 
 ########################################

--- a/policy/modules/contrib/mysql.te
+++ b/policy/modules/contrib/mysql.te
@@ -79,6 +79,10 @@ allow mysqld_t self:udp_socket create_socket_perms;
 kernel_read_network_state(mysqld_t)
 kernel_read_net_sysctls(mysqld_t)
 
+# Allow mysqld_t to read to memory.pressure in cgroup
+fs_read_cgroup_files(mysqld_t)
+fs_write_cgroup_files(mysqld_t)
+
 manage_dirs_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)
 manage_files_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)
 manage_sock_files_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)


### PR DESCRIPTION
Together with https://github.com/devexp-db/mysql-selinux/pull/7 it completely synchronizes the content mysql.* files in these two repositories.