### PR TITLE
Allow plymouthd_t read proc files of systemd_passwd_agent (bsc#1245470)

### DIFF
--- a/policy/modules/contrib/plymouthd.te
+++ b/policy/modules/contrib/plymouthd.te
@@ -100,6 +100,10 @@ userdom_read_admin_home_files(plymouthd_t)
 term_use_unallocated_ttys(plymouthd_t)
 
 optional_policy(`
+	systemd_passwd_agent_read_proc_state(plymouthd_t)
+')
+
+optional_policy(`
 	gnome_read_config(plymouthd_t)
 ')
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1219,6 +1219,24 @@ interface(`systemd_passwd_agent_role',`
 
 ########################################
 ## <summary>
+##	Read the process state (/proc/pid) of systemd_passwd_agent_t.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_passwd_agent_read_proc_state',`
+	gen_require(`
+              type systemd_passwd_agent_t;
+	')
+
+	ps_process_pattern($1, systemd_passwd_agent_t)
+')
+
+########################################
+## <summary>
 ##	Send generic signals to systemd_passwd_agent processes.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
plymouth checks /proc/<pid_of_systemd_passwd_agent>/cmdline and stat for logging purposes.
Might be also dontaudited if that is not needed.

Fixes:

Jun 30 12:41:37 localhost kernel: audit: type=1400 audit(1751280097.809:4): avc:  denied  { search } for  pid=714 comm="plymouthd" name="749" dev="proc" ino=5214 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:system_r:systemd_passwd_agent_t:s0 tclass=dir permissive=1
Jun 30 12:41:37 localhost kernel: audit: type=1400 audit(1751280097.809:5): avc:  denied  { read } for  pid=714 comm="plymouthd" name="cmdline" dev="proc" ino=5229 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:system_r:systemd_passwd_agent_t:s0 tclass=file permissive=1
Jun 30 12:41:37 localhost kernel: audit: type=1400 audit(1751280097.809:6): avc:  denied  { open } for  pid=714 comm="plymouthd" path="/proc/749/cmdline" dev="proc" ino=5229 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:system_r:systemd_passwd_agent_t:s0 tclass=file permissive=1
Jun 30 12:41:37 localhost kernel: audit: type=1400 audit(1751280097.809:7): avc:  denied  { getattr } for  pid=714 comm="plymouthd" path="/proc/749/stat" dev="proc" ino=4542 scontext=system_u:system_r:plymouthd_t:s0 tcontext=system_u:system_r:systemd_passwd_agent_t:s0 tclass=file permissive=1