### PR TITLE
Add policy for importctl

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -101,6 +101,9 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 
 /var/cache/systemd(//.*)?		gen_context(system_u:object_r:systemd_cache_t,s0)
 
+/var/lib/confexts(/.*)?				gen_context(system_u:object_r:systemd_importd_var_lib_t,s0)
+/var/lib/extensions(/.*)?			gen_context(system_u:object_r:systemd_importd_var_lib_t,s0)
+/var/lib/portables(/.*)?			gen_context(system_u:object_r:systemd_importd_var_lib_t,s0)
 /var/lib/machines(/.*)?			gen_context(system_u:object_r:systemd_machined_var_lib_t,s0)
 /var/lib/systemd/coredump(/.*)?		gen_context(system_u:object_r:systemd_coredump_var_lib_t,s0)
 /var/lib/systemd/network(/.*)?         gen_context(system_u:object_r:systemd_networkd_var_lib_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -254,6 +254,9 @@ files_type(systemd_machined_var_lib_t)
 systemd_domain_template(systemd_importd)
 init_nnp_daemon_domain(systemd_importd_t)
 
+type systemd_importd_var_lib_t;
+files_type(systemd_importd_var_lib_t)
+
 type systemd_importd_var_run_t;
 files_pid_file(systemd_importd_var_run_t)
 
@@ -1695,6 +1698,12 @@ allow systemd_importd_t self:tcp_socket create_socket_perms;
 allow systemd_importd_t self:udp_socket create_socket_perms;
 allow systemd_importd_t self:unix_dgram_socket sendto;
 allow systemd_importd_t systemd_importd_exec_t:file execute_no_trans;
+
+manage_dirs_pattern(systemd_importd_t, systemd_importd_var_lib_t, systemd_importd_var_lib_t)
+manage_files_pattern(systemd_importd_t, systemd_importd_var_lib_t, systemd_importd_var_lib_t)
+files_var_lib_filetrans(systemd_importd_t, systemd_importd_var_lib_t, dir, "confexts")
+files_var_lib_filetrans(systemd_importd_t, systemd_importd_var_lib_t, dir, "extensions")
+files_var_lib_filetrans(systemd_importd_t, systemd_importd_var_lib_t, dir, "portables")
 
 manage_dirs_pattern(systemd_importd_t, systemd_importd_var_run_t, systemd_importd_var_run_t)
 manage_files_pattern(systemd_importd_t, systemd_importd_var_run_t, systemd_importd_var_run_t)


### PR DESCRIPTION
Addresses:
```
type=AVC msg=audit(1733403159.611:427): avc:  denied  { write } for  pid=2293 comm="systemd-pull" name="portables" dev="vda3" ino=787511 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1733403159.612:428): avc:  denied  { add_name } for  pid=2293 comm="systemd-pull" name=".#roothash.p7s5f0cd93e261f3c6c" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1733403159.612:429): avc:  denied  { create } for  pid=2293 comm="systemd-pull" name=".#roothash.p7s5f0cd93e261f3c6c" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=file permissive=1
type=AVC msg=audit(1733403159.612:430): avc:  denied  { read write open } for  pid=2293 comm="systemd-pull" path="/var/lib/portables/.#roothash.p7s5f0cd93e261f3c6c" dev="vda3" ino=787522 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=file permissive=1
type=AVC msg=audit(1733403159.612:431): avc:  denied  { getattr } for  pid=2293 comm="systemd-pull" path="/var/lib/portables/.#roothash.p7s5f0cd93e261f3c6c" dev="vda3" ino=787522 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=file permissive=1
type=AVC msg=audit(1733403160.403:432): avc:  denied  { setattr } for  pid=2293 comm="systemd-pull" path="/var/lib/portables/.#rawb2045d0e409d363d" dev="vda3" ino=787525 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=file permissive=1
```

Context: https://bugzilla.suse.com/show_bug.cgi?id=1232670

Originally submitted in #2460 