### PR TITLE
allow gdm and iiosensorproxy talk to each other via D-bus

### DIFF
--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -26,6 +26,10 @@ optional_policy(`
 	optional_policy(`
 		unconfined_dbus_chat(unconfined_t)
 	')
+
+    optional_policy(`
+        xserver_dbus_chat_xdm(iiosensorproxy_t)
+    ')
 ')
 
 optional_policy(`


### PR DESCRIPTION
GDM initiated processes (running as xdm_t) want to call the following D-bus interface, which belongs to the iio-sensor-proxy service, but SELinux denies that action:
 * net.hadess.SensorProxy.ClaimAccelerometer

As a result, the following error message appears in the systemd journal:

  gnome-shell[...]: Failed to claim accelerometer: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Sender is not authorized to send message

A successful D-bus communication in both directions is needed for proper function of this scenario:
 * xdm_t -> send_msg -> iiosensorproxy_t
 * iiosensorproxy_t -> send_msg -> xdm_t

Resolves: RHEL-70850