### PR TITLE
Allow svirt_t to connect to nbdkit over a unix stream socket

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -527,6 +527,10 @@ storage_rw_inherited_fixed_disk_dev(svirt_t)
 userdom_read_all_users_state(svirt_t)
 
 optional_policy(`
+	nbdkit_stream_connect(svirt_t)
+')
+
+optional_policy(`
 	unconfined_stream_connect(svirt_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/05/2025 00:25:52.985:5914) : proctitle=/usr/libexec/qemu-kvm -name guest=avocado-vt-vm1,debug-threads=on -S -object {"qom-type":"secret","id":"masterKey0","format":"ra type=AVC msg=audit(02/05/2025 00:25:52.985:5914) : avc:  denied  { connectto } for  pid=75246 comm=nbd-connect path=/var/lib/libvirt/qemu/domain-6-avocado-vt-vm1/nbdkit-libvirt-1-storage.socket scontext=system_u:system_r:svirt_t:s0:c875,c1021 tcontext=system_u:system_r:nbdkit_t:s0:c875,c1021 tclass=unix_stream_socket permissive=0 type=SYSCALL msg=audit(02/05/2025 00:25:52.985:5914) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0xf a1=0x7f6cc3ffff48 a2=0x6e a3=0x5f items=0 ppid=1 pid=75246 auid=unset uid=unknown(107) gid=unknown(107) euid=unknown(107) suid=unknown(107) fsuid=unknown(107) egid=unknown(107) sgid=unknown(107) fsgid=unknown(107) tty=(none) ses=unset comm=nbd-connect exe=/usr/libexec/qemu-kvm subj=system_u:system_r:svirt_t:s0:c875,c1021 key=(null)

Resolves: RHEL-56029