### PR TITLE
Add file transition for nvidia-modeset

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -7718,6 +7718,7 @@ interface(`dev_filetrans_xserver_named_dev',`
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "nvidia8")
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "nvidia9")
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "nvidiactl")
+	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "nvidia-modeset")
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "nvidia-uvm")
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "opengl")
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "vbox0")


### PR DESCRIPTION
This addresses the following AVC denial that occurs when `kwin_wayland` initially starts after logging into a KDE Wayland session.

```
type=AVC msg=audit(1730072197.188:289): avc:  denied  { getattr } for  pid=2287 comm="kwin_wayland" path="/dev/nvidia-modeset" dev="devtmpfs" ino=1313 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:device_t:s0 tclass=chr_file permissive=0
type=AVC msg=audit(1730072197.189:290): avc:  denied  { read write } for  pid=2287 comm="kwin_wayland" name="nvidia-modeset" dev="devtmpfs" ino=1313 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:device_t:s0 tclass=chr_file permissive=0
```

The file context regex already matches `/dev/nvidia.*`, but with the way the device is created, the label gets set to the generic `device_t` without a file transition rule.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2322522