### PR TITLE
Allow qemu-ga the dac_override and dac_read_search capabilities

### DIFF
--- a/policy/modules/contrib/virt_supplementary.te
+++ b/policy/modules/contrib/virt_supplementary.te
@@ -157,7 +157,7 @@ optional_policy(`
 # virt_qemu_ga local policy
 #
 
-allow virt_qemu_ga_t self:capability { sys_admin sys_time sys_tty_config };
+allow virt_qemu_ga_t self:capability { dac_override dac_read_search sys_admin sys_time sys_tty_config };
 
 allow virt_qemu_ga_t self:passwd passwd;
 


### PR DESCRIPTION
The QEMU Guest Agent is a daemon intended to be run within virtual machines. It allows the hypervisor host to perform various operations in the guest. One of them is fsfreeze to freeze or thaw filesystems required for creating consistent snapshots.

The service gets the list list of all mount points from /proc/self/mounts and then iterates over them, opening each one, and issuing an ioctl for FIFREEZE/FITHAW. If the mountpoint is not owned by root, dac_read_search and subsequently dac_override capabilities are checked. Any failure to freeze a freezable filesystem gets the system back to thawed state.

Resolves: RHEL-52476