### PR TITLE
Update the bootupd policy

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -40,6 +40,7 @@ domain_use_interactive_fds(bootupd_t)
 files_create_boot_dirs(bootupd_t)
 files_read_etc_files(bootupd_t)
 files_manage_boot_files(bootupd_t)
+files_read_root_files(bootupd_t)
 
 fs_getattr_all_fs(bootupd_t)
 fs_manage_dos_dirs(bootupd_t)
@@ -63,6 +64,7 @@ optional_policy(`
 
 optional_policy(`
 	udev_domtrans(bootupd_t)
+	udev_read_pid_files(bootupd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -337,4 +337,5 @@ ifndef(`distro_redhat',`
 /nsr(/.*)?			gen_context(system_u:object_r:var_t,s0)
 /nsr/logs(/.*)?			gen_context(system_u:object_r:var_log_t,s0)
 
+/sysroot/.aleph-version.json	gen_context(system_u:object_r:root_t,s0)
 /sysroot/ostree/deploy/.*-atomic/deploy(/.*)?           gen_context(system_u:object_r:root_t,s0)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2872,6 +2872,24 @@ interface(`files_root_filetrans',`
 
 ########################################
 ## <summary>
+##	Read files in the root directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`files_read_root_files',`
+	gen_require(`
+		type root_t;
+	')
+
+	read_files_pattern($1, root_t, root_t)
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read files in
 ##	the root directory.
 ## </summary>


### PR DESCRIPTION
In particular, the following permissions were allowed:
- allow read files in /sysroot, which have root_t type
- allow read udev pid files in case lsblk was executed from bootupd so no transition to udev applied
- root_t as the default file context for /sysroot/.aleph-version.json

Resolves: rhbz#2320395
Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2362