### PR TITLE
Allow virtqemud execute ovs-vsctl with a domain transition

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2334,6 +2334,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	openvswitch_domtrans(virtqemud_t)
+')
+
+optional_policy(`
 	qemu_exec(virtqemud_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/11/2024 08:50:43.881:638) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(11/11/2024 08:50:43.881:638) : item=0 name=/usr/bin/ovs-vsctl inode=8849936 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:openvswitch_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(11/11/2024 08:50:43.881:638) : arch=x86_64 syscall=access success=yes exit=0 a0=0x7f1e680c6a59 a1=X_OK a2=0x8 a3=0x7f1e680008e0 items=1 ppid=1 pid=6989 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(11/11/2024 08:50:43.881:638) : avc:  denied  { execute } for  pid=6989 comm=rpc-virtqemud name=ovs-vsctl dev="vda2" ino=8849936 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:openvswitch_exec_t:s0 tclass=file permissive=1

Resolves: RHEL-65322