### PR TITLE
Allow NetworkManager manage NetworkManager_etc_rw_t symlinks

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -139,6 +139,7 @@ read_lnk_files_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_et
 read_lnk_files_pattern(NetworkManager_t, NetworkManager_etc_rw_t, NetworkManager_etc_rw_t)
 manage_dirs_pattern(NetworkManager_t, NetworkManager_etc_rw_t, NetworkManager_etc_rw_t)
 manage_files_pattern(NetworkManager_t, NetworkManager_etc_rw_t, NetworkManager_etc_rw_t)
+manage_lnk_files_pattern(NetworkManager_t, NetworkManager_etc_rw_t, NetworkManager_etc_rw_t)
 filetrans_pattern(NetworkManager_t, NetworkManager_etc_t, NetworkManager_etc_rw_t, { dir file })
 
 allow NetworkManager_t NetworkManager_log_t:dir setattr_dir_perms;


### PR DESCRIPTION
Symlinks can be used to override or mask connection files present in /var/lib.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/06/2025 06:13:33.508:5735) : proctitle=/usr/sbin/NetworkManager --no-daemon type=AVC msg=audit(04/06/2025 06:13:33.508:5735) : avc: denied { create } for pid=510435 comm=NetworkManager name=e67e0f3e-2f92-366c-a47e-07d1af9c7cbe.nmmeta~ scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:NetworkManager_etc_rw_t:s0 tclass=lnk_file permissive=0 type=SYSCALL msg=audit(04/06/2025 06:13:33.508:5735) : arch=aarch64 syscall=symlinkat success=no exit=EACCES(Permission denied) a0=0xaaaab849cbd8 a1=0xffffffffffffff9c a2=0xaaaab8f453f0 a3=0xc items=0 ppid=1 pid=510435 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=NetworkManager exe=/usr/sbin/NetworkManager subj=system_u:system_r:NetworkManager_t:s0 key=(null)

Resolves: RHEL-86178