### PR TITLE
Allow virtstoraged read vm sysctls

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2342,6 +2342,7 @@ manage_lnk_files_pattern(virtstoraged_t, virt_etc_rw_t, virt_etc_rw_t)
 
 kernel_get_sysvipc_info(virtstoraged_t)
 kernel_io_uring_use(virtstoraged_t)
+kernel_read_vm_sysctls(virtstoraged_t)
 
 corecmd_exec_bin(virtstoraged_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1730400003.494:574): avc:  denied  { read } for  pid=9258 comm="qemu-img" name="max_map_count" dev="proc" ino=13333 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:sysctl_vm_t:s0 tclass=file permissive=1

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2416