### PR TITLE
Add nbdkit interfaces defined conditionally

### DIFF
--- a/policy/modules/contrib/nbdkit.if
+++ b/policy/modules/contrib/nbdkit.if
@@ -1,0 +1,144 @@
+## <summary>nbdkit: accessing block devices over the network</summary>
+
+########################################
+## <summary>
+##    Execute nbdkit_exec_t in the nbdkit domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##    Domain allowed to transition.
+## </summary>
+## </param>
+#
+ifndef(`nbdkit_domtrans',`
+	interface(`nbdkit_domtrans',`
+		gen_require(`
+			type nbdkit_t, nbdkit_exec_t;
+		')
+
+		corecmd_search_bin($1)
+		domtrans_pattern($1, nbdkit_exec_t, nbdkit_t)
+	')
+')
+
+######################################
+## <summary>
+##    Execute nbdkit in the caller domain.
+## </summary>
+## <param name="domain">
+##    <summary>
+##    Domain allowed access.
+##    </summary>
+## </param>
+#
+ifndef(`nbdkit_exec',`
+	interface(`nbdkit_exec',`
+		gen_require(`
+			type nbdkit_exec_t;
+		')
+	    
+		corecmd_search_bin($1)
+		can_exec($1, nbdkit_exec_t)
+	')
+')
+
+########################################
+## <summary>
+##    Execute nbdkit in the nbdkit domain, and
+##    allow the specified role the nbdkit domain.
+## </summary>
+## <param name="domain">
+##    <summary>
+##    Domain allowed to transition
+##    </summary>
+## </param>
+## <param name="role">
+##    <summary>
+##    The role to be allowed the nbdkit domain.
+##    </summary>
+## </param>
+#
+ifndef(`nbdkit_run',`
+	interface(`nbdkit_run',`
+		gen_require(`
+			type nbdkit_t;
+			attribute_role nbdkit_roles;
+		')
+
+		nbdkit_domtrans($1)
+		roleattribute $2 nbdkit_roles;
+	')
+')
+
+########################################
+## <summary>
+##    Role access for nbdkit
+## </summary>
+## <param name="role">
+##    <summary>
+##    Role allowed access
+##    </summary>
+## </param>
+## <param name="domain">
+##    <summary>
+##    User domain for the role
+##    </summary>
+## </param>
+#
+ifndef(`nbdkit_role',`
+	interface(`nbdkit_role',`
+		gen_require(`
+			type nbdkit_t;
+			attribute_role nbdkit_roles;
+		')
+
+		roleattribute $1 nbdkit_roles;
+
+		nbdkit_domtrans($2)
+
+		ps_process_pattern($2, nbdkit_t)
+		allow $2 nbdkit_t:process { signull signal sigkill };
+	')
+')
+
+########################################
+## <summary>
+##	Allow attempts to connect to nbdkit
+##	with a unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+ifndef(`nbdkit_stream_connect',`
+	interface(`nbdkit_stream_connect',`
+		gen_require(`
+			type nbdkit_t;
+		')
+
+		allow $1 nbdkit_t:unix_stream_socket connectto;
+	')
+')
+
+########################################
+## <summary>
+##      Allow nbdkit_exec_t to be an entrypoint
+##      of the specified domain
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+ifndef(`nbdkit_entrypoint',`
+	interface(`nbdkit_entrypoint',`
+	        gen_require(`
+	                type nbdkit_exec_t;
+	        ')
+	        allow $1 nbdkit_exec_t:file entrypoint;
+	')
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2285,6 +2285,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	nbdkit_domtrans(virtqemud_t)
+')
+
+optional_policy(`
 	numad_domtrans(virtqemud_t)
 ')
 


### PR DESCRIPTION
The nbdkit module has an independent policy managed by the nbdkit team. Its interfaces are needed though as they are used in virt-related modules in selinux-policy.