### PR TITLE
Allow rhsmcertd notify virt-who

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -208,3 +208,8 @@ optional_policy(`
 optional_policy(`
     systemd_userdbd_stream_connect(rhsmcertd_t)
 ')
+
+optional_policy(`
+	virt_read_pid_files(rhsmcertd_t)
+	virt_signal(rhsmcertd_t)
+')


### PR DESCRIPTION
rhc is a commandline tool which uses the D-Bus API to connect to the rhsm service. When a system is being registered or unregistered, virt-who must be notified about that. For that, rhsmcertd needs to read /run/virt-who.pid, and if the service is running, it sends to virt-who the SIGHUP signal so that virt-who is restarted.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/30/2025 14:27:30.381:626) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-service type=OBJ_PID msg=audit(01/30/2025 14:27:30.381:626) : opid=5103 oauid=unset ouid=root oses=-1 obj=system_u:system_r:virtd_t:s0-s0:c0.c1023 ocomm=virt-who type=SYSCALL msg=audit(01/30/2025 14:27:30.381:626) : arch=x86_64 syscall=kill success=yes exit=0 a0=0x13ef a1=SIGHUP a2=0x0 a3=0x7fffee5aa080 items=0 ppid=1 pid=5282 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-service exe=/usr/bin/python3.12 subj=system_u:system_r:rhsmcertd_t:s0 key=(null) type=AVC msg=audit(01/30/2025 14:27:30.381:626) : avc:  denied  { signal } for  pid=5282 comm=rhsm-service scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tclass=process permissive=1

Resolves: RHEL-77114