### PR TITLE
Allow power-profiles-daemon the bpf capability

### DIFF
--- a/policy/modules/contrib/powerprofiles.te
+++ b/policy/modules/contrib/powerprofiles.te
@@ -15,6 +15,7 @@ files_type(powerprofiles_var_lib_t);
 
 permissive powerprofiles_t;
 
+allow powerprofiles_t self:capability2 bpf;
 allow powerprofiles_t self:netlink_kobject_uevent_socket create_socket_perms;
 
 manage_files_pattern(powerprofiles_t, powerprofiles_var_lib_t, powerprofiles_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/03/2025 05:50:18.584:380) : proctitle=/usr/libexec/power-profiles-daemon type=SYSCALL msg=audit(02/03/2025 05:50:18.584:380) : arch=x86_64 syscall=setsockopt success=yes exit=0 a0=0x7 a1=SOL_SOCKET a2=SO_ATTACH_FILTER a3=0x7ffdf5d34be0 items=0 ppid=1 pid=28060 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=power-profiles- exe=/usr/libexec/power-profiles-daemon subj=system_u:system_r:powerprofiles_t:s0 key=(null) type=AVC msg=audit(02/03/2025 05:50:18.584:380) : avc:  denied  { bpf } for  pid=28060 comm=power-profiles- capability=bpf  scontext=system_u:system_r:powerprofiles_t:s0 tcontext=system_u:system_r:powerprofiles_t:s0 tclass=capability2 permissive=1

Resolves: RHEL-61117