### PR TITLE
Allow gnome-remote-desktop watch /etc directory

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -36,6 +36,7 @@ allow gnome_remote_desktop_t self:unix_dgram_socket create_socket_perms;
 domain_use_interactive_fds(gnome_remote_desktop_t)
 
 files_read_etc_files(gnome_remote_desktop_t)
+files_watch_etc_dirs(gnome_remote_desktop_t)
 
 corenet_tcp_bind_generic_node(gnome_remote_desktop_t)
 dev_read_sysfs(gnome_remote_desktop_t)


### PR DESCRIPTION
The denial can be triggered by the following sequence: grdctl --system vnc enable
grdctl --system rdp enable

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/23/2024 02:51:35.701:987) : proctitle=/usr/libexec/gnome-remote-desktop-daemon --system type=PATH msg=audit(10/23/2024 02:51:35.701:987) : item=0 name=/etc/gnome-remote-desktop inode=276729 dev=fc:02 mode=dir,755 ouid=gnome-remote-desktop ogid=gnome-remote-desktop rdev=00:00 obj=system_u:object_r:etc_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/23/2024 02:51:35.701:987) : arch=x86_64 syscall=inotify_add_watch success=yes exit=2 a0=0x3 a1=0x5620c104b9d0 a2=0x1002fce a3=0x5620c1003010 items=1 ppid=1 pid=3596 auid=unset uid=gnome-remote-desktop gid=gnome-remote-desktop euid=gnome-remote-desktop suid=gnome-remote-desktop fsuid=gnome-remote-desktop egid=gnome-remote-desktop sgid=gnome-remote-desktop fsgid=gnome-remote-desktop tty=(none) ses=unset comm=gnome-remote-de exe=/usr/libexec/gnome-remote-desktop-daemon subj=system_u:system_r:gnome_remote_desktop_t:s0 key=(null) type=AVC msg=audit(10/23/2024 02:51:35.701:987) : avc:  denied  { watch } for  pid=3596 comm=gnome-remote-de path=/etc/gnome-remote-desktop dev="vda2" ino=276729 scontext=system_u:system_r:gnome_remote_desktop_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=1

Resolves: rhbz#2321236