### PR TITLE
Allow dirsrv-snmp map dirsv_tmpfs_t files

### DIFF
--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -189,6 +189,7 @@ allow dirsrv_snmp_t self:capability {  dac_read_search };
 allow dirsrv_snmp_t self:fifo_file rw_fifo_file_perms;
 
 rw_files_pattern(dirsrv_snmp_t, dirsrv_tmpfs_t, dirsrv_tmpfs_t)
+allow dirsrv_snmp_t dirsrv_tmpfs_t:file map;
 
 manage_files_pattern(dirsrv_snmp_t, dirsrv_var_run_t, dirsrv_var_run_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1721403956.972:3892): avc:  denied  { map } for  pid=7858 comm="ldap-agent" path="/dev/shm/sem.slapd-example.stats" dev="tmpfs" ino=8 scontext=system_u:system_r:dirsrv_snmp_t:s0 tcontext=system_u:object_r:dirsrv_tmpfs_t:s0 tclass=file permissive=1

Resolves: RHEL-32441