### PR TITLE
Allow tlshd read network sysctls

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -17,6 +17,7 @@ allow ktlshd_t self:netlink_route_socket r_netlink_socket_perms;
 allow ktlshd_t self:udp_socket create_socket_perms;
 allow ktlshd_t self:unix_dgram_socket create_socket_perms;
 
+kernel_read_net_sysctls(ktlshd_t)
 kernel_read_proc_files(ktlshd_t)
 
 domain_read_view_all_domains_keyrings(ktlshd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/28/2025 05:37:51.621:449) : proctitle=/usr/sbin/tlshd type=PATH msg=audit(04/28/2025 05:37:51.621:449) : item=0 name=/proc/sys/net/ipv6/conf/all/disable_ipv6 inode=16043 dev=00:16 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_net_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/28/2025 05:37:51.621:449) : arch=x86_64 syscall=openat success=yes exit=7 a0=AT_FDCWD a1=0x7ffe6f9fbc40 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=5382 pid=5397 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tlshd exe=/usr/sbin/tlshd subj=system_u:system_r:ktlshd_t:s0 key=(null) type=AVC msg=audit(04/28/2025 05:37:51.621:449) : avc:  denied  { open } for  pid=5397 comm=tlshd path=/proc/sys/net/ipv6/conf/all/disable_ipv6 dev="proc" ino=16043 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1 type=AVC msg=audit(04/28/2025 05:37:51.621:449) : avc:  denied  { read } for  pid=5397 comm=tlshd name=disable_ipv6 dev="proc" ino=16043 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1 type=AVC msg=audit(04/28/2025 05:37:51.621:449) : avc:  denied  { search } for  pid=5397 comm=tlshd name=net dev="proc" ino=2205 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=1

Resolves: RHEL-74424