### PR TITLE
Allow systemd-machined the kill user-namespace capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -502,7 +502,7 @@ optional_policy(`
 allow systemd_machined_t self:capability { dac_read_search dac_override setgid sys_admin sys_chroot sys_ptrace kill };
 allow systemd_machined_t systemd_unit_file_t:service { status start stop };
 allow systemd_machined_t self:unix_dgram_socket create_socket_perms;
-allow systemd_machined_t self:cap_userns { setgid setuid sys_admin sys_chroot sys_ptrace };
+allow systemd_machined_t self:cap_userns { kill setgid setuid sys_admin sys_chroot sys_ptrace };
 
 manage_dirs_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 manage_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)


### PR DESCRIPTION
Triggered by an attempt to stop a container with

machinectl stop container_name

The commit addresses the following AVC denial:
type=AVC msg=audit(1728452203.924:854): avc:  denied  { kill } for  pid=920 comm="systemd-machine" capability=5  scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=cap_userns permissive=0

Resolves: rhbz#2317484