### PR TITLE
Define file equivalency for /var/etc

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -28,6 +28,7 @@
 /var/roothome        /root
 /sbin                /usr/bin
 /sysroot/tmp         /tmp
+/var/etc             /etc
 /var/usrlocal        /usr/local
 /var/mnt             /mnt
 /bin                 /usr/bin


### PR DESCRIPTION
Define file equivalency /var/etc = /etc so that /var/etc can be used as a persistent store on systems where /etc/ is ephemeral, like ostree-based systems.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2358623