### PR TITLE
Allow lldpd connect to systemd-homed over a unix socket

### DIFF
--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -102,6 +102,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_homed_stream_connect(lldpad_t)
+')
+
+optional_policy(`
     unconfined_dgram_send(lldpad_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/02/2025 08:11:37.370:2186) : proctitle=/usr/sbin/lldpd -x type=PATH msg=audit(05/02/2025 08:11:37.370:2186) : item=0 name=/run/systemd/userdb/io.systemd.Home inode=1377 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(05/02/2025 08:11:37.370:2186) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.Home } type=SYSCALL msg=audit(05/02/2025 08:11:37.370:2186) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x8 a1=0x7ffe3c575c20 a2=0x26 a3=0x55f5b7267c70 items=1 ppid=1 pid=30767 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=lldpd exe=/usr/sbin/lldpd subj=system_u:system_r:lldpad_t:s0 key=(null) type=AVC msg=audit(05/02/2025 08:11:37.370:2186) : avc:  denied  { connectto } for  pid=30767 comm=lldpd path=/run/systemd/userdb/io.systemd.Home scontext=system_u:system_r:lldpad_t:s0 tcontext=system_u:system_r:systemd_homed_t:s0 tclass=unix_stream_socket permissive=0