### PR TITLE
Allow systemd-homed to start services.

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -720,6 +720,7 @@ optional_policy(`
 
 optional_policy(`
 	systemd_logind_stream_connect(login_pgm)
+	systemd_start_systemd_services(login_pgm)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Follow up to recent homed PR [0], adding a solution for the mentioned, but missing, AVC in that PR. 

We had a parallel bug [1], but I did not progress to much until I found the PR. But I now could get feedback from the reporter which issues he still sees. Maybe this is the proper solution.

Please let me know if it needs changes.

[0] https://github.com/fedora-selinux/selinux-policy/issues/2637
[1] https://bugzilla.suse.com/show_bug.cgi?id=1240411#c21