### PR TITLE
Define file equivalency for /usr/etc

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -32,4 +32,5 @@
 /var/usrlocal        /usr/local
 /var/mnt             /mnt
 /bin                 /usr/bin
+/usr/etc             /etc
 /usr/sbin            /usr/bin

--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -259,8 +259,6 @@ ifdef(`distro_debian',`
 
 /usr/doc(/.*)?/lib(/.*)?	gen_context(system_u:object_r:usr_t,s0)
 
-/usr/etc(/.*)?			gen_context(system_u:object_r:etc_t,s0)
-
 /usr/inclu.e(/.*)?		gen_context(system_u:object_r:usr_t,s0)
 
 /usr/lost\+found	-d	gen_context(system_u:object_r:lost_found_t,mls_systemhigh)


### PR DESCRIPTION
/usr/etc is used by a number of immutable/sealed /usr systems. This permits easily keeping the file contexts up to date.