### PR TITLE
Add the file/watch_mountns permission

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -36,6 +36,7 @@ common file
 	watch_sb
 	watch_with_perm
 	watch_reads
+	watch_mountns
 }
 
 

--- a/policy/flask/flask_documentation.md
+++ b/policy/flask/flask_documentation.md
@@ -46,6 +46,8 @@ The common file permissions that are inherited by a number of object classes.
 
 **watch\_mount** - Set a watch on filesystem objects within the same mount.
 
+**watch\_mountns** - Required to control access to watching for changes to the mount namespace. Changes include the addition of a new filesystem mount, removal of an existing mount, or moving a mount in a namespace.
+
 **watch\_reads** - Required to receive notifications from read-exclusive events on filesystem objects. These events include accessing a file for the purpose of reading and closing a file which has been opened read-only.
 
 **watch\_sb** - Set a watch on filesystem objects within the same filesystem. Superblock watches further require the filesystem watch permission to the superblock.


### PR DESCRIPTION
The watch_mountns permission in the common file class was added to control access to watching for changes to the mount namespace. Changes include the addition of a new filesystem mount, removal of an existing mount, or moving a mount in a namespace.

In kernel v6.15 since the 7d90fb525319 ("selinux: add FILE__WATCH_MOUNTNS") commit.