### PR TITLE
Allow init_t nnp domain transition to redis_t

### DIFF
--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -15,6 +15,7 @@ gen_tunable(redis_enable_notify, false)
 type redis_t;
 type redis_exec_t;
 init_daemon_domain(redis_t, redis_exec_t)
+init_nnp_daemon_domain(redis_t)
 
 type redis_initrc_exec_t;
 init_script_file(redis_initrc_exec_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1745824193.880:2207): avc:  denied  { nnp_transition } for  pid=10529 comm="(s-server)" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:redis_t:s0 tclass=process2 permissive=0

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2663