### PR TITLE
Allow virtqemud relabel tun_socket

### DIFF
--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -2180,3 +2180,22 @@ interface(`virt_manage_qemu_pid_sock_files',`
        files_search_pids($1)
        manage_sock_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
 ')
+
+########################################
+## <summary>
+##	Allow the specified domain to ioctl
+##	virtqemud over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`virt_virtqemud_ioctl_stream_sockets',`
+	gen_require(`
+		type virtqemud_t;
+	')
+
+	allow $1 virtqemud_t:unix_stream_socket ioctl;
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2304,6 +2304,7 @@ optional_policy(`
 
 optional_policy(`
 	ssh_domtrans_ssh(virtqemud_t)
+	ssh_signal(virtqemud_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2109,7 +2109,6 @@ allow virtqemud_t self:bpf { map_create map_read map_write prog_load prog_run };
 allow virtqemud_t self:capability { audit_write chown dac_override dac_read_search fowner fsetid kill net_admin setpcap setgid setuid sys_admin sys_chroot sys_ptrace sys_rawio sys_resource };
 allow virtqemud_t self:capability2 { bpf perfmon };
 allow virtqemud_t self:cap_userns kill;
-
 allow virtqemud_t self:netlink_audit_socket { nlmsg_relay read write };
 allow virtqemud_t self:process { getpgid setcap setexec setrlimit setsched setsockcreate };
 allow virtqemud_t self:tcp_socket create_socket_perms;
@@ -2124,8 +2123,8 @@ allow virtqemud_t svirt_t:tcp_socket create_stream_socket_perms;
 allow virtqemud_t svirt_t:udp_socket create_socket_perms;
 allow virtqemud_t svirt_t:unix_stream_socket { connectto create_stream_socket_perms };
 allow virtqemud_t svirt_socket_t:unix_stream_socket connectto;
-allow virtqemud_t svirt_tcg_t: process { setsched signal signull transition };
-allow virtqemud_t svirt_tcg_t: unix_stream_socket { connectto create_stream_socket_perms };
+allow virtqemud_t svirt_tcg_t:process { getrlimit getsched setsched signal signull transition };
+allow virtqemud_t svirt_tcg_t:unix_stream_socket { connectto create_stream_socket_perms };
 
 allow virtqemud_t svirt_devpts_t:chr_file open;
 allow virtqemud_t svirt_tmpfs_t:file { map write };
@@ -2182,6 +2181,7 @@ manage_sock_files_pattern(virtqemud_t, svirt_image_t, svirt_image_t)
 read_files_pattern(virtqemud_t, svirt_t, svirt_t)
 read_lnk_files_pattern(virtqemud_t, svirt_t, svirt_t)
 read_files_pattern(virtqemud_t, svirt_tcg_t, svirt_tcg_t)
+read_lnk_files_pattern(virtqemud_t, svirt_tcg_t, svirt_tcg_t)
 
 manage_files_pattern(virtqemud_t, virt_content_t, virt_content_t)
 

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2267,7 +2267,10 @@ tunable_policy(`virtqemud_use_execmem',`
 ')
 
 tunable_policy(`virt_use_nfs',`
+	fs_manage_nfs_dirs(virtqemud_t)
 	fs_manage_nfs_files(virtqemud_t)
+	fs_read_nfs_symlinks(virtqemud_t)
+	fs_mmap_nfs_files(virtqemud_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2151,7 +2151,7 @@ files_lock_filetrans(virtqemud_t, virtqemud_lock_t, file)
 
 allow virtqemud_t virtqemud_var_run_t:dir relabelfrom;
 allow virtqemud_t virtqemud_var_run_t:sock_file relabelfrom;
-allow virtqemud_t virt_log_t:file relabelfrom;
+allow virtqemud_t virt_log_t:file relabel_file_perms;
 
 manage_dirs_pattern(virtqemud_t, virt_var_run_t, virt_var_run_t)
 manage_dirs_pattern(virtqemud_t, virtqemud_var_run_t, virtqemud_var_run_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2113,7 +2113,7 @@ allow virtqemud_t self:cap_userns kill;
 allow virtqemud_t self:netlink_audit_socket { nlmsg_relay read write };
 allow virtqemud_t self:process { setcap setexec setrlimit setsched setsockcreate };
 allow virtqemud_t self:tcp_socket create_socket_perms;
-allow virtqemud_t self:tun_socket create;
+allow virtqemud_t self:tun_socket { create relabelfrom relabelto };
 allow virtqemud_t self:udp_socket { connect create getattr };
 
 allow virtqemud_t qemu_var_run_t:{ dir file sock_file } relabelfrom;

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2118,7 +2118,10 @@ allow virtqemud_t self:udp_socket { connect create getattr };
 
 allow virtqemud_t qemu_var_run_t:{ dir file sock_file } relabelfrom;
 
-allow virtqemud_t svirt_t:process { getattr setsched signal signull transition };
+allow virtqemud_t svirt_t:netlink_route_socket create_netlink_socket_perms;
+allow virtqemud_t svirt_t:process { getattr getrlimit setsched signal signull transition };
+allow virtqemud_t svirt_t:tcp_socket create_stream_socket_perms;
+allow virtqemud_t svirt_t:udp_socket create_socket_perms;
 allow virtqemud_t svirt_t:unix_stream_socket { connectto create_stream_socket_perms };
 allow virtqemud_t svirt_socket_t:unix_stream_socket connectto;
 allow virtqemud_t svirt_tcg_t: process { setsched signal signull transition };

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2111,7 +2111,7 @@ allow virtqemud_t self:capability2 { bpf perfmon };
 allow virtqemud_t self:cap_userns kill;
 
 allow virtqemud_t self:netlink_audit_socket { nlmsg_relay read write };
-allow virtqemud_t self:process { setcap setexec setrlimit setsched setsockcreate };
+allow virtqemud_t self:process { getpgid setcap setexec setrlimit setsched setsockcreate };
 allow virtqemud_t self:tcp_socket create_socket_perms;
 allow virtqemud_t self:tun_socket { create relabelfrom relabelto };
 allow virtqemud_t self:udp_socket { connect create getattr };

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2285,6 +2285,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	numad_domtrans(virtqemud_t)
+')
+
+optional_policy(`
 	qemu_exec(virtqemud_t)
 ')
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -272,6 +272,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	virt_virtqemud_ioctl_stream_sockets(ssh_t)
+')
+
+optional_policy(`
 	xserver_user_x_domain_template(ssh, ssh_t, ssh_tmpfs_t)
 	xserver_domtrans_xauth(ssh_t)
 	xserver_map_user_fonts(ssh_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/16/2024 03:49:11.325:19674) : proctitle=/usr/sbin/virtqemud --timeout 120 type=AVC msg=audit(12/16/2024 03:49:11.325:19674) : avc:  denied  { relabelfrom } for  pid=500526 comm=rpc-virtqemud scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=tun_socket permissive=1 type=AVC msg=audit(12/16/2024 03:49:11.325:19674) : avc:  denied  { relabelto } for  pid=500526 comm=rpc-virtqemud scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=tun_socket permissive=1 type=SYSCALL msg=audit(12/16/2024 03:49:11.325:19674) : arch=aarch64 syscall=ioctl success=yes exit=0 a0=0x1a a1=0x400454ca a2=0xffffa57dd800 a3=0x0 items=0 ppid=1 pid=500526 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null)

Resolves: RHEL-71394