### PR TITLE
Allow chronyc sendto to chronyd-restricted

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -256,6 +256,7 @@ allow chronyc_t self:unix_dgram_socket create_socket_perms;
 allow chronyc_t self:netlink_route_socket create_netlink_socket_perms;
 
 allow chronyc_t chronyd_t:unix_dgram_socket sendto;
+allow chronyc_t chronyd_restricted_t:unix_dgram_socket sendto;
 
 allow chronyc_t chronyd_keys_t:file manage_file_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1720332788.481:210): avc:  denied  { sendto } for  pid=4457 comm="chronyc" path="/run/chrony/chronyd.sock" scontext=system_u:system_r:chronyc_t:s0 tcontext=system_u:system_r:chronyd_restricted_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#2296169