### PR TITLE
Allow sysadm_t to write to /dev/kmsg

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -43,6 +43,7 @@ dev_rw_autofs(sysadm_t)
 dev_rw_lvm_control(sysadm_t)
 dev_rw_watchdog(sysadm_t)
 dev_rw_wireless(sysadm_t)
+dev_write_kmsg(sysadm_t)
 dev_setattr_all_chr_files(sysadm_t)
 
 domain_dontaudit_read_all_domains_state(sysadm_t)


### PR DESCRIPTION
This is needed to be able to do `echo '<message>' >/dev/kmsg`, which is, among other things, used in TMT's test wrapper scripts [1]. Allowing this makes it possible to run TMT tests as sysadm_t without AVC denials.

[1] https://github.com/teemtee/tmt/blob/f3a0e53c633e727ded45cc7fbfd60f63b79c9487/tmt/steps/execute/internal.py#L166