### PR TITLE
Allow logrotate stop all systemd services

### DIFF
--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -376,6 +376,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_stop_all_services(logrotate_t)
+')
+
+optional_policy(`
 	varnishd_manage_log(logrotate_t)
 ')
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1511,6 +1511,24 @@ interface(`systemd_start_all_services',`
 	allow $1 systemd_unit_file_type:service start;
 ')
 
+########################################
+## <summary>
+##	Allow the specified domain to stop all systemd services.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_stop_all_services',`
+	gen_require(`
+		attribute systemd_unit_file_type;
+	')
+
+	allow $1 systemd_unit_file_type:service stop;
+')
+
 #######################################
 ## <summary>
 ##  Allow the specified domain to reload all systemd services.


### PR DESCRIPTION
Needed when the following command is used in a postrotate script to restart a service:
systemctl kill --signal=<signal> --kill-who=main <servicename> 2>/dev/null || true

The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(1748111593.330:131): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { stop } for auid=n/a uid=0 gid=0 path="/usr/lib/systemd/system/php-fpm.service" cmdline="" function="bus_unit_method_kill" scontext=system_u:system_r:logrotate_t:s0 tcontext=system_u:object_r:httpd_unit_file_t:s0 tclass=service permissive=1 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'UID="root" AUID="unset" AUID="root" UID="root" GID="root" SAUID="root"

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2369644