### PR TITLE
Allow irqbalance execute shell if irqbalance_run_unconfined is on

### DIFF
--- a/policy/modules/contrib/irqbalance.te
+++ b/policy/modules/contrib/irqbalance.te
@@ -88,11 +88,10 @@ optional_policy(`
 tunable_policy(`irqbalance_run_unconfined',`
 	allow irqbalance_t irqbalance_unconfined_script_t:process2 nnp_transition;
 
+	corecmd_exec_shell(irqbalance_t)
 	domtrans_pattern(irqbalance_t, irqbalance_unconfined_script_exec_t, irqbalance_unconfined_script_t)
 ',`
 	can_exec(irqbalance_t, irqbalance_unconfined_script_exec_t)
-
-	corecmd_check_exec_shell(irqbalance_t)
 ')
 
 allow irqbalance_t irqbalance_unconfined_script_exec_t:dir { getattr search };


### PR DESCRIPTION
This commit fixes the previous 8f0097a79494 commit which used corecmd_check_exec_shell() instead of correct corecmd_exec_shell().

Resolves: RHEL-54019