### PR TITLE
Allow gnome-remote-desktop dbus chat with policykit

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -63,6 +63,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	policykit_dbus_chat(gnome_remote_desktop_t)
+')
+
+optional_policy(`
 	systemd_login_list_pid_dirs(gnome_remote_desktop_t)
 	systemd_login_read_pid_files(gnome_remote_desktop_t)
 	systemd_read_logind_sessions_files(gnome_remote_desktop_t)


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(10/26/2024 06:47:07.080:612) : pid=792 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:gnome_remote_desktop_t:s0 tcontext=system_u:system_r:policykit_t:s0 tclass=dbus permissive=1 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'