### PR TITLE
Update init_explicit_domain() interface

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -472,9 +472,12 @@ interface(`init_ranged_system_domain',`
 interface(`init_explicit_domain',`
 	gen_require(`
 		type init_t;
+		attribute daemon, direct_init_entry;
 		role system_r;
 	')
 
+	typeattribute $1 daemon;
+	typeattribute $2 direct_init_entry;
 	role system_r types $1;
 
 	domain_type($1)


### PR DESCRIPTION
Update init_explicit_domain() interface to assign the domain to the daemon and direct_init_entry attributes.

The commit addresses the following AVC denial:
type=AVC msg=audit(1738831155.685:281701): avc:  denied  { write } for  pid=4004553 comm="chronyd" name="notify" dev="tmpfs" ino=46 scontext=system_u:system_r:chronyd_restricted_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=sock_file permissive=0

Resolves: rhbz#2344148