### PR TITLE
Label all semanage store files in /etc as semanage_store_t

### DIFF
--- a/policy/modules/system/selinuxutil.fc
+++ b/policy/modules/system/selinuxutil.fc
@@ -11,7 +11,7 @@
 /etc/selinux/([^/]*/)?setrans\.conf --	gen_context(system_u:object_r:selinux_config_t,mls_systemhigh)
 /etc/selinux/([^/]*/)?seusers	--	gen_context(system_u:object_r:selinux_config_t,s0)
 /etc/selinux/([^/]*/)?modules/(active|tmp|previous)(/.*)? gen_context(system_u:object_r:semanage_store_t,s0)
-/etc/selinux/(minimum|mls|targeted)/active(/.*)? gen_context(system_u:object_r:semanage_store_t,s0)
+/etc/selinux/(minimum|mls|targeted)/(active|tmp|previous)(/.*)? gen_context(system_u:object_r:semanage_store_t,s0)
 /etc/selinux/([^/]*/)?modules/semanage\.read\.LOCK -- gen_context(system_u:object_r:semanage_read_lock_t,s0)
 /etc/selinux/([^/]*/)?modules/semanage\.trans\.LOCK -- gen_context(system_u:object_r:semanage_trans_lock_t,s0)
 /etc/selinux/([^/]*/)?users(/.*)? --	gen_context(system_u:object_r:selinux_config_t,s0)


### PR DESCRIPTION
/etc/selinux/targeted/tmp needs to have the same file context as /etc/selinux/targeted/active

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2323878