### PR TITLE
Allow init_t nnp domain transition to gssproxy_t

### DIFF
--- a/policy/modules/contrib/gssproxy.te
+++ b/policy/modules/contrib/gssproxy.te
@@ -8,6 +8,7 @@ policy_module(gssproxy, 1.0.0)
 type gssproxy_t;
 type gssproxy_exec_t;
 init_daemon_domain(gssproxy_t, gssproxy_exec_t)
+init_nnp_daemon_domain(gssproxy_t)
 
 type gssproxy_var_lib_t;
 files_type(gssproxy_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=SELINUX_ERR msg=audit(01/29/2025 11:49:37.527:141) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:gssproxy_t:s0 
type=AVC msg=audit(01/29/2025 11:49:37.527:141) : avc:  denied  { nnp_transition } for  pid=1823 comm=(gssproxy) scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:gssproxy_t:s0 tclass=process2 permissive=0 
type=AVC msg=audit(01/29/2025 11:49:37.541:143) : avc:  denied  { add_name } for  pid=1824 comm=gssproxy name=default.sock scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:gssproxy_var_lib_t:s0 tclass=dir permissive=0 
type=SERVICE_START msg=audit(01/29/2025 11:49:37.545:144) : pid=1 uid=root auid=unset ses=unset subj=system_u:system_r:init_t:s0 msg='unit=gssproxy comm=systemd exe=/usr/lib/systemd/systemd hostname=? addr=? terminal=? res=failed'