### PR TITLE
Allow systemd-sleep manage efivarfs files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1755,9 +1755,7 @@ dev_create_sysfs_files(systemd_sleep_t)
 dev_rw_sysfs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
 
-fs_create_efivarfs_files(systemd_sleep_t)
-fs_setattr_efivarfs_files(systemd_sleep_t)
-fs_rw_efivarfs_files(systemd_sleep_t)
+fs_manage_efivarfs_files(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)
 


### PR DESCRIPTION
In addition to previously added permissions, systemd-sleep needs to able to set and clear the HibernateLocation efivar.

The commit addresses the following AVC denial:
type=AVC msg=audit(1733831548.583:399): avc:  denied  { unlink } for  pid=287281 comm="systemd-sleep" name="HibernateLocation-8cf2644b-4b0b-428f-9387-6d876050dc67" dev="efivarfs" ino=693287 scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:object_r:efivarfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2330674