### PR TITLE
Allow utempter use terminal multiplexor

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -423,6 +423,8 @@ domain_use_interactive_fds(utempter_t)
 
 logging_search_logs(utempter_t)
 
+term_use_ptmx(utempter_t)
+
 userdom_append_stream_userdomain(utempter_t)
 userdom_use_inherited_user_terminals(utempter_t)
 # Allow utemper to write to /tmp/.xses-*


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/05/2025 12:20:32.583:2590) : proctitle=/usr/libexec/utempter/utempter del type=PATH msg=audit(06/05/2025 12:20:32.583:2590) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=8617394 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(06/05/2025 12:20:32.583:2590) : item=0 name=/usr/libexec/utempter/utempter inode=14128469 dev=fd:02 mode=file,sgid,711 ouid=root ogid=utmp rdev=00:00 obj=system_u:object_r:utempter_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(06/05/2025 12:20:32.583:2590) : argc=2 a0=/usr/libexec/utempter/utempter a1=del type=SYSCALL msg=audit(06/05/2025 12:20:32.583:2590) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7f2c93493000 a1=0x7ffe2eb96d60 a2=0x7ffe2eb97458 a3=0x7f2c9314b090 items=2 ppid=34352 pid=34355 auid=user25001 uid=user25001 gid=user25001 euid=user25001 suid=user25001 fsuid=user25001 egid=utmp sgid=utmp fsgid=utmp tty=pts2 ses=49 comm=utempter exe=/usr/libexec/utempter/utempter subj=sysadm_u:sysadm_r:utempter_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(06/05/2025 12:20:32.583:2590) : avc:  denied  { read write } for  pid=34355 comm=utempter path=/dev/ptmx dev="devtmpfs" ino=91 scontext=sysadm_u:sysadm_r:utempter_t:s0-s0:c0.c1023 tcontext=system_u:object_r:ptmx_t:s0 tclass=chr_file permissive=0

Resolves: RHEL-56344