### PR TITLE
Allow login_userdomain getattr nsfs files

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -419,6 +419,7 @@ files_watch_generic_tmp_dirs(login_userdomain)
 
 fs_create_cgroup_files(login_userdomain)
 fs_cgroup_filetrans_memory_pressure(login_userdomain)
+fs_getattr_nsfs_files(login_userdomain)
 fs_watch_cgroup_files(login_userdomain)
 
 libs_watch_lib_dirs(login_userdomain)


### PR DESCRIPTION
Similar to 3023aa82e362 ("Allow systemd-related domains getattr nsfs files") and follow-up commits, the same permission is needed for the systemd user instance, running in the user context.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/07/2025 18:55:46.084:26366) : proctitle=systemd-tmpfiles --user --create --remove --boot type=PATH msg=audit(01/07/2025 18:55:46.084:26366) : item=0 name=/proc/self/ns/pid inode=4026531836 dev=00:04 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:nsfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/07/2025 18:55:46.084:26366) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffc89d3c6a0 a2=0x7ffc89d3c6c0 a3=0x0 items=1 ppid=471876 pid=471884 auid=user7401 uid=user7401 gid=user7401 euid=user7401 suid=user7401 fsuid=user7401 egid=user7401 sgid=user7401 fsgid=user7401 tty=(none) ses=765 comm=systemd-tmpfile exe=/usr/bin/systemd-tmpfiles subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(01/07/2025 18:55:46.084:26366) : avc:  denied  { getattr } for