### PR TITLE
Allow init nnp transition to locate_t

### DIFF
--- a/policy/modules/contrib/slocate.te
+++ b/policy/modules/contrib/slocate.te
@@ -8,6 +8,7 @@ policy_module(slocate, 1.12.2)
 type locate_t;
 type locate_exec_t;
 init_system_domain(locate_t, locate_exec_t)
+init_nnp_daemon_domain(locate_t)
 
 type locate_var_lib_t;
 files_type(locate_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/10/2024 17:44:40.322:21885) : proctitle=(updatedb) type=PATH msg=audit(12/10/2024 17:44:40.322:21885) : item=0 name=/usr/sbin/updatedb inode=529731 dev=00:22 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:locate_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(12/10/2024 17:44:40.322:21885) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x55ef08d3db70 a1=0x55ef08d39bc0 a2=0x55ef089bde80 a3=0x0 items=1 ppid=1 pid=326211 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(updatedb) exe=/usr/lib/systemd/systemd-executor subj=system_u:system_r:init_t:s0 key=(null) type=AVC msg=audit(12/10/2024 17:44:40.322:21885) : avc:  denied  { execute_no_trans } for  pid=326211 comm=(updatedb) path=/usr/sbin/updatedb dev="vda3" ino=529731 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:locate_exec_t:s0 tclass=file permissive=0 type=SELINUX_ERR msg=audit(12/10/2024 17:44:40.322:21885) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:locate_t:s0 type=AVC msg=audit(12/10/2024 17:44:40.322:21885) : avc:  denied  { nnp_transition } for  pid=326211 comm=(updatedb) scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:locate_t:s0 tclass=process2 permissive=0

Resolves: rhbz#2330761