### PR TITLE
Fix the genfscon statement for pidfs filesystem

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -178,7 +178,7 @@ genfscon oprofilefs / gen_context(system_u:object_r:oprofilefs_t,s0)
 type pidfs_t;
 fs_type(pidfs_t)
 files_mountpoint(pidfs_t)
-genfscon pidfs_t / gen_context(system_u:object_r:pidfs_t,s0)
+genfscon pidfs / gen_context(system_u:object_r:pidfs_t,s0)
 
 type pstore_t alias pstorefs_t;
 fs_type(pstore_t)


### PR DESCRIPTION
With the 85bbb6d1bc69 ("policy: support pidfs") commit, support for the pidfs filesystem was added, but the filesystem name was specified as pidfs_t instead of pidfs. This commit fixes it.