### PR TITLE
Allow bacula execute container in the container domain

### DIFF
--- a/policy/modules/contrib/bacula.te
+++ b/policy/modules/contrib/bacula.te
@@ -140,6 +140,10 @@ sysnet_dns_name_resolve(bacula_t)
 userdom_home_manager(bacula_t)
 
 optional_policy(`
+	container_runtime_domtrans(bacula_t)
+')
+
+optional_policy(`
 	mysql_stream_connect(bacula_t)
 	mysql_tcp_connect(bacula_t)
 ')


### PR DESCRIPTION
With Docker Plugin, the Bacula Enterprise will save the full container image including all read-only and writable layers into a single image archive. It is not needed to install a Bacula File daemon in each container, so you can backup containers based on common image repository. The Bacula Docker Plugin will contact the Docker service to read and save the contents of any system image or container image using snapshots (default behavior) and dump them using the Docker API.

Bacula does not need to walk through the container file-system to open, read, close and stat files, so it consumes less resources on the Docker infrastructure than a standard file level backup.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/10/2024 04:04:48.749:691) : proctitle=/usr/sbin/bacula-fd -f -c /etc/bacula/bacula-fd.conf -u root -g root type=PATH msg=audit(01/10/2024 04:04:48.749:691) : item=0 name=/usr/bin/docker inode=5509673 dev=fd:01 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:container_runtime_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/10/2024 04:04:48.749:691) : arch=x86_64 syscall=access success=yes exit=0 a0=0x7f9c0526b13e a1=X_OK a2=0x55d5c8c3e900 a3=0x7f9c052552f0 items=1 ppid=1 pid=105441 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=bacula-fd exe=/usr/sbin/bacula-fd subj=system_u:system_r:bacula_t:s0 key=(null) type=AVC msg=audit(01/10/2024 04:04:48.749:691) : avc:  denied  { execute } for  pid=105441 comm=bacula-fd name=docker dev="vda1" ino=5509673 scontext=system_u:system_r:bacula_t:s0 tcontext=system_u:object_r:container_runtime_exec_t:s0 tclass=file permissive=1

https://docs.baculasystems.com/BEDedicatedBackupSolutions/Virtualization/Containers/docker/docker-plugin.html