### PR TITLE
Allow virt_domain read hardware state information unconditionally

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -516,7 +516,6 @@ corenet_udp_bind_all_ports(svirt_t)
 corenet_tcp_bind_all_ports(svirt_t)
 corenet_tcp_connect_all_ports(svirt_t)
 
-dev_read_sysfs(svirt_t)
 dev_rw_dma_dev(svirt_t)
 
 init_dontaudit_read_state(svirt_t)
@@ -1148,6 +1147,7 @@ dev_dontaudit_getattr_all(virt_domain)
 dev_read_generic_symlinks(virt_domain)
 dev_read_rand(virt_domain)
 dev_read_sound(virt_domain)
+dev_read_sysfs(virt_domain)
 dev_read_urand(virt_domain)
 dev_write_sound(virt_domain)
 dev_rw_ksm(virt_domain)
@@ -1234,7 +1234,6 @@ tunable_policy(`virt_use_samba',`
 tunable_policy(`virt_use_usb',`
 	dev_rw_generic_usb_dev(virt_domain)
 	dev_rw_usbfs(virt_domain)
-	dev_read_sysfs(virt_domain)
 	fs_getattr_dos_fs(virt_domain)
 	fs_manage_dos_dirs(virt_domain)
 	fs_manage_dos_files(virt_domain)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/06/2025 12:31:15.483:1776) : proctitle=/usr/libexec/qemu-kvm -name guest=test9,debug-threads=on -S -object {"qom-type":"secret","id":"masterKey0","format":"raw","file" type=PATH msg=audit(02/06/2025 12:31:15.483:1776) : item=0 name=/sys/devices/system/cpu/possible inode=645 dev=00:17 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/06/2025 12:31:15.483:1776) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fbca6f12d88 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=22346 auid=unset uid=qemu gid=qemu euid=qemu suid=qemu fsuid=qemu egid=qemu sgid=qemu fsgid=qemu tty=(none) ses=unset comm=qemu-kvm exe=/usr/libexec/qemu-kvm subj=system_u:system_r:svirt_tcg_t:s0:c848,c874 key=(null) type=AVC msg=audit(02/06/2025 12:31:15.483:1776) : avc:  denied  { read } for  pid=22346 comm=qemu-kvm name=possible dev="sysfs" ino=645 scontext=system_u:system_r:svirt_tcg_t:s0:c848,c874 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: RHEL-71270