### PR TITLE
Allow init mounton crypto sysctl files

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -2217,6 +2217,24 @@ interface(`kernel_read_crypto_sysctls',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain mounton crypto sysctl files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_mounton_crypto_sysctl_files',`
+	gen_require(`
+		type sysctl_crypto_t;
+	')
+
+	allow $1 sysctl_crypto_t:file mounton;
+')
+
+########################################
+## <summary>
 ##	Read general kernel sysctls.
 ## </summary>
 ## <desc>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -262,6 +262,7 @@ kernel_load_module(init_t)
 kernel_read_all_proc(init_t)
 kernel_list_all_proc(init_t)
 kernel_mounton_all_proc(init_t)
+kernel_mounton_crypto_sysctl_files(init_t)
 
 # There is bug in kernel in 4.16 where lot of domains requesting module_request, for now dontauditing
 kernel_dontaudit_request_load_module(init_t)


### PR DESCRIPTION
This issue can be triggered when FIPS mode was enabled. The commit addresses the following AVC denial:
type=AVC msg=audit(1724759306.861:1992): avc:  denied  { mounton } for  pid=13712 comm="(httpd)" path="/run/systemd/mount-rootfs/proc/sys/crypto/fips_enabled" dev="proc" ino=43258 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:sysctl_crypto_t:s0 tclass=file permissive=0

Resolves: RHEL-56250