### PR TITLE
Allow insights_core create/unlink/setattr symbolic and character device files

### DIFF
--- a/policy/modules/contrib/insights_core.te
+++ b/policy/modules/contrib/insights_core.te
@@ -25,7 +25,7 @@ files_tmp_file(insights_core_tmp_t)
 
 #permissive insights_core_t;
 
-allow insights_core_t self:capability { dac_read_search setgid sys_admin sys_rawio};
+allow insights_core_t self:capability { dac_read_search setgid sys_admin sys_rawio mknod};
 allow insights_core_t self:capability2 { checkpoint_restore syslog };
 allow insights_core_t self:cap_userns sys_ptrace;
 allow insights_core_t self:process { getattr setpgid };
@@ -55,6 +55,13 @@ append_files_pattern(insights_core_t, insights_core_var_log_t, insights_core_var
 create_files_pattern(insights_core_t, insights_core_var_log_t, insights_core_var_log_t)
 logging_log_filetrans(insights_core_t, insights_core_var_log_t, dir)
 
+create_chr_files_pattern(insights_core_t, insights_core_tmp_t)
+delete_chr_files_pattern(insights_core_t, insights_core_tmp_t)
+setattr_chr_files_pattern(insights_core_t, insights_core_tmp_t)
+
+create_lnk_files_pattern(insights_core_t, insights_core_tmp_t)
+delete_lnk_files_pattern(insights_core_t, insights_core_tmp_t)
+setattr_lnk_files_pattern(insights_core_t, insights_core_tmp_t)
 
 ### Interactions with insights-client
 optional_policy(`


### PR DESCRIPTION
The rules suggested by `audit2allow` tool are

```
#============= insights_core_t ==============
allow insights_core_t insights_core_tmp_t:chr_file { create setattr unlink };
allow insights_core_t insights_core_tmp_t:lnk_file { create setattr unlink };
allow insights_core_t self:capability mknod;
```

For the original AVC denials see RHINENG-16433