### PR TITLE
Fix files_dontaudit_delete_all_files()

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -10485,7 +10485,7 @@ interface(`files_dontaudit_delete_all_files',`
 		attribute file_type;
 	')
 
-	dontaudit $1 file_type:dir unlink;
+	dontaudit $1 file_type:dir { remove_name rmdir write };
 	dontaudit $1 file_type:file unlink;
 	dontaudit $1 file_type:lnk_file unlink;
 	dontaudit $1 file_type:fifo_file unlink;


### PR DESCRIPTION
Fix the files_dontaudit_delete_all_files() interface to specify the rmdir permission for the dir class instead of unlink.

Resolves: RHEL-86789