### PR TITLE
Allow systemd-tpms-generator read hardware state information

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1387,7 +1387,7 @@ optional_policy(`
 init_read_script_files(systemd_sysv_generator_t)
 
 ### tpm2 generator
-dev_list_sysfs(systemd_tpm2_generator_t)
+dev_read_sysfs(systemd_tpm2_generator_t)
 
 ### zram generator
 allow systemd_zram_generator_t systemd_fstab_generator_unit_file_t:file write_file_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1731242886.290:1391): avc:  denied  { read } for  pid=36299 comm="systemd-tpm2-ge" name="tpm_version_major" dev="sysfs" ino=10911 scontext=system_u:system_r:systemd_tpm2_generator_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(1731242886.290:1391): arch=x86_64 syscall=openat success=no exit=EACCES a0=ffffff9c a1=7f1291d5b820 a2=80100 a3=0 items=0 ppid=36277 pid=36299 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=systemd-tpm2-ge exe=/usr/lib/systemd/system-generators/systemd-tpm2-generator subj=system_u:system_r:systemd_tpm2_generator_t:s0 key=(null)

Resolves: rhbz#2324997