### PR TITLE
Allow ptp4l the sys_admin capability

### DIFF
--- a/policy/modules/contrib/linuxptp.te
+++ b/policy/modules/contrib/linuxptp.te
@@ -159,7 +159,7 @@ allow ptp4l_t self:packet_socket create_socket_perms;
 allow ptp4l_t self:unix_stream_socket create_stream_socket_perms;
 allow ptp4l_t self:shm create_shm_perms;
 allow ptp4l_t self:udp_socket create_socket_perms;
-allow ptp4l_t self:capability { net_admin net_raw sys_time };
+allow ptp4l_t self:capability { net_admin net_raw sys_admin sys_time };
 allow ptp4l_t self:capability2 { bpf wake_alarm };
 allow ptp4l_t self:netlink_route_socket rw_netlink_socket_perms;
 


### PR DESCRIPTION
ptp4l uses the generic netlink socket to get information about virtual PTP clocks for checking whether a PHC not matching the physical NIC PHC is a virtual clock. Binding a generic netlink socket requires the sys_admin capability.

Resolves: RHEL-55133