### PR TITLE
Allow virtd_t connect to virtqemud_t over a unix stream socket

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2129,6 +2129,8 @@ allow virtqemud_t virt_var_run_t:file map;
 allow virtqemud_t virtlogd_t:fifo_file rw_inherited_fifo_file_perms;
 allow virtqemud_t virtlogd_t:unix_stream_socket connectto;
 
+read_files_pattern(virtqemud_t, virsh_t, virsh_t)
+
 read_files_pattern(virtqemud_t, virtd_t, virtd_t)
 
 create_lnk_files_pattern(virtqemud_t, virt_etc_rw_t, virt_etc_rw_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2562,6 +2562,7 @@ allow virt_dbus_t virt_var_run_t:dir search_dir_perms;
 allow virt_dbus_t virt_var_run_t:sock_file write_sock_file_perms;
 
 # ipc to other virt domains
+allow virt_dbus_t virtd_t:unix_stream_socket connectto;
 allow virt_dbus_t virtproxyd_t:unix_stream_socket connectto;
 allow virt_dbus_t virtqemud_t:unix_stream_socket connectto;
 allow virt_dbus_t virtqemud_var_run_t:sock_file write;

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -686,6 +686,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	virt_dbus_chat_dbus(sysadm_t)
 	virt_stream_connect(sysadm_t)
 	virt_filetrans_home_content(sysadm_t)
 	virt_manage_pid_dirs(sysadm_t)

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -24,6 +24,7 @@ allow sysadm_t self:system all_system_perms;
 #
 # Local policy
 #
+kernel_io_uring_use(sysadm_t)
 kernel_manage_perf_event(sysadm_t)
 kernel_prog_run_bpf(sysadm_t)
 kernel_read_fs_sysctls(sysadm_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1728051581.252:5228): avc:  denied  { connectto } for  pid=448937 comm="pool-libvirt-db" path="/run/libvirt/libvirt-sock" scontext=system_u:system_r:virt_dbus_t:s0 tcontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0 type=AVC msg=audit(1728051581.252:5228): avc:  denied  { connectto } for  pid=448937 comm="pool-libvirt-db" uid=zpytela path="/run/libvirt/libvirt-sock" scontext=system_u:system_r:virt_dbus_t:s0 tcontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2316474