### PR TITLE
Confine systemd-hibernate

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -53,6 +53,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/system/.*shutdown.*\.(service|target)		--	gen_context(system_u:object_r:power_unit_file_t,s0)
 /usr/lib/systemd/system/.*suspend.*\.(service|target)		--	gen_context(system_u:object_r:power_unit_file_t,s0)
 /usr/lib/systemd/system/systemd-userdbd\.(service|socket)		--	gen_context(system_u:object_r:systemd_userdbd_unit_file_t,s0)
+/usr/lib/systemd/systemd-hibernate-resume	--	gen_context(system_u:object_r:systemd_hibernate_resume_exec_t,s0)
 /usr/lib/systemd/systemd-hostnamed	--	gen_context(system_u:object_r:systemd_hostnamed_exec_t,s0)
 /usr/lib/systemd/systemd-machined	--	gen_context(system_u:object_r:systemd_machined_exec_t,s0)
 /usr/lib/systemd/systemd-mountfsd	--	gen_context(system_u:object_r:systemd_mountfsd_exec_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -69,6 +69,8 @@ files_tmpfs_file(systemd_coredump_tmpfs_t)
 type systemd_coredump_var_lib_t;
 files_type(systemd_coredump_var_lib_t)
 
+systemd_domain_template(systemd_hibernate_resume)
+
 systemd_domain_template(systemd_hwdb)
 
 type systemd_hwdb_unit_file_t;
@@ -1292,6 +1294,15 @@ fs_read_nsfs_files(systemd_coredump_t)
 optional_policy(`
 	logging_send_syslog_msg(systemd_coredump_t)
 ')
+
+#######################################
+#
+# systemd_hibernate domain
+#
+permissive systemd_hibernate_resume_t;
+
+#allow systemd_hibernate_resume_t efivarfs_t:file unlink;
+
 
 #######################################
 #


### PR DESCRIPTION
This executable is started by systemd-hibernate-clear.service and systemd-hibernate-resume.service.