### PR TITLE
Allow system_dbusd_t r/w unix stream sockets of unconfined_service_t

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -252,6 +252,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_server_rw_stream_sockets(system_dbusd_t)
+')
+
+optional_policy(`
 	userdom_rw_stream(system_dbusd_t)
 	userdom_use_inherited_user_ttys(system_dbusd_t)
 ')

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -228,6 +228,24 @@ interface(`unconfined_server_stream_connectto',`
 
 ########################################
 ## <summary>
+##	Read and write to unconfined_service_t unix stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_server_rw_stream_sockets',`
+	gen_require(`
+		type unconfined_service_t;
+	')
+
+	allow $1 unconfined_service_t:unix_stream_socket { read write };
+')
+
+########################################
+## <summary>
 ##	Connect to unconfined_server with a unix socket.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/08/2025 07:00:17.374:363) : proctitle=dbus-broker --log 4 --controller 9 --machine-id 5340fa388fbd49bc812920f3bcfa5cbc --max-bytes 536870912 --max-fds 4096 --max-matc type=SYSCALL msg=audit(04/08/2025 07:00:17.374:363) : arch=x86_64 syscall=recvmsg success=yes exit=752 a0=0x1c a1=0x7ffe8dfe1e40 a2=MSG_DONTWAIT|MSG_CMSG_CLOEXEC a3=0x0 items=0 ppid=1084 pid=1085 auid=unset uid=dbus gid=dbus euid=dbus suid=dbus fsuid=dbus egid=dbus sgid=dbus fsgid=dbus tty=(none) ses=unset comm=dbus-broker exe=/usr/bin/dbus-broker subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(04/08/2025 07:00:17.374:363) : avc:  denied  { read write } for  pid=1085 comm=dbus-broker path=socket:[25167] dev="sockfs" ino=25167 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=unix_stream_socket permissive=0