### PR TITLE
Allow ssh read network sysctls

### DIFF
--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -1309,6 +1309,7 @@ interface(`gnome_read_home_config',`
 	read_files_pattern($1, config_home_t, config_home_t)
 	read_lnk_files_pattern($1, config_home_t, config_home_t)
 ')
+
 #######################################
 ## <summary>
 ##  append gnome homedir content (.config)
@@ -1344,6 +1345,24 @@ interface(`gnome_delete_home_config',`
 
     delete_files_pattern($1, config_home_t, config_home_t)
     delete_lnk_files_pattern($1, config_home_t, config_home_t)
+')
+
+########################################
+## <summary>
+##	map gnome homedir file
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`gnome_map_home_config_file',`
+	gen_require(`
+		type config_home_t;
+	')
+
+	allow $1 config_home_t:file map;
 ')
 
 ########################################

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -168,6 +168,8 @@ manage_files_pattern(ssh_server, ssh_home_t, ssh_home_t)
 
 kernel_read_device_sysctls(ssh_t)
 kernel_read_kernel_sysctls(ssh_t)
+kernel_read_net_sysctls(ssh_t)
+kernel_read_network_state_symlinks(ssh_t)
 kernel_read_system_state(ssh_t)
 
 corenet_all_recvfrom_netlabel(ssh_t)

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -254,6 +254,7 @@ optional_policy(`
 	gnome_map_generic_cache_files(ssh_t)
 	gnome_read_home_config(ssh_t)
 	gnome_map_home_config_file(ssh_t)
+	gnome_watch_home_config_dirs(ssh_t)
 	gnome_stream_connect_gkeyringd(ssh_t)
 ')
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -253,6 +253,7 @@ optional_policy(`
 	gnome_read_generic_cache_files(ssh_t)
 	gnome_map_generic_cache_files(ssh_t)
 	gnome_read_home_config(ssh_t)
+	gnome_map_home_config_file(ssh_t)
 	gnome_stream_connect_gkeyringd(ssh_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(20.9.2024 09:59:31.339:3693) : proctitle=ssh hostname type=PATH msg=audit(20.9.2024 09:59:31.339:3693) : item=0 name=/proc/net/if_inet6 inode=4026532248 dev=00:17 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:proc_net_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(20.9.2024 09:59:31.339:3693) : arch=x86_64 syscall=access success=yes exit=0 a0=0x7fffe9993063 a1=F_OK a2=0x0 a3=0x8 items=1 ppid=39997 pid=511328 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=pts16 ses=7 comm=ssh exe=/usr/bin/ssh subj=staff_u:staff_r:ssh_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(20.9.2024 09:59:31.339:3693) : avc:  denied  { read } for  pid=511328 comm=ssh name=net dev="proc" ino=4026531845 scontext=staff_u:staff_r:ssh_t:s0-s0:c0.c1023 tcontext=system_u:object_r:proc_net_t:s0 tclass=lnk_file permissive=1