### PR TITLE
Allow iio-sensor-proxy connect to syslog over a unix stream socket

### DIFF
--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -33,5 +33,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	logging_stream_connect_syslog(iiosensorproxy_t)
+')
+
+optional_policy(`
 	udev_read_pid_files(iiosensorproxy_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1733659266.934:144): avc:  denied  { search } for  pid=974 comm="iio-sensor-prox" name="journal" dev="tmpfs" ino=46 scontext=system_u:system_r:iiosensorproxy_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(1733659266.934:144): arch=x86_64 syscall=sendmsg success=no exit=EACCES a0=9 a1=7ffc118c5010 a2=4000 a3=60 items=0 ppid=1 pid=974 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=iio-sensor-prox exe=/usr/libexec/iio-sensor-proxy subj=system_u:system_r:iiosensorproxy_t:s0 key=(null)

Resolves: rhbz#2331002