### PR TITLE
Allow systemd-rfkill read nsfs files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1092,6 +1092,7 @@ dev_read_sysfs(systemd_rfkill_t)
 dev_rw_wireless(systemd_rfkill_t)
 dev_write_kmsg(systemd_rfkill_t)
 
+fs_read_nsfs_files(systemd_rfkill_t)
 
 init_search_var_lib_dirs(systemd_rfkill_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1744736179.846:80): avc:  denied  { read open } for  pid=670 comm="systemd-rfkill" path="net:[4026531840]" dev="nsfs" ino=4026531840 scontext=system_u:system_r:systemd_rfkill_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(1744736179.846:80): arch=x86_64 syscall=ioctl success=no exit=EACCES a0=6 a1=894c a2=7ffd977d144c a3=7ffd977d144c items=0 ppid=1 pid=670 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=systemd-rfkill exe=/usr/lib/systemd/systemd-rfkill subj=system_u:system_r:systemd_rfkill_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2360326