### PR TITLE
Allow systemd create journal pid files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -397,6 +397,7 @@ init_exec_notrans_direct_init_entry(init_t)
 libs_rw_ld_so_cache(init_t)
 
 logging_create_devlog_dev(init_t)
+logging_create_syslog_pid_file(init_t)
 logging_send_syslog_msg(init_t)
 logging_send_audit_msgs(init_t)
 logging_manage_generic_logs(init_t)

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -738,6 +738,24 @@ interface(`logging_read_syslog_pid',`
 
 ########################################
 ## <summary>
+##	Allow domain to create the syslog pid files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`logging_create_syslog_pid_file',`
+	gen_require(`
+		type syslogd_var_run_t;
+	')
+
+	create_files_pattern($1, syslogd_var_run_t, syslogd_var_run_t)
+')
+
+########################################
+## <summary>
 ##	Relabel the syslog pid sock_file.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/15/2025 10:51:00.591:566) : proctitle=(ld-linux) type=PATH msg=audit(05/15/2025 10:51:00.591:566) : item=1 name=/tmp/tmp.SDqu57Z4FO/run/systemd/journal/dev-log inode=7 dev=00:34 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:syslogd_var_run_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(05/15/2025 10:51:00.591:566) : item=0 name=/tmp/tmp.SDqu57Z4FO/run/systemd/journal/ inode=6 dev=00:34 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:syslogd_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(05/15/2025 10:51:00.591:566) : arch=x86_64 syscall=mknodat success=yes exit=0 a0=AT_FDCWD a1=0x55ab96bd1430 a2=0644 a3=0x0 items=2 ppid=1 pid=2531 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(ld-linux) exe=/usr/lib/systemd/systemd-executor subj=system_u:system_r:init_t:s0 key=(null) type=AVC msg=audit(05/15/2025 10:51:00.591:566) : avc:  denied  { create } for  pid=2531 comm=(ld-linux) name=dev-log scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=file permissive=1

Resolves: RHEL-72692