### PR TITLE
Allow virtqemud open svirt_devpts_t char devices

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2117,6 +2117,7 @@ allow virtqemud_t svirt_t:unix_stream_socket { connectto create_stream_socket_pe
 allow virtqemud_t svirt_socket_t:unix_stream_socket connectto;
 allow virtqemud_t svirt_tcg_t: process { setsched signal signull transition };
 allow virtqemud_t svirt_tcg_t: unix_stream_socket { connectto create_stream_socket_perms };
+allow virtqemud_t svirt_devpts_t:chr_file open;
 allow virtqemud_t svirt_tmpfs_t:file { map write };
 
 allow virtqemud_t virt_cache_t:file { relabelfrom relabelto };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1723745525.909:3662): avc:  denied  { open } for  pid=2266 comm="rpc-virtqemud" path="/dev/pts/8" dev="devpts" ino=11 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:svirt_devpts_t:s0 tclass=chr_file permissive=1

Resolves: rhbz#2305192