### PR TITLE
Allow tuned-ppd watch_reads sysfs directories

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -182,6 +182,7 @@ write_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
 corecmd_exec_bin(tuned_ppd_t)
 dev_read_sysfs(tuned_ppd_t)
 dev_watch_sysfs_dirs(tuned_ppd_t)
+dev_watch_reads_sysfs_dirs(tuned_ppd_t)
 
 optional_policy(`
 	auth_read_passwd_file(tuned_ppd_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5084,6 +5084,24 @@ interface(`dev_watch_sysfs_dirs',`
 
 ########################################
 ## <summary>
+##	Watch_reads a sysfs directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_watch_reads_sysfs_dirs',`
+	gen_require(`
+		type sysfs_t;
+	')
+
+	watch_reads_dirs_pattern($1, sysfs_t, sysfs_t)
+')
+
+########################################
+## <summary>
 ##	Access check for a sysfs directories.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1744315263.81:133): avc:  denied  { watch_reads } for  pid=1215 comm="tuned-ppd" path="/sys/firmware/acpi" dev="sysfs" ino=6775 scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2358952