### PR TITLE
Fix the file type for /run/systemd/generator

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -103,7 +103,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/.+\.conf\.d/.+\.conf	-l	gen_context(system_u:object_r:systemd_conf_t,s0)
 /run/.*nologin.*		gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /run/systemd/default-hostname	--	gen_context(system_u:object_r:hostname_etc_t,s0)
-/run/systemd/generator(/.*)?	--	gen_context(system_u:object_r:systemd_unit_file_t,s0)
+/run/systemd/generator(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /run/systemd/sessions(/.*)?	gen_context(system_u:object_r:systemd_logind_sessions_t,s0)
 /run/systemd/shutdown(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)


### PR DESCRIPTION
With the e860245a1922 ("Label /run/systemd/generator with systemd_unit_file_t") commit, default file context was defined for /run/systemd/generator, but only for a plain file.

Resolves: RHEL-68313