### PR TITLE
Allow chronyd read networkmanager's pid files

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -164,6 +164,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	networkmanager_read_pid_files(chronyd_t)
+')
+
+optional_policy(`
     virt_read_lib_files(chronyd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1717458744.849:161): avc:  denied  { getattr } for  pid=1487 comm="chronyd" path="/run/NetworkManager/no-stub-resolv.conf" dev="tmpfs" ino=2481 scontext=system_u:system_r:chronyd_t:s0 tcontext=system_u:object_r:NetworkManager_var_run_t:s0 tclass=file permissive=0

Resolves: rhbz#2290310