### PR TITLE
Allow afterburn to mount and read config drives

### DIFF
--- a/policy/modules/contrib/afterburn.te
+++ b/policy/modules/contrib/afterburn.te
@@ -15,6 +15,9 @@ systemd_unit_file(afterburn_unit_file_t)
 type afterburn_runtime_t;
 files_pid_file(afterburn_runtime_t)
 
+type afterburn_tmp_t;
+files_tmp_file(afterburn_tmp_t)
+
 ########################################
 #
 # afterburn local policy
@@ -28,14 +31,23 @@ allow afterburn_t afterburn_runtime_t:dir manage_dir_perms;
 manage_files_pattern(afterburn_t, afterburn_runtime_t, afterburn_runtime_t)
 files_pid_filetrans(afterburn_t, afterburn_runtime_t, dir, "metadata")
 
+allow afterburn_t afterburn_tmp_t:dir { manage_dir_perms mounton };
+files_tmp_filetrans(afterburn_t, afterburn_tmp_t, dir)
+
 kernel_dgram_send(afterburn_t)
 kernel_read_all_proc(afterburn_t)
+kernel_request_load_module(afterburn_t)
 
 corenet_tcp_connect_http_port(afterburn_t)
 
 domain_use_interactive_fds(afterburn_t)
 
 files_read_etc_files(afterburn_t)
+
+# Mount, unmount, and read config drives
+fs_mount_iso9660_fs(afterburn_t)
+fs_unmount_iso9660_fs(afterburn_t)
+fs_read_iso9660_files(afterburn_t)
 
 optional_policy(`
 	auth_use_nsswitch(afterburn_t)
@@ -60,4 +72,9 @@ optional_policy(`
 
 optional_policy(`
 	sysnet_dns_name_resolve(afterburn_t)
+')
+
+# afterburn invokes udevadm if mount fails
+optional_policy(`
+	udev_exec(afterburn_t)
 ')


### PR DESCRIPTION
On certain platforms (OpenStack and PowerVS are two), afterburn will
look for a config drive before falling back to the metadata service.
This will be a filesystem with a platform-specific well-defined
label. It is expected to be iso9660 filesystem on a virtual cd-rom
drive. afterburn will mount it in a temporary directory and read its
contents.

RHEL-9 only: Allows afterburn to load kernel modules. Required because
afterburn may load the isofs module to read config drives, and
domain_kernel_load_modules defaults to false in RHEL 9.

Resolves: RHEL-79319
