### PR TITLE
Allow virtstoraged write to sysfs files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2388,6 +2388,8 @@ kernel_read_vm_sysctls(virtstoraged_t)
 
 corecmd_exec_bin(virtstoraged_t)
 
+dev_write_sysfs(virtstoraged_t)
+
 fs_getattr_all_fs(virtstoraged_t)
 fs_getattr_configfs_dirs(virtstoraged_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/06/2025 02:46:21.652:10457) : proctitle=/usr/sbin/virtstoraged --timeout 120 type=AVC msg=audit(01/06/2025 02:46:21.652:10457) : avc:  denied  { write } for  pid=128738 comm=rpc-virtstorage name=vport_create dev="sysfs" ino=46896 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1 type=SYSCALL msg=audit(01/06/2025 02:46:21.652:10457) : arch=x86_64 syscall=openat success=yes exit=19 a0=AT_FDCWD a1=0x560c7bbfab60 a2=O_WRONLY|O_TRUNC a3=0x0 items=0 ppid=1 pid=128738 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtstorage exe=/usr/sbin/virtstoraged subj=system_u:system_r:virtstoraged_t:s0 key=(null)

Resolves: RHEL-44637