### PR TITLE
iio-sensor-proxy denial for sys_admin

### DIFF
--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -13,8 +13,6 @@ allow iiosensorproxy_t self:capability2 bpf;
 allow iiosensorproxy_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow iiosensorproxy_t self:unix_dgram_socket create_socket_perms;
 
-kernel_stream_connect(iiosensorproxy_t)
-
 dev_read_iio_dev(iiosensorproxy_t)
 dev_read_input(iiosensorproxy_t)
 dev_create_sysfs_files(iiosensorproxy_t)

--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -13,6 +13,9 @@ allow iiosensorproxy_t self:capability2 bpf;
 allow iiosensorproxy_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow iiosensorproxy_t self:unix_dgram_socket create_socket_perms;
 
+# temporary don't audit because of kernel commit: d4e89d212d, requiring CAP_SYS_ADMIN
+dontaudit iiosensorproxy_t self:capability sys_admin;
+
 kernel_dgram_send(iiosensorproxy_t)
 
 dev_read_iio_dev(iiosensorproxy_t)

--- a/policy/modules/contrib/iiosensorproxy.te
+++ b/policy/modules/contrib/iiosensorproxy.te
@@ -13,6 +13,8 @@ allow iiosensorproxy_t self:capability2 bpf;
 allow iiosensorproxy_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow iiosensorproxy_t self:unix_dgram_socket create_socket_perms;
 
+kernel_dgram_send(iiosensorproxy_t)
+
 dev_read_iio_dev(iiosensorproxy_t)
 dev_read_input(iiosensorproxy_t)
 dev_create_sysfs_files(iiosensorproxy_t)


### PR DESCRIPTION
dontaudit:
type=AVC msg=audit(..): avc:  denied  { sys_admin } for  pid=6002 comm="iio-sensor-prox" capability=21  scontext=system_u:system_r:iiosensorproxy_t:s0 tcontext=system_u:system_r:iiosensorproxy_t:s0 tclass=capability permissive=0

kernel_dgram_send(iiosensorproxy_t):
type=AVC msg=audit(..): avc:  denied  { sendto } for  pid=6002 comm="iio-sensor-prox" path="/systemd/journal/socket" scontext=system_u:system_r:iiosensorproxy_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=0

Fixes: bsc#1244577


*EDIT:* We were missing d37dd6ab, but I still get the `sendto` AVC after retesting with that change included. I am therefor not sure if  `kernel_stream_connect` is needed or could be dropped.  [Reporter confirmed](https://bugzilla.suse.com/show_bug.cgi?id=1244577#c6) that sys_admin was not needed, so therefor dontaudit.