### PR TITLE
Allow svirt_tcg_t to connect to nbdkit over a unix stream socket

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -559,6 +559,10 @@ ps_process_pattern(svirt_tcg_t, virtd_t)
 
 virt_dontaudit_read_state(svirt_tcg_t)
 
+optional_policy(`
+	nbdkit_stream_connect(svirt_tcg_t)
+')
+
 ########################################
 #
 # virtd local policy


### PR DESCRIPTION
The commit addresses the following AVC denial:
avc:  denied  { connectto } for  pid=7024 comm="nbd-connect" path="/var/lib/libvirt/qemu/domain-1-subVmTestCreate8/nbdkit-libvirt-1-storage.socket" scontext=system_u:system_r:svirt_tcg_t:s0:c531,c721 tcontext=system_u:system_r:nbdkit_t:s0:c531,c721 tclass=unix_stream_socket permissive=0

Resolves: rhbz#2342260