### PR TITLE
Allow tuned-ppd read sssd public files

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -213,5 +213,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_read_public_files(tuned_ppd_t)
+')
+
+optional_policy(`
 	xserver_dbus_chat_xdm(tuned_ppd_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/01/2025 04:44:31.570:420) : proctitle=/usr/bin/python3 -Es /usr/sbin/tuned-ppd -l type=PATH msg=audit(04/01/2025 04:44:31.570:420) : item=0 name=/var/lib/sss/mc/passwd nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(04/01/2025 04:44:31.570:420) : cwd=/ type=SYSCALL msg=audit(04/01/2025 04:44:31.570:420) : arch=ppc64le syscall=openat success=no exit=ENOENT(No such file or directory) a0=AT_FDCWD a1=0x111293480 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=29642 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tuned-ppd exe=/usr/bin/python3.9 subj=system_u:system_r:tuned_ppd_t:s0 key=(null) type=AVC msg=audit(04/01/2025 04:44:31.570:420) : avc:  denied  { search } for  pid=29642 comm=tuned-ppd name=mc dev="dm-0" ino=33572570 scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=dir permissive=1 type=AVC msg=audit(04/01/2025 04:44:31.570:420) : avc:  denied  { search } for  pid=29642 comm=tuned-ppd name=sss dev="dm-0" ino=33572569 scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=dir permissive=1

Resolves: RHEL-69526