### PR TITLE
Allow named_t to read NetworkManager's runtime files

### DIFF
--- a/policy/modules/contrib/bind.te
+++ b/policy/modules/contrib/bind.te
@@ -238,6 +238,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	networkmanager_read_pid_files(named_t)
 	networkmanager_rw_udp_sockets(named_t)
 	networkmanager_rw_packet_sockets(named_t)
 	networkmanager_rw_routing_sockets(named_t)


### PR DESCRIPTION
It may need to read the no-stub-resolv.conf file (probably via the /etc/resolv.conf symlink).

Original AVC:
type=AVC msg=audit(1745926926.638:13790): avc:  denied  { read } for  pid=95889 comm="unbound-anchor" name="no-stub-resolv.conf" dev="tmpfs" ino=14695 scontext=system_u:system_r:named_t:s0 tcontext=system_u:object_r:NetworkManager_var_run_t:s0 tclass=file permissive=0

Resolves: rhbz#2362879