### PR TITLE
Label /run/sssd with sssd_var_run_t

### DIFF
--- a/policy/modules/contrib/sssd.fc
+++ b/policy/modules/contrib/sssd.fc
@@ -26,6 +26,7 @@
 
 /var/log/sssd(/.*)?		gen_context(system_u:object_r:sssd_var_log_t,s0)
 
+/run/sssd(/.*)?		gen_context(system_u:object_r:sssd_var_run_t,s0)
 /run/sssd.pid	--	gen_context(system_u:object_r:sssd_var_run_t,s0)
 /run/secrets\.socket	-s	gen_context(system_u:object_r:sssd_var_run_t,s0)
 /run/\.heim_org\.h5l\.kcm-socket	-s	gen_context(system_u:object_r:sssd_var_run_t,s0)

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -101,6 +101,7 @@ manage_dirs_pattern(sssd_t, sssd_var_run_t, sssd_var_run_t)
 manage_files_pattern(sssd_t, sssd_var_run_t, sssd_var_run_t)
 manage_sock_files_pattern(sssd_t, sssd_var_run_t, sssd_var_run_t)
 files_pid_filetrans(sssd_t, sssd_var_run_t, { file dir sock_file })
+allow sssd_t sssd_var_run_t:file map;
 
 kernel_io_uring_use(sssd_t)
 kernel_read_network_state(sssd_t)


### PR DESCRIPTION
Additionally, allow sssd map sssd_var_run_t files.

Resolves: RHEL-57065