### PR TITLE
Systemd oomd

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -60,6 +60,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/systemd-mountwork	--	gen_context(system_u:object_r:systemd_mountfsd_exec_t,s0)
 /usr/lib/systemd/systemd-nsresourced		--	gen_context(system_u:object_r:systemd_nsresourced_exec_t,s0)
 /usr/lib/systemd/systemd-nsresourcework		--	gen_context(system_u:object_r:systemd_nsresourced_exec_t,s0)
+/usr/lib/systemd/systemd-oomd		--	gen_context(system_u:object_r:systemd_oomd_exec_t,s0)
 /usr/lib/systemd/systemd-pcrextend		--	gen_context(system_u:object_r:systemd_pcrextend_exec_t,s0)
 /usr/lib/systemd/systemd-pcrlock		--	gen_context(system_u:object_r:systemd_pcrlock_exec_t,s0)
 /usr/lib/systemd/systemd-pstore		--	gen_context(system_u:object_r:systemd_pstore_exec_t,s0)
@@ -128,6 +129,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/generator/.+	<<none>>
 
 /run/systemd/io\.systemd\.Login	-s	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
+/run/systemd/io\.systemd\.ManagedOOM	-s	gen_context(system_u:object_r:systemd_oomd_var_run_t,s0)
 /run/systemd/io\.systemd\.NamespaceResource	-s	gen_context(system_u:object_r:systemd_nsresourced_runtime_t,s0)
 /run/systemd/nsresource(/.*)?	gen_context(system_u:object_r:systemd_nsresourced_runtime_t,s0)
 /run/systemd/seats(/.*)?	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
@@ -142,6 +144,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/machine(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines.lock	--	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
+/run/systemd/oom(/.*)?		gen_context(system_u:object_r:systemd_oomd_var_run_t,s0)
 /run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)
 /run/systemd/netif(/.*)?	gen_context(system_u:object_r:systemd_networkd_var_run_t,s0)
 /run/systemd/import(/.*)?		gen_context(system_u:object_r:systemd_importd_var_run_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -298,6 +298,11 @@ files_pid_file(systemd_nsresourced_runtime_t)
 
 systemd_domain_template(systemd_mountfsd)
 
+systemd_domain_template(systemd_oomd)
+
+type systemd_oomd_var_run_t;
+files_pid_file(systemd_oomd_var_run_t)
+
 systemd_domain_template(systemd_pcrextend)
 systemd_domain_template(systemd_pcrlock)
 
@@ -1903,6 +1908,24 @@ allow systemd_mountfsd_t systemd_mountfsd_exec_t:file execute_no_trans;
 permissive systemd_mountfsd_t;
 
 kernel_dgram_send(systemd_mountfsd_t)
+
+########################################
+#
+# systemd_oomd local policy
+#
+
+dontaudit systemd_oomd_t self:capability dac_override;
+allow systemd_oomd_t systemd_oomd_var_run_t:sock_file manage_sock_file_perms;
+
+kernel_dgram_send(systemd_oomd_t)
+kernel_read_psi(systemd_oomd_t)
+kernel_stream_connect(systemd_oomd_t)
+
+optional_policy(`
+    dbus_acquire_svc_system_dbusd(systemd_oomd_t)
+')
+
+permissive systemd_oomd_t;
 
 ########################################
 #

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1921,8 +1921,17 @@ kernel_dgram_send(systemd_oomd_t)
 kernel_read_psi(systemd_oomd_t)
 kernel_stream_connect(systemd_oomd_t)
 
+domain_read_all_domains_state(systemd_oomd_t)
+domain_kill_all_domains(systemd_oomd_t)
+
+fs_list_cgroup_dirs(systemd_oomd_t)
+fs_setattr_cgroup_dirs(systemd_oomd_t)
+fs_write_cgroup_dirs(systemd_oomd_t)
+
 optional_policy(`
     dbus_acquire_svc_system_dbusd(systemd_oomd_t)
+    dbus_read_pid_sock_files(systemd_oomd_t)
+    dbus_watch_pid_dir_path(systemd_oomd_t)
 ')
 
 permissive systemd_oomd_t;

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -300,6 +300,9 @@ systemd_domain_template(systemd_mountfsd)
 
 systemd_domain_template(systemd_oomd)
 
+type systemd_oomd_tmpfs_t;
+files_tmpfs_file(systemd_oomd_tmpfs_t)
+
 type systemd_oomd_var_run_t;
 files_pid_file(systemd_oomd_var_run_t)
 
@@ -1916,6 +1919,9 @@ kernel_dgram_send(systemd_mountfsd_t)
 
 dontaudit systemd_oomd_t self:capability dac_override;
 allow systemd_oomd_t systemd_oomd_var_run_t:sock_file manage_sock_file_perms;
+
+manage_files_pattern(systemd_oomd_t, systemd_oomd_tmpfs_t, systemd_oomd_tmpfs_t)
+fs_tmpfs_filetrans(systemd_oomd_t, systemd_oomd_tmpfs_t, file)
 
 kernel_dgram_send(systemd_oomd_t)
 kernel_read_psi(systemd_oomd_t)


### PR DESCRIPTION
Wanted to get some feedback on this backlog change I have been working when there was time. I still have a couple of AVCs that I am not sure how to address:

> type=AVC msg=audit(..): avc:  denied  { search } for  pid=1326 comm="systemd-oomd" name="3209" dev="proc" ino=22552 scontext=system_u:system_r:systemd_oomd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dir permissive=1
> type=AVC msg=audit(..): avc:  denied  { read } for  pid=1326 comm="systemd-oomd" name="stat" dev="proc" ino=22553 scontext=system_u:system_r:systemd_oomd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1
> type=AVC msg=audit(..): avc:  denied  { open } for  pid=1326 comm="systemd-oomd" path="/proc/3209/stat" dev="proc" ino=22553 scontext=system_u:system_r:systemd_oomd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1
> type=AVC msg=audit(..): avc:  denied  { getattr } for  pid=1326 comm="systemd-oomd" path="/proc/3209/stat" dev="proc" ino=22553 scontext=system_u:system_r:systemd_oomd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1
> type=AVC msg=audit(..): avc:  denied  { ioctl } for  pid=1326 comm="systemd-oomd" path="/proc/3209/stat" dev="proc" ino=22553 ioctlcmd=0x5401 scontext=system_u:system_r:systemd_oomd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file permissive=1

Open to pointers for these or any other feedback.