### PR TITLE
Allow chronyd-restricted sendto to chronyc

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -213,6 +213,7 @@ allow chronyd_restricted_t self:tcp_socket create_stream_socket_perms;
 allow chronyd_restricted_t self:udp_socket create_socket_perms;
 allow chronyd_restricted_t self:unix_dgram_socket create_socket_perms;
 
+allow chronyd_restricted_t chronyc_t:unix_dgram_socket sendto;
 allow chronyd_restricted_t chronyd_keys_t:file read_file_perms;
 
 manage_files_pattern(chronyd_restricted_t, chronyd_var_lib_t, chronyd_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/05/2025 13:26:03.929:497) : proctitle=/usr/sbin/chronyd -U -F 2 type=PATH msg=audit(03/05/2025 13:26:03.929:497) : item=0 name=/run/chrony/chronyc.43141.sock inode=1989 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:chronyd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(03/05/2025 13:26:03.929:497) : saddr={ saddr_fam=local path=/run/chrony/chronyc.43141.sock } type=SYSCALL msg=audit(03/05/2025 13:26:03.929:497) : arch=x86_64 syscall=sendmsg success=yes exit=28 a0=0x5 a1=0x7ffee73bf410 a2=0x0 a3=0x0 items=1 ppid=1 pid=43057 auid=unset uid=chrony gid=chrony euid=chrony suid=chrony fsuid=chrony egid=chrony sgid=chrony fsgid=chrony tty=(none) ses=unset comm=chronyd exe=/usr/sbin/chronyd subj=system_u:system_r:chronyd_restricted_t:s0 key=(null) type=AVC msg=audit(03/05/2025 13:26:03.929:497) : avc:  denied  { sendto } for  pid=43057 comm=chronyd path=/run/chrony/chronyc.43141.sock scontext=system_u:system_r:chronyd_restricted_t:s0 tcontext=unconfined_u:unconfined_r:chronyc_t:s0-s0:c0.c1023 tclass=unix_dgram_socket permissive=1

Resolves: RHEL-82299