### PR TITLE
Label /proc/sys/kernel/nmi_watchdog with proc_nmi_watchdog_t

### DIFF
--- a/policy/modules/contrib/pcm.te
+++ b/policy/modules/contrib/pcm.te
@@ -17,6 +17,7 @@ allow pcmsensor_t self:process { ptrace setrlimit };
 
 kernel_read_proc_files(pcmsensor_t)
 kernel_read_debugfs(pcmsensor_t)
+kernel_write_nmi_watchdog_state(pcmsensor_t)
 
 dev_rw_cpu_microcode(pcmsensor_t)
 # /sys/module/msr/parameters/allow_writes

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4161,6 +4161,25 @@ interface(`kernel_read_security_state_symlinks',`
 
 ########################################
 ## <summary>
+##	Allow caller to write nmi_watchdog state information.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+##
+#
+interface(`kernel_write_nmi_watchdog_state',`
+	gen_require(`
+		type sysctl_t, sysctl_kernel_t, sysctl_nmi_watchdog_t;
+	')
+
+	write_files_pattern($1, { proc_t sysctl_t sysctl_kernel_t }, sysctl_nmi_watchdog_t)
+')
+
+########################################
+## <summary>
 ##	Access unlabeled infiniband pkeys.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -187,6 +187,11 @@ type sysctl_kernel_t, sysctl_type;
 fs_associate(sysctl_kernel_t)
 genfscon proc /sys/kernel gen_context(system_u:object_r:sysctl_kernel_t,s0)
 
+# /proc/sys/kernel/nmi_watchdog
+type sysctl_nmi_watchdog_t, sysctl_type;
+fs_associate(sysctl_nmi_watchdog_t)
+genfscon proc /sys/kernel/nmi_watchdog gen_context(system_u:object_r:sysctl_nmi_watchdog_t,s0)
+
 # /sys/kernel/ns_last_pid file
 type sysctl_kernel_ns_last_pid_t, sysctl_type;
 fs_associate(sysctl_kernel_ns_last_pid_t)


### PR DESCRIPTION
The kernel_write_nmi_watchdog_state() interface was added.