### PR TITLE
Allow svirt_t to read certificates in user home directories

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1251,6 +1251,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	userdom_read_home_certs_tunable(virt_use_pcscd, virt_domain)
 	tunable_policy(`virt_use_pcscd',`
 		pcscd_stream_connect(virt_domain)
 	')

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -6018,6 +6018,30 @@ interface(`userdom_delete_all_user_tmp_content',`
 
 ########################################
 ## <summary>
+##	Common permissions for reading SSL certificates in the user
+##	homedir. (INTERNAL)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_read_home_certs_common',`
+	gen_require(`
+		type home_cert_t;
+	')
+
+	userdom_search_user_home_content($1)
+
+	list_dirs_pattern($1, home_cert_t, home_cert_t)
+	read_files_pattern($1, home_cert_t, home_cert_t)
+	read_lnk_files_pattern($1, home_cert_t, home_cert_t)
+	allow $1 home_cert_t:file map;
+')
+
+########################################
+## <summary>
 ##	Read system SSL certificates in the users homedir.
 ## </summary>
 ## <param name="domain">
@@ -6027,11 +6051,39 @@ interface(`userdom_delete_all_user_tmp_content',`
 ## </param>
 #
 interface(`userdom_read_home_certs',`
-	gen_require(`
-        attribute userdom_home_reader_certs_type;
+	userdom_read_home_certs_common($1)
+
+	tunable_policy(`use_ecryptfs_home_dirs',`
+		fs_read_ecryptfs_files($1)
+		fs_read_ecryptfs_symlinks($1)
+	')
+')
+
+########################################
+## <summary>
+##	Read system SSL certificates in the users homedir (for use 
+##	with a boolean).
+## </summary>
+## <param name="boolean">
+##	<summary>
+##	Boolean that will allow the access.
+##	</summary>
+## </param>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+template(`userdom_read_home_certs_tunable',`
+	tunable_policy($1, `
+		userdom_read_home_certs_common($2)
 	')
 
-    typeattribute $1 userdom_home_reader_certs_type;
+	tunable_policy(`$1 && use_ecryptfs_home_dirs',`
+		fs_read_ecryptfs_files($2)
+		fs_read_ecryptfs_symlinks($2)
+	')
 ')
 
 ########################################

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -53,7 +53,6 @@ attribute unpriv_userdomain;
 
 attribute user_home_content_type;
 
-attribute userdom_home_reader_certs_type;
 attribute userdom_home_reader_type;
 attribute userdom_home_manager_type;
 attribute userdom_filetrans_type;
@@ -214,18 +213,6 @@ optional_policy(`
 
 optional_policy(`
 	systemd_userdbd_stream_connect(userdomain)
-')
-
-# rules for types which can read home certs
-allow userdom_home_reader_certs_type home_cert_t:dir list_dir_perms;
-read_files_pattern(userdom_home_reader_certs_type, home_cert_t, home_cert_t)
-read_lnk_files_pattern(userdom_home_reader_certs_type, home_cert_t, home_cert_t)
-userdom_search_user_home_content(userdom_home_reader_certs_type)
-allow userdom_home_reader_certs_type home_cert_t:file map;
-
-tunable_policy(`use_ecryptfs_home_dirs',`
-    fs_read_ecryptfs_files(userdom_home_reader_certs_type)
-    fs_read_ecryptfs_symlinks(userdom_home_reader_certs_type)
 ')
 
 tunable_policy(`use_nfs_home_dirs',`


### PR DESCRIPTION
This appears to be needed for user session VMs with PKCS Smartcard device added.

It would probably better under an opt-in boolean, but the userdom_read_home_certs() interface assigns the type to an attribute, which can't be controlled by a boolean.

Original AVC:
type=AVC msg=audit(1743337047.390:2649): avc:  denied  { read } for  pid=17278 comm="qemu-system-x86" name="pkcs11.txt" dev="dm-0" ino=1557247 scontext=unconfined_u:unconfined_r:svirt_t:s0:c45,c54 tcontext=unconfined_u:object_r:home_cert_t:s0 tclass=file permissive=0

Resolves: rhbz#2356061