### PR TITLE
Allow rpcd read network sysctls

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -161,6 +161,7 @@ kernel_write_proc_files(rpcd_t)
 kernel_read_network_state(rpcd_t)
 # for rpc.rquotad
 kernel_read_sysctl(rpcd_t)
+kernel_read_net_sysctls(rpcd_t)
 kernel_rw_fs_sysctls(rpcd_t)
 kernel_dontaudit_getattr_core_if(rpcd_t)
 kernel_signal(rpcd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
PROCTITLE msg=audit(22.10.2024 22:04:46.449:3240) : proctitle=/usr/sbin/rpc.statd type=AVC msg=audit(22.10.2024 22:04:46.449:3240) : avc:  denied  { search } for  pid=328102 comm=rpc.statd name=net dev="proc" ino=8508325 scontext=system_u:system_r:rpcd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(10/22/2024 16:04:46.449:3240) : arch=aarch64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0xffffed7f78b0 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=0 ppid=1 pid=328102 auid=unset uid=unknown(29) gid=unknown(29) euid=unknown(29) suid=unknown(29) fsuid=unknown(29) egid=unknown(29) sgid=unknown(29) fsgid=unknown(29) tty=(none) ses=unset comm=rpc.statd exe=/usr/sbin/rpc.statd subj=system_u:system_r:rpcd_t:s0 key=(null)

Resolves: RHEL-64737