### PR TITLE
systemd: Let importd manage sysexts, confexts & portable services

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -151,3 +151,18 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/units(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 
 /run/initramfs(/.*)?	<<none>>
+
+/etc/extensions(/.*)?       gen_context(system_u:object_r:systemd_extension_t,s0)
+/run/extensions(/.*)?       gen_context(system_u:object_r:systemd_extension_t,s0)
+/var/lib/extensions(/.*)?   gen_context(system_u:object_r:systemd_extension_t,s0)
+
+/run/confexts(/.*)?            gen_context(system_u:object_r:systemd_confext_t,s0)
+/usr/lib/confexts(/.*)?        gen_context(system_u:object_r:systemd_confext_t,s0)
+/usr/local/lib/confexts(/.*)?  gen_context(system_u:object_r:systemd_confext_t,s0)
+/var/lib/confexts(/.*)?        gen_context(system_u:object_r:systemd_confext_t,s0)
+
+/etc/portables(/.*)?            gen_context(system_u:object_r:systemd_portable_t,s0)
+/run/systemd/portables(/.*)?    gen_context(system_u:object_r:systemd_portable_t,s0)
+/usr/lib/portables(/.*)?        gen_context(system_u:object_r:systemd_portable_t,s0)
+/usr/local/lib/portables(/.*)?  gen_context(system_u:object_r:systemd_portable_t,s0)
+/var/lib/portables(/.*)?        gen_context(system_u:object_r:systemd_portable_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -253,6 +253,18 @@ files_pid_file(systemd_machined_var_run_t)
 type systemd_machined_var_lib_t;
 files_type(systemd_machined_var_lib_t)
 
+# system extensions
+type systemd_extension_t;
+files_type(systemd_extension_t)
+
+# confexts
+type systemd_confext_t;
+files_type(systemd_confext_t)
+
+# portable services
+type systemd_portable_t;
+files_type(systemd_portable_t)
+
 systemd_domain_template(systemd_importd)
 init_nnp_daemon_domain(systemd_importd_t)
 
@@ -1723,6 +1735,11 @@ init_pid_filetrans(systemd_importd_t, systemd_importd_var_run_t, dir)
 
 manage_files_pattern(systemd_importd_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 init_named_pid_filetrans(systemd_importd_t, systemd_machined_var_run_t, file, "machines.lock")
+
+# Manage systemd extensions, confexts and portable services
+manage_files_pattern(systemd_importd_t, systemd_extension_t, systemd_extension_t)
+manage_files_pattern(systemd_importd_t, systemd_confext_t, systemd_confext_t)
+manage_files_pattern(systemd_importd_t, systemd_portable_t, systemd_portable_t)
 
 manage_dirs_pattern(systemd_importd_t, systemd_importd_tmp_t, systemd_importd_tmp_t)
 manage_files_pattern(systemd_importd_t, systemd_importd_tmp_t, systemd_importd_tmp_t)


### PR DESCRIPTION
importctl/importd is a generic disk image download/import/export tool that can be used to update OS images, portable service, system extensions and configuration extensions.

See: https://www.freedesktop.org/software/systemd/man/latest/importctl.html
See: https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html
See: https://www.freedesktop.org/software/systemd/man/latest/portablectl.html

---

Work in progress as I still need to test this.

How to test this in a Fedora 42/Rawhide (cloud image should be fine):
```
$ Install updated policy
$ sudo install -d -m 0755 -o 0 -g 0 /var/lib/extensions /var/lib/extensions.d /etc/sysupdate.d
$ sudo restorecon -RFv /var/lib/extensions /var/lib/extensions.d /etc/sysupdate.d
$ SYSEXT="btop"
$ RELEASE_TAG="fedora-silverblue-42"
$ URL="https://github.com/travier/fedora-sysexts/releases/download/${RELEASE_TAG}/${SYSEXT}.conf"
$ curl --silent --location "${URL}" | sudo tee "/etc/sysupdate.d/${SYSEXT}.conf"
$ sudo /usr/lib/systemd/systemd-sysupdate list
$ sudo systemctl start systemd-sysupdate.service
```