### PR TITLE
Allow iio-sensor-proxy the bpf capability

### DIFF
--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -9,6 +9,7 @@ type iiosensorproxy_t;
 type iiosensorproxy_exec_t;
 init_daemon_domain(iiosensorproxy_t, iiosensorproxy_exec_t)
 
+allow iiosensorproxy_t self:capability2 bpf;
 allow iiosensorproxy_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 dev_read_sysfs(iiosensorproxy_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/11/2024 15:01:06.998:7494) : proctitle=/usr/libexec/iio-sensor-proxy type=SYSCALL msg=audit(10/11/2024 15:01:06.998:7494) : arch=x86_64 syscall=setsockopt success=yes exit=0 a0=0x7 a1=SOL_SOCKET a2=SO_ATTACH_FILTER a3=0x7ffe8852ca40 items=0 ppid=1 pid=215132 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=iio-sensor-prox exe=/usr/libexec/iio-sensor-proxy subj=system_u:system_r:iiosensorproxy_t:s0 key=(null) type=AVC msg=audit(10/11/2024 15:01:06.998:7494) : avc:  denied  { sys_admin } for  pid=215132 comm=iio-sensor-prox capability=sys_admin  scontext=system_u:system_r:iiosensorproxy_t:s0 tcontext=system_u:system_r:iiosensorproxy_t:s0 tclass=capability permissive=0 type=AVC msg=audit(10/11/2024 15:01:06.998:7494) : avc:  denied  { bpf } for  pid=215132 comm=iio-sensor-prox capability=bpf  scontext=system_u:system_r:iiosensorproxy_t:s0 tcontext=system_u:system_r:iiosensorproxy_t:s0 tclass=capability2 permissive=0

Resolves: RHEL-17346