### PR TITLE
Allow systemd's ssh config files to be read like other ssh configs

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -22,6 +22,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/.+\.conf\.d	-d	gen_context(system_u:object_r:systemd_conf_t,s0)
 /usr/lib/systemd/.+\.conf\.d/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
 /usr/lib/systemd/.+\.conf\.d/.+\.conf	-l	gen_context(system_u:object_r:systemd_conf_t,s0)
+/usr/lib/systemd/sshd?_config/.+\.conf	--	gen_context(system_u:object_r:etc_t,s0)
 /usr/lib/systemd/systemd-bootchart	--	gen_context(system_u:object_r:systemd_bootchart_exec_t,s0)
 
 /usr/lib/systemd/systemd-initctl	--	gen_context(system_u:object_r:systemd_initctl_exec_t,s0)


### PR DESCRIPTION
`ssh_basic_client_template` should grant access to `systemd`'s `ssh` conf files like any other `ssh` conf files, so `etc_t` is more appropriate for them than `systemd_conf_t` for them.
