### PR TITLE
contrib: add module for TDX "qgs" daemon

### DIFF
--- a/dist/mls/modules.conf
+++ b/dist/mls/modules.conf
@@ -1384,6 +1384,13 @@ ptchown = module
 # 
 pulseaudio = module
 
+# Layer: service
+# Module: qgs
+#
+# TDX QGS Daemon
+#
+qgs = module
+
 # Layer: services
 # Module: qmail
 #

--- a/dist/targeted/modules.conf
+++ b/dist/targeted/modules.conf
@@ -1803,6 +1803,13 @@ puppet = module
 # 
 pwauth = module
 
+# Layer: service
+# Module: qgs
+#
+# TDX QGS Daemon
+#
+qgs = module
+
 # Layer: services
 # Module: qmail
 #

--- a/policy/modules/contrib/qgs.fc
+++ b/policy/modules/contrib/qgs.fc
@@ -1,0 +1,6 @@
+/etc/qgs\.conf     -- gen_context(system_u:object_r:qgs_etc_t,s0)
+
+/usr/bin/qgs       -- gen_context(system_u:object_r:qgs_exec_t,s0)
+
+/var/lib/qgs(/.*)?    gen_context(system_u:object_r:qgs_var_lib_t,s0)
+/run/tdx-qgs(/.*)?    gen_context(system_u:object_r:qgs_var_run_t,s0)

--- a/policy/modules/contrib/qgs.if
+++ b/policy/modules/contrib/qgs.if
@@ -1,0 +1,97 @@
+## <summary>policy for qgs</summary>
+
+########################################
+## <summary>
+##      Execute qgs_exec_t in the qgs domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##      Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`qgs_domtrans',`
+	gen_require(`
+                type qgs_t, qgs_exec_t;
+	')
+
+	corecmd_search_bin($1)
+        domtrans_pattern($1, qgs_exec_t, qgs_t)
+')
+
+######################################
+## <summary>
+##      Execute qgs in the caller domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`qgs_exec',`
+	gen_require(`
+		type qgs_exec_t;
+	')
+
+        corecmd_search_bin($1)
+	can_exec($1, qgs_exec_t)
+')
+
+########################################
+## <summary>
+##      All of the rules required to administrate
+##      an qgs environment
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <param name="role">
+##      <summary>
+##      Role allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`qgs_admin',`
+        gen_require(`
+                type qgs_t;
+                type qgs_var_lib_t;
+                type qgs_var_run_t;
+        ')
+
+        allow $1 qgs_t:process { signal_perms };
+        ps_process_pattern($1, qgs_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 qgs_t:process ptrace;
+    ')
+
+        files_search_var_lib($1)
+        admin_pattern($1, qgs_var_lib_t)
+        admin_pattern($1, qgs_var_run_t)
+        optional_policy(`
+                systemd_passwd_agent_exec($1)
+                systemd_read_fifo_file_passwd_run($1)
+        ')
+')
+
+## <summary>
+##      Connect to qgs over an unix
+##      domain stream socket.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`qgs_stream_connect',`
+	gen_require(`
+                type qgs_t, qgs_var_run_t;
+        ')
+
+	stream_connect_pattern($1, qgs_var_run_t, qgs_var_run_t, qgs_t)
+')

--- a/policy/modules/contrib/qgs.te
+++ b/policy/modules/contrib/qgs.te
@@ -1,0 +1,71 @@
+policy_module(qgs, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type qgs_t;
+type qgs_exec_t;
+init_daemon_domain(qgs_t, qgs_exec_t)
+
+permissive qgs_t;
+
+type qgs_var_lib_t;
+files_type(qgs_var_lib_t);
+
+type qgs_var_run_t;
+files_pid_file(qgs_var_run_t);
+
+# Config file exclusively for SGX
+type qgs_etc_t;
+
+########################################
+#
+# qgs local policy
+#
+allow qgs_t self:fifo_file rw_fifo_file_perms;
+allow qgs_t self:unix_stream_socket create_stream_socket_perms;
+
+# /var/lib/qgs is the $HOME for 'qgs' and it caches some
+# data under subdirs
+manage_dirs_pattern(qgs_t, qgs_var_lib_t, qgs_var_lib_t)
+manage_files_pattern(qgs_t, qgs_var_lib_t, qgs_var_lib_t)
+manage_lnk_files_pattern(qgs_t, qgs_var_lib_t, qgs_var_lib_t)
+
+# /run/tdx/qgs is where 'qgs' creates UNIX socket
+manage_dirs_pattern(qgs_t, qgs_var_run_t, qgs_var_run_t)
+manage_files_pattern(qgs_t, qgs_var_run_t, qgs_var_run_t)
+manage_sock_files_pattern(qgs_t, qgs_var_run_t, qgs_var_run_t)
+files_pid_filetrans(qgs_t, qgs_var_run_t, { dir })
+
+domain_use_interactive_fds(qgs_t)
+
+# To read /etc/qgs.conf for its configuration
+files_config_file(qgs_etc_t)
+read_files_pattern(qgs_t, qgs_etc_t, qgs_etc_t)
+
+corenet_tcp_connect_http_port(qgs_t)
+
+# It loads enclaves with ...
+dev_rw_sgx_provision(qgs_t)
+
+# ...and executes enclaves to create quotes
+dev_rwx_sgx_enclave(qgs_t)
+
+optional_policy(`
+  logging_send_syslog_msg(qgs_t)
+')
+
+optional_policy(`
+  miscfiles_read_localization(qgs_t)
+')
+
+# It connects to intel.com to acquire certificates
+optional_policy(`
+  miscfiles_read_generic_certs(qgs_t)
+')
+
+optional_policy(`
+  sysnet_dns_name_resolve(qgs_t)
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1355,6 +1355,10 @@ optional_policy(`
 	xserver_rw_shm(virt_domain)
 ')
 
+optional_policy(`
+        qgs_stream_connect(svirt_t)
+')
+
 ########################################
 #
 # xm local policy

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -6863,6 +6863,43 @@ interface(`dev_rw_sgx_vepc',`
 
 ########################################
 ## <summary>
+##      Allow read and write the sgx_enclave devices
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`dev_rwx_sgx_enclave',`
+        gen_require(`
+                type device_t, sgx_enclave_device_t;
+        ')
+
+        rw_chr_files_pattern($1, device_t, sgx_enclave_device_t)
+        allow $1 sgx_enclave_device_t:chr_file { map execute };
+')
+
+########################################
+## <summary>
+##      Allow read and write the sgx_provision devices
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`dev_rw_sgx_provision',`
+        gen_require(`
+                type device_t, sgx_provision_device_t;
+        ')
+
+        rw_chr_files_pattern($1, device_t, sgx_provision_device_t)
+')
+
+########################################
+## <summary>
 ##	Allow read the hfi1_[0-9]+ devices
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The `qgs` daemon provides an API for creating signed quotes of TDX confidential virtual machine, and is used by QEMU. `qgs` uses the SGX software / technology for its implementation, loading and creating several SGX enclaves to create a signed attestation report of a VM. It also talks to public intel.com servers to fetch and then cache x509 certificates.

This is my "best guess" at a policy for the `qgs` daemon.

```
# ps -axuwfZ | grep bin/qgs
system_u:system_r:qgs_t:s0      qgs         2249  0.3  0.0 201376 15076 ?        Ssl  09:31   0:00 /usr/bin/qgs --no-daemon

# ls -alZ /etc/qgs.conf /etc/sgx_default_qcnl.conf 
-rw-r--r--. 1 root root system_u:object_r:qgs_etc_t:s0        49 Feb 17 19:00 /etc/qgs.conf
-rw-r--r--. 1 root root system_u:object_r:sgx_qcnl_etc_t:s0 4911 Feb 17 19:00 /etc/sgx_default_qcnl.conf

# ls -alZ /var/lib/qgs/
total 0
drwx------. 1 qgs  qgs  system_u:object_r:qgs_var_lib_t:s0  20 May  7 09:31 .
drwxr-xr-x. 1 root root system_u:object_r:var_lib_t:s0     956 May  2 04:28 ..
drwxr-xr-x. 1 qgs  qgs  system_u:object_r:qgs_var_lib_t:s0 128 May  7 09:31 .dcap-qcnl

# ls -alZ /var/lib/qgs/.dcap-qcnl/8bcc0451ba880002e901ccf4e5c90341e010cead7744c29fd82c005befd1b52a 
-rw-r--r--. 1 qgs qgs system_u:object_r:qgs_var_lib_t:s0 4121 May  7 09:31 /var/lib/qgs/.dcap-qcnl/8bcc0451ba880002e901ccf4e5c90341e010cead7744c29fd82c005befd1b52a

# ls -alZ /run/tdx-qgs/
total 0
drwxr-xr-x.  2 qgs  qgs  system_u:object_r:var_run_t:s0       60 May  7 09:31 .
drwxr-xr-x. 54 root root system_u:object_r:var_run_t:s0     1460 May  7 09:30 ..
srwxrwxrwx.  1 qgs  qgs  system_u:object_r:qgs_var_run_t:s0    0 May  7 09:31 qgs.socket
```

The last example above is the bit that looks not quite right to me.

I was trying to get the `/run/tdx-qgs` directory to have the `qgs_var_run_t` type label, but I can't figure out how to make that happen. The `/run` dir is tmpfs and the subdir gets created on the fly, but I'm unclear what's missing to get it to automatically gain the `qgs_var_run_t` label when auto-created by `qgs_t`.

Also the type and access rule for the `/etc/sgx_default_qcnl.conf` file is bundled with the 'qgs' policy module. Technically this is not specific to the `qgs` default and is generic for any use of `sgx`. I didn't feel it was worth having a separate 'sgx' policy module just for that, so I bundled it with my 'qgs' policy.

Maybe though, I should have just called this whole thing the `sgx` module instead of `qgs` ?  If doing that though, it would suggest using an `sgx_`  prefix on all types, eg `sgx_qgs_t` instead of just `qgs_t`.

If there is any preference from SELinux maintainers I'll adjust naming.

I'm testing this on Fedora 42 but my target is inclusion in Fedora 43 to support https://fedoraproject.org/w/index.php?title=Changes/ConfidentialVirtHostIntelTDX
