### PR TITLE
Remove unused hypervkvp_unit_file_t

### DIFF
--- a/policy/modules/contrib/hypervkvp.if
+++ b/policy/modules/contrib/hypervkvp.if
@@ -81,7 +81,7 @@ interface(`hypervkvp_manage_lib_files',`
 
 #######################################
 ## <summary>
-##  Execute hypervkvp server in the hypervkvp domain.
+##  Execute hypervkvp server in the hypervkvp domain. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##  <summary>
@@ -90,18 +90,8 @@ interface(`hypervkvp_manage_lib_files',`
 ## </param>
 #
 interface(`hypervkvp_systemctl',`
-    gen_require(`
-        type hypervkvp_t;
-        type hypervkvp_unit_file_t;
-    ')
-
-    systemd_exec_systemctl($1)
-	init_reload_services($1)
-    allow $1 hypervkvp_unit_file_t:file read_file_perms;
-    allow $1 hypervkvp_unit_file_t:service manage_service_perms;
-
-    ps_process_pattern($1, hypervkvp_t)
-    ')
+    refpolicywarn(`$0($*) has been deprecated.')
+')
 
 ########################################
 ## <summary>
@@ -117,7 +107,6 @@ interface(`hypervkvp_systemctl',`
 interface(`hypervkvp_admin',`
 	gen_require(`
 		type hypervkvp_t;
-		type hypervkvp_unit_file_t;
 	')
 
 	allow $1 hypervkvp_t:process signal_perms;
@@ -128,8 +117,4 @@ interface(`hypervkvp_admin',`
 	')
 
 	hypervkvp_manage_lib_files($1)
-
-	hypervkvp_systemctl($1)
-	admin_pattern($1, hypervkvp_unit_file_t)
-	allow $1 hypervkvp_unit_file_t:service all_service_perms;
 ')

--- a/policy/modules/contrib/hypervkvp.te
+++ b/policy/modules/contrib/hypervkvp.te
@@ -14,9 +14,6 @@ init_daemon_domain(hypervkvp_t, hypervkvp_exec_t)
 type hypervkvp_initrc_exec_t;
 init_script_file(hypervkvp_initrc_exec_t)
 
-type hypervkvp_unit_file_t;
-systemd_unit_file(hypervkvp_unit_file_t)
-
 type hypervkvp_var_lib_t;
 files_type(hypervkvp_var_lib_t)
 


### PR DESCRIPTION
/usr/lib/systemd/system/hypervkvpd.service is labeled systemd_unit_file_t. Remove the hypervkvp_unit_file_t type, as it is not used.

I worked on a hyperv issue that is specific to the openSUSE policy and after the previous PR I saw that there are major differences in the packaging. Never the less the type is not used and I thought I will offer the smaller PR anyway. Maybe you will want to take it.