### PR TITLE
Label /usr/lib/node_modules_22/npm/bin with bin_t

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -215,6 +215,7 @@ ifdef(`distro_gentoo',`
 /usr/lib/news/bin(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/NetworkManager/nm\-.*	--	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/node_modules/npm/bin(/.*)?	gen_context(system_u:object_r:bin_t,s0)
+/usr/lib/node_modules_22/npm/bin(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/nspluginwrapper/np.*	gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/ocf(/.*)?		gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/portage/bin(/.*)?	gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
This is a follow-up to the previous commit 80ae5a38e934 ("Label /usr/lib/node_modules/npm/bin with bin_t) as nodejs v22 uses a different base path.

Resolves: RHEL-53124