### PR TITLE
Allow cifs.idmap helper to set attributes on kernel keys

### DIFF
--- a/policy/modules/contrib/cifsutils.te
+++ b/policy/modules/contrib/cifsutils.te
@@ -19,6 +19,7 @@ allow cifs_helper_t self:tcp_socket create_stream_socket_perms;
 allow cifs_helper_t self:udp_socket create_socket_perms;
 
 kernel_view_key(cifs_helper_t)
+kernel_setattr_key(cifs_helper_t)
 
 corenet_tcp_connect_kerberos_port(cifs_helper_t)
 


### PR DESCRIPTION
Fixes:
type=AVC msg=audit(1732584010.899:9249): avc:  denied  { setattr } for  pid=1927557 comm="cifs.idmap" scontext=system_u:system_r:cifs_helper_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=key permissive=0

Resolves: rhbz#2328821