### PR TITLE
Label /dev/pmem[0-9]+ with fixed_disk_device_t

### DIFF
--- a/policy/modules/kernel/storage.fc
+++ b/policy/modules/kernel/storage.fc
@@ -50,6 +50,7 @@
 /dev/pktcdvd[0-7]	-b	gen_context(system_u:object_r:removable_device_t,s0)
 /dev/pktcdvd/control	-c	gen_context(system_u:object_r:pktcdvd_control_device_t,s0)
 /dev/pktcdvd/.+		-b	gen_context(system_u:object_r:removable_device_t,s0)
+/dev/pmem[0-9]+		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/ps3d.*		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/ram.*		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
 /dev/(raw/)?rawctl	-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)


### PR DESCRIPTION
Non-Volatile Dual In-line Memory Modules (NVDIMM) is a persistent memory technology which combines the durability of storage with the low access latency and the high bandwidth of dynamic RAM. In the linux kernel, the support is implemented in the nd_pmem.ko module.