### PR TITLE
Allow syslogd watch syslog_conf_t directories

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -3,6 +3,7 @@
 /etc/rsyslog.conf		gen_context(system_u:object_r:syslog_conf_t,s0)
 /etc/syslog.conf		gen_context(system_u:object_r:syslog_conf_t,s0)
 /etc/rsyslog.d(/.*)?		gen_context(system_u:object_r:syslog_conf_t,s0)
+/etc/syslog-ng(/.*)?		gen_context(system_u:object_r:syslog_conf_t,s0)
 /etc/audit(/.*)?		gen_context(system_u:object_r:auditd_etc_t,mls_systemhigh)
 /etc/rc\.d/init\.d/auditd --	gen_context(system_u:object_r:auditd_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/rsyslog --	gen_context(system_u:object_r:syslogd_initrc_exec_t,s0)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -514,7 +514,7 @@ allow syslogd_t self:netlink_generic_socket create_socket_perms;
 allow syslogd_t self:vsock_socket create_socket_perms;
 
 allow syslogd_t syslog_conf_t:file read_file_perms;
-allow syslogd_t syslog_conf_t:dir list_dir_perms;
+allow syslogd_t syslog_conf_t:dir { list_dir_perms watch_dir_perms };
 # receive messages including a memfd
 allow syslogd_t user_tmp_t:file map;
 


### PR DESCRIPTION
Additionally, /etc/syslog-ng is now labeled with syslog_conf_t.

Resolves: RHEL-87648