### PR TITLE
Fix the storage_rw_inherited_removable_device() interface

### DIFF
--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -902,20 +902,20 @@ interface(`storage_dontaudit_raw_write_removable_device',`
 
 #######################################
 ## <summary>
-##  Alow read and write inherited removable devices.
+##	Allow the caller read/write inherited removable devices.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain to not audit.
-##  </summary>
+##	<summary>
+##	The domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`storage_rw_inherited_removable_device',`
-    gen_require(`
-        type removable_device_t;
-    ')
+	gen_require(`
+		type removable_device_t;
+	')
 
-    dontaudit $1 removable_device_t:blk_file { read write };
+	allow $1 removable_device_t:blk_file { read write };
 ')
 
 ########################################


### PR DESCRIPTION
The interface actually dontaudited the access, in contradiction  to its name.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1414539