### PR TITLE
Allow samba-bgqd read cups config files

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -339,6 +339,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cups_read_config(samba_bgqd_t)
+')
+
+optional_policy(`
 	sssd_read_public_files(samba_bgqd_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/20/2024 01:53:25.982:911) : proctitle=/usr/libexec/samba/samba-bgqd --foreground --no-process-group type=PATH msg=audit(11/20/2024 01:53:25.982:911) : item=0 name=/etc/cups/client.conf nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(11/20/2024 01:53:25.982:911) : arch=x86_64 syscall=openat success=no exit=ENOENT(No such file or directory) a0=AT_FDCWD a1=0x7ffc519178b0 a2=O_RDONLY a3=0x0 items=1 ppid=10091 pid=10093 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=samba-bgqd exe=/usr/libexec/samba/samba-bgqd subj=system_u:system_r:samba_bgqd_t:s0 key=(null) type=AVC msg=audit(11/20/2024 01:53:25.982:911) : avc:  denied  { search } for  pid=10093 comm=samba-bgqd name=cups dev="vda2" ino=262662 scontext=system_u:system_r:samba_bgqd_t:s0 tcontext=system_u:object_r:cupsd_etc_t:s0 tclass=dir permissive=1