### PR TITLE
Label /run/polkit-1 with policykit_var_run_t

### DIFF
--- a/policy/modules/contrib/policykit.fc
+++ b/policy/modules/contrib/policykit.fc
@@ -19,4 +19,4 @@
 /var/lib/polkit-1(/.*)?				gen_context(system_u:object_r:policykit_var_lib_t,s0)
 /var/lib/PolicyKit-public(/.*)?			gen_context(system_u:object_r:policykit_var_lib_t,s0)
 /run/PolicyKit(/.*)?			gen_context(system_u:object_r:policykit_var_run_t,s0)
-
+/run/polkit-1(/.*)?			gen_context(system_u:object_r:policykit_var_run_t,s0)

--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -76,6 +76,7 @@ manage_files_pattern(policykit_t, policykit_var_lib_t, policykit_var_lib_t)
 manage_dirs_pattern(policykit_t, policykit_var_run_t, policykit_var_run_t)
 manage_files_pattern(policykit_t, policykit_var_run_t, policykit_var_run_t)
 files_pid_filetrans(policykit_t, policykit_var_run_t, { file dir })
+watch_dirs_pattern(policykit_t, policykit_var_run_t, policykit_var_run_t)
 
 kernel_read_system_state(policykit_t)
 kernel_read_kernel_sysctls(policykit_t)


### PR DESCRIPTION
Additionally, allow polkitd watch directories with this label.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/17/2025 07:46:36.142:153) : proctitle=/usr/lib/polkit-1/polkitd --no-debug --log-level=notice type=AVC msg=audit(04/17/2025 07:46:36.142:153) : avc:  denied  { watch } for  pid=935 comm=polkitd path=/run/polkit-1/actions dev="tmpfs" ino=1821 scontext=system_u:system_r:policykit_t:s0 tcontext=unconfined_u:object_r:var_run_t:s0 tclass=dir permissive=1 type=SYSCALL msg=audit(04/17/2025 07:46:36.142:153) : arch=x86_64 syscall=inotify_add_watch success=yes exit=1 a0=0x3 a1=0x55ea075eef80 a2=0x1002fce a3=0x4 items=0 ppid=1 pid=935 auid=unset uid=polkitd gid=polkitd euid=polkitd suid=polkitd fsuid=polkitd egid=polkitd sgid=polkitd fsgid=polkitd tty=(none) ses=unset comm=polkitd exe=/usr/lib/polkit-1/polkitd subj=system_u:system_r:policykit_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2360680