### PR TITLE
Allow xenstored_t manage xend_var_lib_t files (bsc#1228540)

### DIFF
--- a/policy/modules/contrib/xen.te
+++ b/policy/modules/contrib/xen.te
@@ -449,6 +449,11 @@ manage_files_pattern(xenstored_t, xenstored_var_lib_t, xenstored_var_lib_t)
 manage_sock_files_pattern(xenstored_t, xenstored_var_lib_t, xenstored_var_lib_t)
 files_var_lib_filetrans(xenstored_t, xenstored_var_lib_t, { file dir sock_file })
 
+# init-xenstore-domain runs as xenstored_t
+# and writes userdata-*.libxl-json and
+# handles userdata lock files in /var/lib/xen
+manage_files_pattern(xenstored_t, xend_var_lib_t, xend_var_lib_t)
+
 stream_connect_pattern(xenstored_t, evtchnd_var_run_t, evtchnd_var_run_t, evtchnd_t)
 
 kernel_read_fs_sysctls(xenstored_t)


### PR DESCRIPTION
init-xenstore-domain adds a xenstore domain and needs to write /var/lib/xen/userdata.*.libxl-json and manage the respective domain-userdata-lock files, which are labelled xend_var_lib_t atm.

Fixes:
type=AVC msg=audit(1730402738.246:35): avc:  denied  { create } for  pid=1419 comm="init-xenstore-d" name="userdata-l.1.00000000-0000-0000-0000-000000000000.domain-userdata-lock" scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:xend_var_lib_t:s0 tclass=file permissive=1 type=AVC msg=audit(1730402738.253:36): avc:  denied  { read write open } for  pid=1419 comm="init-xenstore-d" path="/var/lib/xen/userdata-l.1.00000000-0000-0000-0000-000000000000.domain-userdata-lock" dev="sdb2" ino=4719235 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:xend_var_lib_t:s0 tclass=file permissive=1 type=AVC msg=audit(1730402738.253:37): avc:  denied  { lock } for  pid=1419 comm="init-xenstore-d" path="/var/lib/xen/userdata-l.1.00000000-0000-0000-0000-000000000000.domain-userdata-lock" dev="sdb2" ino=4719235 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:xend_var_lib_t:s0 tclass=file permissive=1 type=AVC msg=audit(1730402738.253:38): avc:  denied  { getattr } for  pid=1419 comm="init-xenstore-d" path="/var/lib/xen/userdata-l.1.00000000-0000-0000-0000-000000000000.domain-userdata-lock" dev="sdb2" ino=4719235 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:xend_var_lib_t:s0 tclass=file permissive=1 type=AVC msg=audit(1730402738.253:39): avc:  denied  { rename } for  pid=1419 comm="init-xenstore-d" name="userdata-n.1.00000000-0000-0000-0000-000000000000.libxl-json" dev="sdb2" ino=4719263 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:xend_var_lib_t:s0 tclass=file permissive=1 type=AVC msg=audit(1730402738.253:40): avc:  denied  { unlink } for  pid=1419 comm="init-xenstore-d" name="userdata-d.1.00000000-0000-0000-0000-000000000000.libxl-json" dev="sdb2" ino=4719273 scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:object_r:xend_var_lib_t:s0 tclass=file permissive=1