### PR TITLE
Add support for the KVM guest memfd anon inodes

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1058,6 +1058,7 @@ kernel_io_uring_use(virt_domain)
 # qemu uses userfaultfd to implement live post-copy migration
 # https://wiki.qemu.org/Features/PostCopyLiveMigration
 kernel_userfaultfd_use(virt_domain)
+kernel_kvm_gmem_use(virt_domain)
 
 userdom_search_user_home_content(virt_domain)
 userdom_read_user_home_content_symlinks(virt_domain)

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -132,6 +132,7 @@ allow domain self:shm create_shm_perms;
 kernel_userfaultfd_domtrans(domain)
 kernel_io_uring_domtrans(domain)
 kernel_secretmem_domtrans(domain)
+kernel_kvm_gmem_domtrans(domain)
 
 kernel_getattr_proc(domain)
 kernel_read_proc_symlinks(domain)
@@ -315,6 +316,7 @@ kernel_manage_perf_event(unconfined_domain_type)
 kernel_userfaultfd_use(unconfined_domain_type)
 kernel_io_uring_use(unconfined_domain_type)
 kernel_secretmem_use(unconfined_domain_type)
+kernel_kvm_gmem_use(unconfined_domain_type)
 
 corenet_filetrans_all_named_dev(named_filetrans_domain)
 

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4662,3 +4662,58 @@ interface(`kernel_secretmem_use',`
 	')
 	allow $1 secretmem_t:anon_inode create;
 ')
+
+########################################
+## <summary>
+##	Set up type transition for KVM guest memfd anon inodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to receive the type transition.
+##	</summary>
+## </param>
+#
+interface(`kernel_kvm_gmem_domtrans',`
+	gen_require(`
+		type kvm_gmem_t;
+	')
+	type_transition $1 self:anon_inode kvm_gmem_t "[kvm-gmem]";
+')
+
+########################################
+## <summary>
+##	Allow the domain to use the KVM guest memfd interface via an
+##	inherited file descriptor.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_kvm_gmem_use_inherited',`
+	gen_require(`
+		type kvm_gmem_t;
+	')
+	# Not sure about the set of reachable permissions here -
+	# may be refined in the future to a smaller/bigger set.
+	allow $1 kvm_gmem_t:anon_inode { getattr read write map };
+')
+
+########################################
+## <summary>
+##	Allow the domain to use the KVM guest memfd interface.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_kvm_gmem_use',`
+	gen_require(`
+		type kvm_gmem_t;
+	')
+	kernel_kvm_gmem_use_inherited($1)
+	allow $1 kvm_gmem_t:anon_inode create;
+')

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -238,6 +238,7 @@ neverallow * unlabeled_t:file entrypoint;
 type userfaultfd_t;
 type io_uring_t;
 type secretmem_t;
+type kvm_gmem_t;
 
 # These initial sids are no longer used, and can be removed:
 sid any_socket		gen_context(system_u:object_r:unlabeled_t,mls_systemhigh)

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -30,6 +30,7 @@ kernel_prog_run_bpf(sysadm_t)
 kernel_read_fs_sysctls(sysadm_t)
 kernel_read_all_proc(sysadm_t)
 kernel_secretmem_use(sysadm_t)
+kernel_kvm_gmem_use(sysadm_t)
 kernel_unconfined(sysadm_t)
 
 auth_manage_shadow(sysadm_t)


### PR DESCRIPTION
These have been introduced in kernel commit a7800aa80ea4 ("KVM: Add KVM_CREATE_GUEST_MEMFD ioctl() for guest-specific backing memory").

Currently the only known user is qemu-kvm (svirt_t).

Resolves: RHEL-69128