### PR TITLE
Allow snapperd execute systemctl in the caller domain

### DIFF
--- a/policy/modules/contrib/snapper.te
+++ b/policy/modules/contrib/snapper.te
@@ -94,3 +94,7 @@ optional_policy(`
 optional_policy(`
     snapper_relabel_snapshots(snapperd_t)
 ')
+
+optional_policy(`
+	systemd_exec_systemctl(snapperd_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1738151778.369:679): avc:  denied  { execute_no_trans } for  pid=5390 comm="snapperd" path="/usr/bin/systemctl" dev="nvme0n1p7" ino=368840 scontext=system_u:system_r:snapperd_t:s0 tcontext=system_u:object_r:systemd_systemctl_exec_t:s0 tclass=file permissive=0

Resolves: rhbz#2342778