### PR TITLE
Allow tuned-ppd create ppd_base_profile with a file transition

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -173,8 +173,10 @@ permissive tuned_ppd_t;
 
 allow tuned_ppd_t tuned_exec_t:file getattr;
 
+allow tuned_ppd_t tuned_rw_etc_t:file create;
 read_files_pattern(tuned_ppd_t, tuned_etc_t, tuned_etc_t)
 rw_files_pattern(tuned_ppd_t, tuned_etc_t, tuned_rw_etc_t)
+filetrans_pattern(tuned_ppd_t, tuned_etc_t, tuned_rw_etc_t, file, "ppd_base_profile")
 
 create_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
 write_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)


### PR DESCRIPTION
The ppd_base_profile file needs to be created with the tuned_rw_etc_t type.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2359851