### PR TITLE
Allow rlimit inheritance for domains transitioning to local_login_t

### DIFF
--- a/policy/modules/system/locallogin.if
+++ b/policy/modules/system/locallogin.if
@@ -16,6 +16,7 @@ interface(`locallogin_domtrans',`
 	')
 
 	auth_domtrans_login_program($1, local_login_t)
+	allow $1 local_login_t:process rlimitinh;
 
 	ifdef(`enable_mcs',`
 		auth_ranged_domtrans_login_program($1, local_login_t, s0 - mcs_systemhigh)


### PR DESCRIPTION
Allows domains using locallogin_domtrans to inherit rlimits.

Observation:
Log in on tty as root and run `ulimit -c`.
Without SELinux, this will result in "unlimited".
With SELinux, this resulted in "0".

We would like to keep the core file size at "unlimited" as documented here, so allow local_login_t inheriting the limits from mainly getty_t: https://github.com/openSUSE/sys-param-check/blob/beb196c21ddbe55b4cd49159375594836207d59c/tests/Tumbleweed/limits.robot#L21

Adresses:
type=AVC msg=audit(1739293467.154:509): avc:  denied  { rlimitinh } for  pid=1750 comm="login" scontext=system_u:system_r:getty_t:s0-s0:c0.c1023 tcontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tclass=process permissive=0


Also happens on fedora rawhide, but not sure if that is intended. Feel free to close if not relevant for you :) 