### PR TITLE
Dontaudit systemd_generator read sssd public files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1367,6 +1367,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_dontaudit_read_public_files(systemd_generator)
 	sssd_dontaudit_search_lib(systemd_generator)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1749761868.959:613): avc:  denied  { search } for  pid=16855 comm="bootc-systemd-g" name="mc" dev="sda3" ino=446687 scontext=system_u:system_r:systemd_bootc_generator_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2372799