### PR TITLE
Fix systemd-homed blobs directory permissions

### DIFF
--- a/policy/modules/system/systemd-homed.fc
+++ b/policy/modules/system/systemd-homed.fc
@@ -21,4 +21,5 @@
 /var/lib/systemd/home                                     -d  gen_context(system_u:object_r:systemd_homed_library_dir_t,s0)
 
 HOME_DIR/\.identity                                       --  gen_context(system_u:object_r:systemd_homed_record_t,s0)
+HOME_DIR/\.identity-blob(/.*)?                                gen_context(system_u:object_r:systemd_homed_record_t,s0)
 HOME_ROOT/(.+)\.home                                      --  gen_context(system_u:object_r:systemd_homed_crypto_luks_t,s0)

--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -75,8 +75,11 @@ files_manage_isid_type_files(systemd_homed_t)
 fs_getattr_tmpfs(systemd_homed_t)
 
 # /var/cache/systemd/home
+create_dirs_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)
+delete_dirs_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)
 list_dirs_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)
-read_files_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)
+rename_dirs_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)
+delete_files_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)
 
 # /var/lib/systemd/home
 manage_files_pattern(systemd_homed_t, systemd_homed_library_dir_t, systemd_homed_record_t)
@@ -138,8 +141,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_manage_userdbd_runtime_sock_files(systemd_homed_t)
-	systemd_search_cache_dirs(systemd_homed_t)
+    systemd_manage_userdbd_runtime_sock_files(systemd_homed_t)
+    systemd_search_cache_dirs(systemd_homed_t)
 ')
 
 optional_policy(`
@@ -147,13 +150,13 @@ optional_policy(`
 ')
 
 optional_policy(`
-   # labeled home directories
-   userdom_home_manager(systemd_homed_t)
-   userdom_manage_home_role(system_r, systemd_homed_t)
+    # labeled home directories
+    userdom_home_manager(systemd_homed_t)
+    userdom_manage_home_role(system_r, systemd_homed_t)
 ')
 
 optional_policy(`
-   usermanage_read_crack_db(systemd_homed_t)
+    usermanage_read_crack_db(systemd_homed_t)
 ')
 
 #######################################
@@ -183,8 +186,10 @@ files_manage_isid_type_files(systemd_homework_t)
 files_mounton_isid(systemd_homework_t)
 
 # /var/cache/systemd/home
-list_dirs_pattern(systemd_homework_t, systemd_homed_cache_t, systemd_homed_cache_t)
-read_files_pattern(systemd_homework_t, systemd_homed_cache_t, systemd_homed_cache_t)
+create_dirs_pattern(systemd_homework_t, systemd_homed_cache_t, systemd_homed_cache_t)
+delete_dirs_pattern(systemd_homework_t, systemd_homed_cache_t, systemd_homed_cache_t)
+rename_dirs_pattern(systemd_homework_t, systemd_homed_cache_t, systemd_homed_cache_t)
+manage_files_pattern(systemd_homework_t, systemd_homed_cache_t, systemd_homed_cache_t)
 
 # /run/systemd/home/notify
 write_sock_files_pattern(systemd_homework_t, systemd_homed_runtime_dir_t, systemd_homed_runtime_socket_t)
@@ -255,7 +260,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_search_cache_dirs(systemd_homework_t)
+    systemd_cache_filetrans(systemd_homework_t, systemd_homed_cache_t, dir, "home")
+    systemd_search_cache_dirs(systemd_homework_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Oct 08 18:42:47 fedora audit[911]: AVC avc:  denied  { write } for  pid=911 comm="systemd-homed" name="home" dev="sda3" ino=196819 scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[911]: AVC avc:  denied  { add_name } for  pid=911 comm="systemd-homed" name="rich" scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[911]: AVC avc:  denied  { create } for  pid=911 comm="systemd-homed" name="rich" scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { write } for  pid=3061 comm="systemd-homewor" name="home" dev="sda3" ino=196819 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { add_name } for  pid=3061 comm="systemd-homewor" name=".#rich7c61b494c6f1bd9c" scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { create } for  pid=3061 comm="systemd-homewor" name=".#rich7c61b494c6f1bd9c" scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { write } for  pid=3061 comm="systemd-homewor" path=2F7661722F63616368652F73797374656D642F686F6D652F2E2372696368376336316234393463366631626439632F23343535323835202864656C6574656429 dev="sda3" ino=455285 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=file permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { setattr } for  pid=3061 comm="systemd-homewor" name="#455285" dev="sda3" ino=455285 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=file permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { link } for  pid=3061 comm="systemd-homewor" name="#455285" dev="sda3" ino=455285 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=file permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { remove_name } for  pid=3061 comm="systemd-homewor" name=".#rich7c61b494c6f1bd9c" dev="sda3" ino=455284 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { rename } for  pid=3061 comm="systemd-homewor" name=".#rich7c61b494c6f1bd9c" dev="sda3" ino=455284 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:42:47 fedora audit[3061]: AVC avc:  denied  { rmdir } for  pid=3061 comm="systemd-homewor" name="rich" dev="sda3" ino=455283 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:44:56 fedora audit[911]: AVC avc:  denied  { remove_name } for  pid=911 comm="systemd-homed" name="avatar" dev="sda3" ino=455285 scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1
Oct 08 18:44:56 fedora audit[911]: AVC avc:  denied  { unlink } for  pid=911 comm="systemd-homed" name="avatar" dev="sda3" ino=455285 scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=file permissive=1
Oct 08 18:44:56 fedora audit[911]: AVC avc:  denied  { rmdir } for  pid=911 comm="systemd-homed" name="rich" dev="sda3" ino=455284 scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:systemd_homed_cache_t:s0 tclass=dir permissive=1