### PR TITLE
Allow irqbalance setpcap cabability in the user namespace

### DIFF
--- a/policy/modules/contrib/irqbalance.te
+++ b/policy/modules/contrib/irqbalance.te
@@ -23,6 +23,7 @@ files_pid_file(irqbalance_var_run_t)
 
 allow irqbalance_t self:capability { setpcap net_admin };
 dontaudit irqbalance_t self:capability sys_tty_config;
+allow irqbalance_t self:cap_userns setpcap;
 allow irqbalance_t self:process { getcap getsched setcap signal_perms };
 allow irqbalance_t self:udp_socket create_socket_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/11/2024 02:40:01.248:253) : proctitle=/usr/sbin/irqbalance type=SYSCALL msg=audit(12/11/2024 02:40:01.248:253) : arch=x86_64 syscall=prctl success=no exit=EPERM(Operation not permitted) a0=PR_CAPBSET_DROP a1=chown a2=0x0 a3=0x0 items=0 ppid=1 pid=70658 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=irqbalance exe=/usr/sbin/irqbalance subj=system_u:system_r:irqbalance_t:s0 key=(null) type=AVC msg=audit(12/11/2024 02:40:01.248:253) : avc:  denied  { setpcap } for  pid=70658 comm=irqbalance capability=setpcap  scontext=system_u:system_r:irqbalance_t:s0 tcontext=system_u:system_r:irqbalance_t:s0 tclass=cap_userns permissive=0