### PR TITLE
Allow local login execute gnome keyring daemon

### DIFF
--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -181,6 +181,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gnome_exec_keyringd(local_login_t)
+')
+
+optional_policy(`
 	gpm_getattr_gpmctl(local_login_t)
 	gpm_setattr_gpmctl(local_login_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(25/06/2025 17:45:50.188:175) : proctitle=/bin/login -- type=PATH msg=audit(25/06/2025 17:45:50.188:175) : item=0 name=/usr/bin/gnome-keyring-daemon inode=149181 dev=fc:01 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:gkeyringd_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(25/06/2025 17:45:50.188:175) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x7efcaaf0ccb5 a1=0x7ffdbdcfda90 a2=0x560983f82d70 a3=0x0 items=1 ppid=1833 pid=1872 auid=twohot uid=twohot gid=twohot euid=twohot suid=twohot fsuid=twohot egid=twohot sgid=twohot fsgid=twohot tty=tty1 ses=3 comm=login exe=/usr/bin/login subj=system_u:system_r:local_login_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(25/06/2025 17:45:50.188:175) : avc:  denied  { execute } for  pid=1872 comm=login name=gnome-keyring-daemon dev="dm-1" ino=149181 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=system_u:object_r:gkeyringd_exec_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2374728