### PR TITLE
Allow systemd-user-runtime-dir get/set tmpfs quotas

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -7476,3 +7476,21 @@ interface(`fs_unmount_tracefs', `
 
 	allow $1 tracefs_t:filesystem unmount;
 ')
+
+########################################
+## <summary>
+##	Get the attributes of the pidfs filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_getattr_pidfs',`
+	gen_require(`
+		type pidfs_t;
+	')
+
+	allow $1 pidfs_t:filesystem getattr;
+')

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -5555,6 +5555,42 @@ interface(`fs_unmount_tmpfs',`
 
 ########################################
 ## <summary>
+##	Get the filesystem quotas of a tmpfs filesystem
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_get_tmpfs_quotas',`
+	gen_require(`
+		type tmpfs_t;
+	')
+
+	allow $1 tmpfs_t:filesystem quotaget;
+')
+
+########################################
+## <summary>
+##	Set the filesystem quotas of a tmpfs filesystem
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_set_tmpfs_quotas',`
+	gen_require(`
+		type tmpfs_t;
+	')
+
+	allow $1 tmpfs_t:filesystem quotamod;
+')
+
+########################################
+## <summary>
 ##	Mount, remount, unmount a tmpfs filesystem.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -71,10 +71,15 @@ files_search_home(systemd_homed_t)
 files_manage_isid_type_dirs(systemd_homed_t)
 files_manage_isid_type_files(systemd_homed_t)
 
+files_list_spool(systemd_homed_t)
+files_list_var(systemd_homed_t)
+
 # /dev/shm
 fs_getattr_tmpfs(systemd_homed_t)
 
 fs_getattr_nsfs_files(systemd_homed_t)
+fs_getattr_pidfs(systemd_homed_t)
+fs_get_tmpfs_quotas(systemd_homed_t)
 
 # /var/cache/systemd/home
 create_dirs_pattern(systemd_homed_t, systemd_homed_cache_t, systemd_homed_cache_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1943,6 +1943,8 @@ domain_obj_id_change_exemption(systemd_user_runtimedir_t)
 files_dontaudit_delete_all_files(systemd_user_runtimedir_t)
 files_dontaudit_list_all_dirs(systemd_user_runtimedir_t)
 
+fs_get_tmpfs_quotas(systemd_user_runtimedir_t)
+fs_set_tmpfs_quotas(systemd_user_runtimedir_t)
 fs_mount_tmpfs(systemd_user_runtimedir_t)
 fs_unmount_tmpfs(systemd_user_runtimedir_t)
 fs_relabel_tmpfs_dirs(systemd_user_runtimedir_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:

type=PROCTITLE msg=audit(04/14/2025 06:20:18.856:507) : proctitle=/usr/lib/systemd/systemd-user-runtime-dir start 1001
type=SYSCALL msg=audit(04/14/2025 06:20:18.856:507) : arch=x86_64 syscall=quotactl_fd success=yes exit=0 a0=0x4 a1=0x80000700 a2=0x3e9 a3=0x7ffd537afc60 items=0 ppid=1 pid=22904 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-user-ru exe=/usr/lib/systemd/systemd-user-runtime-dir subj=system_u:system_r:systemd_user_runtimedir_t:s0 key=(null)
type=AVC msg=audit(04/14/2025 06:20:18.856:507) : avc:  denied  { quotaget } for  pid=22904 comm=systemd-user-ru scontext=system_u:system_r:systemd_user_runtimedir_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=1

type=PROCTITLE msg=audit(04/14/2025 06:20:18.856:508) : proctitle=/usr/lib/systemd/systemd-user-runtime-dir start 1001
type=SYSCALL msg=audit(04/14/2025 06:20:18.856:508) : arch=x86_64 syscall=quotactl_fd success=yes exit=0 a0=0x4 a1=0x80000800 a2=0x3e9 a3=0x7ffd537afc60 items=0 ppid=1 pid=22904 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-user-ru exe=/usr/lib/systemd/systemd-user-runtime-dir subj=system_u:system_r:systemd_user_runtimedir_t:s0 key=(null)
type=AVC msg=audit(04/14/2025 06:20:18.856:508) : avc:  denied  { quotamod } for  pid=22904 comm=systemd-user-ru scontext=system_u:system_r:systemd_user_runtimedir_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=1