### PR TITLE
Allow systemd-journald getattr nsfs files

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -656,6 +656,7 @@ files_var_filetrans(syslogd_t, var_log_t, dir, "log")
 files_var_lib_filetrans(syslogd_t, syslogd_var_lib_t, { file dir })
 
 fs_getattr_all_fs(syslogd_t)
+fs_getattr_nsfs_files(syslogd_t)
 fs_read_efivarfs_files(syslogd_t)
 fs_search_auto_mountpoints(syslogd_t)
 fs_list_cgroup_dirs(syslogd_t)


### PR DESCRIPTION
This is a follow-up commit to 3023aa82e362 ("Allow systemd-related domains getattr nsfs files"). It addresses the following AVC denial: Dec 11 13:42:42 fedora audit[657]: AVC avc:  denied  { getattr } for  pid=657 comm="systemd-journal" path="cgroup:[4026531835]" dev="nsfs" ino=4026531835 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=0