### PR TITLE
Allow tuned-ppd dbus chat with xdm

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -210,3 +210,7 @@ optional_policy(`
 optional_policy(`
 	miscfiles_read_generic_certs(tuned_ppd_t)
 ')
+
+optional_policy(`
+	xserver_dbus_chat_xdm(tuned_ppd_t)
+')


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(03/31/2025 10:41:28.586:5250) : pid=780 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:tuned_ppd_t:s0 tclass=dbus permissive=0 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'