### PR TITLE
Allow virt_domain to use pulseaudio - conditional

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -112,8 +112,14 @@ gen_tunable(virt_use_pcscd, false)
 
 ## <desc>
 ## <p>
-## Allow sandbox containers to send audit messages
+## Allow confined virtual guests to use pulseaudio
+## </p>
+## </desc>
+gen_tunable(virt_use_pulseaudio, false)
 
+## <desc>
+## <p>
+## Allow sandbox containers to send audit messages
 ## </p>
 ## </desc>
 gen_tunable(virt_sandbox_use_audit, true)
@@ -1251,6 +1257,14 @@ optional_policy(`
 optional_policy(`
 	tunable_policy(`virt_use_xserver',`
 		xserver_stream_connect(virt_domain)
+	')
+')
+
+optional_policy(`
+	tunable_policy(`virt_use_pulseaudio',`
+		pulseaudio_read_home_files(virt_domain)
+		unconfined_stream_connect(virt_domain)
+		userdom_stream_connect(virt_domain)
 	')
 ')
 


### PR DESCRIPTION
Introduce a new conditional virt_use_xserver which allows virtual guests to use pulseaudio.

The boolean is disabled by default, because it is unlikely for qemu:///system mode of libvirt to need this functionality (this is intended for qemu:///session mode of libvirt).

Resolves: RHEL-62763