### PR TITLE
C9s selinux 4392

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -1027,10 +1027,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_write_tmp(httpd_t)
-')
-
-optional_policy(`
     ipa_read_lib(httpd_t)
     ipa_manage_pid_files(httpd_t)
 ')

--- a/policy/modules/contrib/bind.if
+++ b/policy/modules/contrib/bind.if
@@ -602,3 +602,22 @@ interface(`bind_exec',`
 	corecmd_search_bin($1)
 	can_exec($1, named_exec_t)
 ')
+
+######################################
+## <summary>
+##	Execute named-checkconf in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bind_exec_named_checkconf',`
+	gen_require(`
+		type named_exec_named_checkconf_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, named_exec_named_checkconf_t)
+')

--- a/policy/modules/contrib/cloudform.te
+++ b/policy/modules/contrib/cloudform.te
@@ -141,10 +141,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_domtrans(cloud_init_t)
-')
-
-optional_policy(`
     mount_domtrans(cloud_init_t)
 ')
 

--- a/policy/modules/contrib/gpg.if
+++ b/policy/modules/contrib/gpg.if
@@ -166,6 +166,24 @@ interface(`gpg_signal',`
 
 ########################################
 ## <summary>
+##	Transition to the gpg-agent domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`gpg_domtrans_agent',`
+	gen_require(`
+		type gpg_agent_t, gpg_agent_exec_t;
+	')
+
+	domtrans_pattern($1, gpg_agent_exec_t, gpg_agent_t)
+')
+
+########################################
+## <summary>
 ##	Read and write GPG agent pipes.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/gpg.if
+++ b/policy/modules/contrib/gpg.if
@@ -223,6 +223,25 @@ interface(`gpg_list_user_secrets',`
 	userdom_search_user_home_dirs($1)
 ')
 
+########################################
+## <summary>
+##	Read Gnu Privacy Guard user secrets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`gpg_read_user_secrets',`
+	gen_require(`
+		type gpg_secret_t;
+	')
+
+	read_files_pattern($1, gpg_secret_t, gpg_secret_t)
+	userdom_search_user_home_dirs($1)
+')
+
 ###########################
 ## <summary>
 ##	Allow to manage gpg named home content

--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -342,7 +342,11 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_manage_lib_files(gpg_agent_t)
+        insights_client_create_lib_dirs(gpg_agent_t)
+        insights_client_setattr_lib_dirs(gpg_agent_t)
+        insights_client_watch_lib_dirs(gpg_agent_t)
+        insights_client_manage_lib_files(gpg_agent_t)
+        insights_client_manage_tmp_sock_files(gpg_agent_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -186,9 +186,11 @@ optional_policy(`
 optional_policy(`
 	insights_client_read_config(gpg_t)
 	insights_client_manage_lib_files(gpg_t)
-	insights_client_write_lib_sock_files(gpg_t)
-	insights_client_read_tmp(gpg_t)
-	insights_client_write_tmp(gpg_t)
+	insights_client_manage_tmp_sock_files(gpg_t)
+')
+
+optional_policy(`
+	insights_core_read_lib_files(gpg_t)
 ')
 
 optional_policy(`
@@ -340,9 +342,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_manage_lib_dirs(gpg_agent_t)
 	insights_client_manage_lib_files(gpg_agent_t)
-	insights_client_manage_lib_sock_files(gpg_agent_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/insights_client.fc
+++ b/policy/modules/contrib/insights_client.fc
@@ -16,15 +16,8 @@
 
 /usr/lib/systemd/system/insights-client.*		--      gen_context(system_u:object_r:insights_client_unit_file_t,s0)
 
-/var/cache/insights(/.*)?					gen_context(system_u:object_r:insights_client_cache_t,s0)
-/var/cache/insights-client(/.*)?				gen_context(system_u:object_r:insights_client_cache_t,s0)
-
 /var/lib/insights(/.*)?						gen_context(system_u:object_r:insights_client_var_lib_t,s0)
 
 /var/log/insights-client(/.*)?					gen_context(system_u:object_r:insights_client_var_log_t,s0)
 
-/var/run/insights-client\.pid				--	gen_context(system_u:object_r:insights_client_var_run_t,s0)
-
-/tmp/insights-client\.ppid	--				gen_context(system_u:object_r:insights_client_tmp_t,s0)
-/var/tmp/insights-client\.ppid	--				gen_context(system_u:object_r:insights_client_tmp_t,s0)
-/var/tmp/insights-client(/.*)?					gen_context(system_u:object_r:insights_client_tmp_t,s0)
+/run/insights-client\.pid				--	gen_context(system_u:object_r:insights_client_run_t,s0)

--- a/policy/modules/contrib/insights_client.fc
+++ b/policy/modules/contrib/insights_client.fc
@@ -20,4 +20,4 @@
 
 /var/log/insights-client(/.*)?					gen_context(system_u:object_r:insights_client_var_log_t,s0)
 
-/run/insights-client\.pid				--	gen_context(system_u:object_r:insights_client_run_t,s0)
+/var/run/insights-client\.pid				--	gen_context(system_u:object_r:insights_client_var_run_t,s0)

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -90,7 +90,7 @@ interface(`insights_client_filetrans_named_content',`
 	gen_require(`
 		type insights_client_etc_t, insights_client_etc_rw_t;
 		type insights_client_tmp_t;
-		type insights_client_var_run_t;
+		type insights_client_run_t;
 	')
 
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".cache.json")
@@ -104,7 +104,7 @@ interface(`insights_client_filetrans_named_content',`
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "insights-client-egg-release")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "machine-id")
 
-	files_pid_filetrans($1, insights_client_var_run_t, file, "insights-client.pid")
+	files_pid_filetrans($1, insights_client_run_t, file, "insights-client.pid")
 
 	files_tmp_filetrans($1, insights_client_tmp_t, dir, "insights-client")
 	files_tmp_filetrans($1, insights_client_tmp_t, file, "insights-client.ppid")
@@ -131,6 +131,25 @@ interface(`insights_client_filetrans_tmp',`
 
 ########################################
 ## <summary>
+##	Read files in /run
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_read_run',`
+	gen_require(`
+		type insights_client_run_t;
+	')
+
+	files_search_pids($1)
+	allow $1 insights_client_run_t:file read_file_perms;
+')
+
+########################################
+## <summary>
 ##	Transition to insights_client named content in /var/run
 ## </summary>
 ## <param name="domain">
@@ -141,10 +160,10 @@ interface(`insights_client_filetrans_tmp',`
 #
 interface(`insights_client_filetrans_run',`
 	gen_require(`
-		type insights_client_var_run_t;
+		type insights_client_run_t;
 	')
 
-	files_pid_filetrans($1, insights_client_var_run_t, file, "insights-client.pid")
+	files_pid_filetrans($1, insights_client_run_t, file, "insights-client.pid")
 ')
 
 ########################################
@@ -169,7 +188,7 @@ interface(`insights_client_read_config',`
 
 ########################################
 ## <summary>
-##	Read insights_client lib files.
+##	Create insights_client config files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -177,19 +196,19 @@ interface(`insights_client_read_config',`
 ##	</summary>
 ## </param>
 #
-interface(`insights_client_read_lib_files',`
+interface(`insights_client_create_config',`
 	gen_require(`
-		type insights_client_var_lib_t;
+		type insights_client_etc_t, insights_client_etc_rw_t;
 	')
 
-	files_search_var_lib($1)
-	read_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
-	allow $1 insights_client_var_lib_t:file map;
+	files_search_etc($1)
+	create_files_pattern($1, insights_client_etc_t, insights_client_etc_t)
+	create_files_pattern($1, insights_client_etc_t, insights_client_etc_rw_t)
 ')
 
 ########################################
 ## <summary>
-##	Manage insights_client lib directories..
+##	Write insights_client rw config files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -197,32 +216,13 @@ interface(`insights_client_read_lib_files',`
 ##	</summary>
 ## </param>
 #
-interface(`insights_client_manage_lib_dirs',`
+interface(`insights_client_manage_config_rw',`
 	gen_require(`
-		type insights_client_var_lib_t;
+		type insights_client_etc_t, insights_client_etc_rw_t;
 	')
 
-	files_search_var_lib($1)
-	manage_dirs_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
-')
-
-########################################
-## <summary>
-##	Watch insights_client lib directories..
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`insights_client_watch_lib_dirs',`
-	gen_require(`
-		type insights_client_var_lib_t;
-	')
-
-	files_search_var_lib($1)
-	watch_dirs_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+	files_search_etc($1)
+	manage_files_pattern($1, insights_client_etc_t, insights_client_etc_rw_t)
 ')
 
 ########################################
@@ -247,7 +247,7 @@ interface(`insights_client_manage_lib_files',`
 
 ########################################
 ## <summary>
-##	Write to insights_client lib socket files.
+##	Create insights_client lib dirs.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -255,18 +255,18 @@ interface(`insights_client_manage_lib_files',`
 ##	</summary>
 ## </param>
 #
-interface(`insights_client_write_lib_sock_files',`
+interface(`insights_client_create_lib_dirs',`
 	gen_require(`
 		type insights_client_var_lib_t;
 	')
 
 	files_search_var_lib($1)
-	write_sock_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+	create_dirs_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
 ')
 
 ########################################
 ## <summary>
-##	Manage insights_client lib socket files.
+##	Setattr insights_client lib dirs.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -274,13 +274,51 @@ interface(`insights_client_write_lib_sock_files',`
 ##	</summary>
 ## </param>
 #
-interface(`insights_client_manage_lib_sock_files',`
+interface(`insights_client_setattr_lib_dirs',`
 	gen_require(`
 		type insights_client_var_lib_t;
 	')
 
 	files_search_var_lib($1)
-	manage_sock_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+	setattr_dirs_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Watch insights_client lib dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_watch_lib_dirs',`
+	gen_require(`
+		type insights_client_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	allow $1 insights_client_var_lib_t:dir watch_dir_perms;
+')
+
+########################################
+## <summary>
+##	Append insights_client log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_append_log',`
+	gen_require(`
+		type insights_client_var_log_t;
+	')
+
+	logging_search_logs($1)
+	allow $1 insights_client_var_log_t:file append_inherited_file_perms;
 ')
 
 ########################################
@@ -319,4 +357,61 @@ interface(`insights_client_write_tmp',`
 
 	files_search_tmp($1)
 	write_files_pattern($1, insights_client_tmp_t, insights_client_tmp_t)
+')
+
+########################################
+## <summary>
+##	Manage insights_client temporary directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_manage_tmp_dirs',`
+	gen_require(`
+		type insights_client_tmp_t;
+	')
+
+	files_search_tmp($1)
+	manage_dirs_pattern($1, insights_client_tmp_t, insights_client_tmp_t)
+')
+
+########################################
+## <summary>
+##	Manage insights_client temporary files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_manage_tmp_files',`
+	gen_require(`
+		type insights_client_tmp_t;
+	')
+
+	files_search_tmp($1)
+	manage_files_pattern($1, insights_client_tmp_t, insights_client_tmp_t)
+')
+
+########################################
+## <summary>
+##	Manage insights_client temporary sock files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_manage_tmp_sock_files',`
+	gen_require(`
+		type insights_client_tmp_t;
+	')
+
+	files_search_tmp($1)
+	manage_sock_files_pattern($1, insights_client_tmp_t, insights_client_tmp_t)
 ')

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -90,7 +90,7 @@ interface(`insights_client_filetrans_named_content',`
 	gen_require(`
 		type insights_client_etc_t, insights_client_etc_rw_t;
 		type insights_client_tmp_t;
-		type insights_client_run_t;
+		type insights_client_var_run_t;
 	')
 
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".cache.json")
@@ -104,7 +104,7 @@ interface(`insights_client_filetrans_named_content',`
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "insights-client-egg-release")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "machine-id")
 
-	files_pid_filetrans($1, insights_client_run_t, file, "insights-client.pid")
+	files_pid_filetrans($1, insights_client_var_run_t, file, "insights-client.pid")
 
 	files_tmp_filetrans($1, insights_client_tmp_t, dir, "insights-client")
 	files_tmp_filetrans($1, insights_client_tmp_t, file, "insights-client.ppid")
@@ -141,11 +141,11 @@ interface(`insights_client_filetrans_tmp',`
 #
 interface(`insights_client_read_run',`
 	gen_require(`
-		type insights_client_run_t;
+		type insights_client_var_run_t;
 	')
 
 	files_search_pids($1)
-	allow $1 insights_client_run_t:file read_file_perms;
+	allow $1 insights_client_var_run_t:file read_file_perms;
 ')
 
 ########################################
@@ -160,10 +160,10 @@ interface(`insights_client_read_run',`
 #
 interface(`insights_client_filetrans_run',`
 	gen_require(`
-		type insights_client_run_t;
+		type insights_client_var_run_t;
 	')
 
-	files_pid_filetrans($1, insights_client_run_t, file, "insights-client.pid")
+	files_pid_filetrans($1, insights_client_var_run_t, file, "insights-client.pid")
 ')
 
 ########################################

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -96,7 +96,7 @@ manage_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_t
 #manage_fifo_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 #manage_sock_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 #files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file fifo_file sock_file })
-files_tmp_filetrans(insights_client_t, insights_client_tmp_t, dir)
+files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file })
 allow insights_client_t insights_client_tmp_t:sock_file write_sock_file_perms;
 #allow insights_client_t insights_client_tmp_t:dir relabel_dir_perms;
 #allow insights_client_t insights_client_tmp_t:file relabel_dir_perms;
@@ -208,9 +208,7 @@ libs_exec_ldconfig(insights_client_t)
 #')
 
 optional_policy(`
-#	auth_domtrans_chk_passwd(insights_client_t)
-	auth_read_passwd_file(insights_client_t)
-#	auth_rw_lastlog(insights_client_t)
+	auth_domtrans_chk_passwd(insights_client_t)
 ')
 
 #optional_policy(`

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -28,8 +28,8 @@ files_type(insights_client_var_lib_t)
 type insights_client_var_lock_t;
 files_lock_file(insights_client_var_lock_t)
 
-type insights_client_run_t;
-files_pid_file(insights_client_run_t)
+type insights_client_var_run_t;
+files_pid_file(insights_client_var_run_t)
 
 type insights_client_tmp_t;
 files_tmp_file(insights_client_tmp_t)
@@ -86,9 +86,9 @@ manage_files_pattern(insights_client_t, insights_client_var_log_t, insights_clie
 logging_log_filetrans(insights_client_t, insights_client_var_log_t, dir)
 
 #manage_dirs_pattern(insights_client_t, insights_client_var_run_t, insights_client_var_run_t)
-manage_files_pattern(insights_client_t, insights_client_run_t, insights_client_run_t)
+manage_files_pattern(insights_client_t, insights_client_var_run_t, insights_client_var_run_t)
 #files_pid_filetrans(insights_client_t, insights_client_var_run_t, { dir file })
-files_pid_filetrans(insights_client_t, insights_client_run_t, file)
+files_pid_filetrans(insights_client_t, insights_client_var_run_t, file)
 
 #manage_dirs_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 create_dirs_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -1,4 +1,4 @@
-policy_module(insights_client, 1.0.0)
+policy_module(insights_client, 1.0)
 
 gen_require(`
 	class passwd rootok;
@@ -22,17 +22,14 @@ files_config_file(insights_client_etc_t)
 type insights_client_etc_rw_t;
 files_config_file(insights_client_etc_rw_t)
 
-type insights_client_cache_t;
-files_type(insights_client_cache_t)
-
 type insights_client_var_lib_t;
 files_type(insights_client_var_lib_t)
 
 type insights_client_var_lock_t;
 files_lock_file(insights_client_var_lock_t)
 
-type insights_client_var_run_t;
-files_pid_file(insights_client_var_run_t)
+type insights_client_run_t;
+files_pid_file(insights_client_run_t)
 
 type insights_client_tmp_t;
 files_tmp_file(insights_client_tmp_t)
@@ -47,380 +44,400 @@ systemd_unit_file(insights_client_unit_file_t)
 #
 # insights_client local policy
 #
-allow insights_client_t self:capability { dac_override dac_read_search fowner ipc_owner kill net_admin net_raw setgid setuid sys_admin sys_nice sys_ptrace sys_rawio sys_resource };
-allow insights_client_t self:cap_userns sys_ptrace;
-allow insights_client_t self:fifo_file rw_fifo_file_perms;
-allow insights_client_t self:netlink_generic_socket create_socket_perms;
-allow insights_client_t self:netlink_netfilter_socket create_socket_perms;
-allow insights_client_t self:netlink_route_socket create_netlink_socket_perms;
-allow insights_client_t self:netlink_selinux_socket create_socket_perms;
-allow insights_client_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
-allow insights_client_t self:packet_socket create_socket_perms;
-allow insights_client_t self:passwd rootok;
-allow insights_client_t self:process { getattr getsession setfscreate setpgid setrlimit setsched };
-allow insights_client_t self:tcp_socket create_socket_perms;
-allow insights_client_t self:udp_socket create_socket_perms;
-allow insights_client_t self:unix_dgram_socket create_socket_perms;
-allow insights_client_t self:unix_stream_socket create_stream_socket_perms;
-allow insights_client_t self:vsock_socket create_socket_perms;
+#permissive insights_client_t;
 
-manage_dirs_pattern(insights_client_t, insights_client_etc_t, insights_client_etc_t)
+#allow insights_client_t self:capability { dac_override dac_read_search fowner ipc_owner kill net_admin net_raw setgid setuid sys_admin sys_nice sys_ptrace sys_rawio sys_resource };
+#allow insights_client_t self:cap_userns sys_ptrace;
+#allow insights_client_t self:fifo_file rw_fifo_file_perms;
+#allow insights_client_t self:netlink_generic_socket create_socket_perms;
+#allow insights_client_t self:netlink_netfilter_socket create_socket_perms;
+#allow insights_client_t self:netlink_route_socket create_netlink_socket_perms;
+#allow insights_client_t self:netlink_selinux_socket create_socket_perms;
+#allow insights_client_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
+#allow insights_client_t self:packet_socket create_socket_perms;
+#allow insights_client_t self:passwd rootok;
+#allow insights_client_t self:process { getattr getsession setfscreate setpgid setrlimit setsched };
+allow insights_client_t self:process setexec;
+allow insights_client_t self:tcp_socket create_socket_perms;
+#allow insights_client_t self:udp_socket create_socket_perms;
+#allow insights_client_t self:unix_dgram_socket create_socket_perms;
+#allow insights_client_t self:unix_stream_socket create_stream_socket_perms;
+allow insights_client_t self:unix_stream_socket connectto;
+#allow insights_client_t self:vsock_socket create_socket_perms;
+
+#manage_dirs_pattern(insights_client_t, insights_client_etc_t, insights_client_etc_t)
 read_files_pattern(insights_client_t, insights_client_etc_t, insights_client_etc_t)
-manage_files_pattern(insights_client_t, insights_client_etc_rw_t, insights_client_etc_rw_t)
+read_files_pattern(insights_client_t, insights_client_etc_t, insights_client_etc_rw_t)
+#manage_files_pattern(insights_client_t, insights_client_etc_rw_t, insights_client_etc_rw_t)
 insights_client_filetrans_named_content(insights_client_t)
 
-manage_files_pattern(insights_client_t, insights_client_cache_t, insights_client_cache_t)
+#manage_files_pattern(insights_client_t, insights_client_cache_t, insights_client_cache_t)
 
 manage_dirs_pattern(insights_client_t, insights_client_var_lib_t, insights_client_var_lib_t)
 manage_files_pattern(insights_client_t, insights_client_var_lib_t, insights_client_var_lib_t)
-files_var_lib_filetrans(insights_client_t, insights_client_var_lib_t, { dir file })
+#files_var_lib_filetrans(insights_client_t, insights_client_var_lib_t, { dir file })
 
-manage_dirs_pattern(insights_client_t, insights_client_var_lock_t, insights_client_var_lock_t)
-manage_files_pattern(insights_client_t, insights_client_var_lock_t, insights_client_var_lock_t)
-files_lock_filetrans(insights_client_t, insights_client_var_lock_t, dir)
+#manage_dirs_pattern(insights_client_t, insights_client_var_lock_t, insights_client_var_lock_t)
+#manage_files_pattern(insights_client_t, insights_client_var_lock_t, insights_client_var_lock_t)
+#files_lock_filetrans(insights_client_t, insights_client_var_lock_t, dir)
 
-manage_dirs_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
+#manage_dirs_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
 manage_files_pattern(insights_client_t, insights_client_var_log_t, insights_client_var_log_t)
 logging_log_filetrans(insights_client_t, insights_client_var_log_t, dir)
 
-manage_dirs_pattern(insights_client_t, insights_client_var_run_t, insights_client_var_run_t)
-manage_files_pattern(insights_client_t, insights_client_var_run_t, insights_client_var_run_t)
-files_pid_filetrans(insights_client_t, insights_client_var_run_t, { dir file })
+#manage_dirs_pattern(insights_client_t, insights_client_var_run_t, insights_client_var_run_t)
+manage_files_pattern(insights_client_t, insights_client_run_t, insights_client_run_t)
+#files_pid_filetrans(insights_client_t, insights_client_var_run_t, { dir file })
+files_pid_filetrans(insights_client_t, insights_client_run_t, file)
 
-manage_dirs_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
+#manage_dirs_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
+create_dirs_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 manage_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
-manage_fifo_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
-manage_sock_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
-files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file fifo_file sock_file })
-allow insights_client_t insights_client_tmp_t:dir relabel_dir_perms;
-allow insights_client_t insights_client_tmp_t:file relabel_dir_perms;
+#manage_fifo_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
+#manage_sock_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
+#files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file fifo_file sock_file })
+files_tmp_filetrans(insights_client_t, insights_client_tmp_t, dir)
+allow insights_client_t insights_client_tmp_t:sock_file write_sock_file_perms;
+#allow insights_client_t insights_client_tmp_t:dir relabel_dir_perms;
+#allow insights_client_t insights_client_tmp_t:file relabel_dir_perms;
 
-manage_files_pattern(insights_client_t, insights_client_tmpfs_t, insights_client_tmpfs_t)
-fs_tmpfs_filetrans(insights_client_t, insights_client_tmpfs_t, file)
-can_exec(insights_client_t, insights_client_tmpfs_t)
+#manage_files_pattern(insights_client_t, insights_client_tmpfs_t, insights_client_tmpfs_t)
+#fs_tmpfs_filetrans(insights_client_t, insights_client_tmpfs_t, file)
+#can_exec(insights_client_t, insights_client_tmpfs_t)
 
-allow insights_client_t insights_client_unit_file_t:file read_file_perms;
-allow insights_client_t insights_client_unit_file_t:service manage_service_perms;
+#allow insights_client_t insights_client_unit_file_t:file read_file_perms;
+#allow insights_client_t insights_client_unit_file_t:service manage_service_perms;
 
-kernel_dgram_send(insights_client_t)
-kernel_get_sysvipc_info(insights_client_t)
-kernel_read_all_sysctls(insights_client_t)
-kernel_list_all_proc(insights_client_t)
-kernel_read_network_state(insights_client_t)
-kernel_read_proc_files(insights_client_t)
-kernel_read_ring_buffer(insights_client_t)
-kernel_read_security_state(insights_client_t)
-kernel_read_software_raid_state(insights_client_t)
-kernel_read_system_state(insights_client_t)
-kernel_request_load_module(insights_client_t)
-kernel_view_key(insights_client_t)
+### Interactions with insights-core
+optional_policy(`
+	insights_core_domtrans(insights_client_t)
+')
 
-corecmd_exec_all_executables(insights_client_t)
+#kernel_dgram_send(insights_client_t)
+#kernel_get_sysvipc_info(insights_client_t)
+#kernel_read_all_sysctls(insights_client_t)
+#kernel_list_all_proc(insights_client_t)
+#kernel_read_network_state(insights_client_t)
+#kernel_read_proc_files(insights_client_t)
+#kernel_read_ring_buffer(insights_client_t)
+#kernel_read_security_state(insights_client_t)
+#kernel_read_software_raid_state(insights_client_t)
+#kernel_read_system_state(insights_client_t)
+#kernel_request_load_module(insights_client_t)
+#kernel_view_key(insights_client_t)
+
+corecmd_exec_bin(insights_client_t)
+#corecmd_exec_all_executables(insights_client_t)
 corenet_tcp_bind_generic_node(insights_client_t)
-corenet_tcp_connect_all_ports(insights_client_t)
-corenet_udp_bind_generic_node(insights_client_t)
+#corenet_tcp_connect_all_ports(insights_client_t)
+#corenet_udp_bind_generic_node(insights_client_t)
 
-dev_getattr_all(insights_client_t)
-dev_getattr_all_blk_files(insights_client_t)
-dev_getattr_all_chr_files(insights_client_t)
-dev_read_cpuid(insights_client_t)
-dev_read_kmsg(insights_client_t)
-dev_read_netcontrol(insights_client_t)
-dev_read_raw_memory(insights_client_t)
-dev_read_vsock(insights_client_t)
-dev_dontaudit_write_raw_memory(insights_client_t)
+#dev_getattr_all(insights_client_t)
+#dev_getattr_all_blk_files(insights_client_t)
+#dev_getattr_all_chr_files(insights_client_t)
+#dev_read_cpuid(insights_client_t)
+#dev_read_kmsg(insights_client_t)
+#dev_read_netcontrol(insights_client_t)
+#dev_read_raw_memory(insights_client_t)
+#dev_read_vsock(insights_client_t)
+#dev_dontaudit_write_raw_memory(insights_client_t)
 dev_read_sysfs(insights_client_t)
-dev_rw_lvm_control(insights_client_t)
+#dev_rw_lvm_control(insights_client_t)
 
-domain_connect_all_stream_sockets(insights_client_t)
-domain_getattr_all_domains(insights_client_t)
-domain_getattr_all_sockets(insights_client_t)
-domain_getattr_all_pipes(insights_client_t)
-domain_manage_all_domains_keyrings(insights_client_t)
-domain_read_all_domains_state(insights_client_t)
-domain_signal_all_domains(insights_client_t)
-domain_signull_all_domains(insights_client_t)
-domain_unix_read_all_semaphores(insights_client_t)
-domain_use_interactive_fds(insights_client_t)
-
-files_getattr_all_files(insights_client_t)
-files_getattr_all_blk_files(insights_client_t)
-files_getattr_all_chr_files(insights_client_t)
-files_getattr_all_file_type_fs(insights_client_t)
-files_getattr_all_pipes(insights_client_t)
-files_getattr_all_sockets(insights_client_t)
-files_manage_etc_symlinks(insights_client_t)
-files_manage_generic_locks(insights_client_t)
-files_map_non_security_files(insights_client_t)
-files_map_read_etc_files(insights_client_t)
-files_read_non_security_files(insights_client_t)
-files_read_all_symlinks(insights_client_t)
-files_status_etc(insights_client_t)
-files_write_generic_tmp_sock_files(insights_client_t)
-
-fs_get_all_fs_quotas(insights_client_t)
-fs_getattr_all_fs(insights_client_t)
-fs_getattr_all_files(insights_client_t)
-fs_read_configfs_dirs(insights_client_t)
-
-init_dontaudit_read_state(insights_client_t)
-init_reload_services(insights_client_t)
-init_status(insights_client_t)
-init_status_all_script_files(insights_client_t)
-init_view_key(insights_client_t)
+#domain_connect_all_stream_sockets(insights_client_t)
+#domain_getattr_all_domains(insights_client_t)
+#domain_getattr_all_sockets(insights_client_t)
+#domain_getattr_all_pipes(insights_client_t)
+#domain_manage_all_domains_keyrings(insights_client_t)
+#domain_read_all_domains_state(insights_client_t)
+#domain_signal_all_domains(insights_client_t)
+#domain_signull_all_domains(insights_client_t)
+#domain_unix_read_all_semaphores(insights_client_t)
+#domain_use_interactive_fds(insights_client_t)
+#
+#files_getattr_all_files(insights_client_t)
+#files_getattr_all_blk_files(insights_client_t)
+#files_getattr_all_chr_files(insights_client_t)
+#files_getattr_all_file_type_fs(insights_client_t)
+#files_getattr_all_pipes(insights_client_t)
+#files_getattr_all_sockets(insights_client_t)
+#files_manage_etc_symlinks(insights_client_t)
+#files_manage_generic_locks(insights_client_t)
+#files_map_non_security_files(insights_client_t)
+#files_map_read_etc_files(insights_client_t)
+#files_read_non_security_files(insights_client_t)
+#files_read_all_symlinks(insights_client_t)
+#files_status_etc(insights_client_t)
+#files_write_generic_tmp_sock_files(insights_client_t)
+#
+#fs_get_all_fs_quotas(insights_client_t)
+#fs_getattr_all_fs(insights_client_t)
+#fs_getattr_all_files(insights_client_t)
+#fs_read_configfs_dirs(insights_client_t)
+#
+#init_dontaudit_read_state(insights_client_t)
+#init_reload_services(insights_client_t)
+#init_status(insights_client_t)
+#init_status_all_script_files(insights_client_t)
+#init_view_key(insights_client_t)
 
 libs_exec_ldconfig(insights_client_t)
 
-miscfiles_read_generic_certs(insights_client_t)
-miscfiles_read_localization(insights_client_t)
+#miscfiles_read_generic_certs(insights_client_t)
+#miscfiles_read_localization(insights_client_t)
+#
+#selinux_compute_access_vector(insights_client_t)
+#
+#seutil_domtrans_semanage(insights_client_t)
+#seutil_read_config(insights_client_t)
+#seutil_read_module_store(insights_client_t)
+#
+#storage_raw_read_fixed_disk(insights_client_t)
+#
+#tunable_policy(`deny_execmem',`',`
+#	allow insights_client_t self:process execmem;
+#')
+#
+#optional_policy(`
+#	abrt_dbus_chat(insights_client_t)
+#')
+#
+#optional_policy(`
+#	apache_exec_modules(insights_client_t)
+#	apache_read_semaphores(insights_client_t)
+#')
 
-selinux_compute_access_vector(insights_client_t)
+optional_policy(`
+#	auth_domtrans_chk_passwd(insights_client_t)
+	auth_read_passwd_file(insights_client_t)
+#	auth_rw_lastlog(insights_client_t)
+')
 
-seutil_domtrans_semanage(insights_client_t)
-seutil_read_config(insights_client_t)
-seutil_read_module_store(insights_client_t)
+#optional_policy(`
+#	bind_domtrans_ndc(insights_client_t)
+#')
+#
+#optional_policy(`
+#	bootloader_exec(insights_client_t)
+#')
+#
+#optional_policy(`
+#	certmonger_dbus_chat(insights_client_t)
+#')
+#
+#optional_policy(`
+#	chronyd_dgram_send(insights_client_t)
+#	chronyd_domtrans_chronyc(insights_client_t)
+#	chronyd_manage_pid(insights_client_t)
+#	chronyd_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	container_runtime_domtrans(insights_client_t)
+#')
+#
+#optional_policy(`
+#	cron_signull_system_job(insights_client_t)
+#	cron_system_entry(insights_client_t, insights_client_exec_t)
+#')
+#
+#optional_policy(`
+#	dbus_system_bus_client(insights_client_t)
+#')
+#
+#optional_policy(`
+#	dmesg_exec(insights_client_t)
+#')
+#
+#optional_policy(`
+#	dmidecode_exec(insights_client_t)
+#')
+#
+#optional_policy(`
+#	fstools_domtrans(insights_client_t)
+#	fsadm_manage_pid(insights_client_t)
+#')
+#
+#optional_policy(`
+#	firewalld_dbus_chat(insights_client_t)
+#')
+#
+#optional_policy(`
+#	fwupd_dbus_chat(insights_client_t)
+#')
+#
+#optional_policy(`
+#	gen_require(`
+#		type glusterd_log_t;
+#	')
+#
+#	logging_log_filetrans(insights_client_t, glusterd_log_t, dir, "gluster")
+#')
 
-storage_raw_read_fixed_disk(insights_client_t)
-
-tunable_policy(`deny_execmem',`',`
-	allow insights_client_t self:process execmem;
+optional_policy(`
+#	gnome_search_gconf(insights_client_t)
+#	gnome_manage_generic_cache_files(insights_client_t)
+#	gnome_manage_home_config(insights_client_t)
+#	gnome_manage_home_config_dirs(insights_client_t)
+	gnome_read_generic_data_home_dirs(insights_client_t)
 ')
 
 optional_policy(`
-	abrt_dbus_chat(insights_client_t)
-')
-
-optional_policy(`
-	apache_exec_modules(insights_client_t)
-	apache_read_semaphores(insights_client_t)
-')
-
-optional_policy(`
-	auth_domtrans_chk_passwd(insights_client_t)
-	auth_read_passwd(insights_client_t)
-	auth_rw_lastlog(insights_client_t)
-')
-
-optional_policy(`
-	bind_domtrans_ndc(insights_client_t)
-')
-
-optional_policy(`
-	bootloader_exec(insights_client_t)
-')
-
-optional_policy(`
-	certmonger_dbus_chat(insights_client_t)
-')
-
-optional_policy(`
-	chronyd_dgram_send(insights_client_t)
-	chronyd_domtrans_chronyc(insights_client_t)
-	chronyd_manage_pid(insights_client_t)
-	chronyd_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	container_runtime_domtrans(insights_client_t)
-')
-
-optional_policy(`
-	cron_signull_system_job(insights_client_t)
-	cron_system_entry(insights_client_t, insights_client_exec_t)
-')
-
-optional_policy(`
-	dbus_system_bus_client(insights_client_t)
-')
-
-optional_policy(`
-	dmesg_exec(insights_client_t)
-')
-
-optional_policy(`
-	dmidecode_exec(insights_client_t)
-')
-
-optional_policy(`
-	fstools_domtrans(insights_client_t)
-	fsadm_manage_pid(insights_client_t)
-')
-
-optional_policy(`
-	firewalld_dbus_chat(insights_client_t)
-')
-
-optional_policy(`
-	fwupd_dbus_chat(insights_client_t)
-')
-
-optional_policy(`
-	gen_require(`
-		type glusterd_log_t;
-	')
-
-	logging_log_filetrans(insights_client_t, glusterd_log_t, dir, "gluster")
-')
-
-optional_policy(`
-	gnome_search_gconf(insights_client_t)
-	gnome_manage_generic_cache_files(insights_client_t)
-	gnome_manage_home_config(insights_client_t)
-	gnome_manage_home_config_dirs(insights_client_t)
-')
-
-optional_policy(`
+	#gpg_exec(insights_client_t)
 	gpg_domtrans(insights_client_t)
-	gpg_manage_admin_home_content(insights_client_t)
+	gpg_read_user_secrets(insights_client_t)
+
+	gpg_agent_stream_connect(insights_client_t)
+	gpg_domtrans_agent(insights_client_t)
 ')
 
-optional_policy(`
-	hostname_exec(insights_client_t)
-')
+#optional_policy(`
+#	hostname_exec(insights_client_t)
+#')
+#
+#optional_policy(`
+#	init_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	iptables_domtrans(insights_client_t)
+#')
+#
+#optional_policy(`
+#	journalctl_domtrans(insights_client_t)
+#')
+#
+#optional_policy(`
+#	logging_domtrans_auditctl(insights_client_t)
+#	logging_manage_generic_logs(insights_client_t)
+#	logging_mmap_generic_logs(insights_client_t)
+#	logging_mmap_journal(insights_client_t)
+#	logging_read_audit_config(insights_client_t)
+#	logging_read_audit_log(insights_client_t)
+#	logging_send_syslog_msg(insights_client_t)
+#')
+#
+#optional_policy(`
+#	lpd_domtrans_lpr(insights_client_t)
+#')
+#
+#optional_policy(`
+#	lvm_domtrans(insights_client_t)
+#	lvm_manage_metadata(insights_client_t)
+#')
 
 optional_policy(`
-	init_stream_connect(insights_client_t)
+	miscfiles_read_generic_certs(insights_client_t)
 ')
 
-optional_policy(`
-	iptables_domtrans(insights_client_t)
-')
+#optional_policy(`
+#	mount_domtrans(insights_client_t)
+#')
+#
+#optional_policy(`
+#	mysql_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	modutils_domtrans_kmod(insights_client_t)
+#	modutils_read_module_deps_files(insights_client_t)
+#')
+#
+#optional_policy(`
+#	networkmanager_dbus_chat(insights_client_t)
+#	networkmanager_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	openvswitch_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	pcp_filetrans_named_content(insights_client_t)
+#	pcp_write_pid_sock_file(insights_client_t)
+#')
+#
+#optional_policy(`
+#	postgresql_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	redis_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	rhcs_rw_cluster_tmpfs(insights_client_t)
+#')
+#
+#optional_policy(`
+#	rhnsd_read_config(insights_client_t)
+#')
 
 optional_policy(`
-	journalctl_domtrans(insights_client_t)
+	rhsmcertd_read_config_files(insights_client_t)
+#	rhsmcertd_manage_config_files(insights_client_t)
+#	rhsmcertd_manage_pid_files(insights_client_t)
+#	rhsmcertd_manage_lib_files(insights_client_t)
+#	rhsmcertd_manage_log(insights_client_t)
 ')
 
-optional_policy(`
-	logging_domtrans_auditctl(insights_client_t)
-	logging_mmap_generic_logs(insights_client_t)
-	logging_mmap_journal(insights_client_t)
-	logging_read_audit_config(insights_client_t)
-	logging_read_audit_log(insights_client_t)
-	logging_send_syslog_msg(insights_client_t)
-')
+#optional_policy(`
+#	rpm_domtrans(insights_client_t)
+#	rpm_manage_db(insights_client_t)
+#	rpm_manage_cache(insights_client_t)
+#	rpm_named_filetrans(insights_client_t)
+#	rpm_read_db(insights_client_t)
+#	rpm_signull(insights_client_t)
+#')
+#
+#optional_policy(`
+#	rtas_errd_dontaudit_write_lock(insights_client_t)
+#')
+#
+#optional_policy(`
+#	samba_manage_var_dirs(insights_client_t)
+#	samba_manage_var_files(insights_client_t)
+#	samba_manage_var_sock_files(insights_client_t)
+#')
+#
+#optional_policy(`
+#	setroubleshoot_dbus_chat(insights_client_t)
+#	setroubleshoot_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	sysnet_exec_ifconfig(insights_client_t)
+#	sysnet_read_config(insights_client_t)
+#')
+#
+#optional_policy(`
+#	systemd_dbus_chat_logind(insights_client_t)
+#	systemd_dbus_chat_timedated(insights_client_t)
+#	systemd_start_all_unit_files(insights_client_t)
+#	systemd_status_all_unit_files(insights_client_t)
+#	systemd_machined_stream_connect(insights_client_t)
+#	systemd_userdbd_stream_connect(insights_client_t)
+#')
+#
+#optional_policy(`
+#	tuned_dbus_chat(insights_client_t)
+#')
+#
+#optional_policy(`
+#	unconfined_domain(insights_client_t)
+#	unconfined_server_create_shm(insights_client_t)
+#	unconfined_server_read_semaphores(insights_client_t)
+#')
 
 optional_policy(`
-	lpd_domtrans_lpr(insights_client_t)
-')
-
-optional_policy(`
-	lvm_domtrans(insights_client_t)
-	lvm_manage_metadata(insights_client_t)
-')
-
-optional_policy(`
-	mount_domtrans(insights_client_t)
-')
-
-optional_policy(`
-	mysql_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	modutils_domtrans_kmod(insights_client_t)
-	modutils_read_module_deps_files(insights_client_t)
-')
-
-optional_policy(`
-	networkmanager_dbus_chat(insights_client_t)
-	networkmanager_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	openvswitch_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	pcp_filetrans_named_content(insights_client_t)
-	pcp_write_pid_sock_file(insights_client_t)
-')
-
-optional_policy(`
-	postgresql_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	redis_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	rhcs_rw_cluster_tmpfs(insights_client_t)
-')
-
-optional_policy(`
-	rhnsd_read_config(insights_client_t)
-')
-
-optional_policy(`
-	rhsmcertd_manage_config_files(insights_client_t)
-	rhsmcertd_manage_pid_files(insights_client_t)
-	rhsmcertd_manage_lib_files(insights_client_t)
-	rhsmcertd_manage_log(insights_client_t)
-')
-
-optional_policy(`
-	rpm_domtrans(insights_client_t)
-	rpm_manage_db(insights_client_t)
-	rpm_manage_cache(insights_client_t)
-	rpm_hawkey_named_filetrans(insights_client_t)
-	rpm_read_db(insights_client_t)
-	rpm_signull(insights_client_t)
-')
-
-optional_policy(`
-	rtas_errd_dontaudit_write_lock(insights_client_t)
-')
-
-optional_policy(`
-	samba_manage_var_dirs(insights_client_t)
-	samba_manage_var_files(insights_client_t)
-	samba_manage_var_sock_files(insights_client_t)
-')
-
-optional_policy(`
-        sap_unconfined_domtrans(insights_client_t)
-')
-
-optional_policy(`
-	setroubleshoot_dbus_chat(insights_client_t)
-	setroubleshoot_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	sysnet_exec_ifconfig(insights_client_t)
-	sysnet_read_config(insights_client_t)
-')
-
-optional_policy(`
-	systemd_dbus_chat_logind(insights_client_t)
-	systemd_dbus_chat_timedated(insights_client_t)
-	systemd_start_all_unit_files(insights_client_t)
-	systemd_status_all_unit_files(insights_client_t)
-	systemd_machined_stream_connect(insights_client_t)
-	systemd_userdbd_stream_connect(insights_client_t)
-')
-
-optional_policy(`
-	timedatex_dbus_chat(insights_client_t)
-')
-
-optional_policy(`
-	tuned_dbus_chat(insights_client_t)
-')
-
-optional_policy(`
-	unconfined_domain(insights_client_t)
-	unconfined_server_create_shm(insights_client_t)
-	unconfined_server_read_semaphores(insights_client_t)
-')
-
-optional_policy(`
-	userdom_manage_admin_files(insights_client_t)
-	userdom_manage_user_tmp_files(insights_client_t)
+#	userdom_manage_admin_files(insights_client_t)
+#	userdom_manage_user_tmp_files(insights_client_t)
 	userdom_user_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file })
-	userdom_view_all_users_keys(insights_client_t)
+	userdom_write_user_tmp_sockets(insights_client_t)
+	#userdom_user_tmp_filetrans(insights_client_t, insights_client_tmp_t, dir)
+#	userdom_view_all_users_keys(insights_client_t)
 ')
-
-optional_policy(`
-	virt_stream_connect(insights_client_t)
-')
+#
+#optional_policy(`
+#	virt_stream_connect(insights_client_t)
+#')

--- a/policy/modules/contrib/insights_core.if
+++ b/policy/modules/contrib/insights_core.if
@@ -1,0 +1,61 @@
+## <summary>policy for insights_core</summary>
+
+########################################
+## <summary>
+##	Allow explicit transition to insights_core_t domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`insights_core_domtrans',`
+	gen_require(`
+		type insights_core_t;
+	')
+
+	allow $1 insights_core_t: process transition;
+	allow insights_core_t $1:fd use;
+	allow insights_core_t $1:fifo_file rw_file_perms;
+	allow insights_core_t $1:process sigchld;
+	allow insights_core_t $1:dir search_dir_perms;
+')
+
+########################################
+## <summary>
+##	Write to an insights_core unnamed pipe.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_core_write_pipes',`
+	gen_require(`
+		type insights_core_t;
+	')
+
+	allow $1 insights_core_t:fifo_file write_fifo_file_perms;
+')
+
+########################################
+## <summary>
+##	Read insights_client lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_core_read_lib_files',`
+	gen_require(`
+		type insights_core_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, insights_core_var_lib_t, insights_core_var_lib_t)
+	allow $1 insights_core_var_lib_t:file map;
+')

--- a/policy/modules/contrib/insights_core.if
+++ b/policy/modules/contrib/insights_core.if
@@ -10,16 +10,18 @@
 ##	</summary>
 ## </param>
 #
-interface(`insights_core_domtrans',`
-	gen_require(`
-		type insights_core_t;
-	')
+ifndef(`insights_core_domtrans',`
+	interface(`insights_core_domtrans',`
+		gen_require(`
+			type insights_core_t;
+		')
 
-	allow $1 insights_core_t: process transition;
-	allow insights_core_t $1:fd use;
-	allow insights_core_t $1:fifo_file rw_file_perms;
-	allow insights_core_t $1:process sigchld;
-	allow insights_core_t $1:dir search_dir_perms;
+		allow $1 insights_core_t: process transition;
+		allow insights_core_t $1:fd use;
+		allow insights_core_t $1:fifo_file rw_file_perms;
+		allow insights_core_t $1:process sigchld;
+		allow insights_core_t $1:dir search_dir_perms;
+	')
 ')
 
 ########################################
@@ -32,12 +34,14 @@ interface(`insights_core_domtrans',`
 ##	</summary>
 ## </param>
 #
-interface(`insights_core_write_pipes',`
-	gen_require(`
-		type insights_core_t;
-	')
+ifndef(`insights_core_write_pipes',`
+	interface(`insights_core_write_pipes',`
+		gen_require(`
+			type insights_core_t;
+		')
 
-	allow $1 insights_core_t:fifo_file write_fifo_file_perms;
+		allow $1 insights_core_t:fifo_file write_fifo_file_perms;
+	')
 ')
 
 ########################################
@@ -50,12 +54,14 @@ interface(`insights_core_write_pipes',`
 ##	</summary>
 ## </param>
 #
-interface(`insights_core_read_lib_files',`
-	gen_require(`
-		type insights_core_var_lib_t;
-	')
+ifndef(`insights_core_read_lib_files',`
+	interface(`insights_core_read_lib_files',`
+		gen_require(`
+			type insights_core_var_lib_t;
+		')
 
-	files_search_var_lib($1)
-	read_files_pattern($1, insights_core_var_lib_t, insights_core_var_lib_t)
-	allow $1 insights_core_var_lib_t:file map;
+		files_search_var_lib($1)
+		read_files_pattern($1, insights_core_var_lib_t, insights_core_var_lib_t)
+		allow $1 insights_core_var_lib_t:file map;
+	')
 ')

--- a/policy/modules/contrib/irqbalance.te
+++ b/policy/modules/contrib/irqbalance.te
@@ -77,6 +77,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_dontaudit_read_public_files(irqbalance_t)
+')
+
+optional_policy(`
 	udev_read_db(irqbalance_t)
 ')
 

--- a/policy/modules/contrib/lpd.te
+++ b/policy/modules/contrib/lpd.te
@@ -294,10 +294,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_write_tmp(lpr_t)
-')
-
-optional_policy(`
 	logging_send_syslog_msg(lpr_t)
 ')
 

--- a/policy/modules/contrib/qgs.fc
+++ b/policy/modules/contrib/qgs.fc
@@ -1,6 +1,6 @@
 /etc/qgs\.conf     -- gen_context(system_u:object_r:qgs_etc_t,s0)
 
-/usr/bin/qgs       -- gen_context(system_u:object_r:qgs_exec_t,s0)
+/usr/sbin/qgs       -- gen_context(system_u:object_r:qgs_exec_t,s0)
 
 /var/lib/qgs(/.*)?    gen_context(system_u:object_r:qgs_var_lib_t,s0)
-/run/tdx-qgs(/.*)?    gen_context(system_u:object_r:qgs_var_run_t,s0)
+/var/run/tdx-qgs(/.*)?    gen_context(system_u:object_r:qgs_var_run_t,s0)

--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -148,11 +148,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_domtrans(rhcd_t)
-	insights_client_read_config(rhcd_t)
-')
-
-optional_policy(`
  	logging_domtrans_auditctl(rhcd_t)
 	logging_send_syslog_msg(rhcd_t)
 ')

--- a/policy/modules/contrib/rhsmcertd.if
+++ b/policy/modules/contrib/rhsmcertd.if
@@ -59,6 +59,26 @@ interface(`rhsmcertd_read_config_files',`
 
 ########################################
 ## <summary>
+##      Write rhsmcertd's config files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`rhsmcertd_write_config_files',`
+        gen_require(`
+                type rhsmcertd_config_t;
+        ')
+
+        files_search_var_lib($1)
+        write_files_pattern($1, rhsmcertd_config_t, rhsmcertd_config_t)
+        allow $1 rhsmcertd_config_t:file setattr;
+')
+
+########################################
+## <summary>
 ##      Manage rhsmcertd's config files.
 ## </summary>
 ## <param name="domain">
@@ -113,6 +133,25 @@ interface(`rhsmcertd_append_log',`
 
 	logging_search_logs($1)
 	append_files_pattern($1, rhsmcertd_log_t, rhsmcertd_log_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to create rhsmcertd log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rhsmcertd_create_log',`
+	gen_require(`
+		type rhsmcertd_log_t;
+	')
+
+	logging_search_logs($1)
+	create_files_pattern($1, rhsmcertd_log_t, rhsmcertd_log_t)
 ')
 
 ########################################
@@ -172,6 +211,25 @@ interface(`rhsmcertd_read_lib_files',`
 
 	files_search_var_lib($1)
 	read_files_pattern($1, rhsmcertd_var_lib_t, rhsmcertd_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to create rhsmcertd lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rhsmcertd_create_lib_files',`
+	gen_require(`
+		type rhsmcertd_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	create_files_pattern($1, rhsmcertd_var_lib_t, rhsmcertd_var_lib_t)
 ')
 
 ########################################

--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -166,10 +166,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_read_config(rhsmcertd_t)
-')
-
-optional_policy(`
 	kpatch_domtrans(rhsmcertd_t)
 	kpatch_read_lib_files(rhsmcertd_t)
 ')

--- a/policy/modules/contrib/sssd.if
+++ b/policy/modules/contrib/sssd.if
@@ -210,6 +210,7 @@ interface(`sssd_dontaudit_read_public_files',`
 		type sssd_public_t;
 	')
 
+	dontaudit $1 sssd_public_t:dir search_dir_perms;
 	dontaudit $1 sssd_public_t:file read_file_perms;
 ')
 

--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -1855,3 +1855,21 @@ interface(`virt_manage_qemu_pid_sock_files',`
        files_search_pids($1)
        manage_sock_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
 ')
+
+########################################
+## <summary>
+##	Execute virsh in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_exec_virsh',`
+	gen_require(`
+		type virsh_exec_t;
+	')
+
+	can_exec($1, virsh_exec_t)
+')

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -634,6 +634,25 @@ interface(`ssh_initrc_domtrans',`
 
 ########################################
 ## <summary>
+##	Execute the ssh server in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ssh_exec_sshd',`
+	gen_require(`
+		type sshd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, sshd_exec_t)
+')
+
+########################################
+## <summary>
 ##	Execute the ssh client in the caller domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -1309,6 +1309,25 @@ interface(`auth_manage_pam_pid',`
 
 ########################################
 ## <summary>
+##	Write to /run/motd files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_write_motd_var_run_files',`
+	gen_require(`
+		type motd_var_run_t;
+	')
+
+	files_search_pids($1)
+	write_files_pattern($1, motd_var_run_t, motd_var_run_t)
+')
+
+########################################
+## <summary>
 ##	Execute pam_console with a domain transition.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -826,7 +826,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	insights_client_rw_pipes(init_t)
+	insights_core_write_pipes(init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -193,10 +193,6 @@ logging_set_audit_parameters(auditctl_t)
 logging_send_syslog_msg(auditctl_t)
 
 optional_policy(`
-	insights_client_write_tmp(auditctl_t)
-')
-
-optional_policy(`
 	rhcd_read_fifo_files(auditctl_t)
 ')
 


### PR DESCRIPTION
The insights_core_t domain is used by the insights client with explicit transition using setexeccon().

Resolves: SELINUX-4392