### PR TITLE
Allow networkmanager send a general signal to iptables

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -395,6 +395,7 @@ optional_policy(`
 
 optional_policy(`
 	iptables_domtrans(NetworkManager_t)
+	iptables_signal(NetworkManager_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/iptables.if
+++ b/policy/modules/system/iptables.if
@@ -221,3 +221,21 @@ interface(`iptables_read_var_run',`
 	allow $1 iptables_var_run_t:dir list_dir_perms;
 	read_files_pattern($1, iptables_var_run_t, iptables_var_run_t)
 ')
+
+#####################################
+## <summary>
+##	Send iptables a general signal.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`iptables_signal',`
+	gen_require(`
+		type iptables_t;
+	')
+
+	allow $1 iptables_t:process signal;
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/09/2025 22:30:34.108:1798) : proctitle=/usr/sbin/NetworkManager --no-daemon type=SYSCALL msg=audit(04/09/2025 22:30:34.108:1798) : arch=x86_64 syscall=kill success=no exit=EACCES(Permission denied) a0=0x101d7 a1=SIGTERM a2=0x55ba97228130 a3=0x0 items=0 ppid=1 pid=63397 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=gmain exe=/usr/sbin/NetworkManager subj=system_u:system_r:NetworkManager_t:s0 key=(null) type=AVC msg=audit(04/09/2025 22:30:34.108:1798) : avc: denied { signal } for pid=63397 comm=gmain scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:system_r:iptables_t:s0 tclass=process permissive=0

Resolves: RHEL-86780