### PR TITLE
Allow virt_domain write to virt_image_t files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1090,7 +1090,7 @@ manage_dirs_pattern(virt_domain, virt_cache_t, virt_cache_t)
 manage_files_pattern(virt_domain, virt_cache_t, virt_cache_t)
 files_var_filetrans(virt_domain, virt_cache_t, { file dir })
 
-read_files_pattern(virt_domain, virt_image_t, virt_image_t)
+rw_files_pattern(virt_domain, virt_image_t, virt_image_t)
 read_lnk_files_pattern(virt_domain, virt_image_t, virt_image_t)
 
 manage_dirs_pattern(virt_domain, svirt_image_t, svirt_image_t)


### PR DESCRIPTION
Required when a guest is configured with a data file and a backing file.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/07/2025 07:07:27.554:1467) : proctitle=/usr/libexec/qemu-kvm -name guest=test1,debug-threads=on -S -object {"qom-type":"secret","id":"masterKey0","format":"raw","file" type=PATH msg=audit(04/07/2025 07:07:27.554:1467) : item=0 name=/var/lib/libvirt/images/datastore_2 inode=25166382 dev=fd:02 mode=file,644 ouid=qemu ogid=qemu rdev=00:00 obj=unconfined_u:object_r:virt_image_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/07/2025 07:07:27.554:1467) : arch=x86_64 syscall=openat success=yes exit=13 a0=AT_FDCWD a1=0x562d7e1add00 a2=O_RDWR|O_DIRECT|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=8451 auid=unset uid=qemu gid=qemu euid=qemu suid=qemu fsuid=qemu egid=qemu sgid=qemu fsgid=qemu tty=(none) ses=unset comm=qemu-kvm exe=/usr/libexec/qemu-kvm subj=system_u:system_r:svirt_tcg_t:s0:c355,c706 key=(null) type=AVC msg=audit(04/07/2025 07:07:27.554:1467) : avc:  denied  { write } for  pid=8451 comm=qemu-kvm name=datastore_2 dev="vda2" ino=25166382 scontext=system_u:system_r:svirt_tcg_t:s0:c355,c706 tcontext=unconfined_u:object_r:virt_image_t:s0 tclass=file permissive=1

Resolves: RHEL-85319