### PR TITLE
Allow systemd-networkd read mount pid files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -659,6 +659,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mount_read_pid_files(systemd_networkd_t)
+')
+
+optional_policy(`
     sosreport_dbus_chat(systemd_networkd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/07/2024 06:23:07.585:1186) : proctitle=/usr/lib/systemd/systemd-networkd type=PATH msg=audit(11/07/2024 06:23:07.585:1186) : item=0 name=/run/mount/utab inode=2608 dev=00:1b mode=file,644 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:mount_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(11/07/2024 06:23:07.585:1186) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f9852ed6571 a2=0x7fffe3e93e60 a3=0x0 items=1 ppid=1 pid=64784 auid=unset uid=systemd-network gid=systemd-network euid=systemd-network suid=systemd-network fsuid=systemd-network egid=systemd-network sgid=systemd-network fsgid=systemd-network tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-networkd subj=system_u:system_r:systemd_networkd_t:s0 key=(null) type=AVC msg=audit(11/07/2024 06:23:07.585:1186) : avc:  denied  { getattr } for  pid=64784 comm=systemd-network path=/run/mount/utab dev="tmpfs" ino=2608 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=unconfined_u:object_r:mount_var_run_t:s0 tclass=file permissive=0