### PR TITLE
Permit init_t (systemd) to start a detached screen/tmux session

### DIFF
--- a/policy/modules/contrib/screen.if
+++ b/policy/modules/contrib/screen.if
@@ -165,3 +165,19 @@ interface(`screen_sigchld',`
 	allow $1 screen_domain:process sigchld;
 ')
 
+########################################
+## <summary>
+##      Permit running screen
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+interface(`screen_exec',`
+	gen_require(`
+		type screen_exec_t;
+	')
+
+	allow $1 screen_exec_t:file mmap_exec_file_perms;
+')

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -2026,3 +2026,7 @@ optional_policy(`
         ccs_read_config(daemon)
     ')
  ')
+
+optional_policy(`
+	screen_exec(init_t)
+')


### PR DESCRIPTION
This policy tweak permits running a screen/tmux session via a system service/unit file.

Given the interactive nature of the process it might be worth putting behind a boolean...