### PR TITLE
Allow collectd bind TCP sockets to the collectd port

### DIFF
--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -84,6 +84,7 @@ corenet_udp_bind_collectd_port(collectd_t)
 corenet_udp_bind_statsd_port(collectd_t)
 corenet_tcp_connect_lmtp_port(collectd_t)
 corenet_tcp_bind_bacula_port(collectd_t)
+corenet_tcp_bind_collectd_port(collectd_t)
 
 dev_getattr_infiniband_dev(collectd_t)
 dev_read_rand(collectd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1742909414.112:693): avc:  denied  { name_bind } for  pid=1907 comm="collectd" src=9103 scontext=system_u:system_r:collectd_t:s0 tcontext=system_u:object_r:collectd_port_t:s0 tclass=tcp_socket permissive=0 type=SYSCALL msg=audit(1742909414.112:693): arch=x86_64 syscall=bind success=no exit=EACCES a0=3 a1=55c8f9e52050 a2=10 a3=7fff70cfb694 items=0 ppid=1 pid=1907 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=collectd exe=/usr/sbin/collectd subj=system_u:system_r:collectd_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2354857