### PR TITLE
Allow systemd-homework connect to init over a unix socket

### DIFF
--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -227,7 +227,7 @@ fsadm_manage_pid(systemd_homework_t)
 
 init_read_state(systemd_homework_t)
 init_rw_stream_sockets(systemd_homework_t)
-init_write_pid_socket(systemd_homework_t)
+init_stream_connect(systemd_homework_t)
 
 storage_raw_read_removable_device(systemd_homework_t)
 storage_rw_inherited_removable_device(systemd_homework_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/16/2024 03:54:11.030:8138) : proctitle=/usr/lib/systemd/systemd-homework lock type=AVC msg=audit(10/16/2024 03:54:11.030:8138) : avc:  denied  { connectto } for  pid=271529 comm=systemd-homewor path=/run/systemd/private scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=0 type=SYSCALL msg=audit(10/16/2024 03:54:11.030:8138) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x4 a1=0x563546f871b8 a2=0x17 a3=0x0 items=1 ppid=813 pid=271529 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-homewor exe=/usr/lib/systemd/systemd-homework subj=system_u:system_r:systemd_homework_t:s0 key=(null) type=SOCKADDR msg=audit(10/16/2024 03:54:11.030:8138) : saddr={ saddr_fam=local path=/run/systemd/private } type=PATH msg=audit(10/16/2024 03:54:11.030:8138) : item=0 name=/run/systemd/private inode=2397 dev=00:1b mode=socket,700 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0