### PR TITLE
Allow systemd-related domains getattr nsfs files

### DIFF
--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -74,6 +74,8 @@ files_manage_isid_type_files(systemd_homed_t)
 # /dev/shm
 fs_getattr_tmpfs(systemd_homed_t)
 
+fs_getattr_nsfs_files(systemd_homed_t)
+
 # /var/cache/systemd/home
 create_dirs_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)
 delete_dirs_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1299,6 +1299,7 @@ kernel_read_proc_files(systemd_generator)
 dev_write_kmsg(systemd_generator)
 files_map_read_etc_files(systemd_generator)
 fs_getattr_all_fs(systemd_generator)
+fs_getattr_nsfs_files(systemd_generator)
 fs_search_cgroup_dirs(systemd_generator)
 init_read_state(systemd_generator)
 
@@ -1309,6 +1310,7 @@ fs_read_efivarfs_files(systemd_bless_boot_generator_t)
 
 ### cryptsetup generator
 manage_dirs_pattern(systemd_cryptsetup_generator_t, systemd_fstab_generator_unit_file_t, systemd_fstab_generator_unit_file_t)
+
 manage_files_pattern(systemd_cryptsetup_generator_t, systemd_fstab_generator_unit_file_t, systemd_fstab_generator_unit_file_t)
 
 ### fstab generator
@@ -1529,6 +1531,7 @@ dev_read_urand(systemd_domain)
 
 fs_search_all(systemd_domain)
 fs_getattr_all_fs(systemd_domain)
+fs_getattr_nsfs_files(systemd_domain)
 
 files_read_etc_files(systemd_domain)
 files_read_etc_runtime_files(systemd_domain)


### PR DESCRIPTION
With systemd v257, all systemd-related domains started to check nsfs.

The commit addresses the following AVC denial:
type=AVC msg=audit(1732756160.385:67): avc:  denied  { getattr } for  pid=707 comm="systemd-resolve" path="cgroup:[4026531835]" dev="nsfs" ino=4026531835 scontext=system_u:system_r:systemd_resolved_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=1 type=SYSCALL msg=audit(1732756160.385:67): arch=x86_64 syscall=newfstatat success=yes exit=0 a0=ffffff9c a1=7fff83b3a8e0 a2=7fff83b3a900 a3=0 items=1 ppid=1 pid=707 auid=4294967295 uid=193 gid=193 euid=193 suid=193 fsuid=193 egid=193 sgid=193 fsgid=193 tty=(none) ses=4294967295 comm=systemd-resolve exe=/usr/lib/systemd/systemd-resolved subj=system_u:system_r:systemd_resolved_t:s0 key=(null) type=PATH msg=audit(1732756160.385:67): item=0 name=/proc/self/ns/cgroup inode=4026531835 dev=00:04 mode=0100444 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:nsfs_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: rhbz#2329280