### PR TITLE
Allow systemd-user-runtime-dir connect to systemd-userdbd over a unix…

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1955,6 +1955,7 @@ allow systemd_user_runtimedir_t self:unix_dgram_socket create_socket_perms;
 systemd_dbus_chat_logind(systemd_user_runtimedir_t)
 
 kernel_dgram_send(systemd_user_runtimedir_t)
+kernel_stream_connect(systemd_user_runtimedir_t)
 
 domain_obj_id_change_exemption(systemd_user_runtimedir_t)
 


### PR DESCRIPTION
… socket

It is actually connecting to kernel_t as the systemd-userdbd socket is still labeled kernel_t.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2365799