### PR TITLE
Allow bootupd read udev pid files

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -63,6 +63,7 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(bootupd_t)
+	udev_read_pid_files(bootupd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=AVC msg=audit(1727251620.089:166): avc:  denied  { search } for  pid=1475 comm="lsblk" name="udev" dev="tmpfs" ino=58 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1727251620.089:167): avc:  denied  { read } for  pid=1475 comm="lsblk" name="b252:0" dev="tmpfs" ino=1331 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(1727251620.089:168): avc:  denied  { open } for  pid=1475 comm="lsblk" path="/run/udev/data/b252:0" dev="tmpfs" ino=1331 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(1727251620.089:169): avc:  denied  { getattr } for  pid=1475 comm="lsblk" path="/run/udev/data/b252:0" dev="tmpfs" ino=1331 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=file permissive=1

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2362