### PR TITLE
Allow ping_t read network sysctls

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -139,6 +139,8 @@ allow ping_t self:packet_socket create_socket_perms;
 allow ping_t self:netlink_route_socket create_netlink_socket_perms;
 allow ping_t self:icmp_socket create_socket_perms;
 
+kernel_read_net_sysctls(ping_t)
+
 corenet_all_recvfrom_netlabel(ping_t)
 corenet_tcp_sendrecv_generic_if(ping_t)
 corenet_raw_sendrecv_generic_if(ping_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/26/2024 02:57:45.290:145) : proctitle=ping -c 3 fqdn type=PATH msg=audit(09/26/2024 02:57:45.290:145) : item=0 name=/proc/sys/net/ipv6/conf/all/disable_ipv6 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/26/2024 02:57:45.290:145) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffd365588a0 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=1225 pid=1446 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=1 comm=ping exe=/usr/bin/ping subj=system_u:system_r:ping_t:s0 key=(null) type=AVC msg=audit(09/26/2024 02:57:45.290:145) : avc:  denied  { search } for  pid=1446 comm=ping name=net dev="proc" ino=2244 scontext=system_u:system_r:ping_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: RHEL-54299