### PR TITLE
Allow lldpad create and use netlink_generic_socket

### DIFF
--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -31,6 +31,7 @@ allow lldpad_t self:capability2 bpf;
 allow lldpad_t self:shm create_shm_perms;
 allow lldpad_t self:fifo_file rw_fifo_file_perms;
 allow lldpad_t self:unix_stream_socket { accept connectto listen };
+allow lldpad_t self:netlink_generic_socket create_socket_perms;
 allow lldpad_t self:netlink_route_socket create_netlink_socket_perms;
 allow lldpad_t self:packet_socket create_socket_perms;
 allow lldpad_t self:tcp_socket create_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/09/2024 03:28:11.980:549) : proctitle=/usr/sbin/lldpad -t type=SOCKADDR msg=audit(10/09/2024 03:28:11.980:549) : saddr={ saddr_fam=netlink nlnk-fam=16 nlnk-pid=0 } type=SYSCALL msg=audit(10/09/2024 03:28:11.980:549) : arch=x86_64 syscall=sendmsg success=yes exit=32 a0=0x6 a1=0x7ffc33602210 a2=0x0 a3=0x20000 items=0 ppid=1 pid=25921 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=lldpad exe=/usr/sbin/lldpad subj=system_u:system_r:lldpad_t:s0 key=(null) type=AVC msg=audit(10/09/2024 03:28:11.980:549) : avc:  denied  { write } for  pid=25921 comm=lldpad scontext=system_u:system_r:lldpad_t:s0 tcontext=system_u:system_r:lldpad_t:s0 tclass=netlink_generic_socket permissive=1