### PR TITLE
Allow power-profiles-daemon write sysfs files

### DIFF
--- a/policy/modules/contrib/powerprofiles.te
+++ b/policy/modules/contrib/powerprofiles.te
@@ -21,7 +21,7 @@ manage_files_pattern(powerprofiles_t, powerprofiles_var_lib_t, powerprofiles_var
 
 kernel_read_proc_files(powerprofiles_t)
 
-dev_read_sysfs(powerprofiles_t)
+dev_rw_sysfs(powerprofiles_t)
 
 optional_policy(`
 	dbus_connect_system_bus(powerprofiles_t)


### PR DESCRIPTION
Triggered when power-profiles-daemon attempts to set the performance profile, e.g. when a game is launched.

The commit addresses the following AVC denial:
type=AVC msg=audit(1735563341.961:181): avc:  denied  { write } for  pid=2897 comm="power-profiles-" name="energy_performance_preference" dev="sysfs" ino=23260 scontext=system_u:system_r:powerprofiles_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1

Resolves: rhbz#2334965