### PR TITLE
Allow systemd-networkd to rw memfd objects in tmpfs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -647,6 +647,7 @@ fs_list_cgroup_dirs(systemd_networkd_t)
 fs_read_xenfs_files(systemd_networkd_t)
 fs_read_nsfs_files(systemd_networkd_t)
 fs_cgroup_write_memory_pressure(systemd_networkd_t)
+fs_rw_tmpfs_files(systemd_networkd_t)
 
 dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)


### PR DESCRIPTION
systemd-networkd is trying to read and write memfd:data-fd.

Address:
```
time->Tue Mar  4 16:37:06 2025
type=AVC msg=audit(1741102626.057:128): avc:  denied  { write } for  pid=1430 comm="systemd-network" path=2F6D656D66643A646174612D6664202864656C6574656429 dev="tmpfs" ino=3104 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1 ----
time->Tue Mar  4 16:37:06 2025
type=AVC msg=audit(1741102626.112:132): avc:  denied  { read } for  pid=1446 comm="systemd-network" path=2F6D656D66643A646174612D6664202864656C6574656429 dev="tmpfs" ino=3104 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1 ----
time->Tue Mar  4 16:37:06 2025
type=AVC msg=audit(1741102626.114:133): avc:  denied  { getattr } for  pid=1446 comm="systemd-network" path=2F6D656D66643A646174612D6664202864656C6574656429 dev="tmpfs" ino=3104 scontext=system_u:system_r:systemd_networkd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1
```