### PR TITLE
Allow apcupsd's apccontrol to send messages using wall

### DIFF
--- a/policy/modules/contrib/apcupsd.te
+++ b/policy/modules/contrib/apcupsd.te
@@ -113,6 +113,7 @@ logging_send_syslog_msg(apcupsd_t)
 sysnet_dns_name_resolve(apcupsd_t)
 
 systemd_dbus_chat_logind(apcupsd_t)
+systemd_read_logind_sessions_files(apcupsd_t)
 
 userdom_use_inherited_user_ttys(apcupsd_t)
 


### PR DESCRIPTION
I had a brief look and it looks like this could also be relevant for RH and not only for openSUSE.

Fixes these AVC denials:
type=AVC .. avc: denied { read } for pid=4272 comm="wall" name="sessions" dev="tmpfs" ino=85 scontext=system_u:system_r:apcupsd_t:s0 tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=dir type=AVC .. avc: denied { read } for pid=4272 comm="wall" name="1" dev="tmpfs" ino=2016 scontext=system_u:system_r:apcupsd_t:s0 tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=file type=AVC .. avc: denied { open } for pid=4272 comm="wall" path="/run/systemd/sessions/1" dev="tmpfs" ino=2016 scontext=system_u:system_r:apcupsd_t:s0 tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=file type=AVC .. avc: denied { getattr } for pid=4272 comm="wall" path="/run/systemd/sessions/1" dev="tmpfs" ino=2016 scontext=system_u:system_r:apcupsd_t:s0 tcontext=system_u:object_r:systemd_logind_sessions_t:s0 tclass=file

Details in:
https://bugzilla.opensuse.org/show_bug.cgi?id=1235688