### PR TITLE
feat: add boolean to control unconfined domain access to user_namespace

### DIFF
--- a/dist/targeted/booleans.conf
+++ b/dist/targeted/booleans.conf
@@ -23,3 +23,4 @@ unconfined_mozilla_plugin_transition=true
 xguest_exec_content = true
 mozilla_plugin_can_network_connect = true
 use_virtualbox = true
+unconfined_domain_can_create_user_namespace = true

--- a/policy/global_tunables
+++ b/policy/global_tunables
@@ -153,3 +153,10 @@ gen_tunable(use_virtualbox, false)
 ## </p>
 ## </desc>
 gen_tunable(deny_bluetooth,false)
+
+## <desc>
+## <p>
+## Allow unconfined domain to create user_namespace.
+## </p>
+## </desc>
+gen_tunable(unconfined_domain_can_create_user_namespace, false)

--- a/policy/global_tunables
+++ b/policy/global_tunables
@@ -159,4 +159,4 @@ gen_tunable(deny_bluetooth,false)
 ## Allow unconfined domain to create user_namespace.
 ## </p>
 ## </desc>
-gen_tunable(unconfined_domain_can_create_user_namespace, false)
+gen_tunable(unconfined_domain_can_create_user_namespace, true)

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -272,8 +272,10 @@ allow unconfined_domain_type self:io_uring sqpoll;
 dev_io_uring_cmd_on_all_dev_nodes(unconfined_domain_type)
 files_io_uring_cmd_on_all_files(unconfined_domain_type)
 
-# allow using the user_namespace class
-allow unconfined_domain_type self:user_namespace create;
+tunable_policy(`unconfined_domain_can_create_user_namespace',`
+	# allow using the user_namespace class
+	allow unconfined_domain_type self:user_namespace create;
+')
 
 # Use bpf tools
 allow unconfined_domain_type domain:bpf { map_create map_read map_write prog_load prog_run };

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -375,7 +375,10 @@ optional_policy(`
 # login_userdomain local policy
 
 allow login_userdomain self:service status;
-allow login_userdomain self:user_namespace create;
+
+tunable_policy(`unconfined_domain_can_create_user_namespace',`
+	allow login_userdomain self:user_namespace create;
+')
 
 corenet_udp_bind_howl_port(login_userdomain)
 corenet_tcp_bind_xmsg_port(login_userdomain)


### PR DESCRIPTION
This doesn't change the default behavior, but adds a boolean to control unconfined access to the user_namespace class.

This is the first step of many needed to achieve parity with https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces