### PR TITLE
Allow dirsrv read network sysctls

### DIFF
--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -106,6 +106,7 @@ list_dirs_pattern(dirsrv_t, dirsrv_share_t, dirsrv_share_t)
 kernel_read_network_state(dirsrv_t)
 kernel_read_system_state(dirsrv_t)
 kernel_read_kernel_sysctls(dirsrv_t)
+kernel_read_net_sysctls(dirsrv_t)
 kernel_dontaudit_search_fs_sysctl(dirsrv_t)
 
 corecmd_search_bin(dirsrv_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/11/2024 05:35:23.841:2235) : proctitle=/usr/sbin/ns-slapd -D /etc/dirsrv/slapd-test -i /run/dirsrv/slapd-test.pid type=SYSCALL msg=audit(09/11/2024 05:35:23.841:2235) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f74651fab60 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=0 ppid=1 pid=10450 auid=unset uid=dirsrv gid=dirsrv euid=dirsrv suid=dirsrv fsuid=dirsrv egid=dirsrv sgid=dirsrv fsgid=dirsrv tty=(none) ses=unset comm=ns-slapd exe=/usr/sbin/ns-slapd subj=system_u:system_r:dirsrv_t:s0 key=(null) type=AVC msg=audit(09/11/2024 05:35:23.841:2235) : avc:  denied  { search } for  pid=10450 comm=ns-slapd name=net dev="proc" ino=32137 scontext=system_u:system_r:dirsrv_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: RHEL-58381