### PR TITLE
Make bootupd use its bootupd_tmp_t private type

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -10,6 +10,9 @@ type bootupd_exec_t;
 init_daemon_domain(bootupd_t, bootupd_exec_t)
 permissive bootupd_t;
 
+type bootupd_tmp_t;
+files_tmp_file(bootupd_tmp_t)
+
 type bootupd_unit_file_t;
 systemd_unit_file(bootupd_unit_file_t)
 
@@ -25,6 +28,9 @@ allow bootupd_t self:process { fork setfscreate setpgid };
 allow bootupd_t self:fifo_file rw_fifo_file_perms;
 allow bootupd_t self:unix_dgram_socket create_socket_perms;
 allow bootupd_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_files_pattern(bootupd_t, bootupd_tmp_t, bootupd_tmp_t)
+files_tmp_filetrans(bootupd_t, bootupd_tmp_t, file)
 
 manage_files_pattern(bootupd_t, bootupd_var_run_t, bootupd_var_run_t)
 manage_sock_files_pattern(bootupd_t, bootupd_var_run_t, bootupd_var_run_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/07/2025 12:38:13.674:2638) : proctitle=/usr/bin/bootupctl update type=PATH msg=audit(04/07/2025 12:38:13.674:2638) : item=0 name=/tmp inode=235 dev=00:29 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/07/2025 12:38:13.674:2638) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x7ffca48d1d60 a2=O_RDWR|O_DIRECTORY|O_CLOEXEC|__O_TMPFILE a3=0x1b6 items=1 ppid=1 pid=91537 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=bootupctl exe=/usr/bin/bootupctl subj=system_u:system_r:bootupd_t:s0 key=(null) type=AVC msg=audit(04/07/2025 12:38:13.674:2638) : avc:  denied  { write open } for  pid=91537 comm=bootupctl path=/tmp/#235 (deleted) dev="tmpfs" ino=235 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:tmp_t:s0 tclass=file permissive=1 type=AVC msg=audit(04/07/2025 12:38:13.674:2638) : avc:  denied  { write } for  pid=91537 comm=bootupctl name=/ dev="tmpfs" ino=1 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=1