### PR TITLE
Support ssh connections via systemd-ssh-generator

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -317,6 +317,7 @@ optional_policy(`
 allow sshd_t self:netlink_route_socket r_netlink_socket_perms;
 allow sshd_t self:key { search link write };
 allow sshd_t self:process setcurrent;
+allow sshd_t self:vsock_socket rw_socket_perms;
 
 allow sshd_t sshd_keytab_t:file read_file_perms;
 
@@ -639,6 +640,8 @@ logging_send_audit_msgs(sshd_sandbox_t)
 #
 #  sshd [net] child local policy
 #
+
+allow sshd_net_t sshd_t:vsock_socket rw_socket_perms;
 
 allow sshd_t sshd_net_t:process signal;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1730885285.653:214): avc:  denied  { read write } for  pid=1191 comm="sshd" path="socket:[11153]" dev="sockfs" ino=11153 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=vsock_socket permissive=0

Command which triggers the denial:
ssh -o "StrictHostKeyChecking no" root@qemu:system/guest

Resolves: rhbz#2324525