### PR TITLE
Allow gconfd write to dbusd session tmp socket files

### DIFF
--- a/policy/modules/contrib/gnome.te
+++ b/policy/modules/contrib/gnome.te
@@ -122,13 +122,16 @@ read_files_pattern(gconfd_t, gconf_etc_t, gconf_etc_t)
 
 dev_read_urand(gconfd_t)
 
-
-
 logging_send_syslog_msg(gconfd_t)
 
 userdom_manage_user_tmp_sockets(gconfd_t)
 userdom_manage_user_tmp_dirs(gconfd_t)
 userdom_tmp_filetrans_user_tmp(gconfd_t, dir)
+
+optional_policy(`
+	dbus_system_bus_client(gconfd_t)
+	dbus_write_session_tmp_sock_files(gconfd_t)
+')
 
 optional_policy(`
 	nscd_dontaudit_search_pid(gconfd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/05/2025 02:57:50.026:652) : proctitle=/usr/libexec/gconfd-2 type=PATH msg=audit(02/05/2025 02:57:50.026:652) : item=0 name=/run/user/1000/bus inode=18 dev=00:26 mode=socket,666 ouid=user26930 ogid=user26930 rdev=00:00 obj=staff_u:object_r:session_dbusd_tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(02/05/2025 02:57:50.026:652) : saddr={ saddr_fam=local path=/run/user/1000/bus } type=SYSCALL msg=audit(02/05/2025 02:57:50.026:652) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x4 a1=0x7fff8317d7b0 a2=0x14 a3=0x31 items=1 ppid=21899 pid=21940 auid=user26930 uid=user26930 gid=user26930 euid=user26930 suid=user26930 fsuid=user26930 egid=user26930 sgid=user26930 fsgid=user26930 tty=(none) ses=5 comm=gconfd-2 exe=/usr/libexec/gconfd-2 subj=staff_u:staff_r:gconfd_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/05/2025 02:57:50.026:652) : avc:  denied  { write } for  pid=21940 comm=gconfd-2 name=bus dev="tmpfs" ino=18 scontext=staff_u:staff_r:gconfd_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:session_dbusd_tmp_t:s0 tclass=sock_file permissive=0

Resolves: RHEL-77984