### PR TITLE
Allow dovecot-deliver read mail aliases

### DIFF
--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -399,6 +399,7 @@ optional_policy(`
 	mta_mailserver_delivery(dovecot_deliver_t)
     mta_mmap_home_rw(dovecot_deliver_t)
 	mta_manage_spool(dovecot_deliver_t)
+	mta_read_aliases(dovecot_deliver_t)
 	mta_read_queue(dovecot_deliver_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/19/2025 09:17:40.244:948) : proctitle=/usr/libexec/dovecot/dovecot-lda -f root@localhost-a bobo@localhost type=PATH msg=audit(02/19/2025 09:17:40.244:948) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=9068074 dev=ca:03 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(02/19/2025 09:17:40.244:948) : item=0 name=/usr/libexec/dovecot/dovecot-lda inode=176160896 dev=ca:03 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:dovecot_deliver_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(02/19/2025 09:17:40.244:948) : argc=5 a0=/usr/libexec/dovecot/dovecot-lda a1=-f a2=root@localhost a3=-a a4=bobo@localhost type=SYSCALL msg=audit(02/19/2025 09:17:40.244:948) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x561b37e5eef0 a1=0x561b37e5d040 a2=0x561b37e5ef20 a3=0x8 items=2 ppid=16859 pid=16861 auid=unset uid=bobo gid=bobo euid=bobo suid=bobo fsuid=bobo egid=bobo sgid=bobo fsgid=bobo tty=(none) ses=unset comm=dovecot-lda exe=/usr/libexec/dovecot/dovecot-lda subj=system_u:system_r:dovecot_deliver_t:s0 key=(null) type=AVC msg=audit(02/19/2025 09:17:40.244:948) : avc:  denied  { read } for  pid=16861 comm=dovecot-lda path=/etc/aliases.lmdb dev="xvda3" ino=16920576 scontext=system_u:system_r:dovecot_deliver_t:s0 tcontext=system_u:object_r:etc_aliases_t:s0 tclass=file permissive=0

Resolves: RHEL-80153