### PR TITLE
Revert "Allow unconfined_t execute kmod in the kmod domain"

### DIFF
--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -341,10 +341,6 @@ optional_policy(`
 #')
 
 optional_policy(`
-	modutils_domtrans_kmod(unconfined_t)
-')
-
-optional_policy(`
 	mozilla_role_plugin(unconfined_r)
 
 	tunable_policy(`unconfined_mozilla_plugin_transition', `


### PR DESCRIPTION
This reverts commit 55262ef418d0 as it prevents
insmod ./module.ko
from working.

Resolves: RHEL-54710