### PR TITLE
Allow systemd-generator send system log messages

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1309,6 +1309,10 @@ fs_getattr_nsfs_files(systemd_generator)
 fs_search_cgroup_dirs(systemd_generator)
 init_read_state(systemd_generator)
 
+optional_policy(`
+	logging_stream_connect_syslog(systemd_generator)
+')
+
 ### Rules for individual systemd generator domains
 
 ### bless-boot generator


### PR DESCRIPTION
Sych permissions are needed when the systemd-journald socket listener is replaced with rsyslog for performance reasons (it is faster to have the logs sent directly to rsyslog, then to their log aggregator, rather than having the extra step of app -> journald -> rsyslog).

Resolves: RHEL-75879