### PR TITLE
Allow systemd-coredump the sys_admin capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1231,7 +1231,7 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # sys_ptrace - to read /proc/<pid>/exe of the dumped process
 # setgid setuid - to set own credentials to match the dumped process credentials
 # setpcap - to drop capabilities
-allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_ptrace };
+allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_admin sys_ptrace };
 dontaudit systemd_coredump_t self:capability sys_resource;
 allow systemd_coredump_t self:cap_userns { dac_read_search dac_override sys_admin sys_ptrace };
 


### PR DESCRIPTION
During processing a coredump, the systemd-coredump service performs the following check [1]:

/* We require that this process belongs to a delegated cgroup
* (i.e. Delegate=yes), with CoredumpReceive=yes also. */ r = cg_is_delegated(unit);

and subsequently [2]:

r = cg_get_xattr_bool(path, "trusted.delegate");

Accessing extended attributes in the trusted class requires CAP_SYS_ADMIN.

[1] https://github.com/systemd/systemd/blob/e8908d2fc180f5a98dd37bfbc9c5952de5f18899/src/coredump/coredump.c#L1541-L1543
[2] https://github.com/systemd/systemd/blob/e8908d2fc180f5a98dd37bfbc9c5952de5f18899/src/basic/cgroup-util.c#L2255

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/22/2025 17:10:46.879:818) : proctitle=/usr/lib/systemd/systemd-coredump 20554 1000 1000 4 1737562246 18446744073709551615 localhost-live type=PATH msg=audit(01/22/2025 17:10:46.879:818) : item=0 name=/sys/fs/cgroup/user.slice/user-1000.slice/user inode=7948 dev=00:1b mode=dir,755 ouid=user1 ogid=user1 rdev=00:00 obj=system_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/22/2025 17:10:46.879:818) : arch=x86_64 syscall=lgetxattr success=no exit=ENODATA(No data available) a0=0x55f7839bd400 a1=0x7fc229b4610f a2=0x55f7839b7770 a3=0x67 items=1 ppid=2 pid=21347 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-coredum exe=/usr/lib/systemd/systemd-coredump subj=system_u:system_r:systemd_coredump_t:s0 key=(null) type=AVC msg=audit(01/22/2025 17:10:46.879:818) : avc:  denied  { sys_admin } for  pid=21347 comm=systemd-coredum capability=sys_admin  scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=capability permissive=0

Resolves: rhbz#2335200