### PR TITLE
Label wine's windows libraries as textrel_shlib_t

### DIFF
--- a/policy/modules/system/libraries.fc
+++ b/policy/modules/system/libraries.fc
@@ -166,6 +166,7 @@ ifdef(`distro_redhat',`
 
 /usr/.*\.so(\.[^/]*)*		--	gen_context(system_u:object_r:lib_t,s0)
 /usr/lib/wine/.+\.so	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
+/usr/lib/wine/.+-windows/.+\.(exe|dll|acm|drv|sys)	--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/NX/lib/libXcomp\.so.*		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 /usr/NX/lib/libjpeg\.so.* 		--	gen_context(system_u:object_r:textrel_shlib_t,s0)
 


### PR DESCRIPTION
Fixes these AVCs when running 'winecfg' without having 'selinuxuser_execmod' enabled: 

> type=AVC msg=audit(..): avc:  denied  { execmod } for pid=8451 comm="wineboot.exe" path="/usr/lib64/wine/x86_64-windows/ntdll.dll" dev="vda2" ino=197231 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=system_u:object_r:lib_t:s0 tclass=file permissive=0 
> type=AVC msg=audit(..): avc:  denied  { execmod } for pid=8445 comm="start.exe" path="/usr/lib/wine/i386-windows/ntdll.dll" dev="vda2" ino=196385 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=system_u:object_r:lib_t:s0 tclass=file permissive=0
