### PR TITLE
Allow systemd-networkd use its private tmpfs files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -572,6 +572,7 @@ optional_policy(`
     systemd_allow_create_mount_dir(init_t)
     systemd_hostnamed_delete_config(init_t)
 	systemd_manage_conf_files(init_t)
+	systemd_rw_networkd_tmpfs_files(init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2736,6 +2736,24 @@ interface(`systemd_networkd_watch_pid_dirs',`
 
 ########################################
 ## <summary>
+##	Read and write to systemd-networkd tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_rw_networkd_tmpfs_files',`
+	gen_require(`
+		type systemd_networkd_tmpfs_t;
+	')
+
+	allow $1 systemd_networkd_tmpfs_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
 ##	Mmap systemd_resolved_exec_t files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -76,6 +76,9 @@ systemd_unit_file(systemd_hwdb_unit_file_t)
 systemd_domain_template(systemd_networkd)
 init_nnp_daemon_domain(systemd_networkd_t)
 
+type systemd_networkd_tmpfs_t;
+files_tmpfs_file(systemd_networkd_tmpfs_t)
+
 type systemd_networkd_unit_file_t;
 systemd_unit_file(systemd_networkd_unit_file_t)
 
@@ -608,6 +611,9 @@ allow init_t systemd_networkd_t:netlink_route_socket create_netlink_socket_perms
 
 allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
 create_files_pattern(systemd_networkd_t, systemd_networkd_var_lib_t, systemd_networkd_var_lib_t)
+
+manage_files_pattern(systemd_networkd_t, systemd_networkd_tmpfs_t, systemd_networkd_tmpfs_t)
+fs_tmpfs_filetrans(systemd_networkd_t, systemd_networkd_tmpfs_t, file)
 
 manage_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 manage_lnk_files_pattern(systemd_networkd_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)


### PR DESCRIPTION
Additionally, allow init (pid 1) rw access to such files.

The commit addresses the following AVC denial:
type=AVC msg=audit(12/20/2024 11:24:50.627:296) : avc:  denied  { read write } for  pid=1 comm=systemd path=/memfd:data-fd (deleted) dev="tmpfs" ino=133 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_networkd_tmpfs_t:s0 tclass=file permissive=0