### PR TITLE
Allow virtqemud send a generic signal to passt

### DIFF
--- a/policy/modules/contrib/passt.if
+++ b/policy/modules/contrib/passt.if
@@ -38,3 +38,13 @@ ifndef(`passt_stream_connect',`
 		allow $1 passt_t:unix_stream_socket connectto;
 	')
 ')
+
+ifndef(`passt_signal',`
+	interface(`passt_signal',`
+		gen_require(`
+			type passt_t;
+		')
+
+	allow $1 passt_t:process signal;
+	')
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2347,6 +2347,7 @@ optional_policy(`
 
 optional_policy(`
 	passt_domtrans(virtqemud_t)
+	passt_signal(virtqemud_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This permission is required when a hotplug interface is unplugged.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/30/2024 05:05:48.974:590) : proctitle=/usr/sbin/virtqemud --timeout 120 type=AVC msg=audit(10/30/2024 05:05:48.974:590) : avc:  denied  { signal } for  pid=4187 comm=rpc-virtqemud scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:passt_t:s0:c615,c907 tclass=process permissive=1 type=SYSCALL msg=audit(10/30/2024 05:05:48.974:590) : arch=x86_64 syscall=kill success=yes exit=0 a0=0x1789 a1=SIGTERM a2=0x7febf274e585 a3=0xc8 items=0 ppid=1 pid=4187 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null)

Resolves: RHEL-44994