### PR TITLE
Allow virtqemud read sblim-gatherd process state

### DIFF
--- a/policy/modules/contrib/sblim.if
+++ b/policy/modules/contrib/sblim.if
@@ -68,6 +68,25 @@ interface(`sblim_read_pid_files',`
 
 ########################################
 ## <summary>
+##	Allow the domain to read sblim-gatherd state files in /proc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sblim_read_gatherd_state',`
+	gen_require(`
+		type sblim_gatherd_t;
+	')
+
+	kernel_search_proc($1)
+	ps_process_pattern($1, sblim_gatherd_t)
+')
+
+########################################
+## <summary>
 ##	Transition to sblim named content
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2349,6 +2349,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sblim_read_gatherd_state(virtqemud_t)
+')
+
+optional_policy(`
 	ssh_domtrans_ssh(virtqemud_t)
 	ssh_signal_ssh(virtqemud_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/12/2025 08:15:56.879:953) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(03/12/2025 08:15:56.879:953) : item=0 name=/proc/30423/stat inode=55309 dev=00:16 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:sblim_gatherd_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/12/2025 08:15:56.879:953) : arch=x86_64 syscall=openat success=yes exit=19 a0=AT_FDCWD a1=0x564c95fc5810 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=30100 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=prio-rpc-virtqe exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(03/12/2025 08:15:56.879:953) : avc:  denied  { open } for  pid=30100 comm=prio-rpc-virtqe path=/proc/30423/stat dev="proc" ino=55309 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:sblim_gatherd_t:s0 tclass=file permissive=1 type=AVC msg=audit(03/12/2025 08:15:56.879:953) : avc:  denied  { read } for  pid=30100 comm=prio-rpc-virtqe name=stat dev="proc" ino=55309 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:sblim_gatherd_t:s0 tclass=file permissive=1