### PR TITLE
Allow virtqemud read insights-core state files

### DIFF
--- a/policy/modules/contrib/insights_core.if
+++ b/policy/modules/contrib/insights_core.if
@@ -59,3 +59,22 @@ interface(`insights_core_read_lib_files',`
 	read_files_pattern($1, insights_core_var_lib_t, insights_core_var_lib_t)
 	allow $1 insights_core_var_lib_t:file map;
 ')
+
+########################################
+## <summary>
+##	Allow the specified domain to read insights-core state files in /proc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_core_read_state',`
+	gen_require(`
+		type insights_core_t;
+	')
+
+	kernel_search_proc($1)
+	ps_process_pattern($1, insights_core_t)
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2332,6 +2332,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	insights_core_read_state(virtqemud_t)
+')
+
+optional_policy(`
 	nbdkit_domtrans(virtqemud_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/05/2025 05:42:01.713:202) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(06/05/2025 05:42:01.713:202) : item=0 name=/proc/10149/stat inode=30657 dev=00:16 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:insights_core_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/05/2025 05:42:01.713:202) : arch=x86_64 syscall=openat success=yes exit=19 a0=AT_FDCWD a1=0x555aa56ad850 a2=O_RDONLY a3=0x0 items=1 ppid=1 pid=9890 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(06/05/2025 05:42:01.713:202) : avc:  denied { open } for  pid=9890 comm=rpc-virtqemud path=/proc/10149/stat dev="proc" ino=30657 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:insights_core_t:s0 tclass=file permissive=1 type=AVC msg=audit(06/05/2025 05:42:01.713:202) : avc:  denied { read } for  pid=9890 comm=rpc-virtqemud name=stat dev="proc" ino=30657 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:insights_core_t:s0 tclass=file permissive=1 type=AVC msg=audit(06/05/2025 05:42:01.713:202) : avc:  denied { search } for  pid=9890 comm=rpc-virtqemud name=10149 dev="proc" ino=30652 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:insights_core_t:s0 tclass=dir permissive=1

Resolves: RHEL-99318