### PR TITLE
Allow systemd-machined write to its private tmp files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -248,6 +248,11 @@ systemd_domain_template(systemd_machined)
 type systemd_machined_unit_file_t;
 systemd_unit_file(systemd_machined_unit_file_t)
 
+type systemd_machined_tmp_t;
+files_tmp_file(systemd_machined_tmp_t)
+type systemd_machined_tmpfs_t;
+files_tmpfs_file(systemd_machined_tmpfs_t)
+
 # /run/systemd/machines
 type systemd_machined_var_run_t;
 files_pid_file(systemd_machined_var_run_t)
@@ -516,10 +521,16 @@ optional_policy(`
 # systemd_machined local policy
 #
 
-allow systemd_machined_t self:capability { dac_read_search dac_override setgid sys_admin sys_chroot sys_ptrace kill };
+allow systemd_machined_t self:capability { chown dac_read_search dac_override fowner fsetid setgid sys_admin sys_chroot sys_ptrace kill };
 allow systemd_machined_t systemd_unit_file_t:service { status start stop };
 allow systemd_machined_t self:unix_dgram_socket create_socket_perms;
 allow systemd_machined_t self:cap_userns { kill setgid setuid sys_admin sys_chroot sys_ptrace };
+
+allow systemd_machined_t systemd_machined_tmp_t:file { create setattr write_file_perms };
+files_tmp_filetrans(systemd_machined_t, systemd_machined_tmp_t, file)
+
+allow systemd_machined_t systemd_machined_tmpfs_t:file { create setattr write_file_perms };
+fs_tmpfs_filetrans(systemd_machined_t, systemd_machined_tmpfs_t, file)
 
 manage_dirs_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 manage_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/23/2025 06:33:34.954:1520) : proctitle=(sd-copy) type=PATH msg=audit(04/23/2025 06:33:34.954:1520) : item=0 name=/ inode=1 dev=00:3e mode=dir,sticky,777 ouid=vu-test-0 ogid=vg-test-0 rdev=00:00 obj=system_u:object_r:tmpfs_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/23/2025 06:33:34.954:1520) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=0x11 a1=0xde8fb0 a2=O_WRONLY|O_CREAT|O_EXCL|O_NOCTTY|O_NOFOLLOW|O_CLOEXEC a3=0x1ed items=1 ppid=77335 pid=77336 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(sd-copy) exe=/usr/lib/systemd/systemd-machined subj=system_u:system_r:systemd_machined_t:s0 key=(null) type=AVC msg=audit(04/23/2025 06:33:34.954:1520) : avc:  denied  { create } for  pid=77336 comm=(sd-copy) name=id scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0