### PR TITLE
Allow mdadm nosuid_transition

### DIFF
--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -10,6 +10,7 @@ attribute_role mdadm_roles;
 type mdadm_t;
 type mdadm_exec_t;
 init_daemon_domain(mdadm_t, mdadm_exec_t)
+init_nosuid_domain(mdadm_t)
 role mdadm_roles types mdadm_t;
 
 type mdadm_initrc_exec_t;

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -157,6 +157,24 @@ interface(`init_nnp_daemon_domain',`
 
 ########################################
 ## <summary>
+##	Allow nosuid_transition from systemd into a confined domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_nosuid_domain',`
+	gen_require(`
+		type init_t;
+	')
+
+	allow init_t $1:process2 nosuid_transition;
+')
+
+########################################
+## <summary>
 ##	Create a domain which can be started by init,
 ##	with a range transition.
 ## </summary>


### PR DESCRIPTION
The commit addresses the following AVC denial:
[  800.646103] audit: type=1400 audit(1730358324.784:337): avc:  denied  { nosuid_transition } for  pid=22100 comm="shutdown" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:mdadm_t:s0 tclass=process2 permissive=0 [  800.648808] dracut: Disassembling mdraid devices. [  800.651371] audit: type=1401 audit(1730358324.784:337): op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:mdadm_t:s0 [  800.682578] dracut: Disassembling device-mapper devices [  800.694704] audit: type=1300 audit(1730358324.784:337): arch=c000003e syscall=59 success=yes exit=0 a0=5579c4e6f690 a1=5579c4eda6c0 a2=5579c4edc400 a3=8 items=1 ppid=22099 pid=22100 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=ttyS1 ses=4294967295 comm="mdadm" exe="/usr/sbin/mdadm" subj=system_u:system_r:init_t:s0 key=(null) [  800.694709] audit: type=1309 audit(1730358324.784:337): argc=4 a0="mdadm" a1="-vv" a2="--wait-clean" a3="--scan" [  800.694711] audit: type=1307 audit(1730358324.784:337): cwd="/" [  800.694713] audit: type=1302 audit(1730358324.784:337): item=0 name="/lib64/ld-linux-x86-64.so.2" inode=4448 dev=00:19 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 [  800.694716] audit: type=1327 audit(1730358324.784:337): proctitle="mdadm -vv --p"

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2323040