### PR TITLE
Allow virtqemud read virtd_t files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2129,6 +2129,8 @@ allow virtqemud_t virt_var_run_t:file map;
 allow virtqemud_t virtlogd_t:fifo_file rw_inherited_fifo_file_perms;
 allow virtqemud_t virtlogd_t:unix_stream_socket connectto;
 
+read_files_pattern(virtqemud_t, virtd_t, virtd_t)
+
 create_lnk_files_pattern(virtqemud_t, virt_etc_rw_t, virt_etc_rw_t)
 delete_lnk_files_pattern(virtqemud_t, virt_etc_rw_t, virt_etc_rw_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(09/05/2024 15:02:11.223:415) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(09/05/2024 15:02:11.223:415) : item=0 name=/proc/5600/stat inode=16564 dev=00:16 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:virtd_t:s0-s0:c0.c1023 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/05/2024 15:02:11.223:415) : arch=x86_64 syscall=openat success=yes exit=19 a0=AT_FDCWD a1=0x55addb9db960 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=5563 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=prio-rpc-virtqe exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(09/05/2024 15:02:11.223:415) : avc:  denied  { open } for  pid=5563 comm=prio-rpc-virtqe path=/proc/5600/stat dev="proc" ino=16564 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tclass=file permissive=1 type=AVC msg=audit(09/05/2024 15:02:11.223:415) : avc:  denied  { read } for  pid=5563 comm=prio-rpc-virtqe name=stat dev="proc" ino=16564 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tclass=file permissive=1 type=AVC msg=audit(09/05/2024 15:02:11.223:415) : avc:  denied  { search } for  pid=5563 comm=prio-rpc-virtqe name=5600 dev="proc" ino=16560 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tclass=dir permissive=1

Resolves: RHEL-57713