### PR TITLE
Allow mpd use the io_uring API

### DIFF
--- a/policy/modules/contrib/mpd.te
+++ b/policy/modules/contrib/mpd.te
@@ -123,6 +123,7 @@ manage_lnk_files_pattern(mpd_t, mpd_home_t, mpd_home_t)
 
 kernel_read_system_state(mpd_t)
 kernel_read_kernel_sysctls(mpd_t)
+kernel_io_uring_use(mpd_t)
 
 corecmd_exec_bin(mpd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(03/14/2025 15:52:33.356:25827) : proctitle=/usr/bin/mpd --no-daemon type=SYSCALL msg=audit(03/14/2025 15:52:33.356:25827) : arch=x86_64 syscall=io_uring_setup success=yes exit=12 a0=0x400 a1=0x7ffecbd77460 a2=0x7ffecbd77460 a3=0x180 items=0 ppid=1 pid=1922862 auid=unset uid=mpd gid=mpd euid=mpd suid=mpd fsuid=mpd egid=mpd sgid=mpd fsgid=mpd tty=(none) ses=unset comm=mpd exe=/usr/bin/mpd subj=system_u:system_r:mpd_t:s0 key=(null) type=AVC msg=audit(03/14/2025 15:52:33.356:25827) : avc:  denied  { create } for  pid=1922862 comm=mpd anonclass=[io_uring] scontext=system_u:system_r:mpd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1

type=PROCTITLE msg=audit(03/14/2025 15:52:33.356:25828) : proctitle=/usr/bin/mpd --no-daemon
type=MMAP msg=audit(03/14/2025 15:52:33.356:25828) : fd=12 flags=MAP_SHARED|MAP_POPULATE
type=SYSCALL msg=audit(03/14/2025 15:52:33.356:25828) : arch=x86_64 syscall=mmap success=yes exit=140674878001152 a0=0x0 a1=0x8040 a2=PROT_READ|PROT_WRITE a3=MAP_SHARED|MAP_POPULATE items=0 ppid=1 pid=1922862 auid=unset uid=mpd gid=mpd euid=mpd suid=mpd fsuid=mpd egid=mpd sgid=mpd fsgid=mpd tty=(none) ses=unset comm=mpd exe=/usr/bin/mpd subj=system_u:system_r:mpd_t:s0 key=(null)
type=AVC msg=audit(03/14/2025 15:52:33.356:25828) : avc:  denied  { read write } for  pid=1922862 comm=mpd path=anon_inode:[io_uring] dev="anon_inodefs" ino=3194181 scontext=system_u:system_r:mpd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1
type=AVC msg=audit(03/14/2025 15:52:33.356:25828) : avc:  denied  { map } for  pid=1922862 comm=mpd path=anon_inode:[io_uring] dev="anon_inodefs" ino=3194181 scontext=system_u:system_r:mpd_t:s0 tcontext=system_u:object_r:io_uring_t:s0 tclass=anon_inode permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2346956