### PR TITLE
Allow virtqemud send a generic signal to the ssh client domain

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2308,7 +2308,7 @@ optional_policy(`
 
 optional_policy(`
 	ssh_domtrans_ssh(virtqemud_t)
-	ssh_signal(virtqemud_t)
+	ssh_signal_ssh(virtqemud_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -678,6 +678,24 @@ interface(`ssh_exec',`
 
 ########################################
 ## <summary>
+##	Send a generic signal to the ssh client domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`ssh_signal_ssh',`
+	gen_require(`
+		type ssh_t, ssh_exec_t;
+	')
+
+	allow $1 ssh_t:process signal;
+')
+
+########################################
+## <summary>
 ##	Execute the ssh client in the ssh client domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This is a partial update to the previous commit 477e0bd39736 ("Support virt live migration using ssh") which incorectly allowed the permission to the ssh server.

The commit addresses the following AVC denial:
type=AVC msg=audit(1736307102.011:826): avc:  denied  { signal } for  pid=2370 comm="virtqemud" scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:ssh_t:s0 tclass=process permissive=1

Resolves: RHEL-53972