### PR TITLE
Allow gnome-remote-desktop additional sockets permissions

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -30,7 +30,9 @@ files_var_lib_filetrans(gnome_remote_desktop_t, gnome_remote_desktop_var_lib_t, 
 
 #============= gnome_remote_desktop_t ==============
 corenet_tcp_bind_gnome_remote_desktop_port(gnome_remote_desktop_t)
+allow gnome_remote_desktop_t self:netlink_route_socket r_netlink_socket_perms;
 allow gnome_remote_desktop_t self:tcp_socket create_stream_socket_perms;
+allow gnome_remote_desktop_t self:udp_socket create_socket_perms;
 allow gnome_remote_desktop_t self:unix_dgram_socket create_socket_perms;
 
 domain_use_interactive_fds(gnome_remote_desktop_t)


### PR DESCRIPTION
In particular, these permissions were allowed:
- create, use and nlmsg_read netlink_route_socket
- create and use udp socket

The commit addresses the following AVC denial:
type=AVC msg=audit(1744950310.572:1428): avc:  denied  { create } for  pid=301095 comm="gnome-remote-de" scontext=system_u:system_r:gnome_remote_desktop_t:s0 tcontext=system_u:system_r:gnome_remote_desktop_t:s0 tclass=netlink_route_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2360900