### PR TITLE
Allow iio-sensor-proxy sendto to journald over a unix datagram socket

### DIFF
--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -13,6 +13,8 @@ allow iiosensorproxy_t self:capability2 bpf;
 allow iiosensorproxy_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow iiosensorproxy_t self:unix_dgram_socket create_socket_perms;
 
+kernel_stream_connect(iiosensorproxy_t)
+
 dev_read_iio_dev(iiosensorproxy_t)
 dev_read_input(iiosensorproxy_t)
 dev_create_sysfs_files(iiosensorproxy_t)


### PR DESCRIPTION
The permission actually allows iio-sensor-proxy send messages to kernel unix datagram sockets as the journald socket is still labeled kernel_t.

The commit addresses the following AVC denial:
type=AVC msg=audit(1745001092.22:111): avc:  denied  { sendto } for  pid=815 comm="iio-sensor-prox" path="/systemd/journal/socket" scontext=system_u:system_r:iiosensorproxy_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2368281