### PR TITLE
allow kdm to create /root/.kde/ with correct label

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -2422,6 +2422,7 @@ interface(`xserver_filetrans_admin_home_content',`
 
 	optional_policy(`
 		gnome_cache_filetrans($1, xdm_home_t, dir, "xdm")
+		gnome_filetrans_admin_home_content($1)
 	')
 ')
 


### PR DESCRIPTION
When the kdm service is started, it wants to create the .kde directory under /root/, but SELinux denies that action. When the /root/.kde directory exists, the kdm service wants to create a symlink in it, but SELinux denies that action too. The intended symlink should point this way:
 * /root/.kde/cache-machine-<FQDN> --> /var/tmp/kdecache-root

The fix has 2 parts. First, SELinux policy should label the newly created /root/.kde directory correctly (xdm_home_t). Second, SELinux policy should allow the kdm initiated process to create a symlink in that directory.

Resolves: bz#2275868