### PR TITLE
Allow virtqemud relabel from tmpfs lnk files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2283,6 +2283,7 @@ fs_create_tmpfs_chr_blk_files(virtqemud_t)
 fs_setattr_tmpfs_chr_blk_files(virtqemud_t)
 fs_relabel_tmpfs_blk_file(virtqemud_t)
 fs_relabel_tmpfs_chr_file(virtqemud_t)
+fs_relabelfrom_tmpfs_lnk_files(virtqemud_t)
 fs_unmount_xattr_fs(virtqemud_t)
 
 seutil_read_default_contexts(virtqemud_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1744744407.650:300): avc:  denied  { relabelfrom } for  pid=9366 comm="rpc-virtqemud" name="win10" dev="tmpfs" ino=7 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=lnk_file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2359843