### PR TITLE
Grant rhsmcertd chown capability & userdb access

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -41,7 +41,7 @@ files_type(cloud_what_var_cache_t)
 # Local policy
 #
 
-allow rhsmcertd_t self:capability { fowner kill sys_nice };
+allow rhsmcertd_t self:capability { chown fowner fsetid kill sys_nice };
 allow rhsmcertd_t self:process { signal_perms setsched };
 dontaudit rhsmcertd_t self:process setfscreate;
 
@@ -203,4 +203,8 @@ optional_policy(`
 
 optional_policy(`
     container_manage_config_files(rhsmcertd_t)
+')
+
+optional_policy(`
+    systemd_userdbd_stream_connect(rhsmcertd_t)
 ')


### PR DESCRIPTION
After registering a host with RHSM, the rhsm-service writes a certificate and key file to /etc/pki/consumer. This key-pair is used by other services on the system for authentication, so they need to be readable by a group of other services. After writing the certificates to the filesystem, rhsm-service changes the group from 'root' to 'rhsm'. In order to perform this group change, the process needs the 'chown' capability.

This PR fixes the following denial:
```
----
type=PROCTITLE msg=audit(10/09/24 11:08:27.220:631) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-service
type=PATH msg=audit(10/09/24 11:08:27.220:631) : item=0 name=/run/systemd/userdb/ inode=42 dev=00:1c mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/09/24 11:08:27.220:631) : cwd=/
type=SYSCALL msg=audit(10/09/24 11:08:27.220:631) : arch=aarch64 syscall=openat success=yes exit=12 a0=AT_FDCWD a1=0xffffa966f388 a2=O_RDONLY|O_NONBLOCK|O_DIRECT|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=4594 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-service exe=/usr/bin/python3.12 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)
type=AVC msg=audit(10/09/24 11:08:27.220:631) : avc:  denied  { read } for  pid=4594 comm=rhsm-service name=userdb dev="tmpfs" ino=42 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=1
----
type=PROCTITLE msg=audit(10/09/24 11:08:27.220:632) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-service
type=PATH msg=audit(10/09/24 11:08:27.220:632) : item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=43 dev=00:1c mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/09/24 11:08:27.220:632) : cwd=/
type=SOCKADDR msg=audit(10/09/24 11:08:27.220:632) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DynamicUser }
type=SYSCALL msg=audit(10/09/24 11:08:27.220:632) : arch=aarch64 syscall=connect success=yes exit=0 a0=0xd a1=0xffffcc016b08 a2=0x2d a3=0x0 items=1 ppid=1 pid=4594 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-service exe=/usr/bin/python3.12 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)
type=AVC msg=audit(10/09/24 11:08:27.220:632) : avc:  denied  { write } for  pid=4594 comm=rhsm-service name=io.systemd.DynamicUser dev="tmpfs" ino=43 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=sock_file permissive=1
----
type=PROCTITLE msg=audit(10/09/24 11:08:27.230:633) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-service
type=PATH msg=audit(10/09/24 11:08:27.230:633) : item=0 name=/etc/pki/consumer/key.pem inode=25167617 dev=fc:02 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cert_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/09/24 11:08:27.230:633) : cwd=/
type=SYSCALL msg=audit(10/09/24 11:08:27.230:633) : arch=aarch64 syscall=fchownat success=yes exit=0 a0=AT_FDCWD a1=0xffffa8d10150 a2=0x0 a3=0x3e1 items=1 ppid=1 pid=4594 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-service exe=/usr/bin/python3.12 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)
type=AVC msg=audit(10/09/24 11:08:27.230:633) : avc:  denied  { chown } for  pid=4594 comm=rhsm-service capability=chown  scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:system_r:rhsmcertd_t:s0 tclass=capability permissive=1
----
type=PROCTITLE msg=audit(10/09/24 11:08:27.230:634) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-service
type=PATH msg=audit(10/09/24 11:08:27.230:634) : item=0 name=/etc/pki/consumer/key.pem inode=25167617 dev=fc:02 mode=file,644 ouid=root ogid=rhsm rdev=00:00 obj=system_u:object_r:cert_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(10/09/24 11:08:27.230:634) : cwd=/
type=SYSCALL msg=audit(10/09/24 11:08:27.230:634) : arch=aarch64 syscall=fchmodat success=yes exit=0 a0=AT_FDCWD a1=0xffffa8d10150 a2=0640 a3=0x1 items=1 ppid=1 pid=4594 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-service exe=/usr/bin/python3.12 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)
type=AVC msg=audit(10/09/24 11:08:27.230:634) : avc:  denied  { fsetid } for  pid=4594 comm=rhsm-service capability=fsetid  scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:system_r:rhsmcertd_t:s0 tclass=capability permissive=1
```

This is a continuation of #2378. I am relatively new to the area of writing SELinux policies. We did introduce new capabilities in subscription-manager, so these denials seem appropriate. My goal with this PR is to contribute the correct changes to the rhsmcertd module to permit the ownership changes that rhsm-service is now performing.