### PR TITLE
Allow auditctl signal auditd

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -161,6 +161,8 @@ allow auditctl_t self:netlink_audit_socket nlmsg_readpriv;
 
 allow auditctl_t self:process getcap;
 
+allow auditctl_t auditd_t:process signal;
+
 read_files_pattern(auditctl_t, auditd_etc_t, auditd_etc_t)
 allow auditctl_t auditd_etc_t:dir list_dir_perms;
 allow auditctl_t auditd_etc_t:file map;


### PR DESCRIPTION
When restarting the audit service using "service auditd restart" from a custom service (e.g. an automation service), the auditctl --signal stop command may wait forever for auditd response, which never comes because auditd didn't receive the SIGTERM event at all.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/26/2024 09:41:41.369:168901) : proctitle=/sbin/auditctl --signal stop type=SYSCALL msg=audit(11/26/2024 09:41:41.369:168901) : arch=x86_64 syscall=pidfd_send_signal success=no exit=EACCES(Permission denied) a0=0x4 a1=0xf a2=0x0 a3=0x0 items=0 ppid=6984 pid=6987 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=auditctl exe=/usr/sbin/auditctl subj=system_u:system_r:auditctl_t:s0 key=(null) type=AVC msg=audit(11/26/2024 09:41:41.369:168901) : avc:  denied  { signal } for  pid=6987 comm=auditctl scontext=system_u:system_r:auditctl_t:s0 tcontext=system_u:system_r:auditd_t:s0 tclass=process permissive=0

Resolves: RHEL-68969