### PR TITLE
mdadm fails to create array due to incorrect labels (missing named filetrans)

### DIFF
--- a/policy/modules/contrib/raid.if
+++ b/policy/modules/contrib/raid.if
@@ -203,11 +203,13 @@ interface(`raid_create_conf_dirs',`
 interface(`raid_filetrans_named_content',`
 	gen_require(`
 		type mdadm_conf_t;
+		type mdadm_var_run_t;
 	')
 
     files_etc_filetrans($1, mdadm_conf_t, file, "mdadm.conf")
     files_etc_filetrans($1, mdadm_conf_t, file, "mdadm.conf.anacbak")
     files_etc_filetrans($1, mdadm_conf_t, dir, "mdadm.conf.d")
+    files_pid_filetrans($1, mdadm_var_run_t, dir, "mdadm")
 ')
 
 ########################################

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -359,6 +359,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+    raid_filetrans_named_content(named_filetrans_domain)
+')
+
+optional_policy(`
 	snapper_filetrans_named_content(named_filetrans_domain)
 ')
 


### PR DESCRIPTION
Also happens on rawhide when i checked

SUSE Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1236807

When using mdadm as unconfined user, the file transitions are not correct for /run/mdadm and it sets var_run_t instead of mdadm_var_run_t.

Reproducer:
```
$ mdadm --create --verbose /dev/md/abuild --level=mirror --raid-devices=2 --assume-clean /dev/sda /dev/sdb
...
mdadm: Defaulting to version 1.2 metadata
mdadm: array /dev/md/abuild started.
mdadm: timeout waiting for /dev/md/abuild

$ ls -alZ /var/run/mdadm
-> is var_run_t, but should be mdadm_var_run_t
```

AVCs:
type=AVC msg=audit(1740006894.587:256): avc:  denied  { read } for pid=1659 comm="mdadm" name="map" dev="tmpfs" ino=2150 scontext=system_u:system_r:mdadm_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:var_run_t:s0 tclass=file permissive=0"


