### PR TITLE
Allow xdm dbus chat with power-profiles-daemon

### DIFF
--- a/policy/modules/contrib/powerprofiles.te
+++ b/policy/modules/contrib/powerprofiles.te
@@ -30,6 +30,10 @@ optional_policy(`
 	optional_policy(`
 		policykit_dbus_chat(powerprofiles_t)
 	')
+
+	optional_policy(`
+		xserver_dbus_chat_xdm(powerprofiles_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(12/17/2024 13:45:50.041:5188) : pid=788 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:powerprofiles_t:s0 tcontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tclass=dbus permissive=1 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'