### PR TITLE
Allow collectd accept and listen to tcp sockets

### DIFF
--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -49,12 +49,12 @@ allow collectd_t self:process { getsched setsched signal };
 allow collectd_t self:fifo_file rw_fifo_file_perms;
 allow collectd_t self:packet_socket { create_socket_perms map };
 allow collectd_t self:rawip_socket create_socket_perms;
+allow collectd_t self:tcp_socket { accept listen };
 allow collectd_t self:unix_stream_socket { accept listen connectto };
 allow collectd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 allow collectd_t self:netlink_generic_socket create_socket_perms;
 allow collectd_t self:netlink_rdma_socket create_socket_perms;
 allow collectd_t self:udp_socket create_socket_perms;
-allow collectd_t self:rawip_socket create_socket_perms;
 
 manage_dirs_pattern(collectd_t, collectd_log_t, collectd_log_t)
 manage_files_pattern(collectd_t, collectd_log_t, collectd_log_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/23/2025 11:42:46.726:3006) : proctitle=/usr/lib/systemd/systemd-executor --deserialize 54 --log-level info --log-target journal-or-kmsg type=AVC msg=audit(04/23/2025 11:42:46.726:3006) : avc:  denied  { listen } for  pid=2003 comm=collectd lport=9103 scontext=system_u:system_r:collectd_t:s0 tcontext=system_u:system_r:collectd_t:s0 tclass=tcp_socket permissive=0 type=SYSCALL msg=audit(04/23/2025 11:42:46.726:3006) : arch=x86_64 syscall=listen success=no exit=EACCES(Permission denied) a0=0x3 a1=0x10 a2=0x10 a3=0x7ffd6ae82d54 items=0 ppid=1 pid=2003 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=collectd exe=/usr/bin/collectd subj=system_u:system_r:collectd_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2354857