### PR TITLE
Fix the /etc/mdevctl\.d(/.*)? regexp

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -60,7 +60,7 @@ ifdef(`distro_suse',`
 /etc/nologin.*		--	gen_context(system_u:object_r:etc_runtime_t,s0)
 /etc/securetty  	--  	gen_context(system_u:object_r:etc_runtime_t,s0)
 
-/etc/mdevctl\.d(/.*)		gen_context(system_u:object_r:mdevctl_conf_t,s0)
+/etc/mdevctl\.d(/.*)?		gen_context(system_u:object_r:mdevctl_conf_t,s0)
 /etc/sysctl\.conf(\.old)?               --      gen_context(system_u:object_r:system_conf_t,s0)
 /etc/sysconfig/ebtables.*				--      gen_context(system_u:object_r:system_conf_t,s0)
 /etc/sysconfig/ip6?tables.*             --      gen_context(system_u:object_r:system_conf_t,s0)


### PR DESCRIPTION
In the 1d355565faf commit ("Label /etc/mdevctl.d with mdevctl_conf_t"), an insufficient regexp was used, matching only files in the directory and not the directory itself.

Resolves: rhbz#2314826