### PR TITLE
Allow sadc read global pressure stall information

### DIFF
--- a/policy/modules/contrib/sysstat.te
+++ b/policy/modules/contrib/sysstat.te
@@ -35,6 +35,7 @@ kernel_read_network_state(sysstat_t)
 kernel_read_kernel_sysctls(sysstat_t)
 kernel_read_fs_sysctls(sysstat_t)
 kernel_read_rpc_sysctls(sysstat_t)
+kernel_read_psi(sysstat_t)
 
 corecmd_exec_shell(sysstat_t)
 corecmd_exec_bin(sysstat_t)


### PR DESCRIPTION
Required when the per-cgroup psi monitoring is disabled with the "cgroup_disable=pressure" kernel option.