### PR TITLE
Fix the cups_read_pid_files() interface to use read_files_pattern

### DIFF
--- a/policy/modules/contrib/cups.if
+++ b/policy/modules/contrib/cups.if
@@ -124,7 +124,7 @@ interface(`cups_read_pid_files',`
 	')
 
 	files_search_pids($1)
-	allow $1 cupsd_var_run_t:file read_file_perms;
+	read_files_pattern($1, cupsd_var_run_t, cupsd_var_run_t)
 ')
 
 ########################################


### PR DESCRIPTION
Until now, just allow rule to read was present, not giving the search access to the parent directory.

Resolves: RHEL-69517