### PR TITLE
F40 backports

### DIFF
--- a/policy/modules/contrib/boothd.te
+++ b/policy/modules/contrib/boothd.te
@@ -77,5 +77,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+       systemd_userdbd_stream_connect(boothd_t)
+')
+
+optional_policy(`
 	sysnet_read_config(boothd_t)
 ')

--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -356,6 +356,7 @@ domain_read_all_domains_state(session_bus_type)
 files_list_home(session_bus_type)
 files_dontaudit_search_var(session_bus_type)
 files_watch_usr_dirs(session_bus_type)
+files_watch_var_lib_dirs(session_bus_type)
 
 fs_getattr_romfs(session_bus_type)
 fs_getattr_xattr_fs(session_bus_type)
@@ -384,6 +385,7 @@ userdom_manage_tmpfs_files(session_bus_type, file)
 userdom_tmpfs_filetrans(session_bus_type, file)
 
 optional_policy(`
+	gnome_atspi_domtrans(session_bus_type)
 	gnome_read_config(session_bus_type)
 	gnome_read_gconf_home_files(session_bus_type)
 ')

--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -166,7 +166,7 @@ template(`virt_driver_template',`
 
 	# This sequence of quotation marks is needed to prevent "interface"
 	# from being interpreted as a keyword and further parsed by m4 macros
-	filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, "``interface''")
+	filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, ``"interface"'')
 	filetrans_pattern($1, virt_var_run_t, virtnodedevd_var_run_t, dir, "nodedev")
 	filetrans_pattern($1, virt_var_run_t, virtnwfilterd_var_run_t, dir, "nwfilter")
 	filetrans_pattern($1, virt_var_run_t, virtsecretd_var_run_t, dir, "secrets")

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -25,6 +25,7 @@ gen_tunable(staff_use_svirt, false)
 allow staff_t self:cap_userns { setpcap };
 allow staff_t self:io_uring sqpoll;
 allow staff_t self:netlink_generic_socket { create_socket_perms };
+allow staff_t self:netlink_route_socket nlmsg_write;
 
 corenet_ib_access_unlabeled_pkeys(staff_t)
 

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -28,6 +28,7 @@ kernel_manage_perf_event(sysadm_t)
 kernel_prog_run_bpf(sysadm_t)
 kernel_read_fs_sysctls(sysadm_t)
 kernel_read_all_proc(sysadm_t)
+kernel_secretmem_use(sysadm_t)
 kernel_unconfined(sysadm_t)
 
 auth_manage_shadow(sysadm_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -484,7 +484,7 @@ optional_policy(`
 allow systemd_machined_t self:capability { dac_read_search dac_override setgid sys_admin sys_chroot sys_ptrace kill };
 allow systemd_machined_t systemd_unit_file_t:service { status start stop };
 allow systemd_machined_t self:unix_dgram_socket create_socket_perms;
-allow systemd_machined_t self:cap_userns { setgid setuid sys_admin sys_chroot sys_ptrace };
+allow systemd_machined_t self:cap_userns { kill setgid setuid sys_admin sys_chroot sys_ptrace };
 
 manage_dirs_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 manage_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)


### PR DESCRIPTION
In particular, session_bus_type (e.g. staff_dbusd_t) was allowed to:
- watch directories in /var/lib
- execute gnome at-spi with a domain transition

The commit addresses the following AVC denials:
type=AVC msg=audit(10/06/24 12:26:17.286:3657) : avc:  denied  { execute } for  pid=302496 comm=dbus-daemon name=at-spi-bus-launcher dev="dm-1" ino=4077266 scontext=staff_u:staff_r:staff_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:gnome_atspi_exec_t:s0 tclass=file permissive=0 type=AVC msg=audit(10/06/24 12:45:54.010:687) : avc:  denied  { watch } for  pid=12716 comm=dbus-broker-lau path=/var/lib/flatpak/exports/share/dbus-1/services dev="dm-0" ino=2174243 scontext=staff_u:staff_r:staff_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_lib_t:s0 tclass=dir permissive=0

Resolves: rhbz#2291173