### PR TITLE
Add label rshim_var_run_t for /run/rshim.pid

### DIFF
--- a/policy/modules/contrib/rshim.fc
+++ b/policy/modules/contrib/rshim.fc
@@ -1,3 +1,5 @@
 /usr/bin/rshim				--	gen_context(system_u:object_r:rshim_exec_t,s0)
 
+/run/rshim\.pid	--	gen_context(system_u:object_r:rshim_var_run_t,s0)
+
 /usr/lib/systemd/system/rshim.*		--	gen_context(system_u:object_r:rshim_unit_file_t,s0)

--- a/policy/modules/contrib/rshim.te
+++ b/policy/modules/contrib/rshim.te
@@ -9,6 +9,9 @@ type rshim_t;
 type rshim_exec_t;
 init_daemon_domain(rshim_t, rshim_exec_t)
 
+type rshim_var_run_t;
+files_pid_file(rshim_var_run_t)
+
 type rshim_unit_file_t;
 systemd_unit_file(rshim_unit_file_t)
 
@@ -23,6 +26,9 @@ allow rshim_t self:process { fork };
 allow rshim_t self:system module_load;
 allow rshim_t self:unix_stream_socket create_stream_socket_perms;
 allow rshim_t self:netlink_kobject_uevent_socket getopt;
+
+manage_files_pattern(rshim_t, rshim_var_run_t, rshim_var_run_t)
+files_pid_filetrans(rshim_t, rshim_var_run_t, file)
 
 kernel_read_proc_files(rshim_t)
 


### PR DESCRIPTION
Add SELinux label into rshim policy so rshim_t process domain can manage pidfiles stored in /run/rshim.pid