### PR TITLE
Allow rhsmcertd connect to systemd-machined

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -206,7 +206,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-    systemd_userdbd_stream_connect(rhsmcertd_t)
+	systemd_machined_stream_connect(rhsmcertd_t)
+	systemd_userdbd_stream_connect(rhsmcertd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This permission is required for the "rhc connect" command to finish when the systemd-machined service is running.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/18/2025 05:29:27.898:370) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-service type=PATH msg=audit(03/18/2025 05:29:27.898:370) : item=0 name=/run/systemd/userdb/io.systemd.Machine inode=1899 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(03/18/2025 05:29:27.898:370) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.Machine } type=SYSCALL msg=audit(03/18/2025 05:29:27.898:370) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x11 a1=0x7ffd2634cb40 a2=0x29 a3=0x55acb551e010 items=1 ppid=1 pid=9494 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-service exe=/usr/bin/python3.12 subj=system_u:system_r:rhsmcertd_t:s0 key=(null) type=AVC msg=audit(03/18/2025 05:29:27.898:370) : avc:  denied  { connectto } for  pid=9494 comm=rhsm-service path=/run/systemd/userdb/io.systemd.Machine scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=unix_stream_socket permissive=0

Resolves: RHEL-83925