### PR TITLE
Allow virtqemud additional permissions on scsi generic chr files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2303,6 +2303,10 @@ init_stream_connect_script(virtqemud_t)
 selinux_compute_create_context(virtqemud_t)
 
 storage_manage_fixed_disk(virtqemud_t)
+storage_read_scsi_generic(virtqemud_t)
+storage_write_scsi_generic(virtqemud_t)
+storage_delete_scsi_generic_dev(virtqemud_t)
+storage_setattr_scsi_generic_dev(virtqemud_t)
 
 sysnet_exec_ifconfig(virtqemud_t)
 sysnet_manage_config(virtqemud_t)

--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -565,6 +565,25 @@ interface(`storage_getattr_scsi_generic_dev',`
 
 ########################################
 ## <summary>
+##	Allow the caller to unlink the generic SCSI interface device nodes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`storage_delete_scsi_generic_dev',`
+	gen_require(`
+		type scsi_generic_device_t;
+	')
+
+	allow $1 scsi_generic_device_t:chr_file delete_chr_file_perms;
+	dev_remove_entry_generic_dirs($1)
+')
+
+########################################
+## <summary>
 ##	Allow the caller to set the attributes of
 ##	the generic SCSI interface device nodes.
 ## </summary>


### PR DESCRIPTION
In particular: read, write, setattr, unlink.
Triggered when a device is being hot-plugged or hot-unplugged to/from a vm.

The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(06/25/2025 04:34:13.163:11278) : proctitle=/usr/sbin/virtqemud --timeout 120 type=AVC msg=audit(06/25/2025 04:34:13.163:11278) : avc:  denied  { read write } for  pid=151041 comm=rpc-virtqemud name=sg4 dev="tmpfs" ino=14 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:scsi_generic_device_t:s0 tclass=chr_file permissive=1 type=AVC msg=audit(06/25/2025 04:34:13.163:11278) : avc:  denied  { open } for  pid=151041 comm=rpc-virtqemud path=/dev/sg4 dev="tmpfs" ino=14 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:scsi_generic_device_t:s0 tclass=chr_file permissive=1 type=SYSCALL msg=audit(06/25/2025 04:34:13.163:11278) : arch=x86_64 syscall=openat success=yes exit=21 a0=AT_FDCWD a1=0x7f1574006fd0 a2=O_RDWR a3=0x0 items=0 ppid=150846 pid=151041 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null)

Resolves: RHEL-44628