### PR TITLE
Allow varnishd execute the prlimit64() syscall

### DIFF
--- a/policy/modules/contrib/varnishd.te
+++ b/policy/modules/contrib/varnishd.te
@@ -50,7 +50,8 @@ logging_log_file(varnishlog_log_t)
 # Local policy
 #
 
-allow varnishd_t self:capability { kill dac_read_search dac_override  ipc_lock setuid setgid chown fowner fsetid };
+allow varnishd_t self:capability { kill dac_read_search dac_override  ipc_lock setuid setgid chown fowner fsetid sys_resource };
+allow varnishd_t self:process setrlimit;
 dontaudit varnishd_t self:capability sys_tty_config;
 allow varnishd_t self:process { execmem signal };
 allow varnishd_t self:fifo_file rw_fifo_file_perms;
@@ -132,6 +133,7 @@ optional_policy(`
 #
 
 allow varnishlog_t self:process { execmem };
+allow varnishlog_t varnishd_t:process signull;
 
 manage_files_pattern(varnishlog_t, varnishlog_var_run_t, varnishlog_var_run_t)
 files_pid_filetrans(varnishlog_t, varnishlog_var_run_t, file)


### PR DESCRIPTION
The setrlimit process permission and sys_resource capability are required since v7.6.1 which added an attempt to raise RLIMIT_MEMLOCK to infinity on startup [1].
Additionally, the varnishncsa service was allowed in this commit to send signull to varnish.

[1] https://github.com/varnishcache/varnish-cache/issues/4193

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(02/04/2025 05:12:10.309:622) : proctitle=/usr/sbin/varnishd -a :6081 -a localhost:8443,PROXY -f /etc/varnish/default.vcl -P /run/varnish/varnishd.pid -p feature=+http2 -
type=SYSCALL msg=audit(02/04/2025 05:12:10.309:622) : arch=aarch64 syscall=prlimit64 success=yes exit=0 a0=0x0 a1=0x8 a2=0xffffd2243c40 a3=0x0 items=0 ppid=13428 pid=13430 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=varnishd exe=/usr/sbin/varnishd subj=system_u:system_r:varnishd_t:s0 key=(null)
type=AVC msg=audit(02/04/2025 05:12:10.309:622) : avc:  denied  { setrlimit } for  pid=13430 comm=varnishd scontext=system_u:system_r:varnishd_t:s0 tcontext=system_u:system_r:varnishd_t:s0 tclass=process permissive=1
type=AVC msg=audit(02/04/2025 05:12:10.309:622) : avc:  denied  { sys_resource } for  pid=13430 comm=varnishd capability=sys_resource  scontext=system_u:system_r:varnishd_t:s0 tcontext=system_u:system_r:varnishd_t:s0 tclass=capability permissive=1

Resolves: RHEL-77779