### PR TITLE
Allow tlp the setpgid process permission

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -23,6 +23,7 @@ systemd_unit_file(tlp_unit_file_t)
 # tlp local policy
 #
 allow tlp_t self:capability { net_admin setgid setuid sys_admin sys_rawio };
+allow tlp_t self:process setpgid;
 allow tlp_t self:unix_stream_socket create_stream_socket_perms;
 allow tlp_t self:udp_socket create_socket_perms;
 allow tlp_t self:unix_dgram_socket create_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(14. okt. 2024 09:35:47.580:341) : avc:  denied  { setpgid } for  pid=10546 comm=timeout scontext=system_u:system_r:tlp_t:s0 tcontext=system_u:system_r:tlp_t:s0 tclass=process permissive=0 type=PROCTITLE msg=audit(14. okt. 2024 18:00:35.038:594) : proctitle=timeout 2 flock -x 9 type=SYSCALL msg=audit(14. okt. 2024 18:00:35.038:594) : arch=x86_64 syscall=setpgid success=no exit=EACCES(Permission denied) a0=0x0 a1=0x0 a2=0x0 a3=0x10000000000000 items=0 ppid=40368 pid=40408 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=timeout exe=/usr/bin/timeout subj=system_u:system_r:tlp_t:s0 key=(null)

Resolves: rhbz#2317893