### PR TITLE
Update the pcmsensor policy

### DIFF
--- a/policy/modules/contrib/pcm.te
+++ b/policy/modules/contrib/pcm.te
@@ -1,5 +1,4 @@
 policy_module(pcm, 1.0)
-#policy_module(pcmsensor, 1.0)
 
 ########################################
 #
@@ -13,11 +12,18 @@ init_daemon_domain(pcmsensor_t, pcmsensor_exec_t)
 permissive pcmsensor_t;
 
 allow pcmsensor_t self:capability { sys_rawio sys_resource };
-allow pcmsensor_t self:process { ptrace setrlimit };
+allow pcmsensor_t self:capability2 perfmon;
+allow pcmsensor_t self:perf_event { cpu kernel open read };
+allow pcmsensor_t self:process { ptrace setrlimit setsched };
+allow pcmsensor_t self:tcp_socket create_stream_socket_perms;
 
 kernel_read_proc_files(pcmsensor_t)
 kernel_read_debugfs(pcmsensor_t)
 kernel_rw_nmi_watchdog_state(pcmsensor_t)
+kernel_write_proc_files(pcmsensor_t)
+
+corenet_tcp_bind_generic_node(pcmsensor_t)
+corenet_tcp_bind_generic_port(pcmsensor_t)
 
 dev_rw_cpu_microcode(pcmsensor_t)
 # /sys/module/msr/parameters/allow_writes


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(02/19/2025 13:57:51.692:640) : proctitle=/usr/sbin/pcm-sensor-server type=SYSCALL msg=audit(02/19/2025 13:57:51.692:640) : arch=x86_64 syscall=sched_setaffinity success=yes exit=0 a0=0x7acc a1=0x400 a2=0x7fcd44000f80 a3=0x3f items=0 ppid=1 pid=30948 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pcm-sensor-serv exe=/usr/sbin/pcm-sensor-server subj=system_u:system_r:pcmsensor_t:s0 key=(null) type=AVC msg=audit(02/19/2025 13:57:51.692:640) : avc:  denied  { setsched } for  pid=30948 comm=pcm-sensor-serv scontext=system_u:system_r:pcmsensor_t:s0 tcontext=system_u:system_r:pcmsensor_t:s0 tclass=process permissive=1

Resolves: RHEL-80452