### PR TITLE
Miscellaneous fixes for confined users

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -19,6 +19,7 @@
 /usr/local/lib64 /usr/lib
 /usr/local/lib32 /usr/lib
 /etc/systemd/system /usr/lib/systemd/system
+/etc/systemd/user /usr/lib/systemd/user
 /var/lib/xguest/home /home
 /var/named/chroot/usr/lib64 /usr/lib
 /var/named/chroot/lib64 /usr/lib

--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -61,3 +61,9 @@ userdom_rw_inherited_user_home_content_files(journalctl_t)
 optional_policy(`
 	rhcd_read_fifo_files(journalctl_t)
 ')
+
+# Needed for journalctl (with the "less" pager) to stop complaining about
+# "lesshst" files
+optional_policy(`
+	gnome_dontaudit_read_config(journalctl_t)
+')

--- a/policy/modules/contrib/snapper.te
+++ b/policy/modules/contrib/snapper.te
@@ -98,3 +98,7 @@ optional_policy(`
 optional_policy(`
 	systemd_exec_systemctl(snapperd_t)
 ')
+
+optional_policy(`
+    seutil_dontaudit_read_file_contexts(snapperd_t)
+)

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -264,6 +264,7 @@ optional_policy(`
         systemd_dbus_chat_timedated(sysadm_t)
         systemd_dbus_chat_hostnamed(sysadm_t)
         systemd_dbus_chat_localed(sysadm_t)
+        systemd_dbus_chat_networkd(sysadm_t)
     ')
 
 	optional_policy(`

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -126,6 +126,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 
 /run/systemd/generator		-d	gen_context(system_u:object_r:systemd_unit_file_t,s0)
 /run/systemd/generator/.+	<<none>>
+/run/user/%{USERID}/systemd/generator		-d	gen_context(system_u:object_r:systemd_unit_file_t,s0)
+/run/user/%{USERID}/systemd/generator/.+	<<none>>
 
 /run/systemd/io\.systemd\.Login	-s	gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
 /run/systemd/io\.systemd\.NamespaceResource	-s	gen_context(system_u:object_r:systemd_nsresourced_runtime_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2845,6 +2845,27 @@ interface(`systemd_map_resolved_exec_files',`
 
 ########################################
 ## <summary>
+##	Send and receive messages from
+##	systemd networkd over dbus.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_dbus_chat_networkd',`
+	gen_require(`
+		type systemd_networkd_t;
+		class dbus send_msg;
+	')
+
+	allow $1 systemd_networkd_t:dbus send_msg;
+	allow $1 systemd_networkd_t:unix_stream_socket connectto;
+')
+
+########################################
+## <summary>
 ##	Exchange messages with
 ##	systemd resolved over dbus or varlink.
 ## </summary>

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -967,6 +967,11 @@ init_read_state(systemctl_domain)
 init_list_pid_dirs(systemctl_domain)
 init_use_fds(systemctl_domain)
 
+# Needed for "sudo systemctl --user --machine=USER@ ..."
+optional_policy(`
+	userdom_rw_admindom_stream()
+')
+
 #######################################
 #
 # Localed policy

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -7039,3 +7039,17 @@ interface(`userdom_prog_run_bpf_userdomain',`
 
 	allow $1 userdomain:bpf { map_create map_read map_write prog_load prog_run };
 ')
+
+########################################
+## <summary>
+##	Allow userdomain to read/write to admindomain Unix stream sockets.
+## </summary>
+#
+interface(`userdom_rw_admindom_stream',`
+	gen_require(`
+		attribute userdomain;
+		attribute admindomain;
+	')
+
+	allow userdomain admindomain:unix_stream_socket rw_socket_perms;
+')

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -673,3 +673,8 @@ optional_policy(`
 optional_policy(`
 	systemd_manage_all_unit_files(userdomain)
 ')
+
+# Allow administrators to use the "snapper" command
+optional_policy(`
+	snapper_dbus_chat(confined_admindomain)
+')

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -667,3 +667,9 @@ optional_policy(`
 	ssh_delete_tmp(confined_admindomain)
 	ssh_signal(confined_admindomain)
 ')
+
+# Allow users to manage their own systemd user unit files in
+# $XDG_RUNTIME_DIR/systemd/generator
+optional_policy(`
+	systemd_manage_all_unit_files(userdomain)
+')


### PR DESCRIPTION
I've been running using SELinux-confined users on my Fedora IoT server for a few months now, but I've needed a few custom rules for it to work properly. This patch contains those rules.

There are quite a few (very small) changes here, so please let me know if you have any questions or want me to make any changes.

Full disclosure: I've been using a [CIL version of these rules](https://github.com/gucci-on-fleek/maxchernoff.ca/blob/1d593bb8dfc281845c7efd7215d2da7b51c4eedf/etc/selinux/local-policies/local-systemd.cil) for a couple months now, and I've confirmed that the policies still build (`make all`) and validate (`make validate`) correctly, but I haven't tested installing the `.pp` modules from this patch on my server.

(Vaguely related to containers/container-selinux#383)