### PR TITLE
Fix missing permissions for combination of `ftpd_anon_write` and `ftpd_use_cifs`/`ftpd_use_nfs`

### DIFF
--- a/policy/modules/contrib/ftp.te
+++ b/policy/modules/contrib/ftp.te
@@ -267,6 +267,7 @@ tunable_policy(`ftpd_use_nfs',`
 
 tunable_policy(`ftpd_use_nfs && ftpd_anon_write',`
 	fs_manage_nfs_files(ftpd_t)
+	fs_manage_nfs_dirs(ftpd_t)
 ')
 
 tunable_policy(`ftpd_full_access',`

--- a/policy/modules/contrib/ftp.te
+++ b/policy/modules/contrib/ftp.te
@@ -249,6 +249,7 @@ tunable_policy(`ftpd_use_cifs',`
 
 tunable_policy(`ftpd_use_cifs && ftpd_anon_write',`
 	fs_manage_cifs_files(ftpd_t)
+	fs_manage_cifs_dirs(ftpd_t)
 ')
 
 tunable_policy(`ftpd_use_fusefs',`


### PR DESCRIPTION
Closes #2674 