### PR TITLE
Add context for plymouth debug log files

### DIFF
--- a/policy/modules/contrib/plymouthd.fc
+++ b/policy/modules/contrib/plymouthd.fc
@@ -5,6 +5,7 @@
 /run/plymouth(/.*)?			gen_context(system_u:object_r:plymouthd_var_run_t,s0)
 /var/log/boot\.log.*			gen_context(system_u:object_r:plymouthd_var_log_t,mls_systemhigh)
 /var/spool/plymouth/boot\.log.*			gen_context(system_u:object_r:plymouthd_var_log_t,mls_systemhigh)
+/var/log/plymouth.*\.log.*			gen_context(system_u:object_r:plymouthd_var_log_t,mls_systemhigh)
 
 /usr/bin/plymouthd		--	gen_context(system_u:object_r:plymouthd_exec_t,s0)
 


### PR DESCRIPTION
Support Plymouth writing debug information to:

- /var/log/plymouth-debug.log
- /var/log/plymouth-shutdown-debug.log

Addresses:
```
type=AVC msg=audit(1739993589.246:359): avc:  denied  { write } for  pid=25671 comm="plymouthd" name="plymouth-shutdown-debug.log" dev="dm-1" ino=14375 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=0
```

Context: https://bugzilla.suse.com/show_bug.cgi?id=1237440