### PR TITLE
Allow login_userdomain read thumb tmp files

### DIFF
--- a/policy/modules/contrib/thumb.if
+++ b/policy/modules/contrib/thumb.if
@@ -151,3 +151,22 @@ interface(`thumb_filetrans_home_content',`
 		gnome_cache_filetrans($1, thumb_home_t, dir, "thumbnails")
 	')
 ')
+
+########################################
+## <summary>
+##	Allow the specified domain to read thumb tmp files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`thumb_read_tmp_files',`
+	gen_require(`
+		type thumb_tmp_t;
+	')
+
+	files_search_tmp($1)
+	allow $1 thumb_tmp_t:file read_file_perms;
+')

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -502,6 +502,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	thumb_read_tmp_files(login_userdomain)
+')
+
+optional_policy(`
 	xserver_stream_accept_xdm(login_userdomain)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12.10.2024 20:41:27.864:3152) : proctitle=/usr/lib64/thunderbird/thunderbird --sm-client-id 10cddccc67000172131745800000026000005 type=PATH msg=audit(12.10.2024 20:41:27.864:3152) : item=0 name=/tmp/dolphin-FkDhKKba2b9bd45efcab81fbdbb9e917d536e3.png inode=7131 dev=00:2b mode=file,644 ouid=username ogid=username rdev=00:00 obj=staff_u:object_r:thumb_tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(12.10.2024 20:41:27.864:3152) : arch=x86_64 syscall=openat success=yes exit=113 a0=AT_FDCWD a1=0x7fffab449f00 a2=O_RDONLY|O_NOATIME|O_CLOEXEC a3=0x0 items=1 ppid=2500 pid=3488 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=(none) ses=3 comm=pool-org.mozill exe=/usr/lib64/thunderbird/thunderbird subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(12.10.2024 20:41:27.864:3152) : avc:  denied  { open } for  pid=3488 comm=pool-org.mozill path=/tmp/dolphin-FkDhKKba2b9bd45efcab81fbdbb9e917d536e3.png dev="tmpfs" ino=7131 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:thumb_tmp_t:s0 tclass=file permissive=1