### PR TITLE
Revert "Allow nfsidmap connect to systemd-homed over a unix socket"

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -479,7 +479,3 @@ optional_policy(`
 	systemd_machined_stream_connect(nfsidmap_t)
 	systemd_userdbd_stream_connect(nfsidmap_t)
 ')
-
-optional_policy(`
-	systemd_homed_stream_connect(nfsidmap_t)
-')


### PR DESCRIPTION
This reverts commit c8c88d4806f4773939eced63529e36ec2f47c42c which does not apply to F40.