### PR TITLE
Allow virtqemud use hostdev usb devices conditionally

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2295,6 +2295,11 @@ tunable_policy(`virt_use_nfs',`
 	fs_mmap_nfs_files(virtqemud_t)
 ')
 
+tunable_policy(`virt_use_usb',`
+	dev_rw_generic_usb_dev(virtqemud_t)
+	dev_setattr_generic_usb_dev(virtqemud_t)
+')
+
 optional_policy(`
 	dmidecode_domtrans(virtqemud_t)
 ')


### PR DESCRIPTION
Use case: Create/destroy a domain with hostdev usb. Permissions are only allowed when the virt_use_usb boolean is on.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/22/2025 03:26:11.055:703) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(01/22/2025 03:26:11.055:703) : item=0 name=/dev/bus/usb/001/001 inode=106 dev=00:06 mode=character,664 ouid=root ogid=root rdev=bd:00 obj=system_u:object_r:usb_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/22/2025 03:26:11.055:703) : arch=x86_64 syscall=openat success=yes exit=6 a0=AT_FDCWD a1=0x7f9250001dc0 a2=O_RDWR a3=0x0 items=1 ppid=6198 pid=6590 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(01/22/2025 03:26:11.055:703) : avc:  denied  { open } for  pid=6590 comm=rpc-virtqemud path=/dev/bus/usb/001/001 dev="devtmpfs" ino=106 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:usb_device_t:s0 tclass=chr_file permissive=1 type=AVC msg=audit(01/22/2025 03:26:11.055:703) : avc:  denied  { read write } for  pid=6590 comm=rpc-virtqemud name=001 dev="devtmpfs" ino=106 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:usb_device_t:s0 tclass=chr_file permissive=1

Resolves: RHEL-74230