### PR TITLE
Allow svirt_t read sysfs files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -510,6 +510,7 @@ corenet_udp_bind_all_ports(svirt_t)
 corenet_tcp_bind_all_ports(svirt_t)
 corenet_tcp_connect_all_ports(svirt_t)
 
+dev_read_sysfs(svirt_t)
 dev_rw_dma_dev(svirt_t)
 
 init_dontaudit_read_state(svirt_t)


### PR DESCRIPTION
Triggered by:
virt-install --import --disk /var/lib/libvirt/images/image.qcow2 -r 4000 --machine machinetype -n instancename --osinfo generic

The commit addresses the following AVC denial:
type=AVC msg=audit(1733476544.855:6456): avc:  denied  { read } for  pid=369525 comm="qemu-system-x86" name="possible" dev="sysfs" ino=4677 scontext=system_u:system_r:svirt_t:s0:c199,c344 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: rhbz#2330756