### PR TITLE
Allow systemd-homed get filesystem quotas

### DIFF
--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -110,6 +110,7 @@ kernel_read_system_state(systemd_homed_t)
 dev_getattr_generic_blk_files(systemd_homed_t)
 dev_read_sysfs(systemd_homed_t)
 
+fs_get_xattr_fs_quotas(systemd_homed_t)
 fs_getattr_cgroup(systemd_homed_t)
 fs_getattr_xattr_fs(systemd_homed_t)
 fs_search_cgroup_dirs(systemd_homed_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/07/2025 04:20:36.210:878) : proctitle=/usr/lib/systemd/systemd-homed type=PATH msg=audit(01/07/2025 04:20:36.210:878) : item=1 name=/dev/vda2 inode=324 dev=00:06 mode=block,660 ouid=root ogid=disk rdev=fc:02 obj=system_u:object_r:fixed_disk_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(01/07/2025 04:20:36.210:878) : item=0 name=/dev/vda2 nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/07/2025 04:20:36.210:878) : arch=x86_64 syscall=quotactl success=no exit=EACCES(Permission denied) a0=0x80000700 a1=0x56175d9c8bd0 a2=0xeabe a3=0x7ffe3e1896f0 items=2 ppid=1 pid=709 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-homed exe=/usr/lib/systemd/systemd-homed subj=system_u:system_r:systemd_homed_t:s0 key=(null) type=AVC msg=audit(01/07/2025 04:20:36.210:878) : avc:  denied  { quotaget } for  pid=709 comm=systemd-homed scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0