### PR TITLE
Allow gnome-shell get attributes of systemd inhibit pipes

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -745,6 +745,7 @@ mount_watch_pid_dirs(xdm_t)
 mount_watch_pid_files(xdm_t)
 mount_watch_reads_pid_files(xdm_t)
 
+systemd_getattr_inhibit_pipes(xdm_t)
 systemd_write_inhibit_pipes(xdm_t)
 systemd_dbus_chat_localed(xdm_t)
 systemd_dbus_chat_hostnamed(xdm_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -713,6 +713,24 @@ interface(`systemd_dontaudit_write_inherited_logind_sessions_pipes',`
 
 ######################################
 ## <summary>
+##	Getattr systemd inhibit pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_getattr_inhibit_pipes',`
+	gen_require(`
+		type systemd_logind_inhibit_var_run_t;
+	')
+
+	allow $1 systemd_logind_inhibit_var_run_t:fifo_file getattr;
+')
+
+######################################
+## <summary>
 ##	Write systemd inhibit pipes.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1743815403.976:153): avc:  denied  { getattr } for  pid=1167 comm="gnome-shell" path="/run/systemd/inhibit/4.ref" dev="tmpfs" ino=3196 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_logind_inhibit_var_run_t:s0 tclass=fifo_file permissive=0

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2624