### PR TITLE
Allow spamd-update status systemd services

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -681,6 +681,7 @@ optional_policy(`
 
 optional_policy(`
 	systemd_exec_systemctl(spamd_update_t)
+	systemd_status_systemd_services(spamd_update_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(09/18/2024 02:41:36.362:404) : pid=1 uid=root auid=unset ses=unset subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=unset uid=root gid=root path=/usr/lib/systemd/system/mimedefang.service cmdline="" function="mac_selinux_filter" scontext=system_u:system_r:spamd_update_t:s0 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=service permissive=0 exe=/usr/lib/systemd/systemd sauid=root hostname=? addr=? terminal=?'