### PR TITLE
Allow nfsidmap connect to systemd-homed over a unix socket

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -478,3 +478,7 @@ optional_policy(`
 	systemd_machined_stream_connect(nfsidmap_t)
 	systemd_userdbd_stream_connect(nfsidmap_t)
 ')
+
+optional_policy(`
+	systemd_homed_stream_connect(nfsidmap_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1730526325.738:1384): avc:  denied  { connectto } for  pid=30373 comm="nfsidmap" path="/run/systemd/userdb/io.systemd.Home" scontext=system_u:system_r:nfsidmap_t:s0 tcontext=system_u:system_r:systemd_homed_t:s0 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2323363