### PR TITLE
Allow virtstoraged the sys_rawio capability

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2412,7 +2412,7 @@ optional_policy(`
 #
 # virtstoraged local policy
 #
-allow virtstoraged_t self:capability { dac_override dac_read_search fsetid ipc_lock };
+allow virtstoraged_t self:capability { dac_override dac_read_search fsetid ipc_lock sys_rawio};
 
 allow virtstoraged_t self:process { setsched };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/24/2024 06:20:17.115:14082) : proctitle=/lib/udev/scsi_id --replace-whitespace --whitelisted --export --device /dev/disk/by-path/pci-0000:06:00.1-fc-0x5005076812163b4b- type=AVC msg=audit(06/24/2024 06:20:17.115:14082) : avc:  denied  { ioctl } for  pid=292863 comm=scsi_id path=/dev/sde dev="devtmpfs" ino=3830 ioctlcmd=0x2285 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1 type=SYSCALL msg=audit(06/24/2024 06:20:17.115:14082) : arch=x86_64 syscall=ioctl success=no exit=EINVAL(Invalid argument) a0=0x3 a1=0x2285 a2=0x7ffcba402760 a3=0x0 items=0 ppid=292842 pid=292863 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=scsi_id exe=/usr/lib/udev/scsi_id subj=system_u:system_r:virtstoraged_t:s0 key=(null)

type=PROCTITLE msg=audit(06/24/2024 06:20:17.115:14083) : proctitle=/lib/udev/scsi_id --replace-whitespace --whitelisted --export --device /dev/disk/by-path/pci-0000:06:00.1-fc-0x5005076812163b4b-
type=AVC msg=audit(06/24/2024 06:20:17.115:14083) : avc:  denied  { sys_rawio } for  pid=292863 comm=scsi_id capability=sys_rawio  scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:system_r:virtstoraged_t:s0 tclass=capability permissive=1
type=SYSCALL msg=audit(06/24/2024 06:20:17.115:14083) : arch=x86_64 syscall=ioctl success=yes exit=0 a0=0x3 a1=0x2285 a2=0x7ffcba402700 a3=0x0 items=0 ppid=292842 pid=292863 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=scsi_id exe=/usr/lib/udev/scsi_id subj=system_u:system_r:virtstoraged_t:s0 key=(null)
Resolves: RHEL-44639