### PR TITLE
Allow zram-generator raw read fixed disk device

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1484,7 +1484,7 @@ filetrans_pattern(systemd_zram_generator_t, systemd_unit_file_t, systemd_zram_ge
 dev_create_sysfs_files(systemd_zram_generator_t)
 dev_rw_sysfs(systemd_zram_generator_t)
 
-storage_getattr_fixed_disk_dev(systemd_zram_generator_t)
+storage_raw_read_fixed_disk_blk_device(systemd_zram_generator_t)
 
 optional_policy(`
 	fstools_domtrans(systemd_zram_generator_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1750025919.99:1202): avc:  denied  { open } for  pid=5692 comm="zram-generator" path="/dev/sda3" dev="devtmpfs" ino=164 scontext=system_u:system_r:systemd_zram_generator_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2372927