### PR TITLE
Allow pcmsensor read nmi_watchdog state information

### DIFF
--- a/policy/modules/contrib/pcm.te
+++ b/policy/modules/contrib/pcm.te
@@ -17,7 +17,7 @@ allow pcmsensor_t self:process { ptrace setrlimit };
 
 kernel_read_proc_files(pcmsensor_t)
 kernel_read_debugfs(pcmsensor_t)
-kernel_write_nmi_watchdog_state(pcmsensor_t)
+kernel_rw_nmi_watchdog_state(pcmsensor_t)
 
 dev_rw_cpu_microcode(pcmsensor_t)
 # /sys/module/msr/parameters/allow_writes

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4161,6 +4161,25 @@ interface(`kernel_read_security_state_symlinks',`
 
 ########################################
 ## <summary>
+##	Allow caller to read/write nmi_watchdog state information.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+##
+#
+interface(`kernel_rw_nmi_watchdog_state',`
+	gen_require(`
+		type sysctl_t, sysctl_kernel_t, sysctl_nmi_watchdog_t;
+	')
+
+	rw_files_pattern($1, { proc_t sysctl_t sysctl_kernel_t }, sysctl_nmi_watchdog_t)
+')
+
+########################################
+## <summary>
 ##	Allow caller to write nmi_watchdog state information.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/28/2025 04:45:49.809:582) : proctitle=/usr/sbin/pcm-sensor-server type=PATH msg=audit(01/28/2025 04:45:49.809:582) : item=0 name=/proc/sys/kernel/nmi_watchdog inode=39502 dev=00:16 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_nmi_watchdog_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/28/2025 04:45:49.809:582) : arch=x86_64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0x562599d7e1ce a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=21032 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pcm-sensor-serv exe=/usr/sbin/pcm-sensor-server subj=system_u:system_r:pcmsensor_t:s0 key=(null) type=AVC msg=audit(01/28/2025 04:45:49.809:582) : avc:  denied  { read } for  pid=21032 comm=pcm-sensor-serv name=nmi_watchdog dev="proc" ino=39502 scontext=system_u:system_r:pcmsensor_t:s0 tcontext=system_u:object_r:sysctl_nmi_watchdog_t:s0 tclass=file permissive=1

Resolves: RHEL-52838