### PR TITLE
Allow plymouthd read/write input event devices

### DIFF
--- a/policy/modules/contrib/plymouthd.te
+++ b/policy/modules/contrib/plymouthd.te
@@ -71,6 +71,7 @@ dev_write_framebuffer(plymouthd_t)
 dev_map_framebuffer(plymouthd_t)
 dev_read_kmsg(plymouthd_t)
 dev_write_kmsg(plymouthd_t)
+dev_rw_input_dev(plymouthd_t)
 dev_rw_xserver_misc(plymouthd_t)
 
 domain_use_interactive_fds(plymouthd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(7.5.2025 15:27:35.237:8269) : proctitle=/usr/bin/plymouthd --mode=shutdown --attach-to-session type=PATH msg=audit(7.5.2025 15:27:35.237:8269) : item=0 name=/dev/input/event11 inode=830 dev=00:06 mode=character,660 ouid=root ogid=input rdev=0d:4b obj=system_u:object_r:event_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(7.5.2025 15:27:35.237:8269) : arch=x86_64 syscall=openat success=no exit=EACCES(Operace zamítnuta) a0=AT_FDCWD a1=0x55e0713ff020 a2=O_RDWR|O_NONBLOCK a3=0x0 items=1 ppid=1 pid=402884 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=plymouthd exe=/usr/bin/plymouthd subj=system_u:system_r:plymouthd_t:s0 key=(null) type=AVC msg=audit(7.5.2025 15:27:35.237:8269) : avc:  denied  { read write } for  pid=402884 comm=plymouthd name=event11 dev="devtmpfs" ino=830 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:object_r:event_device_t:s0 tclass=chr_file permissive=0