### PR TITLE
Allow svirt-tcg read init state

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -562,6 +562,8 @@ corenet_tcp_connect_all_ports(svirt_tcg_t)
 
 ps_process_pattern(svirt_tcg_t, virtd_t)
 
+init_read_state(svirt_tcg_t)
+
 virt_dontaudit_read_state(svirt_tcg_t)
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/09/2025 11:52:58.743:203) : proctitle=/usr/libexec/qemu-kvm -name guest=test7,debug-threads=on -S -object {"qom-type":"secret","id":"masterKey0","format":"raw","file" type=PATH msg=audit(06/09/2025 11:52:58.743:203) : item=0 name=/proc/1/cmdline nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/09/2025 11:52:58.743:203) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55afe2fdfa80 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=1532 auid=unset uid=qemu gid=qemu euid=qemu suid=qemu fsuid=qemu egid=qemu sgid=qemu fsgid=qemu tty=(none) ses=unset comm=qemu-kvm exe=/usr/libexec/qemu-kvm subj=system_u:system_r:svirt_tcg_t:s0:c215,c297 key=(null) type=AVC msg=audit(06/09/2025 11:52:58.743:203) : avc:  denied  { search } for  pid=1532 comm=qemu-kvm name=1 dev="proc" ino=2184 scontext=system_u:system_r:svirt_tcg_t:s0:c215,c297 tcontext=system_u:system_r:init_t:s0 tclass=dir permissive=0

Resolves: RHEL-95725