### PR TITLE
Allow systemd-user-runtime-dir delete gnome homedir content

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1952,6 +1952,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gnome_delete_home_config_dirs(systemd_user_runtimedir_t)
+')
+
+optional_policy(`
 	userdom_manage_tmp_dirs(systemd_user_runtimedir_t)
 	userdom_mounton_tmp_dirs(systemd_user_runtimedir_t)
 	userdom_relabel_user_tmp_dirs(systemd_user_runtimedir_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/11/2025 17:05:05.993:4774) : proctitle=/usr/lib/systemd/systemd-user-runtime-dir stop 1004 type=PATH msg=audit(04/11/2025 17:05:05.993:4774) : item=1 name=user inode=43 dev=00:41 mode=file,600 ouid=unknown(1004) ogid=unknown(1004) rdev=00:00 obj=unconfined_u:object_r:config_home_t:s0 nametype=DELETE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(04/11/2025 17:05:05.993:4774) : item=0 name=/ inode=42 dev=00:41 mode=dir,700 ouid=unknown(1004) ogid=unknown(1004) rdev=00:00 obj=unconfined_u:object_r:config_home_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/11/2025 17:05:05.993:4774) : arch=x86_64 syscall=unlinkat success=yes exit=0 a0=0x5 a1=0x557882d77153 a2=0x0 a3=0x4 items=2 ppid=1 pid=152473 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-user-ru exe=/usr/lib/systemd/systemd-user-runtime-dir subj=system_u:system_r:systemd_user_runtimedir_t:s0 key=(null) type=AVC msg=audit(04/11/2025 17:05:05.993:4774) : avc:  denied  { remove_name } for  pid=152473 comm=systemd-user-ru name=user dev="tmpfs" ino=43 scontext=system_u:system_r:systemd_user_runtimedir_t:s0 tcontext=unconfined_u:object_r:config_home_t:s0 tclass=dir permissive=1 type=AVC msg=audit(04/11/2025 17:05:05.993:4774) : avc:  denied  { write } for  pid=152473 comm=systemd-user-ru name=dconf dev="tmpfs" ino=42 scontext=system_u:system_r:systemd_user_runtimedir_t:s0 tcontext=unconfined_u:object_r:config_home_t:s0 tclass=dir permissive=1 type=PROCTITLE msg=audit(04/11/2025 17:05:05.993:4774) : proctitle=/usr/lib/systemd/systemd-user-runtime-dir stop 1004 type=PATH msg=audit(04/11/2025 17:05:05.993:4774) : item=1 name=user inode=43 dev=00:41 mode=file,600 ouid=unknown(1004) ogid=unknown(1004) rdev=00:00 obj=unconfined_u:object_r:config_home_t:s0 nametype=DELETE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(04/11/2025 17:05:05.993:4774) : item=0 name=/ inode=42 dev=00:41 mode=dir,700 ouid=unknown(1004) ogid=unknown(1004) rdev=00:00 obj=unconfined_u:object_r:config_home_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(04/11/2025 17:05:05.993:4774) : cwd=/ type=SYSCALL msg=audit(04/11/2025 17:05:05.993:4774) : arch=x86_64 syscall=unlinkat success=yes exit=0 a0=0x5 a1=0x557882d77153 a2=0x0 a3=0x4 items=2 ppid=1 pid=152473 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-user-ru exe=/usr/lib/systemd/systemd-user-runtime-dir subj=system_u:system_r:systemd_user_runtimedir_t:s0 key=(null) type=AVC msg=audit(04/11/2025 17:05:05.993:4774) : avc:  denied  { remove_name } for  pid=152473 comm=systemd-user-ru name=user dev="tmpfs" ino=43 scontext=system_u:system_r:systemd_user_runtimedir_t:s0 tcontext=unconfined_u:object_r:config_home_t:s0 tclass=dir permissive=1 type=AVC msg=audit(04/11/2025 17:05:05.993:4774) : avc:  denied  { write } for  pid=152473 comm=systemd-user-ru name=dconf dev="tmpfs" ino=42 scontext=system_u:system_r:systemd_user_runtimedir_t:s0 tcontext=unconfined_u:object_r:config_home_t:s0 tclass=dir permissive=1 ----