### PR TITLE
Allow httpd get attributes of dirsrv unit files

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -991,6 +991,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	dirsrv_getattr_unit_files(httpd_t)
 	dirsrv_manage_config(httpd_t)
 	dirsrv_manage_log(httpd_t)
 	dirsrv_manage_var_run(httpd_t)

--- a/policy/modules/contrib/dirsrv.if
+++ b/policy/modules/contrib/dirsrv.if
@@ -104,7 +104,23 @@ interface(`dirsrv_systemctl',`
 	ps_process_pattern($1, dirsrv_t)
 ')
 
+########################################
+## <summary>
+##	Allow domain to getattr dirsrv unit files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`dirsrv_getattr_unit_files',`
+	gen_require(`
+		type dirsrv_unit_file_t;
+	')
 
+	allow $1 dirsrv_unit_file_t:file getattr_file_perms;
+')
 
 #######################################
 ## <summary>


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(3.10.2024 23:49:42.622:3489) : proctitle=(wsgi:ipa)      -DFOREGROUND
type=AVC msg=audit(3.10.2024 23:49:42.622:3489) : avc:  denied  { getattr } for  pid=21525 comm=httpd path=/usr/lib/systemd/system/dirsrv@.service dev="vda3" ino=1451794 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:dirsrv_unit_file_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(3.10.2024 23:49:42.622:3489) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Operace zamítnuta) a0=AT_FDCWD a1=0x7f3a270cda40 a2=0x7f3a25bfe420 a3=0x0 items=1 ppid=21518 pid=21525 auid=unset uid=988 gid=988 euid=988 suid=988 fsuid=988 egid=988 sgid=988 fsgid=988 tty=(none) ses=unset comm=httpd exe=/usr/sbin/httpd subj=system_u:system_r:httpd_t:s0 key=(null)
type=CWD msg=audit(3.10.2024 23:49:42.622:3489) : cwd=/
type=PATH msg=audit(3.10.2024 23:49:42.622:3489) : item=0 name=/usr/lib/systemd/system/dirsrv@.service inode=1451794 dev=fc:03 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:dirsrv_unit_file_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: RHEL-62706