### PR TITLE
Allow boothd connect to systemd-machined over a unix socket

### DIFF
--- a/policy/modules/contrib/boothd.te
+++ b/policy/modules/contrib/boothd.te
@@ -86,5 +86,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_machined_stream_connect(boothd_t)
+')
+
+optional_policy(`
 	sysnet_read_config(boothd_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/05/2025 13:10:15.591:4642) : proctitle=/usr/sbin/boothd daemon -S -c /etc/booth/booth.conf type=PATH msg=audit(02/05/2025 13:10:15.591:4642) : item=0 name=/run/systemd/userdb/io.systemd.Machine inode=8541 dev=00:1b mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(02/05/2025 13:10:15.591:4642) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.Machine } type=SYSCALL msg=audit(02/05/2025 13:10:15.591:4642) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0xa a1=0x7ffc9e2493e0 a2=0x29 a3=0x55b439292380 items=1 ppid=1 pid=153336 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=boothd exe=/usr/sbin/boothd subj=system_u:system_r:boothd_t:s0 key=(null) type=AVC msg=audit(02/05/2025 13:10:15.591:4642) : avc:  denied  { connectto } for  pid=153336 comm=boothd path=/run/systemd/userdb/io.systemd.Machine scontext=system_u:system_r:boothd_t:s0 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=unix_stream_socket permissive=0