### PR TITLE
systemd: allow reading /dev/cpu/0/msr

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -283,6 +283,7 @@ dev_setattr_all_blk_files(init_t)
 dev_setattr_all_chr_files(init_t)
 dev_read_urand(init_t)
 dev_read_raw_memory(init_t)
+dev_read_cpuid(init_t)
 # Early devtmpfs
 dev_rw_generic_chr_files(init_t)
 dev_filetrans_all_named_dev(init_t)


### PR DESCRIPTION
To detect confidential virtualization on AMD processors, systemd as of v254 needs to perform an MSR read.