### PR TITLE
mariadb bin can be located in /usr/sbin instead of /usr/bin

### DIFF
--- a/policy/modules/contrib/mysql.fc
+++ b/policy/modules/contrib/mysql.fc
@@ -21,30 +21,30 @@ HOME_DIR/\.my\.cnf -- gen_context(system_u:object_r:mysqld_home_t, s0)
 #
 # /usr
 #
-/usr/bin/mysqld_safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
-/usr/bin/mysqld_safe_helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/bin/mysql_upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mysqld_safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
+/usr/(s)?bin/mysqld_safe_helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mysql_upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/libexec/mysqld	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/libexec/mysqld_safe-scl-helper --  gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 
 
-/usr/bin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/bin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
-/usr/bin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mysqld(-max|-debug)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
+/usr/(s)?bin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 #
 # /usr - mariadb
 #
-/usr/bin/mariadbd-safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
-/usr/bin/mariadbd-safe-helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mariadbd-safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
+/usr/(s)?bin/mariadbd-safe-helper    --      gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mariadb-upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/usr/bin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/libexec/mariadbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/usr/bin/mariadb-backup	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/(s)?bin/mariadb-backup	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 #
 # /var


### PR DESCRIPTION
Dear maintainer,

When installing mariadb using their official repository (https://mirror.mariadb.org/yum/) the binaries are located in `/usr/sbin` instead of `/usr/bin`. Due to this, Mariadb service is not confined:

```bash
system_u:system_r:unconfined_service_t:s0 mysql 221126 1 37 12:22 ?        00:00:03 /usr/sbin/mariadbd
```

If you look at `mysqld.fc`, we can see the context is only set for binaries in `/usr/bin`.

Because SELinux is already configured, but for `/usr/bin`, I think the related SELinux configuration should also confine mariadb binaries located in `/usr/sbin` directory.

I've used a simple regex for this, but I can (if preferred) just copy/paste the lines with `/usr/bin` to `/usr/sbin`.

Regards,
