### PR TITLE
Allow blueman the kill capability

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -26,7 +26,7 @@ files_tmpfs_file(blueman_tmpfs_t)
 # Local policy
 #
 
-allow blueman_t self:capability { net_admin sys_nice };
+allow blueman_t self:capability { kill net_admin sys_nice };
 allow blueman_t self:process { execmem signal_perms setsched };
 
 allow blueman_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
Required when a serial port is disconnected from a bluetooth device using blueman.

The commit addresses the following AVC denial:
type=AVC msg=audit(1740494828.656:1174): avc:  denied  { kill } for  pid=53900 comm="blueman-mechani" capability=5  scontext=system_u:system_r:blueman_t:s0 tcontext=system_u:system_r:blueman_t:s0 tclass=capability permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2347520