### PR TITLE
Allow NetworkManager create icmp_socket

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -99,6 +99,7 @@ tunable_policy(`deny_ptrace',`',`
 ')
 
 allow NetworkManager_t self:fifo_file rw_fifo_file_perms;
+allow NetworkManager_t self:icmp_socket create_socket_perms;
 allow NetworkManager_t self:unix_dgram_socket { sendto create_socket_perms };
 allow NetworkManager_t self:unix_stream_socket{ create_stream_socket_perms connectto };
 allow NetworkManager_t self:netlink_generic_socket create_socket_perms;


### PR DESCRIPTION
Recently added feature to NetworkManager which allows to ping an address before it's set causes the following AVCs denial:
type=PROCTITLE msg=audit(04/07/2025 09:47:11.525:1735) : proctitle=/usr/bin/ping -I eth0 -c 1 -w 15 8.8.8.8 type=SYSCALL msg=audit(04/07/2025 09:47:11.525:1735) : arch=x86_64 syscall=socket success=no exit=EACCES(Permission denied) a0=inet a1=SOCK_DGRAM a2=icmp a3=0x55a2dc2dc010 items=0 ppid=759 pid=10039 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ping exe=/usr/bin/ping subj=system_u:system_r:NetworkManager_t:s0 key=(null) type=AVC msg=audit(04/07/2025 09:47:11.525:1735) : avc:  denied  { create } for  pid=10039 comm=ping scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=icmp_socket permissive=0

Resolves: RHEL-86258