### PR TITLE
Allow smbd to load libcephfs proxy conditionally

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -87,6 +87,13 @@ gen_tunable(samba_share_fusefs, false)
 ## </desc>
 gen_tunable(samba_load_libgfapi, false)
 
+## <desc>
+## <p>
+## Allow smbd to load libcephfs proxy from ceph.
+## </p>
+## </desc>
+gen_tunable(samba_load_libcephfs_proxy, false)
+
 type nmbd_t;
 type nmbd_exec_t;
 init_daemon_domain(nmbd_t, nmbd_exec_t)
@@ -586,6 +593,13 @@ tunable_policy(`samba_load_libgfapi',`
     corenet_tcp_connect_all_ports(smbd_t)
     corenet_tcp_bind_all_ports(smbd_t)
     corenet_sendrecv_all_packets(smbd_t)
+')
+
+optional_policy(`
+    tunable_policy(`samba_load_libcephfs_proxy',`
+        unconfined_stream_connect_rw(smbd_t)
+        rw_sock_files_pattern(smbd_t, var_run_t, var_run_t)
+    ')
 ')
 
 optional_policy(`

--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -424,6 +424,26 @@ interface(`unconfined_stream_connect',`
 
 ########################################
 ## <summary>
+##	Connect to the unconfined domain using
+##	a unix domain stream socket with
+##	additional read+write permissions.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_stream_connect_rw',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:unix_stream_socket { connectto read write };
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read or write
 ##	unconfined domain tcp sockets.
 ## </summary>


### PR DESCRIPTION
The design for [libcephfs proxy](https://docs.ceph.com/en/latest/dev/libcephfs_proxy/) was accepted sometime back with the corresponding implementation subsequently [merged](https://github.com/ceph/ceph/pull/58376) into upstream Ceph. This additional way to integrate CephFS with Samba is comprised of two components. The daemon i.e, libcephfsd is responsible for creating the unix domain socket as a starting point of communication. On the other side proxy library, which is [designed](https://gitlab.com/samba-team/samba/-/merge_requests/3792) to be loaded within _smbd_, connects to the already created socket and thereby communicates with the daemon.

During the development and testing stages we happened to notice some AVC denial messages in the audit logs:

> type=AVC msg=audit(1742367267.967:6919): avc:  denied  { write } for  pid=62992
  comm="smbd[192.168.12" name="libcephfsd.sock" dev="tmpfs" ino=6049
  scontext=system_u:system_r:smbd_t:s0 tcontext=unconfined_u:object_r:var_run_t:s0
  tclass=sock_file permissive=1

> type=AVC msg=audit(1742367267.967:6919): avc:  denied  { connectto } for  pid=62992
  comm="smbd[192.168.12" path="/run/libcephfsd.sock" scontext=system_u:system_r:smbd_t:s0
  tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
  tclass=unix_stream_socket permissive=1

> type=AVC msg=audit(1742367267.970:6920): avc:  denied  { read write } for  pid=62992
  comm="smbd[192.168.12" path="socket:[189595]" dev="sockfs" ino=189595 scontext=system_u:system_r:smbd_t:s0
  tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
  tclass=unix_stream_socket permissive=1

Therefore we propose a new boolean - **_samba_load_libcephfs_proxy_**, off by default, to contain the necessary allow rules for _smbd_t_ to operate in a proxy mode using libcephfs.