### PR TITLE
Allow tomcat execute cracklib-check with a domain transition

### DIFF
--- a/policy/modules/admin/usermanage.if
+++ b/policy/modules/admin/usermanage.if
@@ -377,3 +377,22 @@ interface(`usermanage_read_crack_db',`
 	files_search_var($1)
 	read_files_pattern($1, crack_db_t, crack_db_t)
 ')
+
+########################################
+## <summary>
+##	Execute crack in the crack domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`usermanage_domtrans_crack',`
+	gen_require(`
+		type crack_t, crack_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, crack_exec_t, crack_t)
+')

--- a/policy/modules/contrib/tomcat.te
+++ b/policy/modules/contrib/tomcat.te
@@ -61,6 +61,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	usermanage_domtrans_crack(tomcat_t)
+')
+
+optional_policy(`
 	ipa_read_lib(tomcat_t)
 	ipa_read_tmp(tomcat_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(1741087013.728:884): proctitle="/usr/sbin/cracklib-check" type=PATH msg=audit(1741087013.728:884): item=0 name="/lib64/ld-linux-x86-64.so.2" inode=10075 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(1741087013.728:884): cwd="/usr/share/tomcat" type=EXECVE msg=audit(1741087013.728:884): argc=1 a0="/usr/sbin/cracklib-check" type=SYSCALL msg=audit(1741087013.728:884): arch=c000003e syscall=59 success=yes exit=0 a0=557f85ff32a0 a1=557f85ff3300 a2=7ffd3c5a3008 a3=7fda9fbd4e80 items=1 ppid=33812 pid=34056 auid=4294967295 uid=17 gid=17 euid=17 suid=17 fsuid=17 egid=17 sgid=17 fsgid=17 tty=(none) ses=4294967295 comm="cracklib-check" exe="/usr/sbin/cracklib-check" subj=system_u:system_r:tomcat_t:s0 key=(null) type=AVC msg=audit(1741087013.728:884): avc:  denied  { map } for  pid=34056 comm="cracklib-check" path="/usr/sbin/cracklib-check" dev="vda1" ino=558735 scontext=system_u:system_r:tomcat_t:s0 tcontext=system_u:object_r:crack_exec_t:s0 tclass=file permissive=1 type=AVC msg=audit(1741087013.728:884): avc:  denied  { execute_no_trans } for  pid=34056 comm="jspawnhelper" path="/usr/sbin/cracklib-check" dev="vda1" ino=558735 scontext=system_u:system_r:tomcat_t:s0 tcontext=system_u:object_r:crack_exec_t:s0 tclass=file permissive=1 type=AVC msg=audit(1741087013.728:884): avc:  denied  { read open } for  pid=34056 comm="jspawnhelper" path="/usr/sbin/cracklib-check" dev="vda1" ino=558735 scontext=system_u:system_r:tomcat_t:s0 tcontext=system_u:object_r:crack_exec_t:s0 tclass=file permissive=1 type=AVC msg=audit(1741087013.728:884): avc:  denied  { execute } for  pid=34056 comm="jspawnhelper" name="cracklib-check" dev="vda1" ino=558735 scontext=system_u:system_r:tomcat_t:s0 tcontext=system_u:object_r:crack_exec_t:s0 tclass=file permissive=1

Resolves: RHEL-82090