### PR TITLE
Allow sysadm_sudo_t signal rpm script

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -614,6 +614,10 @@ optional_policy(`
 	optional_policy(`
 		crontab_admin_domtrans(sysadm_sudo_t)
 	')
+
+	optional_policy(`
+		rpm_script_signal(sysadm_sudo_t)
+	')
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/30/2025 20:18:40.794:7542) : proctitle=sudo dnf update -y type=OBJ_PID msg=audit(04/30/2025 20:18:40.794:7542) : opid=270590 oauid=sysadm11984 ouid=root oses=124 obj=sysadm_u:sysadm_r:rpm_script_t:s0-s0:c0.c1023 ocomm=update-mime-dat type=OBJ_PID msg=audit(04/30/2025 20:18:40.794:7542) : opid=270346 oauid=sysadm11984 ouid=root oses=124 obj=sysadm_u:sysadm_r:rpm_t:s0-s0:c0.c1023 ocomm=dnf type=OBJ_PID msg=audit(04/30/2025 20:18:40.794:7542) : opid=270589 oauid=sysadm11984 ouid=root oses=124 obj=sysadm_u:sysadm_r:rpm_script_t:s0-s0:c0.c1023 ocomm=sh type=SYSCALL msg=audit(04/30/2025 20:18:40.794:7542) : arch=x86_64 syscall=kill success=yes exit=0 a0=0xfffbdff6 a1=SIGHUP a2=0x0 a3=0x4b items=0 ppid=270317 pid=270345 auid=sysadm11984 uid=sysadm11984 gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=124 comm=sudo exe=/usr/bin/sudo subj=sysadm_u:sysadm_r:sysadm_sudo_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(04/30/2025 20:18:40.794:7542) : avc:  denied  { signal } for  pid=270345 comm=sudo scontext=sysadm_u:sysadm_r:sysadm_sudo_t:s0-s0:c0.c1023 tcontext=sysadm_u:sysadm_r:rpm_script_t:s0-s0:c0.c1023 tclass=process permissive=0 type=AVC msg=audit(04/30/2025 20:18:40.794:7542) : avc:  denied  { signal } for  pid=270345 comm=sudo scontext=sysadm_u:sysadm_r:sysadm_sudo_t:s0-s0:c0.c1023 tcontext=sysadm_u:sysadm_r:rpm_script_t:s0-s0:c0.c1023 tclass=process permissive=0