### PR TITLE
Make bootupd_t permissive

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -8,6 +8,7 @@ policy_module(bootupd, 1.0.0)
 type bootupd_t;
 type bootupd_exec_t;
 init_daemon_domain(bootupd_t, bootupd_exec_t)
+permissive bootupd_t;
 
 type bootupd_unit_file_t;
 systemd_unit_file(bootupd_unit_file_t)


### PR DESCRIPTION
The updated package does not use a service unit nor a socket to be started by systemd.