### PR TITLE
Allow traceroute_t bind rawip sockets to unreserved ports

### DIFF
--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -75,6 +75,7 @@ corenet_tcp_sendrecv_all_ports(netutils_t)
 corenet_udp_sendrecv_all_ports(netutils_t)
 corenet_tcp_connect_all_ports(netutils_t)
 corenet_sendrecv_all_client_packets(netutils_t)
+corenet_rawip_bind_unreserved_port(netutils_t)
 corenet_udp_bind_generic_node(netutils_t)
 
 dev_read_sysfs(netutils_t)

--- a/policy/modules/kernel/corenetwork.if.in
+++ b/policy/modules/kernel/corenetwork.if.in
@@ -1698,6 +1698,24 @@ interface(`corenet_udp_send_all_ports',`
 
 ########################################
 ## <summary>
+##	Bind rawip sockets to unreserved ports.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corenet_rawip_bind_unreserved_port',`
+	gen_require(`
+		type unreserved_port_t;
+	')
+
+	allow $1 unreserved_port_t:rawip_socket name_bind;
+')
+
+########################################
+## <summary>
 ##	Bind SCTP sockets to generic ports.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This domain is used for confined users,can be also reproduced with a command like
runcon system_u:system_r:initrc_t:s0 /bin/bash -c "mtr --raw --udp -c 1 127.0.0.1"

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/16/2024 05:48:11.897:1396) : proctitle=mtr-packet type=SOCKADDR msg=audit(08/16/2024 05:48:11.897:1396) : saddr={ saddr_fam=inet laddr=10.0.187.156 lport=27594 } type=SYSCALL msg=audit(08/16/2024 05:48:11.897:1396) : arch=x86_64 syscall=bind success=no exit=EACCES(Permission denied) a0=0x4 a1=0x55e39d06b348 a2=0x10 a3=0x7ffcece8df10 items=0 ppid=93106 pid=93130 auid=user7066 uid=user7066 gid=user7066 euid=user7066 suid=user7066 fsuid=user7066 egid=user7066 sgid=user7066 fsgid=user7066 tty=pts2 ses=13 comm=mtr-packet exe=/usr/sbin/mtr-packet subj=user_u:user_r:traceroute_t:s0 key=(null) type=AVC msg=audit(08/16/2024 05:48:11.897:1396) : avc:  denied  { name_bind } for  pid=93130 comm=mtr-packet src=27594 scontext=user_u:user_r:traceroute_t:s0 tcontext=system_u:object_r:unreserved_port_t:s0 tclass=rawip_socket permissive=0

Resolves: RHEL-54561