### PR TITLE
Allow systemd-networkd list cgroup directories

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -629,6 +629,7 @@ corenet_udp_bind_dhcpc_port(systemd_networkd_t)
 corenet_tcp_bind_dhcpd_port(systemd_networkd_t)
 corenet_udp_bind_dhcpd_port(systemd_networkd_t)
 
+fs_list_cgroup_dirs(systemd_networkd_t)
 fs_read_xenfs_files(systemd_networkd_t)
 fs_read_nsfs_files(systemd_networkd_t)
 fs_cgroup_write_memory_pressure(systemd_networkd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/17/2024 14:14:25.953:7959) : proctitle=/usr/lib/systemd/systemd-networkd type=PATH msg=audit(12/17/2024 14:14:25.953:7959) : item=0 name=/sys/fs/cgroup inode=1 dev=00:1c mode=dir,555 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(12/17/2024 14:14:25.953:7959) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x557a85427950 a2=O_RDONLY|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=354425 auid=unset uid=systemd-network gid=systemd-network euid=systemd-network suid=systemd-network fsuid=systemd-network egid=systemd-network sgid=systemd-network fsgid=systemd-network tty=(none) ses=unset comm=systemd-network exe=/usr/lib/systemd/systemd-networkd subj=system_u:system_r:systemd_networkd_t:s0 key=(null) type=AVC msg=audit(12/17/2024 14:14:25.953:7959) : avc:  denied  { read } for  pid=354425 comm=systemd-network name=/ dev="cgroup2" ino=1 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=dir permissive=0