### PR TITLE
Rename winbind_rpcd_* types to samba_dcerpcd_*

### DIFF
--- a/policy/modules/contrib/samba.fc
+++ b/policy/modules/contrib/samba.fc
@@ -18,9 +18,9 @@
 /usr/lib/systemd/system/nmb.*   --      gen_context(system_u:object_r:samba_unit_file_t,s0)
 /usr/lib/systemd/system/winbind.*   --  gen_context(system_u:object_r:samba_unit_file_t,s0)
 
-/usr/libexec/samba/rpcd_lsad	--	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
+/usr/libexec/samba/rpcd_lsad	--	gen_context(system_u:object_r:samba_dcerpcd_exec_t,s0)
 /usr/libexec/samba/samba-bgqd	--	gen_context(system_u:object_r:samba_bgqd_exec_t,s0)
-/usr/libexec/samba/samba-dcerpcd --	gen_context(system_u:object_r:winbind_rpcd_exec_t,s0)
+/usr/libexec/samba/samba-dcerpcd --	gen_context(system_u:object_r:samba_dcerpcd_exec_t,s0)
 
 /usr/bin/net			--	gen_context(system_u:object_r:samba_net_exec_t,s0)
 /usr/bin/ntlm_auth		--	gen_context(system_u:object_r:winbind_helper_exec_t,s0)

--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -1102,7 +1102,7 @@ interface(`samba_admin',`
 
 ########################################
 ## <summary>
-##	Execute winbind rpcd in the winbind_rpcd_t domain.
+##	Execute winbind rpcd in the samba_dcerpcd_t domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -1112,11 +1112,11 @@ interface(`samba_admin',`
 #
 interface(`samba_domtrans_winbind_rpcd',`
 	gen_require(`
-		type winbind_rpcd_t, winbind_rpcd_exec_t;
+		type samba_dcerpcd_t, samba_dcerpcd_exec_t;
 	')
 
 	corecmd_search_bin($1)
-	domtrans_pattern($1, winbind_rpcd_exec_t, winbind_rpcd_t)
+	domtrans_pattern($1, samba_dcerpcd_exec_t, samba_dcerpcd_t)
 ')
 
 ########################################

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -191,19 +191,23 @@ role system_r types winbind_helper_t;
 type winbind_helper_exec_t;
 domain_entry_file(winbind_helper_t, winbind_helper_exec_t)
 
-type winbind_rpcd_t;
-type winbind_rpcd_exec_t;
-application_domain(winbind_rpcd_t, winbind_rpcd_exec_t)
-role system_r types winbind_rpcd_t;
+type samba_dcerpcd_t;
+type samba_dcerpcd_exec_t;
+typealias samba_dcerpcd_t alias winbind_rpcd_t;
+typealias samba_dcerpcd_exec_t alias winbind_rpcd_exec_t;
+application_domain(samba_dcerpcd_t, samba_dcerpcd_exec_t)
+role system_r types samba_dcerpcd_t;
 
 type winbind_log_t;
 logging_log_file(winbind_log_t)
 
-type winbind_rpcd_var_run_t;
-files_pid_file(winbind_rpcd_var_run_t)
+type samba_dcerpcd_var_run_t;
+typealias samba_dcerpcd_var_run_t alias winbind_rpcd_var_run_t;
+files_pid_file(samba_dcerpcd_var_run_t)
 
-type winbind_rpcd_tmp_t;
-files_tmp_file(winbind_rpcd_tmp_t)
+type samba_dcerpcd_tmp_t;
+typealias samba_dcerpcd_tmp_t alias winbind_rpcd_tmp_t;
+files_tmp_file(samba_dcerpcd_tmp_t)
 
 type winbind_var_run_t;
 files_pid_file(winbind_var_run_t)
@@ -301,7 +305,7 @@ optional_policy(`
 # samba-gpupdate Local policy
 #
 
-domtrans_pattern(winbind_rpcd_t, samba_gpupdate_exec_t, samba_gpupdate_t)
+domtrans_pattern(samba_dcerpcd_t, samba_gpupdate_exec_t, samba_gpupdate_t)
 
 optional_policy(`
 	certmonger_domtrans(samba_gpupdate_t)
@@ -544,15 +548,15 @@ tunable_policy(`samba_domain_controller',`
 	usermanage_domtrans_groupadd(smbd_t)
 	allow smbd_t self:passwd passwd;
 
-	usermanage_domtrans_passwd(winbind_rpcd_t)
-	allow winbind_rpcd_t self:passwd passwd;
+	usermanage_domtrans_passwd(samba_dcerpcd_t)
+	allow samba_dcerpcd_t self:passwd passwd;
 ')
 
 tunable_policy(`samba_enable_home_dirs',`
 	userdom_manage_user_home_content(smbd_t)
 	userdom_watch_user_home_dirs(smbd_t)
-	userdom_manage_user_home_content(winbind_rpcd_t)
-	userdom_watch_user_home_dirs(winbind_rpcd_t)
+	userdom_manage_user_home_content(samba_dcerpcd_t)
+	userdom_watch_user_home_dirs(samba_dcerpcd_t)
 ')
 
 optional_policy(`
@@ -675,11 +679,11 @@ tunable_policy(`samba_export_all_ro',`
     files_dontaudit_list_security_dirs(nmbd_t)
     files_dontaudit_search_security_files(nmbd_t)
     files_dontaudit_read_security_files(nmbd_t)
-    fs_read_noxattr_fs_files(winbind_rpcd_t)
-    files_read_non_security_files(winbind_rpcd_t)
-    files_dontaudit_list_security_dirs(winbind_rpcd_t)
-    files_dontaudit_search_security_files(winbind_rpcd_t)
-    files_dontaudit_read_security_files(winbind_rpcd_t)
+    fs_read_noxattr_fs_files(samba_dcerpcd_t)
+    files_read_non_security_files(samba_dcerpcd_t)
+    files_dontaudit_list_security_dirs(samba_dcerpcd_t)
+    files_dontaudit_search_security_files(samba_dcerpcd_t)
+    files_dontaudit_read_security_files(samba_dcerpcd_t)
 ')
 
 tunable_policy(`samba_export_all_rw',`
@@ -696,12 +700,12 @@ tunable_policy(`samba_export_all_rw',`
     files_dontaudit_list_security_dirs(nmbd_t)
     files_dontaudit_search_security_files(nmbd_t)
     files_dontaudit_read_security_files(nmbd_t)
-    fs_manage_noxattr_fs_files(winbind_rpcd_t)
-    files_manage_non_security_files(winbind_rpcd_t)
-    files_manage_non_security_dirs(winbind_rpcd_t)
-    files_dontaudit_list_security_dirs(winbind_rpcd_t)
-    files_dontaudit_search_security_files(winbind_rpcd_t)
-    files_dontaudit_read_security_files(winbind_rpcd_t)
+    fs_manage_noxattr_fs_files(samba_dcerpcd_t)
+    files_manage_non_security_files(samba_dcerpcd_t)
+    files_manage_non_security_dirs(samba_dcerpcd_t)
+    files_dontaudit_list_security_dirs(samba_dcerpcd_t)
+    files_dontaudit_search_security_files(samba_dcerpcd_t)
+    files_dontaudit_read_security_files(samba_dcerpcd_t)
 ')
 
 userdom_filetrans_home_content(nmbd_t)
@@ -834,7 +838,7 @@ allow smbcontrol_t samba_var_t:file map;
 
 allow smbcontrol_t nmbd_t:unix_dgram_socket sendto;
 allow smbcontrol_t smbd_t:unix_dgram_socket sendto;
-allow smbcontrol_t winbind_rpcd_t:unix_dgram_socket sendto;
+allow smbcontrol_t samba_dcerpcd_t:unix_dgram_socket sendto;
 allow smbcontrol_t winbind_t:unix_dgram_socket sendto;
 
 samba_read_config(smbcontrol_t)
@@ -1109,7 +1113,7 @@ manage_dirs_pattern(winbind_t, { smbd_var_run_t winbind_var_run_t }, winbind_var
 manage_files_pattern(winbind_t, winbind_var_run_t, winbind_var_run_t)
 manage_sock_files_pattern(winbind_t, winbind_var_run_t, winbind_var_run_t)
 files_pid_filetrans(winbind_t, winbind_var_run_t, { sock_file file dir })
-files_pid_filetrans(winbind_t, winbind_rpcd_var_run_t, file, "samba-dcerpcd.pid")
+files_pid_filetrans(winbind_t, samba_dcerpcd_var_run_t, file, "samba-dcerpcd.pid")
 filetrans_pattern(winbind_t, smbd_var_run_t, winbind_var_run_t, dir)
 # /run/samba/krb5cc_samba
 manage_files_pattern(winbind_t, smbd_var_run_t, smbd_var_run_t)
@@ -1252,145 +1256,145 @@ optional_policy(`
 
 ########################################
 #
-# Winbind-rpcd local policy
+# samba_dcerpcd local policy
 #
 
-allow winbind_rpcd_t self:capability { setgid setuid };
-allow winbind_rpcd_t self:key { read write };
-allow winbind_rpcd_t self:netlink_route_socket create_netlink_socket_perms;
-allow winbind_rpcd_t self:process setcap;
-allow winbind_rpcd_t self:unix_dgram_socket { create_socket_perms sendto };
-allow winbind_rpcd_t self:unix_stream_socket connectto;
-allow winbind_rpcd_t self:udp_socket create_socket_perms;
+allow samba_dcerpcd_t self:capability { setgid setuid };
+allow samba_dcerpcd_t self:key { read write };
+allow samba_dcerpcd_t self:netlink_route_socket create_netlink_socket_perms;
+allow samba_dcerpcd_t self:process setcap;
+allow samba_dcerpcd_t self:unix_dgram_socket { create_socket_perms sendto };
+allow samba_dcerpcd_t self:unix_stream_socket connectto;
+allow samba_dcerpcd_t self:udp_socket create_socket_perms;
 
-allow winbind_rpcd_t winbind_rpcd_exec_t:file execute_no_trans;
+allow samba_dcerpcd_t samba_dcerpcd_exec_t:file execute_no_trans;
 
-read_files_pattern(winbind_rpcd_t, samba_etc_t, samba_etc_t)
+read_files_pattern(samba_dcerpcd_t, samba_etc_t, samba_etc_t)
 
-write_files_pattern(winbind_rpcd_t, winbind_var_run_t, winbind_var_run_t)
-write_sock_files_pattern(winbind_rpcd_t, winbind_var_run_t, winbind_var_run_t)
+write_files_pattern(samba_dcerpcd_t, winbind_var_run_t, winbind_var_run_t)
+write_sock_files_pattern(samba_dcerpcd_t, winbind_var_run_t, winbind_var_run_t)
 
-manage_files_pattern(winbind_rpcd_t, winbind_rpcd_var_run_t, winbind_rpcd_var_run_t)
-files_pid_filetrans(winbind_rpcd_t, winbind_rpcd_var_run_t, { dir file })
+manage_files_pattern(samba_dcerpcd_t, samba_dcerpcd_var_run_t, samba_dcerpcd_var_run_t)
+files_pid_filetrans(samba_dcerpcd_t, samba_dcerpcd_var_run_t, { dir file })
 
-manage_files_pattern(winbind_rpcd_t, winbind_rpcd_tmp_t, winbind_rpcd_tmp_t)
-files_tmp_filetrans(winbind_rpcd_t, winbind_rpcd_tmp_t, file)
+manage_files_pattern(samba_dcerpcd_t, samba_dcerpcd_tmp_t, samba_dcerpcd_tmp_t)
+files_tmp_filetrans(samba_dcerpcd_t, samba_dcerpcd_tmp_t, file)
 
 # access to files of other samba domains
-manage_dirs_pattern(winbind_rpcd_t, samba_share_t, samba_share_t)
-manage_files_pattern(winbind_rpcd_t, samba_share_t, samba_share_t)
+manage_dirs_pattern(samba_dcerpcd_t, samba_share_t, samba_share_t)
+manage_files_pattern(samba_dcerpcd_t, samba_share_t, samba_share_t)
 
-manage_dirs_pattern(winbind_rpcd_t, smbd_var_run_t, smbd_var_run_t)
-read_files_pattern(winbind_rpcd_t, smbd_var_run_t, smbd_var_run_t)
-manage_sock_files_pattern(winbind_rpcd_t, smbd_var_run_t, smbd_var_run_t)
+manage_dirs_pattern(samba_dcerpcd_t, smbd_var_run_t, smbd_var_run_t)
+read_files_pattern(samba_dcerpcd_t, smbd_var_run_t, smbd_var_run_t)
+manage_sock_files_pattern(samba_dcerpcd_t, smbd_var_run_t, smbd_var_run_t)
 
-manage_dirs_pattern(winbind_rpcd_t, samba_log_t, samba_log_t)
-manage_files_pattern(winbind_rpcd_t, samba_log_t, samba_log_t)
+manage_dirs_pattern(samba_dcerpcd_t, samba_log_t, samba_log_t)
+manage_files_pattern(samba_dcerpcd_t, samba_log_t, samba_log_t)
 
-manage_dirs_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
-manage_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
-manage_sock_files_pattern(winbind_rpcd_t, samba_var_t, samba_var_t)
-allow winbind_rpcd_t samba_var_t:file { map } ;
+manage_dirs_pattern(samba_dcerpcd_t, samba_var_t, samba_var_t)
+manage_files_pattern(samba_dcerpcd_t, samba_var_t, samba_var_t)
+manage_sock_files_pattern(samba_dcerpcd_t, samba_var_t, samba_var_t)
+allow samba_dcerpcd_t samba_var_t:file { map } ;
 
-manage_files_pattern(winbind_rpcd_t, smbd_tmp_t, smbd_tmp_t)
+manage_files_pattern(samba_dcerpcd_t, smbd_tmp_t, smbd_tmp_t)
 
-kernel_read_network_state(winbind_rpcd_t)
+kernel_read_network_state(samba_dcerpcd_t)
 
-corecmd_exec_bin(winbind_rpcd_t)
+corecmd_exec_bin(samba_dcerpcd_t)
 
-corenet_tcp_connect_ipp_port(winbind_rpcd_t)
-corenet_tcp_connect_ldap_port(winbind_rpcd_t)
+corenet_tcp_connect_ipp_port(samba_dcerpcd_t)
+corenet_tcp_connect_ldap_port(samba_dcerpcd_t)
 
-dev_getattr_fs(winbind_rpcd_t)
+dev_getattr_fs(samba_dcerpcd_t)
 
-term_getattr_pty_fs(winbind_rpcd_t)
-term_use_ptmx(winbind_rpcd_t)
+term_getattr_pty_fs(samba_dcerpcd_t)
+term_use_ptmx(samba_dcerpcd_t)
 
 optional_policy(`
-	auth_domtrans_chk_passwd(winbind_rpcd_t)
-	auth_read_passwd(winbind_rpcd_t)
+	auth_domtrans_chk_passwd(samba_dcerpcd_t)
+	auth_read_passwd(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	ctdbd_stream_connect(winbind_rpcd_t)
-	ctdbd_map_lib_files(winbind_rpcd_t)
+	ctdbd_stream_connect(samba_dcerpcd_t)
+	ctdbd_map_lib_files(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	cups_read_config(winbind_rpcd_t)
-	cups_stream_connect(winbind_rpcd_t)
+	cups_read_config(samba_dcerpcd_t)
+	cups_stream_connect(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	dbus_system_bus_client(winbind_rpcd_t)
+	dbus_system_bus_client(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	dirsrv_stream_connect(winbind_rpcd_t)
+	dirsrv_stream_connect(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	init_stream_connectto(winbind_rpcd_t)
+	init_stream_connectto(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	kerberos_read_keytab(winbind_rpcd_t)
-	kerberos_use(winbind_rpcd_t)
+	kerberos_read_keytab(samba_dcerpcd_t)
+	kerberos_use(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	logging_send_syslog_msg(winbind_rpcd_t)
+	logging_send_syslog_msg(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	lpd_domtrans_lpr(winbind_rpcd_t)
+	lpd_domtrans_lpr(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	miscfiles_read_generic_certs(winbind_rpcd_t)
-	miscfiles_read_public_files(winbind_rpcd_t)
+	miscfiles_read_generic_certs(samba_dcerpcd_t)
+	miscfiles_read_public_files(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	nscd_socket_use(winbind_rpcd_t)
+	nscd_socket_use(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	sssd_read_public_files(winbind_rpcd_t)
-	sssd_stream_connect(winbind_rpcd_t)
+	sssd_read_public_files(samba_dcerpcd_t)
+	sssd_stream_connect(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	sysnet_read_config(winbind_rpcd_t)
+	sysnet_read_config(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	systemd_machined_stream_connect(winbind_rpcd_t)
-	systemd_userdbd_stream_connect(winbind_rpcd_t)
+	systemd_machined_stream_connect(samba_dcerpcd_t)
+	systemd_userdbd_stream_connect(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	term_use_generic_ptys(winbind_rpcd_t)
+	term_use_generic_ptys(samba_dcerpcd_t)
 ')
 
 optional_policy(`
-	unconfined_dgram_send(winbind_rpcd_t)
+	unconfined_dgram_send(samba_dcerpcd_t)
 ')
 
 # inter-process communication with other samba domains
-allow smbd_t winbind_rpcd_t:process noatsecure;
-allow smbd_t winbind_rpcd_t:unix_stream_socket connectto;
-allow winbind_t winbind_rpcd_t:unix_stream_socket connectto;
-allow winbind_rpcd_t samba_bgqd_t:unix_dgram_socket sendto;
-allow winbind_rpcd_t nmbd_t:unix_dgram_socket sendto;
-allow winbind_rpcd_t smbd_t:unix_dgram_socket sendto;
-allow winbind_rpcd_t winbind_t:unix_dgram_socket sendto;
-allow winbind_rpcd_t winbind_t:unix_stream_socket connectto;
+allow smbd_t samba_dcerpcd_t:process noatsecure;
+allow smbd_t samba_dcerpcd_t:unix_stream_socket connectto;
+allow winbind_t samba_dcerpcd_t:unix_stream_socket connectto;
+allow samba_dcerpcd_t samba_bgqd_t:unix_dgram_socket sendto;
+allow samba_dcerpcd_t nmbd_t:unix_dgram_socket sendto;
+allow samba_dcerpcd_t smbd_t:unix_dgram_socket sendto;
+allow samba_dcerpcd_t winbind_t:unix_dgram_socket sendto;
+allow samba_dcerpcd_t winbind_t:unix_stream_socket connectto;
 
 # accessing other samba services and their resources
-allow samba_bgqd_t winbind_rpcd_t:fifo_file write;
-allow winbind_rpcd_t samba_bgqd_exec_t:file exec_file_perms;
-allow winbind_rpcd_t samba_bgqd_var_run_t:file write_file_perms;
+allow samba_bgqd_t samba_dcerpcd_t:fifo_file write;
+allow samba_dcerpcd_t samba_bgqd_exec_t:file exec_file_perms;
+allow samba_dcerpcd_t samba_bgqd_var_run_t:file write_file_perms;
 
 samba_domtrans_winbind_rpcd(smbd_t)
 samba_domtrans_winbind_rpcd(winbind_t)


### PR DESCRIPTION
In the current policy for samba, there are samba-dcerpcd and rpcd-* processes labeled with winbind_rpcd_t. However, samba-dcerpcd is a standalone DCERPC server, started by smbd or winbind. So to avoid confusion that it is winbind only, all related types were renamed to match the binary, in particular
- winbind_rpcd_t to samba_dcerpcd_t
- winbind_rpcd_exec_t to samba_dcerpcd_exec_t
- winbind_rpcd_var_run_t to samba_dcerpcd_var_run_t
- winbind_rpcd_tmp_t to samba_dcerpcd_tmp_t

The previous type names are kept as aliases for compatibility reasons.

Resolves: RHEL-14759