### PR TITLE
Update systemd-networkd policy in systemd v257

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -601,7 +601,7 @@ optional_policy(`
 #
 
 allow systemd_networkd_t self:bpf { map_create map_read map_write prog_load prog_run };
-allow systemd_networkd_t self:capability { dac_read_search dac_override net_admin net_raw setuid fowner chown setgid setpcap };
+allow systemd_networkd_t self:capability { dac_read_search dac_override net_admin net_raw setuid fowner chown setgid setpcap sys_admin };
 allow systemd_networkd_t self:capability2 bpf;
 allow systemd_networkd_t self:process { getcap setcap };
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -600,7 +600,9 @@ optional_policy(`
 # systemd-networkd local policy
 #
 
+allow systemd_networkd_t self:bpf { map_create map_read map_write prog_load prog_run };
 allow systemd_networkd_t self:capability { dac_read_search dac_override net_admin net_raw setuid fowner chown setgid setpcap };
+allow systemd_networkd_t self:capability2 bpf;
 allow systemd_networkd_t self:process { getcap setcap };
 
 allow systemd_networkd_t self:netlink_kobject_uevent_socket create_socket_perms;


### PR DESCRIPTION
In particular, permissions to read cgroup dirs and work with bpf programs were allowed.

The commit addresses, among others, the following AVC denial: type=PROCTITLE msg=audit(11/20/2024 02:20:27.486:845) : proctitle=/usr/lib/systemd/systemd-networkd type=SYSCALL msg=audit(11/20/2024 02:20:27.486:845) : arch=x86_64 syscall=bpf success=no exit=EACCES(Permission denied) a0=BPF_PROG_LOAD a1=0x7ffeeb990170 a2=0x94 a3=0x7fee005e937e items=0 ppid=1 pid=9637 auid=unset uid=systemd-network gid=systemd-network euid=systemd-network suid=systemd-network fsuid=systemd-network egid=systemd-network sgid=systemd-network fsgid=systemd-network tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-networkd subj=system_u:system_r:systemd_networkd_t:s0 key=(null) type=AVC msg=audit(11/20/2024 02:20:27.486:845) : avc:  denied  { prog_load } for  pid=9637 comm=systemd-network scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:system_r:systemd_networkd_t:s0 tclass=bpf permissive=0