### PR TITLE
Update the files_search_mnt() interface

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -5582,6 +5582,7 @@ interface(`files_search_mnt',`
 	')
 
 	allow $1 mnt_t:dir search_dir_perms;
+	allow $1 mnt_t:lnk_file read_lnk_file_perms;
 ')
 
 ########################################


### PR DESCRIPTION
Update the files_search_mnt() interface to also allow reading symlinks with the mnt_t type.

The commit addresses the following AVC denial:
hostname: type=PROCTITLE msg=audit(03/17/25 12:16:03.309:1150) : proctitle=/usr/sbin/automount --systemd-service --dont-check-daemon hostname: type=SYSCALL msg=audit(03/17/25 12:16:03.309:1150) : arch=x86_64 syscall=ioctl success=no exit=EACCES(Permission denied) a0=0x3 a1=0xc018937e a2=0x7f5bf4002da0 a3=0x8 items=0 ppid=1 pid=30259 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=automount exe=/usr/sbin/automount subj=system_u:system_r:automount_t:s0 key=(null) hostname: type=AVC msg=audit(03/17/25 12:16:03.309:1150) : avc: denied \{ read } for pid=30259 comm=automount name=mnt dev="overlay" ino=572 scontext=system_u:system_r:automount_t:s0 tcontext=system_u:object_r:mnt_t:s0 tclass=lnk_file permissive=0

Resolves: RHEL-85178