### PR TITLE
Allow gnome-remote-desktop read resolv.conf

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -67,6 +67,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sysnet_read_config(gnome_remote_desktop_t)
+')
+
+optional_policy(`
 	systemd_login_list_pid_dirs(gnome_remote_desktop_t)
 	systemd_login_read_pid_files(gnome_remote_desktop_t)
 	systemd_read_logind_sessions_files(gnome_remote_desktop_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1737164018.876:514): avc:  denied  { open } for  pid=4749 comm="gnome-remote-de" path="/etc/resolv.conf" dev="sdb2" ino=22950647 scontext=system_u:system_r:gnome_remote_desktop_t:s0 tcontext=unconfined_u:object_r:net_conf_t:s0 tclass=file permissive=1

Resolves: rhbz#2338713