### PR TITLE
virtqemud_t fixes from cockpit tests (bsc#1242998)

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -396,6 +396,9 @@ files_lock_file(virtqemud_lock_t)
 type virtqemud_tmp_t;
 files_tmp_file(virtqemud_tmp_t)
 
+type virtqemud_tmpfs_t;
+files_tmpfs_file(virtqemud_tmpfs_t)
+
 type virtqemud_var_run_t, virt_driver_var_run;
 files_pid_file(virtqemud_var_run_t)
 
@@ -2201,6 +2204,9 @@ manage_dirs_pattern(virtqemud_t, virtqemud_tmp_t, virtqemud_tmp_t)
 manage_files_pattern(virtqemud_t, virtqemud_tmp_t, virtqemud_tmp_t)
 manage_sock_files_pattern(virtqemud_t, virtqemud_tmp_t, virtqemud_tmp_t)
 files_tmp_filetrans(virtqemud_t, virtqemud_tmp_t, { file dir sock_file})
+
+manage_files_pattern(virtqemud_t, virtqemud_tmpfs_t, virtqemud_tmpfs_t)
+fs_tmpfs_filetrans(virtqemud_t, virtqemud_tmpfs_t, file)
 
 manage_dirs_pattern(virtqemud_t, qemu_var_run_t, qemu_var_run_t)
 manage_files_pattern(virtqemud_t, qemu_var_run_t, qemu_var_run_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2146,7 +2146,7 @@ allow virtqemud_t self:capability2 { bpf perfmon };
 allow virtqemud_t self:cap_userns kill;
 allow virtqemud_t self:netlink_audit_socket { nlmsg_relay read write };
 allow virtqemud_t self:process { getpgid setcap setexec setrlimit setsched setsockcreate };
-allow virtqemud_t self:tcp_socket create_socket_perms;
+allow virtqemud_t self:tcp_socket create_stream_socket_perms;
 allow virtqemud_t self:tun_socket { create relabelfrom relabelto };
 allow virtqemud_t self:udp_socket { connect create_socket_perms };
 

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2308,6 +2308,7 @@ sysnet_exec_ifconfig(virtqemud_t)
 sysnet_manage_config(virtqemud_t)
 
 term_use_generic_ptys(virtqemud_t)
+term_use_ptmx(virtqemud_t)
 
 tunable_policy(`virtqemud_use_execmem',`
 	allow virtqemud_t self:process { execmem execstack };

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2307,6 +2307,8 @@ storage_manage_fixed_disk(virtqemud_t)
 sysnet_exec_ifconfig(virtqemud_t)
 sysnet_manage_config(virtqemud_t)
 
+term_use_generic_ptys(virtqemud_t)
+
 tunable_policy(`virtqemud_use_execmem',`
 	allow virtqemud_t self:process { execmem execstack };
 ')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2266,6 +2266,7 @@ dev_rw_sev(virtqemud_t)
 dev_setattr_input_dev(virtqemud_t)
 dev_setattr_sev(virtqemud_t)
 dev_setattr_urand(virtqemud_t)
+dev_setattr_userfaultfd(virtqemud_t)
 dev_unmount_fs(virtqemud_t)
 
 files_mounton_non_security(virtqemud_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -5849,6 +5849,24 @@ interface(`dev_rw_usbfs',`
 	read_lnk_files_pattern($1, usbfs_t, usbfs_t)
 ')
 
+########################################
+## <summary>
+##	Setattr userfaultfd device.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_setattr_userfaultfd',`
+	gen_require(`
+		type device_t, userfaultfd_device_t;
+	')
+
+	setattr_chr_files_pattern($1, device_t, userfaultfd_device_t)
+')
+
 ######################################
 ## <summary>
 ##	Read and write userio device.


### PR DESCRIPTION
These AVCs were found during cockpit tests on SUSE, might be interesting for fedora as well

Use case:
- set up cockpit
- on cockpit web interface create and start a virtual machine
- see denials in audit log

Versions:
- libvirt 11.2.0
- cockpit 334
- policy: opensuse selinux-policy with fedora commits until 23514206ea45e1d1d2f8a4c08288065c813fcc91

