### PR TITLE
Allow system-dbusd list systemd-machined directories

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -233,6 +233,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_machined_list_lib(system_dbusd_t)
 	systemd_status_systemd_services(system_dbusd_t)
 	systemd_use_fds_logind(system_dbusd_t)
 	systemd_write_inherited_logind_sessions_pipes(system_dbusd_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2404,8 +2404,6 @@ interface(`systemd_machined_watch_pid_dirs',`
 	allow $1 systemd_machined_var_run_t:dir watch_dir_perms;
 ')
 
-
-
 ########################################
 ## <summary>
 ##      Search systemd-machined lib directories.
@@ -2423,6 +2421,25 @@ interface(`systemd_machined_search_lib',`
 
         allow $1 systemd_machined_var_lib_t:dir search_dir_perms;
         files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	List systemd-machined lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_machined_list_lib',`
+	gen_require(`
+		type systemd_machined_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	list_dirs_pattern($1, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
 ')
 
 ########################################


### PR DESCRIPTION
Required for journalctl to show messages from a running container: journalctl -M tux
Failed to open root directory: Remote peer disconnected

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/08/2025 11:42:27.425:2640) : proctitle=dbus-broker --log 4 --controller 9 --machine-id 2e673951238e45078386ce1351f65115 --max-bytes 536870912 --max-fds 4096 --max-matc type=SYSCALL msg=audit(04/08/2025 11:42:27.425:2640) : arch=x86_64 syscall=recvmsg success=yes exit=60 a0=0x1a a1=0x7ffdb3d081c0 a2=MSG_DONTWAIT|MSG_CMSG_CLOEXEC a3=0x562d8c9b7ce0 items=0 ppid=619 pid=639 auid=unset uid=dbus gid=dbus euid=dbus suid=dbus fsuid=dbus egid=dbus sgid=dbus fsgid=dbus tty=(none) ses=unset comm=dbus-broker exe=/usr/bin/dbus-broker subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(04/08/2025 11:42:27.425:2640) : avc:  denied  { read } for  pid=639 comm=dbus-broker path=/ dev="vda2" ino=42045937 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_machined_var_lib_t:s0 tclass=dir permissive=1

Resolves: RHEL-86528