### PR TITLE
Hyperv: allow fcopy_uio_daemon to run as unconfined_service_t

### DIFF
--- a/policy/modules/contrib/hypervkvp.fc
+++ b/policy/modules/contrib/hypervkvp.fc
@@ -7,4 +7,6 @@
 
 /usr/bin/hypervvssd        --  gen_context(system_u:object_r:hypervvssd_exec_t,s0)
 
+/usr/lib/hyper-v/bin/.*fcopy_uio_daemon	--	gen_context(system_u:object_r:bin_t,s0)
+
 /var/lib/hyperv(/.*)?		gen_context(system_u:object_r:hypervkvp_var_lib_t,s0)

--- a/policy/modules/contrib/hypervkvp.fc
+++ b/policy/modules/contrib/hypervkvp.fc
@@ -1,7 +1,5 @@
 /etc/rc\.d/init\.d/hypervkvpd	--	gen_context(system_u:object_r:hypervkvp_initrc_exec_t,s0)
 
-/usr/lib/systemd/system/hypervvssd.*      --  gen_context(system_u:object_r:hypervvssd_unit_file_t,s0)
-
 /usr/bin/hv_kvp_daemon		--	gen_context(system_u:object_r:hypervkvp_exec_t,s0)
 /usr/bin/hypervkvpd		--	gen_context(system_u:object_r:hypervkvp_exec_t,s0)
 

--- a/policy/modules/contrib/hypervkvp.te
+++ b/policy/modules/contrib/hypervkvp.te
@@ -14,9 +14,6 @@ init_daemon_domain(hypervkvp_t, hypervkvp_exec_t)
 type hypervkvp_initrc_exec_t;
 init_script_file(hypervkvp_initrc_exec_t)
 
-type hypervkvp_unit_file_t;
-systemd_unit_file(hypervkvp_unit_file_t)
-
 type hypervkvp_var_lib_t;
 files_type(hypervkvp_var_lib_t)
 
@@ -26,9 +23,6 @@ files_tmpfs_file(hypervkvp_tmp_t)
 type hypervvssd_t, hyperv_domain;
 type hypervvssd_exec_t;
 init_daemon_domain(hypervvssd_t, hypervvssd_exec_t)
-
-type hypervvssd_unit_file_t;
-systemd_unit_file(hypervvssd_unit_file_t)
 
 ########################################
 #


### PR DESCRIPTION
The fcopy_uio_daemon is not functional before this change and does not even start.

While trying to find a resolution, I also found some seemingly unneeded pieces. I included the cleanup as well, but am a bit unsure if I might have missed something relevant.

Let me know if the cleanup should be dropped. 