### PR TITLE
Allow samba-bgqd connect to cupsd over an unix domain stream socket

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -341,6 +341,7 @@ optional_policy(`
 optional_policy(`
 	cups_read_config(samba_bgqd_t)
 	cups_read_pid_files(samba_bgqd_t)
+	cups_stream_connect(samba_bgqd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/06/2025 14:35:38.782:414) : proctitle=/usr/libexec/samba/samba-bgqd --foreground --no-process-group type=PATH msg=audit(01/06/2025 14:35:38.782:414) : item=0 name=/run/cups/cups.sock inode=1046 dev=00:18 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cupsd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(01/06/2025 14:35:38.782:414) : saddr={ saddr_fam=local path=/run/cups/cups.sock } type=SYSCALL msg=audit(01/06/2025 14:35:38.782:414) : arch=x86_64 syscall=connect success=yes exit=0 a0=0xe a1=0x55b2bbdaba08 a2=0x16 a3=0x7ffeebd02214 items=1 ppid=12920 pid=12922 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=samba-bgqd exe=/usr/libexec/samba/samba-bgqd subj=system_u:system_r:samba_bgqd_t:s0 key=(null) type=AVC msg=audit(01/06/2025 14:35:38.782:414) : avc:  denied  { connectto } for  pid=12922 comm=samba-bgqd path=/run/cups/cups.sock scontext=system_u:system_r:samba_bgqd_t:s0 tcontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1 type=AVC msg=audit(01/06/2025 14:35:38.782:414) : avc:  denied  { write } for  pid=12922 comm=samba-bgqd name=cups.sock dev="tmpfs" ino=1046 scontext=system_u:system_r:samba_bgqd_t:s0 tcontext=system_u:object_r:cupsd_var_run_t:s0 tclass=sock_file permissive=1

Resolves: RHEL-72860