### PR TITLE
Allow mongod to receive pressure stall information

### DIFF
--- a/policy/modules/contrib/mongodb.te
+++ b/policy/modules/contrib/mongodb.te
@@ -68,6 +68,7 @@ files_tmp_filetrans(mongod_t, mongod_tmp_t, { file dir sock_file })
 ## also typically has symlinks (e.g. /proc/net/snmp).
 kernel_list_proc(mongod_t)
 kernel_read_proc_symlinks(mongod_t)
+kernel_read_psi(mongod_t)
 
 kernel_read_system_state(mongod_t)
 kernel_read_network_state(mongod_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1748425890.1:508): avc:  denied  { open } for  pid=1493 comm="ftdc" path="/proc/pressure/io" dev="proc" ino=4026532080 scontext=system_u:system_r:mongod_t:s0 tcontext=system_u:object_r:proc_psi_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(1748425890.1:508): arch=x86_64 syscall=openat success=no exit=EACCES a0=ffffffffffffff9c a1=711039428d00 a2=0 a3=0 items=0 ppid=1 pid=1493 auid=4294967295 uid=967 gid=967 euid=967 suid=967 fsuid=967 egid=967 sgid=967 fsgid=967 tty=(none) ses=4294967295 comm=ftdc exe=/usr/bin/mongod subj=system_u:system_r:mongod_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2368929