### PR TITLE
Allow tuned-ppd connect to sssd over a unix stream socket

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -217,6 +217,7 @@ optional_policy(`
 
 optional_policy(`
 	sssd_read_public_files(tuned_ppd_t)
+	sssd_stream_connect(tuned_ppd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1747582830.333:224): avc:  denied  { write } for  pid=4833 comm="tuned-ppd" name="nss" dev="dm-0" ino=1048662 scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=sock_file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2367076