### PR TITLE
Allow systemd-user-runtime-dir sendto to syslogd

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1976,6 +1976,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	logging_dgram_send(systemd_user_runtimedir_t)
+')
+
+optional_policy(`
 	userdom_manage_tmp_dirs(systemd_user_runtimedir_t)
 	userdom_mounton_tmp_dirs(systemd_user_runtimedir_t)
 	userdom_relabel_user_tmp_dirs(systemd_user_runtimedir_t)


### PR DESCRIPTION
Allow systemd-user-runtime-dir send a message to syslogd over a unix domain datagram socket.

The commit addresses the following AVC denial:
type=AVC msg=audit(1747337748.202:637): avc:  denied  { sendto } for  pid=5555 comm="systemd-user-ru" path="/run/systemd/journal/socket" scontext=system_u:system_r:systemd_user_runtimedir_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=unix_dgram_socket permissive=1 type=SYSCALL msg=audit(1747337748.202:637): arch=x86_64 syscall=connect success=yes exit=0 a0=3 a1=7ffd71cccdd0 a2=1e a3=0 items=0 ppid=1 pid=5555 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=systemd-user-ru exe=/usr/lib/systemd/systemd-user-runtime-dir subj=system_u:system_r:systemd_user_runtimedir_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2366663