### PR TITLE
Allow init_t nnp domain transition to pcscd_t

### DIFF
--- a/policy/modules/contrib/pcscd.te
+++ b/policy/modules/contrib/pcscd.te
@@ -8,6 +8,7 @@ policy_module(pcscd, 1.8.0)
 type pcscd_t;
 type pcscd_exec_t;
 init_daemon_domain(pcscd_t, pcscd_exec_t)
+init_nnp_daemon_domain(pcscd_t)
 
 type pcscd_initrc_exec_t;
 init_script_file(pcscd_initrc_exec_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/29/2025 05:51:41.333:635) : proctitle=/usr/bin/pcscd --foreground --auto-exit type=PATH msg=audit(03/29/2025 05:51:41.333:635) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=137382 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(03/29/2025 05:51:41.333:635) : item=0 name=/usr/bin/pcscd inode=141132 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:pcscd_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(03/29/2025 05:51:41.333:635) : argc=3 a0=/usr/bin/pcscd a1=--foreground a2=--auto-exit type=SYSCALL msg=audit(03/29/2025 05:51:41.333:635) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x563c8a625a80 a1=0x563c8a2a0d60 a2=0x563c8a29cfa0 a3=0x0 items=2 ppid=1 pid=2616 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pcscd exe=/usr/bin/pcscd subj=system_u:system_r:init_t:s0 key=(null) type=SELINUX_ERR msg=audit(03/29/2025 05:51:41.333:635) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:pcscd_t:s0 type=AVC msg=audit(03/29/2025 05:51:41.333:635) : avc:  denied  { nnp_transition } for  pid=2616 comm=(pcscd) scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:pcscd_t:s0 tclass=process2 permissive=0