### PR TITLE
Allow staff user connect to generic tcp ports

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -28,6 +28,7 @@ allow staff_t self:netlink_generic_socket { create_socket_perms };
 allow staff_t self:netlink_route_socket nlmsg_write;
 
 corenet_ib_access_unlabeled_pkeys(staff_t)
+corenet_tcp_bind_generic_port(staff_t)
 
 kernel_io_uring_use(staff_t)
 kernel_read_ring_buffer(staff_t)


### PR DESCRIPTION
The commit addresses the following example AVC denial: type=PROCTITLE msg=audit(19.11.2024 15:26:24.707:3073) : proctitle=/usr/lib64/firefox/firefox type=SOCKADDR msg=audit(19.11.2024 15:26:24.707:3073) : saddr={ saddr_fam=inet laddr=192.168.1.111 lport=61288 } type=SYSCALL msg=audit(19.11.2024 15:26:24.707:3073) : arch=x86_64 syscall=bind success=yes exit=0 a0=0x241 a1=0x7fffebdbd620 a2=0x10 a3=0x7fffebdbd390 items=0 ppid=36488 pid=545011 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=(none) ses=5 comm=Socket Thread exe=/usr/lib64/firefox/firefox subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(19.11.2024 15:26:24.707:3073) : avc:  denied  { name_bind } for  pid=545011 comm=Socket Thread src=61288 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unreserved_port_t:s0 tclass=tcp_socket permissive=1