### PR TITLE
systemd: rework systemd_manage_random_seed

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1657,7 +1657,7 @@ interface(`systemd_manage_random_seed',`
 	')
 
 	allow $1 random_seed_t:file manage_file_perms;
-	files_var_lib_filetrans($1, random_seed_t, file, "random_seed")
+	init_var_lib_filetrans($1, random_seed_t, file, "random-seed");
 ')
 
 ########################################


### PR DESCRIPTION
Follow-up for 2497483ae16e172a5fd361c7b09c6152c87144a1. When the service created the file, it'd have init_var_lib_t, not random_seed_t as expected. It seems that the transition rule didn't match, because /var/lib/systemd is init_var_lib_t, not var_lib_t. (The transition rule made sense when the path was /var/lib/random-seed.)

With this change, when the file is created at boot, it gets the expected context.

Fixes issue reported in
https://bodhi.fedoraproject.org/updates/FEDORA-2025-3fc35b11d8.