### PR TITLE
Allow nut-upsmon write systemd inhibit pipes

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -119,6 +119,7 @@ optional_policy(`
 optional_policy(`
 	systemd_read_logind_sessions_files(nut_upsmon_t)
 	systemd_start_power_services(nut_upsmon_t)
+	systemd_write_inhibit_pipes(nut_upsmon_t)
 ')
 
 ########################################


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1747088012.000:22345): avc:  denied  { write } for  pid=1452 comm="upsmon" path="/run/systemd/inhibit/6237.ref" dev="tmpfs" ino=46602 scontext=system_u:system_r:nut_upsmon_t:s0 tcontext=system_u:object_r:systemd_logind_inhibit_var_run_t:s0 tclass=fifo_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2365764