### PR TITLE
Add policy for systemd-import-generator

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -84,6 +84,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/system-generators/systemd-fstab-generator	--	gen_context(system_u:object_r:systemd_fstab_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-getty-generator	--	gen_context(system_u:object_r:systemd_getty_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-gpt-auto-generator	--	gen_context(system_u:object_r:systemd_gpt_generator_exec_t,s0)
+/usr/lib/systemd/system-generators/systemd-import-generator	--	gen_context(system_u:object_r:systemd_import_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-rc-local-generator	--	gen_context(system_u:object_r:systemd_rc_local_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-ssh-generator	--	gen_context(system_u:object_r:systemd_ssh_generator_exec_t,s0)
 /usr/lib/systemd/system-generators/systemd-sysv-generator	--	gen_context(system_u:object_r:systemd_sysv_generator_exec_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -208,6 +208,8 @@ systemd_generator_template(systemd_fstab_generator)
 systemd_generator_template(systemd_getty_generator)
 # gpt-generator
 systemd_generator_template(systemd_gpt_generator)
+# import-generator
+systemd_generator_template(systemd_import_generator)
 # rc-local-generator
 systemd_generator_template(systemd_rc_local_generator)
 # ssh-generator
@@ -1373,6 +1375,9 @@ optional_policy(`
 
 ### systemd rc_local generator
 init_exec_script_files(systemd_rc_local_generator_t)
+
+### systemd import generator
+permissive systemd_import_generator_t;
 
 ### ssh generator
 allow systemd_ssh_generator_t self:vsock_socket create;


### PR DESCRIPTION
A new generator sytemd-import-generator has been added in systemd v257 to synthesize image download jobs. This provides functionality similar to importctl, but is configured via the kernel command line and system credentials. It may be used to automatically download sysext, confext, portable service, nspawn container or vmspawn VM images at boot.