### PR TITLE
Dontaudit systemd-coredump the sys_resource capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1226,7 +1226,8 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # sys_ptrace - to read /proc/<pid>/exe of the dumped process
 # setgid setuid - to set own credentials to match the dumped process credentials
 # setpcap - to drop capabilities
-allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_admin sys_ptrace sys_resource };
+allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_ptrace };
+dontaudit systemd_coredump_t self:capability sys_resource;
 allow systemd_coredump_t self:cap_userns { dac_read_search dac_override sys_admin sys_ptrace };
 
 # To set its capability set


### PR DESCRIPTION
After joining container namespace, the sd-parse-elf process wants to drop privileges (i.e. switch under systemd-resolve user) and as part of that process it calls the getpwnam() function. When /etc/nsswitch.conf in container has 'systemd' in passwd and group entries, that causes glibc to try to load that module. However, it is not loading (i.e. trying to create executable mapping of underlying .so file) the module from rootfs but from container and because coredumpt_t doesn't not have execute permission in container_t files we get AVC denial.

While there, the capabilities granted previously were removed.

Resolves: RHEL-46339