### PR TITLE
Allow nmbd read network sysctls

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -756,6 +756,7 @@ allow nmbd_t smbcontrol_t:unix_dgram_socket sendto;
 kernel_getattr_core_if(nmbd_t)
 kernel_getattr_message_if(nmbd_t)
 kernel_read_kernel_sysctls(nmbd_t)
+kernel_read_net_sysctls(nmbd_t)
 kernel_read_network_state(nmbd_t)
 kernel_read_software_raid_state(nmbd_t)
 kernel_read_system_state(nmbd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1747783057.719:377): avc:  denied  { search } for  pid=3602 comm="nmbd" name="net" dev="proc" ino=16387 scontext=system_u:system_r:nmbd_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2368432