### PR TITLE
Label SetroubleshootPrivileged.py with setroubleshootd_exec_t

### DIFF
--- a/policy/modules/contrib/setroubleshoot.fc
+++ b/policy/modules/contrib/setroubleshoot.fc
@@ -1,6 +1,7 @@
 /usr/bin/setroubleshootd	--	gen_context(system_u:object_r:setroubleshootd_exec_t,s0)
 
 /usr/share/setroubleshoot/SetroubleshootFixit\.py* -- gen_context(system_u:object_r:setroubleshoot_fixit_exec_t,s0)
+/usr/share/setroubleshoot/SetroubleshootPrivileged\.py	--	gen_context(system_u:object_r:setroubleshootd_exec_t,s0)
 
 /run/setroubleshoot(/.*)?		gen_context(system_u:object_r:setroubleshoot_var_run_t,s0)
 


### PR DESCRIPTION
The service is a short-living service only, it should not need more than to run "rpm -q --qf" and browse the policy store.

Resolves: RHEL-77319