### PR TITLE
Allow tuned-ppd watch sysfs directories

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -181,6 +181,7 @@ write_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
 
 corecmd_exec_bin(tuned_ppd_t)
 dev_read_sysfs(tuned_ppd_t)
+dev_watch_sysfs_dirs(tuned_ppd_t)
 
 optional_policy(`
 	auth_read_passwd_file(tuned_ppd_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5066,6 +5066,24 @@ interface(`dev_write_sysfs_dirs',`
 
 ########################################
 ## <summary>
+##	Watch a sysfs directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_watch_sysfs_dirs',`
+	gen_require(`
+		type sysfs_t;
+	')
+
+	watch_dirs_pattern($1, sysfs_t, sysfs_t)
+')
+
+########################################
+## <summary>
 ##	Access check for a sysfs directories.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=SYSCALL msg=audit(1743497172.400:82): arch=x86_64 syscall=inotify_add_watch success=yes exit=EPERM a0=6 a1=7fc40ea0e040 a2=2 a3=0 items=0 ppid=1 pid=1519 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=tuned-ppd exe=/usr/bin/python3.13 subj=system_u:system_r:tuned_ppd_t:s0 key=(null) type=AVC msg=audit(1743497172.400:82): avc:  denied  { watch } for  pid=1519 comm="tuned-ppd" path="/sys/devices/system/cpu/intel_pstate" dev="sysfs" ino=23780 scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1