### PR TITLE
Allow unix_update(8) to write to the kernel audit log

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -385,6 +385,7 @@ auth_manage_shadow(updpwd_t)
 auth_etc_filetrans_shadow(updpwd_t)
 auth_use_nsswitch(updpwd_t)
 
+logging_send_audit_msgs(updpwd_t)
 logging_send_syslog_msg(updpwd_t)
 
 userdom_use_inherited_user_terminals(updpwd_t)


### PR DESCRIPTION
## Overview ##

unix\_update(8), a `pam_unix.so` helper for updating user passwords, expects to be able to log security events to the kernel audit log but cannot.

## Steps to reproduce ##

For example, on Fedora Server 41 with the following packages:

- [kernel-6.11.4-301.fc41.x86\_64]
- [pam-1.6.1-7.fc41.x86\_64]
- [selinux-policy-targeted-41.28-1.fc41.noarch]

Restrict the capabilities on passwd(1) to trigger the invocation of unix_update(8) when changing your password:

```console
user@localhost:~$ sudo setcap cap_sys_resource,cap_audit_write=ep /usr/bin/passwd
user@localhost:~$ passwd
```

```
Current password:
New password:
Retype new password:
passwd: password updated successfully
```

Look for denials:

```console
user@localhost:~$ sudo ausearch -c unix_update -m AVC -ts recent
```

```
----
time->Tue Jan 14 19:09:35 2025
type=PROCTITLE msg=audit(1736899775.574:224): proctitle=2F7573722F7362696E2F756E69785F7570646174650075736572007570646174650031002D31
type=SYSCALL msg=audit(1736899775.574:224): arch=c000003e syscall=41 success=no exit=-13 a0=10 a1=80003 a2=9 a3=55d2d676b7b0 items=0 ppid=2408 pid=2414 auid=1000 uid=1000 gid=1000 euid=0 suid=0 fsuid=0 egid=1000 sgid=1000 fsgid=1000 tty=tty1 ses=1 comm="unix_update" exe="/usr/sbin/unix_update" subj=unconfined_u:unconfined_r:updpwd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(1736899775.574:224): avc:  denied  { create } for  pid=2414 comm="unix_update" scontext=unconfined_u:unconfined_r:updpwd_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:updpwd_t:s0-s0:c0.c1023 tclass=netlink_audit_socket permissive=0
----
time->Tue Jan 14 19:09:35 2025
type=PROCTITLE msg=audit(1736899775.595:225): proctitle=2F7573722F7362696E2F756E69785F7570646174650075736572007570646174650031002D31
type=SYSCALL msg=audit(1736899775.595:225): arch=c000003e syscall=41 success=no exit=-13 a0=10 a1=80003 a2=9 a3=55d2d676b7b0 items=0 ppid=2408 pid=2414 auid=1000 uid=1000 gid=1000 euid=0 suid=0 fsuid=0 egid=1000 sgid=1000 fsgid=1000 tty=tty1 ses=1 comm="unix_update" exe="/usr/sbin/unix_update" subj=unconfined_u:unconfined_r:updpwd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(1736899775.595:225): avc:  denied  { create } for  pid=2414 comm="unix_update" scontext=unconfined_u:unconfined_r:updpwd_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:updpwd_t:s0-s0:c0.c1023 tclass=netlink_audit_socket permissive=0
```

[kernel-6.11.4-301.fc41.x86\_64]: https://koji.fedoraproject.org/koji/rpminfo?rpmID=40418357
[pam-1.6.1-7.fc41.x86\_64]: https://koji.fedoraproject.org/koji/rpminfo?rpmID=40792342
[selinux-policy-targeted-41.28-1.fc41.noarch]: https://koji.fedoraproject.org/koji/rpminfo?rpmID=41099542