### PR TITLE
Allow virtqemud manage fixed disk device nodes

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2261,8 +2261,7 @@ init_stream_connect_script(virtqemud_t)
 
 selinux_compute_create_context(virtqemud_t)
 
-storage_rw_fixed_disk_blk_dev(virtqemud_t)
-storage_setattr_fixed_disk_dev(virtqemud_t)
+storage_manage_fixed_disk(virtqemud_t)
 
 sysnet_exec_ifconfig(virtqemud_t)
 sysnet_manage_config(virtqemud_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/17/2025 05:33:41.871:189) : proctitle=/usr/sbin/virtqemud --timeout 120 type=SYSCALL msg=audit(01/17/2025 05:33:41.871:189) : arch=x86_64 syscall=unlink success=yes exit=0 a0=0x7f57e8041ff0 a1=0x7f57e8041ff0 a2=0x0 a3=0x0 items=0 ppid=1331 pid=1571 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(01/17/2025 05:33:41.871:189) : avc:  denied  { unlink } for  pid=1571 comm=rpc-virtqemud name=pmem0 dev="tmpfs" ino=14 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1

Resolves: RHEL-71656