### PR TITLE
Allow iio-sensor-proxy create and use unix dgram socket

### DIFF
--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -11,6 +11,7 @@ init_daemon_domain(iiosensorproxy_t, iiosensorproxy_exec_t)
 
 allow iiosensorproxy_t self:capability2 bpf;
 allow iiosensorproxy_t self:netlink_kobject_uevent_socket create_socket_perms;
+allow iiosensorproxy_t self:unix_dgram_socket create_socket_perms;
 
 dev_read_sysfs(iiosensorproxy_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1731194683.438:143): avc:  denied  { create } for  pid=1001 comm="iio-sensor-prox" scontext=system_u:system_r:iiosensorproxy_t:s0 tcontext=system_u:system_r:iiosensorproxy_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: rhbz#2324955