### PR TITLE
Allow cups sys_ptrace capability in the user namespace

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -141,6 +141,7 @@ optional_policy(`
 allow cupsd_t self:capability { ipc_lock sys_admin dac_read_search dac_override kill fsetid fowner chown  sys_resource sys_tty_config };
 dontaudit cupsd_t self:capability { sys_tty_config net_admin };
 allow cupsd_t self:capability2 { block_suspend bpf wake_alarm };
+allow cupsd_t self:cap_userns sys_ptrace;
 allow cupsd_t self:process { getpgid setpgid setsched };
 allow cupsd_t self:unix_stream_socket { accept connectto listen };
 allow cupsd_t self:netlink_selinux_socket create_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1727848187.513:977): avc:  denied  { sys_ptrace } for  pid=38857 comm="boomaga" capability=19  scontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tclass=cap_userns permissive=0

Resolves: rhbz#2316054