### PR TITLE
Allow sssd watch lib dirs

### DIFF
--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -128,6 +128,7 @@ files_list_tmp(sssd_t)
 files_read_etc_runtime_files(sssd_t)
 files_list_var_lib(sssd_t)
 files_watch_etc_dirs(sssd_t)
+files_watch_lib_dirs(sssd_t)
 
 fs_getattr_cgroup(sssd_t)
 fs_search_cgroup_dirs(sssd_t)


### PR DESCRIPTION
These denials appear when sssd is used as the files provider, but files are stored in the same location that nss-altfiles uses (/usr/lib).

The commit addresses the following AVC denial:
type=AVC msg=audit(1678211275.874:251916): avc:  denied  { watch } for  pid=982783 comm="sssd_be" path="/usr/lib" dev="dm-0" ino=33554564 scontext=system_u:system_r:sssd_t:s0 tc

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2176235