### PR TITLE
Allow ssh_t read systemd config files

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -268,6 +268,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_read_conf_files(ssh_t)
+')
+
+optional_policy(`
 	xserver_user_x_domain_template(ssh, ssh_t, ssh_tmpfs_t)
 	xserver_domtrans_xauth(ssh_t)
 	xserver_map_user_fonts(ssh_t)


### PR DESCRIPTION
This denials is triggered for a confined user running the ssh command with new systemd in place.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/17/2024 10:12:02.296:1297) : proctitle=ssh hostname type=SYSCALL msg=audit(12/17/2024 10:12:02.296:1297) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x557fc44a7a80 a2=O_RDONLY a3=0x0 items=0 ppid=3510 pid=3581 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=pts2 ses=7 comm=ssh exe=/usr/bin/ssh subj=staff_u:staff_r:ssh_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(12/17/2024 10:12:02.296:1297) : avc:  denied  { open } for  pid=3581 comm=ssh path=/usr/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf dev="vda2" ino=175565 scontext=staff_u:staff_r:ssh_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_conf_t:s0 tclass=file permissive=0

Resolves: rhbz#2323483