### PR TITLE
Allow alsa watch generic device directories

### DIFF
--- a/policy/modules/contrib/alsa.te
+++ b/policy/modules/contrib/alsa.te
@@ -84,6 +84,7 @@ dev_getattr_fs(alsa_t)
 dev_read_sound(alsa_t)
 dev_rw_sysfs(alsa_t)
 dev_read_urand(alsa_t)
+dev_watch_generic_dirs(alsa_t)
 dev_write_sound(alsa_t)
 
 files_search_var_lib(alsa_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/04/2024 11:46:59.694:466) : proctitle=alsactl monitor type=PATH msg=audit(10/04/2024 11:46:59.694:466) : item=0 name=/dev/snd/ inode=330 dev=00:05 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/04/2024 11:46:59.694:466) : arch=x86_64 syscall=inotify_add_watch success=yes exit=1 a0=0x5 a1=0x55c4988e9097 a2=0x100 a3=0x0 items=1 ppid=3133 pid=29220 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=tty3 ses=4 comm=alsactl exe=/usr/sbin/alsactl subj=system_u:system_r:alsa_t:s0 key=(null) type=AVC msg=audit(10/04/2024 11:46:59.694:466) : avc:  denied  { watch } for  pid=29220 comm=alsactl path=/dev/snd dev="devtmpfs" ino=330 scontext=system_u:system_r:alsa_t:s0 tcontext=system_u:object_r:device_t:s0 tclass=dir permissive=1

Resolves: RHEL-61472