### PR TITLE
Label plasma user service files as xdm_unit_file_t.

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -91,6 +91,7 @@ HOME_DIR/\.dmrc.*	--	gen_context(system_u:object_r:xdm_home_t,s0)
 #
 
 /usr/lib/systemd/user/.*gnome.*\.(service|target)		--	gen_context(system_u:object_r:xdm_unit_file_t,s0)
+/usr/lib/systemd/user/plasma-.*\.(service|target)		--	gen_context(system_u:object_r:xdm_unit_file_t,s0)
 
 /usr/bin/mdm-binary	--	gen_context(system_u:object_r:xdm_exec_t,s0)
 /usr/bin/gdm(3)?	--	gen_context(system_u:object_r:xdm_exec_t,s0)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -720,7 +720,6 @@ optional_policy(`
 
 optional_policy(`
 	systemd_logind_stream_connect(login_pgm)
-	systemd_start_systemd_services(login_pgm)
 ')
 
 optional_policy(`


### PR DESCRIPTION
I am 90% sure that the PR [0] from yesterday is actually wrong and far to broad as a result. Because of the homed context I was to focused on the homed related problem solution, but I now think the reported AVC is just a simple plasma labeling problem. 

The sesearch command did keep nagging me that something was wrong with my PR:

> $ sesearch -A -s xdm_t -t systemd_unit_file_type  -c service -p start
> [..]
> allow xdm_t xdm_unit_file_t:service { start status };


Trying to confirm that the proposed change also fixes the issue. Sorry for the wrong PR from yesterday and only catching it now. Will drop the draft state once I got confirmation.

[0] https://github.com/fedora-selinux/selinux-policy/pull/2690