### PR TITLE
Update policy for xdm with confined users

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -357,6 +357,7 @@ domain_read_all_domains_state(session_bus_type)
 files_list_home(session_bus_type)
 files_dontaudit_search_var(session_bus_type)
 files_watch_usr_dirs(session_bus_type)
+files_watch_var_lib_dirs(session_bus_type)
 
 fs_getattr_romfs(session_bus_type)
 fs_getattr_xattr_fs(session_bus_type)
@@ -385,6 +386,7 @@ userdom_manage_tmpfs_files(session_bus_type, file)
 userdom_tmpfs_filetrans(session_bus_type, file)
 
 optional_policy(`
+	gnome_atspi_domtrans(session_bus_type)
 	gnome_read_config(session_bus_type)
 	gnome_read_gconf_home_files(session_bus_type)
 ')


### PR DESCRIPTION
In particular, session_bus_type (e.g. staff_sbusd_t) was allowed to:
- watch directories in /var/lib
- execute gnome at-spi with a domain transition

The commit addresses the following AVC denials:
type=AVC msg=audit(10/06/24 12:26:17.286:3657) : avc:  denied  { execute } for  pid=302496 comm=dbus-daemon name=at-spi-bus-launcher dev="dm-1" ino=4077266 scontext=staff_u:staff_r:staff_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:gnome_atspi_exec_t:s0 tclass=file permissive=0 type=AVC msg=audit(10/06/24 12:45:54.010:687) : avc:  denied  { watch } for  pid=12716 comm=dbus-broker-lau path=/var/lib/flatpak/exports/share/dbus-1/services dev="dm-0" ino=2174243 scontext=staff_u:staff_r:staff_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_lib_t:s0 tclass=dir permissive=0

Resolves: rhbz#2291173