### PR TITLE
Allow geoclue search virt lib directory

### DIFF
--- a/policy/modules/contrib/geoclue.te
+++ b/policy/modules/contrib/geoclue.te
@@ -88,3 +88,7 @@ optional_policy(`
 optional_policy(`
 	pcscd_stream_connect(geoclue_t)
 ')
+
+optional_policy(`
+	virt_read_lib_files(geoclue_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1727584699.664:1239): avc:  denied  { search } for pid=2073 comm="pool-geoclue" name="libvirt" dev="nvme1n1p2" ino=478 scontext=system_u:system_r:geoclue_t:s0 tcontext=system_u:object_r:virt_var_lib_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2315512