### PR TITLE
Add gnome_filetrans_gstreamer_admin_home_content() interface

### DIFF
--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -1584,6 +1584,34 @@ interface(`gnome_filetrans_gstreamer_home_content',`
     gnome_cache_filetrans($1, gstreamer_home_t, dir, "gstreamer-12")
 ')
 
+
+#######################################
+## <summary>
+##  file name transition gstreamer admin home content files.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`gnome_filetrans_gstreamer_admin_home_content',`
+    gen_require(`
+        type gstreamer_home_t;
+    ')
+
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, file, ".grl-bookmarks")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, file, ".grl-metadata-store")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, file, ".grl-podcasts")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, dir, ".gstreamer-0.12")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, dir, ".gstreamer-0.10")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, dir, ".gstreamer-1.0")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, dir, ".gstreamer-1.2")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, dir, ".gstreamer-10")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, dir, ".gstreamer-12")
+    userdom_admin_home_dir_filetrans($1, gstreamer_home_t, dir, ".orc")
+')
+
 #######################################
 ## <summary>
 ##  manage gstreamer home content files.
@@ -1954,7 +1982,7 @@ gen_require(`
 	userdom_admin_home_dir_filetrans($1, gconf_home_t, dir, ".gconfd")
 	userdom_admin_home_dir_filetrans($1, gconf_home_t, dir, ".local")
 	userdom_admin_home_dir_filetrans($1, gnome_home_t, dir, ".gnome2")
-	gnome_filetrans_gstreamer_home_content($1)
+	gnome_filetrans_gstreamer_admin_home_content($1)
 	# /root/.color/icc: legacy
 	userdom_admin_home_dir_filetrans($1, icc_data_home_t, dir, "icc")
 ')


### PR DESCRIPTION
Before this commit, gnome_filetrans_home_content() was called both from gnome_filetrans_admin_home_content() and gnome_filetrans_home_content() interfaces.
As gdm can be run both for admin and non-admin users, a copy gnome_filetrans_gstreamer_admin_home_content(), with slightly different rules, is now called from gnome_filetrans_admin_home_content() instead.