### PR TITLE
Allow asterisk read network sysctls

### DIFF
--- a/policy/modules/contrib/asterisk.te
+++ b/policy/modules/contrib/asterisk.te
@@ -81,6 +81,7 @@ files_pid_filetrans(asterisk_t, asterisk_var_run_t, { dir file sock_file fifo_fi
 can_exec(asterisk_t, asterisk_exec_t)
 
 kernel_read_kernel_sysctls(asterisk_t)
+kernel_read_net_sysctls(asterisk_t)
 kernel_read_network_state(asterisk_t)
 kernel_read_system_state(asterisk_t)
 kernel_request_load_module(asterisk_t)


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2322867