### PR TITLE
Allow staff user nlmsg_write

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -25,6 +25,7 @@ gen_tunable(staff_use_svirt, false)
 allow staff_t self:cap_userns { setpcap };
 allow staff_t self:io_uring sqpoll;
 allow staff_t self:netlink_generic_socket { create_socket_perms };
+allow staff_t self:netlink_route_socket nlmsg_write;
 
 corenet_ib_access_unlabeled_pkeys(staff_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(03/07/24 14:44:11.816:3069) : avc:  denied  { nlmsg_write } for  pid=543746 comm=bwrap scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=netlink_route_socket permissive=0

Resolves: rhbz#2295425