### PR TITLE
Allow sssd_selinux_manager_t the setcap process permission

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -288,6 +288,7 @@ allow sssd_t sssd_selinux_manager_t:process signal;
 
 allow sssd_selinux_manager_t self:capability { setgid setuid };
 dontaudit sssd_selinux_manager_t self:capability net_admin;
+allow sssd_selinux_manager_t self:process setcap;
 
 domtrans_pattern(sssd_t, sssd_selinux_manager_exec_t, sssd_selinux_manager_t)
 


### PR DESCRIPTION
SSSD is being reworked [1] to not rely on effective capabilities but to raise a permitted capability when needed, and drop it completely when not needed anymore.
[1] https://github.com/SSSD/sssd/pull/7731

The commit addresses the following AVC denial:
type=AVC msg=audit(1733309927.245:4711): avc: denied { setcap } for pid=43967 comm="selinux_child" scontext=system_u:system_r:sssd_selinux_manager_t:s0 tcontext=system_u:system_r:sssd_selinux_manager_t:s0 tclass=process permissive=1 type=SYSCALL msg=audit(1733309927.245:4711): arch=c000003e syscall=126 success=yes exit=0 a0=55795759750c a1=557957597514 a2=557957597514 a3=80 items=0 ppid=41662 pid=43967 auid=4294967295 uid=990 gid=986 euid=990 suid=990 fsuid=990 egid=986 sgid=986 fsgid=986 tty=(none) ses=4294967295 comm="selinux_child" exe="/usr/libexec/sssd/selinux_child" subj=system_u:system_r:sssd_selinux_manager_t:s0 key=(null)ARCH=x86_64 SYSCALL=capset AUID="unset" UID="sssd" GID="sssd" EUID="sssd" SUID="sssd" FSUID="sssd" EGID="sssd" SGID="sssd" FSGID="sssd" type=CAPSET msg=audit(1733309927.245:4711): pid=43967 cap_pi=0000000000000080 cap_pp=00000000000000c0 cap_pe=0000000000000080 cap_pa=0

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2455
Resolves: rhbz#2331486