### PR TITLE
Allow systemd-importd/machinectl to perform actions

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -29,6 +29,24 @@ template(`systemd_domain_template',`
 
 ######################################
 ## <summary>
+##  Allow read on machined dirs for dbusd
+## </summary>
+## <param name="domain_prefix">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`systemd_read_machine_var_lib_dirs',`
+        gen_require(`
+                type system_dbusd_t;
+        ')
+
+         allow $1 systemd_machined_var_lib_t:dir read;
+')
+
+######################################
+## <summary>
 ##	Creates types and rules for systemd generators
 ## </summary>
 ## <param name="prefix">
@@ -239,7 +257,7 @@ interface(`systemd_search_cache_dirs',`
 
 ######################################
 ## <summary>
-##      Allow domain to search systemd unit dirs.
+##      Allow domain systemd importd init files executions.
 ## </summary>
 ## <param name="domain">
 ##      <summary>
@@ -247,6 +265,23 @@ interface(`systemd_search_cache_dirs',`
 ##      </summary>
 ## </param>
 #
+interface(`systemd_init_exec',`
+        gen_require(`
+                type init_exec_t;
+        ')
+        allow $1 init_exec_t:file { map execute execute_no_trans open read };
+')
+
+######################################
+## <summary>
+##      Allow domain to search systemd unit dirs.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      domain allowed access.
+##      </summary>
+## </param>
+
 interface(`systemd_search_unit_dirs',`
         gen_require(`
                 attribute systemd_unit_file_type;
@@ -2497,6 +2532,11 @@ interface(`systemd_machined_manage_lib_files',`
         files_search_var_lib($1)
         manage_dirs_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
         manage_files_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
+        manage_lnk_files_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
+        allow $1 systemd_machined_var_lib_t:chr_file { relabelto relabelfrom create getattr setattr };
+        allow $1 systemd_machined_var_lib_t:file { relabelfrom relabelto };
+        allow $1 systemd_machined_var_lib_t:lnk_file { relabelfrom relabelto };
+        allow $1 systemd_machined_var_lib_t:dir { relabelfrom relabelto };
 ')
 
 ########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -534,6 +534,12 @@ files_tmp_filetrans(systemd_machined_t, systemd_machined_tmp_t, file)
 allow systemd_machined_t systemd_machined_tmpfs_t:file { create setattr write_file_perms };
 fs_tmpfs_filetrans(systemd_machined_t, systemd_machined_tmpfs_t, file)
 
+systemd_read_machine_var_lib_dirs(system_dbusd_t)
+
+allow systemd_machined_t init_var_run_t:dir create;
+allow systemd_machined_t init_var_run_t:file { create unlink write };
+allow systemd_machined_t systemd_machined_var_lib_t:chr_file unlink;
+
 manage_dirs_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 manage_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 manage_lnk_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
@@ -1732,7 +1738,8 @@ init_stream_connectto(systemd_initctl_t)
 #
 # systemd_importd local policy
 #
-allow systemd_importd_t self:capability { chown fowner fsetid mknod setpcap sys_admin };
+
+allow systemd_importd_t self:capability { dac_override linux_immutable chown fowner fsetid mknod setpcap sys_admin };
 allow systemd_importd_t self:process { setcap setfscreate };
 allow systemd_importd_t self:unix_stream_socket create_stream_socket_perms;
 allow systemd_importd_t self:unix_dgram_socket create_socket_perms;
@@ -1747,6 +1754,11 @@ manage_sock_files_pattern(systemd_importd_t, systemd_importd_var_run_t, systemd_
 init_pid_filetrans(systemd_importd_t, systemd_importd_var_run_t, dir)
 
 manage_files_pattern(systemd_importd_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
+
+systemd_init_exec(systemd_importd_t)
+
+manage_lnk_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
+
 init_named_pid_filetrans(systemd_importd_t, systemd_machined_var_run_t, file, "machines.lock")
 
 manage_dirs_pattern(systemd_importd_t, systemd_importd_tmp_t, systemd_importd_tmp_t)


### PR DESCRIPTION
# Summary

This PR adds capabilities to add systemd-importd permissions. This was tested with Amazon Linux 2023 and Fedora 41. We found that these commands also failed on other distros with SELinux enforced. Below is the script used to test systemd-importd.

The details below demonstrate why this policy was created for Amazon Linux, and shows how this policy is not quite complete for Fedora 41.

I would appreciate feedback on what else maybe needed from this policy change and how to improve it so it maybe used in Fedora, Amazon Linux, and other distros.

## Important note on `dac_overrride`
I added `dac_override` as an allowed capability for importd, this is also allowed for `machined` which seems to serve a similiar purpose for importd so it seems appropriate to add it.

SImiliar PR: https://github.com/fedora-selinux/selinux-policy/pull/2586

# Technical details


## Test script used for validation

This is the script I used for testing systemd-importd/systemd-container

```shell
#!/bin/bash


# Install systemd-container
pkg="systemd-container"
sudo dnf install  "${pkg}" -y
dnf info "${pkg}"


# Set variables for different use cases
file_name="amzn2023"
file_name_tar="${file_name}-tar"
file_name_raw="${file_name}-raw"
file_tar="${file_name}.tar.xz"
file_raw="${file_name}.xfs.gpt.qcow2"
tmp_path="/tmp-machines"
tmp_file_path_tar="${tmp_path}/${file_tar}"
tmp_file_path_raw="${tmp_path}/${file_raw}"

# cleanup
sudo machinectl remove "${file_name_raw}"
sudo machinectl remove "${file_name_tar}"
sudo machinectl remove fake-fs

# Get the latest system release from the cdn
# This will follow the redirect and follow the redirect, assumes trailing slash at the end of url
SYS_REL=$(echo $(curl -Ls -o /dev/null -w %{url_effective} https://cdn.amazonlinux.com/al2023/os-images/latest/ )  | sed 's|/$||' | awk -F'/' '{ print $NF }')

TAR_URL="https://cdn.amazonlinux.com/al2023/os-images/${SYS_REL}/container/al2023-container-${SYS_REL}-x86_64.tar.xz"
RAW_URL="https://cdn.amazonlinux.com/al2023/os-images/${SYS_REL}/kvm/al2023-kvm-${SYS_REL}-kernel-6.1-x86_64.xfs.gpt.qcow2"

echo "pulling raw ${RAW_URL}"
echo "pulling tar ${TAR_URL}"

# Test downloading image from the cdn
sudo machinectl pull-tar --verify=no "${TAR_URL}"  "${file_name_tar}"
sudo machinectl pull-raw --verify=no "${RAW_URL}"  "${file_name_raw}"

# Create dir with SELinux context allowed by systemd-import
sudo rm -rf ${tmp_path}
FULL_CONTEXT=$(ls -Zd /var/lib/machines | awk '{ print $1}' )
sudo mkdir --context="${FULL_CONTEXT}" ${tmp_path}

# Test exporting images
sudo machinectl export-tar  "${file_name_tar}" "${tmp_file_path_tar}"
sudo machinectl export-raw  "${file_name_raw}" "${tmp_file_path_raw}"

# Remove package, this should also allow the import-tar
# to import a new image of the same name
sudo machinectl remove "${file_name_raw}"
sudo machinectl remove "${file_name_tar}"

sudo machinectl import-raw "${tmp_file_path_raw}" "${file_name_raw}"
sudo machinectl import-tar "${tmp_file_path_tar}" "${file_name_tar}"

sudo rm "${tmp_file_path_tar}"
sudo rm "${tmp_file_path_raw}"

# Create fake file system
# Set the base directory for the fake filesystem
FAKE_FS_DIR="/path/to/fake-fs"

# Set the file context for the new fake fs directory
sudo semanage fcontext -a -e /var/lib/machines "${FAKE_FS_DIR}"
sudo semanage fcontext -a -e /var/lib/machines "${FAKE_FS_DIR}(/.*)?"
# Create the directory structure
sudo mkdir --context="${FULL_CONTEXT}" -p ${FAKE_FS_DIR}{/etc,/bin,/usr,/var}

# Create the example files and add SElinux context allowed by systemd import
sudo touch "${FAKE_FS_DIR}/etc/hosts"
sudo chcon "${FULL_CONTEXT}" "$FAKE_FS_DIR/etc/hosts"
sudo touch "${FAKE_FS_DIR}/bin/hello.sh"
sudo chcon "${FULL_CONTEXT}" "${FAKE_FS_DIR}/bin/hello.sh"

# Restore contexts recursively
sudo restorecon -R -v "${FAKE_FS_DIR}"

# Write the content to the hello.sh file
# temporarily disable history subsitution
set +H
sudo tee "${FAKE_FS_DIR}/bin/hello.sh" << EOF
#!/bin/bash
echo Hello, world
EOF
set -H

# Make the hello.sh script executable
sudo chmod +x "${FAKE_FS_DIR}/bin/hello.sh"

echo "Fake filesystem created at ${FAKE_FS_DIR}"

# Test importing a filesystem
sudo machinectl import-fs "${FAKE_FS_DIR}"

# cleanup
sudo machinectl remove "${file_name_raw}"
sudo machinectl remove "${file_name_tar}"
sudo machinectl remove fake-fs

```

## AVC Errors addressesed in Amazon Linux 2023

Below are the AVC errors generated from the script above, this PR addresses the denials below.

The `fake-fs-path` errors can generally be ignored because this dir is custom for the test and is not apart of the default systemd package, however the dbusd permissions are important to note as it seems important for the `import-fs` functionality

```
type=AVC msg=audit(1742314226.708:6312): avc:  denied  { relabelfrom } for  pid=28961 comm="systemd-pull" name="pts" dev="xvda1" ino=159392876 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1742314226.708:6313): avc:  denied  { relabelto } for  pid=28961 comm="systemd-pull" name="pts" dev="xvda1" ino=159392876 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1742314226.708:6314): avc:  denied  { relabelfrom } for  pid=28961 comm="systemd-pull" name="i18n" dev="xvda1" ino=176166599 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314226.708:6315): avc:  denied  { relabelto } for  pid=28961 comm="systemd-pull" name="i18n" dev="xvda1" ino=176166599 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314289.198:6340): avc:  denied  { execute } for  pid=29037 comm="(sd-transfer)" name="systemd-export" dev="xvda1" ino=9064017 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314289.198:6341): avc:  denied  { read open } for  pid=29037 comm="(sd-transfer)" path="/usr/lib/systemd/systemd-export" dev="xvda1" ino=9064017 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314289.198:6342): avc:  denied  { execute_no_trans } for  pid=29037 comm="(sd-transfer)" path="/usr/lib/systemd/systemd-export" dev="xvda1" ino=9064017 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314289.198:6343): avc:  denied  { map } for  pid=29037 comm="systemd-export" path="/usr/lib/systemd/systemd-export" dev="xvda1" ino=9064017 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314289.218:6344): avc:  denied  { getattr } for  pid=29038 comm="gtar" path="/var/lib/machines/amzn2023-tar/dev/stderr" dev="xvda1" ino=150998004 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1742314289.218:6345): avc:  denied  { read } for  pid=29038 comm="gtar" name="stderr" dev="xvda1" ino=150998004 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1742314289.218:6346): avc:  denied  { getattr } for  pid=29038 comm="gtar" path="/var/lib/machines/amzn2023-tar/dev/random" dev="xvda1" ino=150998007 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1742314355.097:6366): avc:  denied  { create } for  pid=29132 comm="(sd-imgrm)" name="nspawn" scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1742314355.097:6367): avc:  denied  { create } for  pid=29132 comm="(sd-imgrm)" name="inode-51713:142606525" scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314355.097:6368): avc:  denied  { write } for  pid=29132 comm="(sd-imgrm)" path="/run/systemd/nspawn/locks/inode-51713:142606525" dev="tmpfs" ino=1470 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314355.097:6369): avc:  denied  { unlink } for  pid=29132 comm="(sd-imgrm)" name="inode-51713:142606525" dev="tmpfs" ino=1470 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314355.157:6376): avc:  denied  { unlink } for  pid=29137 comm="(sd-imgrm)" name="random" dev="xvda1" ino=150998007 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1742314355.467:6389): avc:  denied  { relabelfrom } for  pid=29148 comm="gtar" name="pts" dev="xvda1" ino=159383737 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1742314355.467:6390): avc:  denied  { relabelto } for  pid=29148 comm="gtar" name="pts" dev="xvda1" ino=159383737 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=dir permissive=1
type=AVC msg=audit(1742314355.467:6391): avc:  denied  { create } for  pid=29148 comm="gtar" name="stderr" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1742314355.467:6392): avc:  denied  { setattr } for  pid=29148 comm="gtar" name="stderr" dev="xvda1" ino=150995104 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1742314355.467:6393): avc:  denied  { relabelfrom } for  pid=29148 comm="gtar" name="stderr" dev="xvda1" ino=150995104 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1742314355.467:6394): avc:  denied  { relabelto } for  pid=29148 comm="gtar" name="stderr" dev="xvda1" ino=150995104 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=lnk_file permissive=1
type=AVC msg=audit(1742314355.467:6395): avc:  denied  { create } for  pid=29148 comm="gtar" name="random" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1742314355.467:6396): avc:  denied  { setattr } for  pid=29148 comm="gtar" name="random" dev="xvda1" ino=150998005 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1742314355.467:6397): avc:  denied  { relabelfrom } for  pid=29148 comm="gtar" name="random" dev="xvda1" ino=150998005 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1742314355.467:6398): avc:  denied  { relabelto } for  pid=29148 comm="gtar" name="random" dev="xvda1" ino=150998005 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=chr_file permissive=1
type=AVC msg=audit(1742314355.477:6399): avc:  denied  { relabelfrom } for  pid=29148 comm="gtar" name="i18n" dev="xvda1" ino=176163718 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314355.477:6400): avc:  denied  { relabelto } for  pid=29148 comm="gtar" name="i18n" dev="xvda1" ino=176163718 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=file permissive=1
type=AVC msg=audit(1742314355.477:6401): avc:  denied  { dac_override } for  pid=29148 comm="gtar" capability=1  scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:system_r:systemd_importd_t:s0 tclass=capability permissive=1
type=AVC msg=audit(1742314361.867:6482): avc:  denied  { read } for  pid=1973 comm="dbus-broker" path="/path/to/fake-fs" dev="xvda1" ino=33574800 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=dir permissive=1
```



## Fedora 41 test

This was tested in and AWS EC2 instance in us-west-2 with the AMI id: `ami-0ea0f0aecf4b692ea`

### selinux-policy version 
```
[fedora@ip-172-31-36-231 ~]$ rpm -qf /etc/selinux/
libsemanage-3.7-2.fc41.x86_64
selinux-policy-41.33-1.fc41.noarch
```

### Kernel version
```
[fedora@ip-172-31-36-231 ~]$ uname -r
6.12.15-200.fc41.x86_64
```

## set selinux to Permissive and validate no AVC errors to start with
The below AVC logs before running the test script above

```
[fedora@ip-172-31-36-231 ~]$ sudo getenforce
Enforcing
[fedora@ip-172-31-36-231 ~]$ sudo setenforce Permissive
[fedora@ip-172-31-36-231 ~]$ sudo getenforce
Permissive

[fedora@ip-172-31-36-231 ~]$ sudo dnf install selinux-policy-devel

[fedora@ip-172-31-36-231 ~]$ sudo ausearch -m AVC
----
time->Tue Mar 18 17:45:08 2025
type=PROCTITLE msg=audit(1742319908.632:87): proctitle=6A6F75726E616C63746C002D2D7570646174652D636174616C6F67
type=PATH msg=audit(1742319908.632:87): item=3 name="/var/lib/systemd/catalog/database" inode=24045 dev=00:28 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:unlabeled_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319908.632:87): item=2 name="/var/lib/systemd/catalog/.#database99ab9c75fe86f849" inode=24057 dev=00:28 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:init_var_lib_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319908.632:87): item=1 name="/var/lib/systemd/catalog/" inode=1085 dev=00:28 mode=040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:init_var_lib_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319908.632:87): item=0 name="/var/lib/systemd/catalog/" inode=1085 dev=00:28 mode=040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:init_var_lib_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1742319908.632:87): cwd="/"
type=SYSCALL msg=audit(1742319908.632:87): arch=c000003e syscall=82 success=no exit=-13 a0=561af5c0b0e0 a1=561af5ba3c40 a2=ffffffffffffffff a3=4 items=4 ppid=1 pid=742 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="journalctl" exe="/usr/bin/journalctl" subj=system_u:system_r:init_t:s0 key=(null)
type=AVC msg=audit(1742319908.632:87): avc:  denied  { unlink } for  pid=742 comm="journalctl" name="database" dev="nvme0n1p4" ino=24045 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=0
----
time->Tue Mar 18 17:45:16 2025
type=PROCTITLE msg=audit(1742319916.262:90): proctitle=2F7362696E2F6C64636F6E666967002D58
type=PATH msg=audit(1742319916.262:90): item=3 name="/var/cache/ldconfig/aux-cache" inode=24041 dev=00:28 mode=0100600 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:unlabeled_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319916.262:90): item=2 name="/var/cache/ldconfig/aux-cache~" inode=24058 dev=00:28 mode=0100600 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ldconfig_cache_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319916.262:90): item=1 name="/var/cache/ldconfig/" inode=278 dev=00:28 mode=040700 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ldconfig_cache_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319916.262:90): item=0 name="/var/cache/ldconfig/" inode=278 dev=00:28 mode=040700 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ldconfig_cache_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1742319916.262:90): cwd="/"
type=SYSCALL msg=audit(1742319916.262:90): arch=c000003e syscall=82 success=no exit=-13 a0=555587139c20 a1=7fa6b0f34740 a2=4927 a3=180 items=4 ppid=1 pid=732 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="ldconfig" exe="/usr/sbin/ldconfig" subj=system_u:system_r:ldconfig_t:s0 key=(null)
type=AVC msg=audit(1742319916.262:90): avc:  denied  { unlink } for  pid=732 comm="ldconfig" name="aux-cache" dev="nvme0n1p4" ino=24041 scontext=system_u:system_r:ldconfig_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=0

```

## baseline with test script and reproduce
These AVC logs are from after running the test script above
```
[fedora@ip-172-31-36-231 ~]$ sudo ausearch -m AVC
----
time->Tue Mar 18 17:45:08 2025
type=PROCTITLE msg=audit(1742319908.632:87): proctitle=6A6F75726E616C63746C002D2D7570646174652D636174616C6F67
type=PATH msg=audit(1742319908.632:87): item=3 name="/var/lib/systemd/catalog/database" inode=24045 dev=00:28 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:unlabeled_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319908.632:87): item=2 name="/var/lib/systemd/catalog/.#database99ab9c75fe86f849" inode=24057 dev=00:28 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:init_var_lib_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319908.632:87): item=1 name="/var/lib/systemd/catalog/" inode=1085 dev=00:28 mode=040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:init_var_lib_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319908.632:87): item=0 name="/var/lib/systemd/catalog/" inode=1085 dev=00:28 mode=040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:init_var_lib_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1742319908.632:87): cwd="/"
type=SYSCALL msg=audit(1742319908.632:87): arch=c000003e syscall=82 success=no exit=-13 a0=561af5c0b0e0 a1=561af5ba3c40 a2=ffffffffffffffff a3=4 items=4 ppid=1 pid=742 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="journalctl" exe="/usr/bin/journalctl" subj=system_u:system_r:init_t:s0 key=(null)
type=AVC msg=audit(1742319908.632:87): avc:  denied  { unlink } for  pid=742 comm="journalctl" name="database" dev="nvme0n1p4" ino=24045 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=0
----
time->Tue Mar 18 17:45:16 2025
type=PROCTITLE msg=audit(1742319916.262:90): proctitle=2F7362696E2F6C64636F6E666967002D58
type=PATH msg=audit(1742319916.262:90): item=3 name="/var/cache/ldconfig/aux-cache" inode=24041 dev=00:28 mode=0100600 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:unlabeled_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319916.262:90): item=2 name="/var/cache/ldconfig/aux-cache~" inode=24058 dev=00:28 mode=0100600 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ldconfig_cache_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319916.262:90): item=1 name="/var/cache/ldconfig/" inode=278 dev=00:28 mode=040700 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ldconfig_cache_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1742319916.262:90): item=0 name="/var/cache/ldconfig/" inode=278 dev=00:28 mode=040700 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ldconfig_cache_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1742319916.262:90): cwd="/"
type=SYSCALL msg=audit(1742319916.262:90): arch=c000003e syscall=82 success=no exit=-13 a0=555587139c20 a1=7fa6b0f34740 a2=4927 a3=180 items=4 ppid=1 pid=732 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="ldconfig" exe="/usr/sbin/ldconfig" subj=system_u:system_r:ldconfig_t:s0 key=(null)
type=AVC msg=audit(1742319916.262:90): avc:  denied  { unlink } for  pid=732 comm="ldconfig" name="aux-cache" dev="nvme0n1p4" ino=24041 scontext=system_u:system_r:ldconfig_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=0
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.329:734): avc:  denied  { read } for  pid=79237 comm="systemd-pull" name=".#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.329:735): avc:  denied  { open } for  pid=79237 comm="systemd-pull" path="/var/lib/machines/.#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.329:736): avc:  denied  { getattr } for  pid=79237 comm="systemd-pull" path="/var/lib/machines/.#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.329:737): avc:  denied  { ioctl } for  pid=79237 comm="systemd-pull" path="/var/lib/machines/.#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 ioctlcmd=0x9412 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:738): avc:  denied  { search } for  pid=79240 comm="gtar" name=".#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:739): avc:  denied  { write } for  pid=79240 comm="gtar" name=".#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:740): avc:  denied  { add_name } for  pid=79240 comm="gtar" name="dev" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:741): avc:  denied  { create } for  pid=79240 comm="gtar" name="dev" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:742): avc:  denied  { search } for  pid=79240 comm="gtar" name="dev" dev="nvme0n1p4" ino=257 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:743): avc:  denied  { write } for  pid=79240 comm="gtar" name="dev" dev="nvme0n1p4" ino=257 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:744): avc:  denied  { add_name } for  pid=79240 comm="gtar" name="pts" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:745): avc:  denied  { setattr } for  pid=79240 comm="gtar" name="pts" dev="nvme0n1p4" ino=258 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:746): avc:  denied  { create } for  pid=79240 comm="gtar" name="fd" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:747): avc:  denied  { write open } for  pid=79240 comm="gtar" path="/var/lib/machines/.#tara6c35e2fbe71b3b1/dev/fd" dev="nvme0n1p4" ino=259 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:748): avc:  denied  { getattr } for  pid=79240 comm="gtar" path="/var/lib/machines/.#tara6c35e2fbe71b3b1/dev/fd" dev="nvme0n1p4" ino=259 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:749): avc:  denied  { getattr } for  pid=79240 comm="gtar" path="/var/lib/machines/.#tara6c35e2fbe71b3b1/dev" dev="nvme0n1p4" ino=257 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.335:750): avc:  denied  { create } for  pid=79240 comm="gtar" name="stderr" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=lnk_file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.336:751): avc:  denied  { setattr } for  pid=79240 comm="gtar" name="stderr" dev="nvme0n1p4" ino=260 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=lnk_file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.336:752): avc:  denied  { create } for  pid=79240 comm="gtar" name="random" scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=chr_file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.336:753): avc:  denied  { setattr } for  pid=79240 comm="gtar" name="random" dev="nvme0n1p4" ino=263 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=chr_file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.336:754): avc:  denied  { setattr } for  pid=79240 comm="gtar" name="i18n" dev="nvme0n1p4" ino=270 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:15 2025
type=AVC msg=audit(1742322855.377:755): avc:  denied  { dac_override } for  pid=79240 comm="gtar" capability=1  scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:system_r:systemd_importd_t:s0 tclass=capability permissive=1
----
time->Tue Mar 18 18:34:16 2025
type=AVC msg=audit(1742322856.682:756): avc:  denied  { read } for  pid=79240 comm="gtar" name="__init__.cpython-39.opt-1.pyc" dev="nvme0n1p4" ino=2273 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:16 2025
type=AVC msg=audit(1742322856.683:757): avc:  denied  { link } for  pid=79240 comm="gtar" name="__init__.cpython-39.opt-1.pyc" dev="nvme0n1p4" ino=2273 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:19 2025
type=AVC msg=audit(1742322859.313:758): avc:  denied  { remove_name } for  pid=79240 comm="gtar" name="fd" dev="nvme0n1p4" ino=259 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:19 2025
type=AVC msg=audit(1742322859.313:759): avc:  denied  { unlink } for  pid=79240 comm="gtar" name="fd" dev="nvme0n1p4" ino=259 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:19 2025
type=AVC msg=audit(1742322859.339:760): avc:  denied  { setattr } for  pid=79240 comm="gtar" name=".#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:19 2025
type=AVC msg=audit(1742322859.339:761): avc:  denied  { getattr } for  pid=79237 comm="systemd-pull" path="/var/lib/machines/.#tara6c35e2fbe71b3b1/etc/os-release" dev="nvme0n1p4" ino=7278 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=lnk_file permissive=1
----
time->Tue Mar 18 18:34:19 2025
type=AVC msg=audit(1742322859.339:762): avc:  denied  { read } for  pid=79237 comm="systemd-pull" name="os-release" dev="nvme0n1p4" ino=7278 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=lnk_file permissive=1
----
time->Tue Mar 18 18:34:19 2025
type=AVC msg=audit(1742322859.449:763): avc:  denied  { rename } for  pid=79237 comm="systemd-pull" name=".#tara6c35e2fbe71b3b1" dev="nvme0n1p4" ino=256 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:36 2025
type=AVC msg=audit(1742322876.272:788): avc:  denied  { execute } for  pid=79271 comm="(sd-transfer)" name="systemd-export" dev="nvme0n1p4" ino=70309 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:36 2025
type=AVC msg=audit(1742322876.273:789): avc:  denied  { read open } for  pid=79271 comm="(sd-transfer)" path="/usr/lib/systemd/systemd-export" dev="nvme0n1p4" ino=70309 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:36 2025
type=AVC msg=audit(1742322876.273:790): avc:  denied  { execute_no_trans } for  pid=79271 comm="(sd-transfer)" path="/usr/lib/systemd/systemd-export" dev="nvme0n1p4" ino=70309 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:36 2025
type=AVC msg=audit(1742322876.273:791): avc:  denied  { map } for  pid=79271 comm="systemd-export" path="/usr/lib/systemd/systemd-export" dev="nvme0n1p4" ino=70309 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_exec_t:s0 tclass=file permissive=1
----
time->Tue Mar 18 18:34:36 2025
type=AVC msg=audit(1742322876.353:792): avc:  denied  { read } for  pid=79272 comm="gtar" name="dev" dev="nvme0n1p4" ino=257 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:36 2025
type=AVC msg=audit(1742322876.353:793): avc:  denied  { open } for  pid=79272 comm="gtar" path="/var/lib/machines/.#amzn2023-tar5f1de04896699f1a/dev" dev="nvme0n1p4" ino=257 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1
----
time->Tue Mar 18 18:34:36 2025
type=AVC msg=audit(1742322876.353:794): avc:  denied  { getattr } for  pid=79272 comm="gtar" path="/var/lib/machines/.#amzn2023-tar5f1de04896699f1a/dev/random" dev="nvme0n1p4" ino=263 scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=chr_file permissive=1

```

## update srpm locally with this patch and install new version of selinux-policy
The steps below demonstrate applying the changes in this PR as a patch to the selinux-policy package. I downloaded the srpm, applied this patch, rebuilt the selinx-policy package, installed the rpm, and tested the script above
``` 
#  download srpm and build new version 
selinux-policy-41.34-1.fc41.src.rpm 

# setup rpmbuild tree and download patch and move files to the appropriate directories
# in rpmbuild/SOURCES, I created a patch file from this PR
[fedora@ip-172-31-36-231 SOURCES]$ curl https://github.com/cwolfe007/selinux-policy/commit/2f7beb4e76755251bdd1a8340a2a58f4a10cad26.patch -o importd.patch


```
Update the spec file with the new patch and build the package

```
# Update rpmbuild/SEPC/selinux-policy.spec file
... 
Patch01: importd.patch # add patch
Summary: SELinux policy configuration
Name: selinux-policy
Version: 41.34.1 # updated release with appended .1
Release: 1%{?dist}
...

```


## test with new changes
I added the newly built rpms in rpmbuild/RPMS as a local repo for dnf 

```shell
[fedora@ip-172-31-36-231 ~]$ dnf info selinux-policy
Updating and loading repositories:
 fedora 41 - x86_64                                                                                                                                                                                                                                                                    100% |  83.5 KiB/s |  30.5 KiB |  00m00s
Repositories loaded.
Installed packages
Name            : selinux-policy
Epoch           : 0
Version         : 41.34
Release         : 1.fc41
Architecture    : noarch
Installed size  : 31.6 KiB
Source          : selinux-policy-41.34-1.fc41.src.rpm
From repository : updates
Summary         : SELinux policy configuration
URL             : https://github.com/fedora-selinux/selinux-policy
License         : GPL-2.0-or-later
Description     : SELinux core policy package.
                : Originally based off of reference policy,
                : the policy has been adjusted to provide support for Fedora.
Vendor          : Fedora Project

Available packages
Name           : selinux-policy
Epoch          : 0
Version        : 41.34.1
Release        : 1.fc41
Architecture   : noarch
Download size  : 61.0 KiB
Installed size : 31.6 KiB
Source         : selinux-policy-41.34.1-1.fc41.src.rpm
Repository     : selocal
Summary        : SELinux policy configuration
URL            : https://github.com/fedora-selinux/selinux-policy
License        : GPL-2.0-or-later
Description    : SELinux core policy package.
               : Originally based off of reference policy,
               : the policy has been adjusted to provide support for Fedora.
Vendor         :

```


Below is the output from installing the new package


```
...
Package                                              Arch         Version                                               Repository                        Size
Upgrading:
 selinux-policy                                      noarch       41.34.1-1.fc41                                        selocal                       31.6 KiB
   replacing selinux-policy                          noarch       41.34-1.fc41                                          updates                       31.6 KiB
 selinux-policy-devel                                noarch       41.34.1-1.fc41                                        selocal                       22.8 MiB
   replacing selinux-policy-devel                    noarch       41.34-1.fc41                                          updates                       22.8 MiB
 selinux-policy-targeted                             noarch       41.34.1-1.fc41                                        selocal                       18.6 MiB
   replacing selinux-policy-targeted                 noarch       41.34-1.fc41                                          updates                       18.6 MiB

Transaction Summary:
 Upgrading:          3 packages
 Replacing:          3 packages

Total size of inbound packages is 8 MiB. Need to download 8 MiB.
After this operation, 2 KiB extra will be used (install 41 MiB, remove 41 MiB).
Is this ok [y/N]: y
[1/3] selinux-policy-0:41.34.1-1.fc41.noarch                                                                          100% |   2.8 MiB/s |  61.0 KiB |  00m00s
[2/3] selinux-policy-targeted-0:41.34.1-1.fc41.noarch                                                                 100% |  73.0 MiB/s |   6.6 MiB |  00m00s
[3/3] selinux-policy-devel-0:41.34.1-1.fc41.noarch                                                                    100% |  11.7 MiB/s |   1.2 MiB |  00m00s
--------------------------------------------------------------------------------------------------------------------------------------------------------------
[3/3] Total                                                                                                           100% |  66.2 MiB/s |   7.8 MiB |  00m00s
Running transaction
[1/8] Verify package files                                                                                            100% |  13.0   B/s |   3.0   B |  00m00s
[2/8] Prepare transaction                                                                                             100% |  13.0   B/s |   6.0   B |  00m00s
[3/8] Upgrading selinux-policy-0:41.34.1-1.fc41.noarch                                                                100% |   2.8 KiB/s |  33.2 KiB |  00m12s
[4/8] Upgrading selinux-policy-targeted-0:41.34.1-1.fc41.noarch                                                       100% |  19.7 MiB/s |  14.8 MiB |  00m01s
[5/8] Upgrading selinux-policy-devel-0:41.34.1-1.fc41.noarch                                                          100% |   3.7 MiB/s |  23.1 MiB |  00m06s
[6/8] Removing selinux-policy-devel-0:41.34-1.fc41.noarch                                                             100% |  57.0 KiB/s |   1.4 KiB |  00m00s
[7/8] Removing selinux-policy-0:41.34-1.fc41.noarch                                                                   100% | 631.0   B/s |  12.0   B |  00m00s
[8/8] Removing selinux-policy-targeted-0:41.34-1.fc41.noarch                                                          100% | 132.0   B/s |   1.7 KiB |  00m13s
Warning: skipped OpenPGP checks for 3 packages from repository: selocal
Complete!
[fedora@ip-172-31-36-231 ~]$ sudo setenforce Enforcing
[fedora@ip-172-31-36-231 ~]$ sudo getenforce
Enforcing
```

The below is the output audit2allow to more easily see the policy gaps that this PR is missing for F41, these logs are the result of running the script above post installing the new selinux-policy rpm
```
[fedora@ip-172-31-36-231 ~]$ sudo ausearch -m AVC | audit2allow -m test

module test 1.0;

require {
        type system_dbusd_t;
        type init_exec_t;
        type ldconfig_t;
        type systemd_machined_var_lib_t;
        type init_t;
        type systemd_machined_t;
        type systemd_importd_t;
        type unlabeled_t;
        class file { create execute execute_no_trans getattr ioctl link map open read relabelfrom relabelto setattr unlink write };
        class dir { add_name create getattr ioctl open read relabelfrom relabelto remove_name rename search setattr write };
        class lnk_file { create getattr read relabelfrom relabelto setattr };
        class chr_file { create getattr relabelfrom relabelto setattr };
        class capability dac_override;
}

#============= init_t ==============
allow init_t unlabeled_t:file { unlink write }; # missing, do we add this? 

#============= ldconfig_t ==============
allow ldconfig_t unlabeled_t:file unlink; # missing, do we add this? 


# The below can be ignored as these AVC errors are already covered in the patch form this PR

#============= system_dbusd_t ==============

#!!!! This avc is allowed in the current policy
allow system_dbusd_t systemd_machined_var_lib_t:dir read;

#============= systemd_importd_t ==============

#!!!! This avc is allowed in the current policy
allow systemd_importd_t init_exec_t:file { execute execute_no_trans map open read };

#!!!! This avc is allowed in the current policy
allow systemd_importd_t self:capability dac_override;
allow systemd_importd_t unlabeled_t:chr_file { create getattr relabelfrom relabelto setattr };
allow systemd_importd_t unlabeled_t:dir { add_name create getattr ioctl open read relabelfrom relabelto remove_name rename search setattr write };
allow systemd_importd_t unlabeled_t:file { create getattr ioctl link open read relabelfrom relabelto setattr unlink write };
allow systemd_importd_t unlabeled_t:lnk_file { create getattr read relabelfrom relabelto setattr };

#============= systemd_machined_t ==============
allow systemd_machined_t unlabeled_t:dir write;

```


