### PR TITLE
Allow virtstoraged write qemu runtime files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2427,6 +2427,8 @@ manage_files_pattern(virtstoraged_t, virt_var_lib_t, virt_var_lib_t)
 
 manage_lnk_files_pattern(virtstoraged_t, virt_etc_rw_t, virt_etc_rw_t)
 
+write_files_pattern(virtstoraged_t, qemu_var_run_t, qemu_var_run_t)
+
 kernel_get_sysvipc_info(virtstoraged_t)
 kernel_io_uring_use(virtstoraged_t)
 kernel_read_vm_sysctls(virtstoraged_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1718346618.947:1352): avc:  denied  { write } for  pid=617282 comm="rpc-virtstorage" path="/var/lib/libvirt/qemu/nvram/cs10-clone_VARS.fd" dev="nvme0n1p2" ino=4007421 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:qemu_var_run_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2292362