### PR TITLE
Allow virtnodedev create mdevctl config dirs

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2046,6 +2046,7 @@ dev_write_sysfs_dirs(virtnodedevd_t)
 files_map_var_lib_files(virtnodedevd_t)
 files_etc_filetrans_mdevctl_conf(virtnodedevd_t)
 files_etc_filetrans_mdevctl_conf_scripts(virtnodedevd_t)
+files_create_mdevctl_conf_dirs(virtnodedevd_t)
 files_manage_mdevctl_conf_files(virtnodedevd_t)
 files_watch_mdevctl_conf_dirs(virtnodedevd_t)
 

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6123,6 +6123,25 @@ interface(`files_manage_mdevctl_conf_files',`
 
 #######################################
 ## <summary>
+##	Create mdevctl configuration dirs
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_create_mdevctl_conf_dirs',`
+	gen_require(`
+		type mdevctl_conf_t;
+	')
+
+	files_search_etc(mdevctl_conf_t)
+	allow $1 mdevctl_conf_t:dir create_dir_perms;
+')
+
+#######################################
+## <summary>
 ##	Watch mdevctl configuration dirs
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
When a persistent nodedev mediated device is created (or 'defined' in libvirt jargon), these devices need to be started again from a file definition after maintenance operations like reboot or DASD passthrough re-assignments.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/19/2025 08:33:20.768:672) : proctitle=mdevctl define --parent=0000:00:1f.3 --jsonfile=/dev/stdin --uuid=8d312cf6-f92a-485c-8db8-ba9299848f46 type=PATH msg=audit(06/19/2025 08:33:20.768:672) : item=1 name=/etc/mdevctl.d/0000:00:1f.3 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(06/19/2025 08:33:20.768:672) : item=0 name=/etc/mdevctl.d/ inode=54526464 dev=fd:02 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:mdevctl_conf_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/19/2025 08:33:20.768:672) : arch=x86_64 syscall=mkdir success=no exit=EACCES(Permission denied) a0=0x7fffcc469c30 a1=0777 a2=0x1c a3=0x55ced86ae283 items=2 ppid=6455 pid=6691 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=mdevctl exe=/usr/sbin/mdevctl subj=system_u:system_r:virtnodedevd_t:s0 key=(null) type=AVC msg=audit(06/19/2025 08:33:20.768:672) : avc:  denied  { create } for  pid=6691 comm=mdevctl name=0000:00:1f.3 scontext=system_u:system_r:virtnodedevd_t:s0 tcontext=system_u:object_r:mdevctl_conf_t:s0 tclass=dir permissive=0

Resolves: RHEL-98559