### PR TITLE
Allow power-profiles-daemon watch sysfs directories

### DIFF
--- a/policy/modules/contrib/powerprofiles.te
+++ b/policy/modules/contrib/powerprofiles.te
@@ -23,6 +23,7 @@ manage_files_pattern(powerprofiles_t, powerprofiles_var_lib_t, powerprofiles_var
 kernel_read_proc_files(powerprofiles_t)
 
 dev_rw_sysfs(powerprofiles_t)
+dev_watch_sysfs_dirs(powerprofiles_t)
 
 optional_policy(`
 	dbus_connect_system_bus(powerprofiles_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1742596982.867:681): avc:  denied  { watch } for  pid=8624 comm="power-profiles-" path="/sys/devices/system/cpu/intel_pstate" dev="sysfs" ino=20695 scontext=system_u:system_r:powerprofiles_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2354200