### PR TITLE
Allow svirt_t the sys_rawio capability

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -484,6 +484,7 @@ files_mountpoint(container_ro_file_t)
 # svirt local policy
 #
 
+allow svirt_t self:capability sys_rawio;
 allow svirt_t self:process ptrace;
 
 allow svirt_t self:netlink_rdma_socket create_socket_perms;


### PR DESCRIPTION
This permission is needed when a vm needs raw access to SCSI disks.

libvirt explicitly grants the qemu process CAP_SYS_RAWIO only if it has a disk with the property enabled in the definition and otherwise a qemu process started by libvirt will not have that capability.

Note the previous commit 181dc5c40f52 ("Allow svirt_t the sys_rawio capability") allowed the permission actually to the svirt_tcg_t domain.

Resolves: RHEL-56955