### PR TITLE
Allow virtnodedev watch mdevctl config dirs

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2008,9 +2008,9 @@ dev_rw_sysfs(virtnodedevd_t)
 dev_write_sysfs_dirs(virtnodedevd_t)
 
 files_map_var_lib_files(virtnodedevd_t)
-files_watch_etc_dirs(virtnodedevd_t)
 files_etc_filetrans_mdevctl_conf(virtnodedevd_t)
 files_manage_mdevctl_conf_files(virtnodedevd_t)
+files_watch_mdevctl_conf_dirs(virtnodedevd_t)
 
 miscfiles_read_hwdata(virtnodedevd_t)
 

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6084,6 +6084,25 @@ interface(`files_manage_mdevctl_conf_files',`
 	manage_files_pattern($1, mdevctl_conf_t, mdevctl_conf_t)
 ')
 
+#######################################
+## <summary>
+##	Watch mdevctl configuration dirs
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_watch_mdevctl_conf_dirs',`
+	gen_require(`
+		type mdevctl_conf_t;
+	')
+
+	files_search_etc(mdevctl_conf_t)
+	allow $1 mdevctl_conf_t:dir watch_dir_perms;
+')
+
 ###################################
 ## <summary>
 ##	Create /etc/mdevctl.d with the correct type


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1727331873.951:1167): avc:  denied  { watch } for  pid=254281 comm="gmain" path="/etc/mdevctl.d/scripts.d" dev="sdc3" ino=10149729 scontext=system_u:system_r:virtnodedevd_t:s0 tcontext=system_u:object_r:mdevctl_conf_t:s0 tclass=dir permissive=0

Resolves: rhbz#2314826