### PR TITLE
Allow virtstoraged fsetid capability

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2398,7 +2398,8 @@ optional_policy(`
 #
 # virtstoraged local policy
 #
-allow virtstoraged_t self:capability { dac_override dac_read_search ipc_lock };
+allow virtstoraged_t self:capability { dac_override dac_read_search fsetid ipc_lock };
+
 allow virtstoraged_t self:process { setsched };
 
 files_tmp_filetrans(virtstoraged_t, virtstoraged_tmp_t, { file dir })


### PR DESCRIPTION
This capability is required to set an image owner when virt-manager creates a new image.

The commit addresses the following AVC denial:
type=AVC msg=audit(1744988450.23:416): avc:  denied  { fsetid } for  pid=8412 comm="rpc-virtstorage" capability=4  scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:system_r:virtstoraged_t:s0 tclass=capability permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2360987