### PR TITLE
Allow virtqemud read sgx_vepc devices

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2194,6 +2194,7 @@ corenet_tcp_bind_vnc_port(virtqemud_t)
 
 dev_delete_urand(virtqemud_t)
 dev_read_cpuid(virtqemud_t)
+dev_read_sgx_vepc(virtqemud_t)
 dev_read_sysfs(virtqemud_t)
 dev_read_urand(virtqemud_t)
 dev_rw_vfio_dev(virtqemud_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -6755,6 +6755,24 @@ interface(`dev_rw_papr_sysparm',`
 
 ########################################
 ## <summary>
+##	Allow read the sgx_vepc devices
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_read_sgx_vepc',`
+	gen_require(`
+		type device_t, sgx_vepc_device_t;
+	')
+
+	read_chr_files_pattern($1, device_t, sgx_vepc_device_t)
+')
+
+########################################
+## <summary>
 ##	Allow read the hfi1_[0-9]+ devices
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1729238705.963:170): avc:  denied  { read write } for  pid=1681 comm="qemu-system-x86" name="sgx_vepc" dev="devtmpfs" ino=86 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:sgx_vepc_device_t:s0 tclass=chr_file permissive=1 type=AVC msg=audit(1729238705.963:170): avc:  denied  { open } for  pid=1681 comm="qemu-system-x86" path="/dev/sgx_vepc" dev="devtmpfs" ino=86 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:sgx_vepc_device_t:s0 tclass=chr_file permissive=1 type=SYSCALL msg=audit(1729238705.963:170): arch=x86_64 syscall=openat success=yes exit=EBUSY a0=ffffff9c a1=5625f5cca88d a2=80002 a3=0 items=0 ppid=1 pid=1681 auid=4294967295 uid=107 gid=107 euid=107 suid=107 fsuid=107 egid=107 sgid=107 fsgid=107 tty=(none) ses=4294967295 comm=qemu-system-x86 exe=/usr/bin/qemu-system-x86_64 subj=system_u:system_r:virtqemud_t:s0 key=(null)