### PR TITLE
Label /dev/hfi1_[0-9]+ devices

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -46,6 +46,7 @@
 /dev/graphics		-c	gen_context(system_u:object_r:xserver_misc_device_t,s0)
 /dev/gtrsc.*		-c	gen_context(system_u:object_r:clock_device_t,s0)
 /dev/hfmodem		-c	gen_context(system_u:object_r:sound_device_t,s0)
+/dev/hfi1_[0-9]+	-c	gen_context(system_u:object_r:hfi1_device_t,s0)
 /dev/hiddev.*		-c	gen_context(system_u:object_r:usb_device_t,s0)
 /dev/hidraw.*		-c	gen_context(system_u:object_r:usb_device_t,s0)
 /dev/hpet		-c	gen_context(system_u:object_r:clock_device_t,s0)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -6755,6 +6755,24 @@ interface(`dev_rw_papr_sysparm',`
 
 ########################################
 ## <summary>
+##	Allow read the hfi1_[0-9]+ devices
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_read_hfi1',`
+	gen_require(`
+		type device_t, hfi1_device_t;
+	')
+
+	read_chr_files_pattern($1, device_t, hfi1_device_t)
+')
+
+########################################
+## <summary>
 ##	Create all named devices with the correct label
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -159,6 +159,12 @@ type gpio_device_t;
 dev_node(gpio_device_t)
 
 #
+# Type for /dev/hfi1_[0-9]+
+#
+type hfi1_device_t;
+dev_node(hfi1_device_t)
+
+#
 # Type for /dev/ipmi/0
 #
 type ipmi_device_t;


### PR DESCRIPTION
Support for Cornelis Omni-Path Express Gen1 driver.