### PR TITLE
Allow svirt_t the sys_rawio capability

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -528,6 +528,7 @@ optional_policy(`
 # svirt_prot_exec local policy
 #
 
+allow svirt_tcg_t self:capability sys_rawio;
 allow svirt_tcg_t self:process { execmem execstack };
 allow svirt_tcg_t self:netlink_route_socket r_netlink_socket_perms;
 


### PR DESCRIPTION
This permission is needed when virt-install needs raw access to SCSI disks.

libvirt explicitly grants the qemu process CAP_SYS_RAWIO only if it has a disk with the property enabled in the definition and otherwise a qemu process started by libvirt will not have that capability.

Resolves: RHEL-56955