### PR TITLE
Allow mptcpd the net_admin capability

### DIFF
--- a/policy/modules/contrib/mptcpd.te
+++ b/policy/modules/contrib/mptcpd.te
@@ -17,6 +17,8 @@ files_config_file(mptcpd_etc_t)
 #
 # mptcpd local policy
 #
+
+allow mptcpd_t self:capability net_admin;
 allow mptcpd_t self:fifo_file rw_fifo_file_perms;
 allow mptcpd_t self:netlink_generic_socket create_socket_perms;
 allow mptcpd_t self:netlink_route_socket r_netlink_socket_perms;


### PR DESCRIPTION
mptcpd needs CAP_NET_ADMIN [1] to configure endpoint/subflows in the kernel: update mptcpd.te accordingly.

[1] https://github.com/multipath-tcp/mptcpd

Closes: https://github.com/fedora-selinux/selinux-policy/issues/2583