### PR TITLE
Move systemd-homed interfaces to seperate optional_policy block

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -230,6 +230,9 @@ optional_policy(`
 
 optional_policy(`
 	systemd_homed_write_pipes(system_dbusd_t)
+')
+
+optional_policy(`
 	systemd_status_systemd_services(system_dbusd_t)
 	systemd_use_fds_logind(system_dbusd_t)
 	systemd_write_inherited_logind_sessions_pipes(system_dbusd_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2288,6 +2288,9 @@ optional_policy(`
 
 optional_policy(`
 	systemd_dbus_chat_machined(virtqemud_t)
+')
+
+optional_policy(`
 	systemd_homed_stream_connect(virtqemud_t)
 ')
 

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -573,6 +573,9 @@ optional_policy(`
 
 optional_policy(`
 	systemd_homed_stream_connect(nsswitch_domain)
+')
+
+optional_policy(`
 	systemd_userdbd_stream_connect(nsswitch_domain)
 	systemd_machined_stream_connect(nsswitch_domain)
 ')


### PR DESCRIPTION
Since the systemd_homed module is not enabled on the minimum policy, optional_policy blocks including systemd-homed interfaces are not included. This causes the other systemd interfaces rules not being included as well if they are in the same optional_policy block.

This causes issues e.g. Switch to tty2 -> hangs
Dec 06 10:43:27 localhost.localdomain systemd-logind[1211]: Failed to start autovt@tty2.service: Transport endpoint is not connected

type=AVC msg=audit(1733346662.199:29): avc:  denied  { write } for  pid=1117 comm="dbus-broker" path="/run/systemd/inhibit/1.ref" dev="tmpfs" ino=1906 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_logind_inhibit_var_run_t:s0 tclass=fifo_file permissive=0
type=AVC msg=audit(1733346665.790:52): avc:  denied  { read } for  pid=1235 comm="login" name="userdb" dev="tmpfs" ino=42 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1733346665.797:58): avc:  denied  { read } for  pid=1235 comm="login" name="userdb" dev="tmpfs" ino=42 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1733346665.797:59): avc:  denied  { read } for  pid=1235 comm="login" name="userdb" dev="tmpfs" ino=42 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=0



more infos: https://bugzilla.suse.com/show_bug.cgi?id=1234228