### PR TITLE
Allow journalctl connect to systemd-userdbd over a unix socket

### DIFF
--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -26,6 +26,7 @@ allow journalctl_t self:unix_stream_socket create_stream_socket_perms;
 
 kernel_read_fs_sysctls(journalctl_t)
 kernel_read_system_state(journalctl_t)
+kernel_stream_connect(journalctl_t)
 
 corecmd_exec_bin(journalctl_t)
 


### PR DESCRIPTION
It is actually required to connect to the kernel_t as systemd-userdbd still runs in the kernel_t domain.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/17/2024 08:14:22.490:1934) : proctitle=journalctl --no-pager --user -u local-notifier type=PATH msg=audit(10/17/2024 08:14:22.490:1934) : item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=48 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(10/17/2024 08:14:22.490:1934) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DynamicUser } type=SYSCALL msg=audit(10/17/2024 08:14:22.490:1934) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x4 a1=0x7fffdad19ed0 a2=0x2d a3=0x563c77854010 items=1 ppid=67664 pid=67665 auid=user2043 uid=user2043 gid=user2043 euid=user2043 suid=user2043 fsuid=user2043 egid=user2043 sgid=user2043 fsgid=user2043 tty=pts1 ses=26 comm=journalctl exe=/usr/bin/journalctl subj=sysadm_u:sysadm_r:journalctl_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(10/17/2024 08:14:22.490:1934) : avc:  denied  { connectto } for  pid=67665 comm=journalctl path=/systemd/userdb/io.systemd.DynamicUser scontext=sysadm_u:sysadm_r:journalctl_t:s0-s0:c0.c1023 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0

Resolves: RHEL-58072