### PR TITLE
Allow insights-client manage insights_client_var_log_t files

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -82,8 +82,7 @@ manage_files_pattern(insights_client_t, insights_client_var_lib_t, insights_clie
 #files_lock_filetrans(insights_client_t, insights_client_var_lock_t, dir)
 
 #manage_dirs_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
-#manage_files_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
-read_files_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
+manage_files_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
 logging_log_filetrans(insights_client_t, insights_client_var_log_t, dir)
 
 #manage_dirs_pattern(insights_client_t, insights_client_var_run_t, insights_client_var_run_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/24/2025 00:31:23.523:121) : proctitle=/usr/bin/python3 /usr/bin/insights-client type=PATH msg=audit(02/24/2025 00:31:23.523:121) : item=1 name=/var/log/insights-client/insights-client.log inode=34000645 dev=fd:00 mode=file,600 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:insights_client_var_log_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(02/24/2025 00:31:23.523:121) : item=0 name=/var/log/insights-client/ inode=33869923 dev=fd:00 mode=dir,700 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:insights_client_var_log_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/24/2025 00:31:23.523:121) : arch=x86_64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0x7f96a9cf4190 a2=O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC a3=0x1b6 items=2 ppid=1 pid=1785 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=insights-client exe=/usr/bin/python3.12 subj=system_u:system_r:insights_client_t:s0 key=(null) type=AVC msg=audit(02/24/2025 00:31:23.523:121) : avc: denied { create } for pid=1785 comm=insights-client name=insights-client.log scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:insights_client_var_log_t:s0 tclass=file permissive=1