### PR TITLE
Label /dev/diag as power_device_t

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -24,6 +24,7 @@
 /dev/crash		-c	gen_context(system_u:object_r:crash_device_t,mls_systemhigh)
 /dev/crypto/nx-gzip	-c	gen_context(system_u:object_r:accelerator_device_t,mls_systemhigh)
 /dev/dahdi/.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
+/dev/diag		-c	gen_context(system_u:object_r:diagnostic_device_t,s0)
 /dev/dlm.*		-c	gen_context(system_u:object_r:dlm_control_device_t,s0)
 /dev/dma_heap/.+	-c	gen_context(system_u:object_r:dma_device_t,s0)
 /dev/dmfm.*		-c	gen_context(system_u:object_r:sound_device_t,s0)

--- a/policy/modules/kernel/devices.te
+++ b/policy/modules/kernel/devices.te
@@ -105,6 +105,12 @@ type accelerator_device_t;
 dev_node(accelerator_device_t)
 
 #
+# Type for the /dev/diag device
+#
+type diagnostic_device_t;
+dev_node(diagnostic_device_t)
+
+#
 # dlm_misc_device_t is the type of /dev/misc/dlm.*
 #
 type dlm_control_device_t;


### PR DESCRIPTION
According to [1] it is used to get "power readings", so presumably power_device_t fits well for it. It is an s390(x)-specific device.

[1] https://github.com/ibm-s390-linux/s390-tools/blob/6dd671f24e56275380ab25eb73b217fbb49fd07e/zpwr/zpwr.c