### PR TITLE
Allow tuned-ppd manage tuned log files

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -178,8 +178,7 @@ read_files_pattern(tuned_ppd_t, tuned_etc_t, tuned_etc_t)
 rw_files_pattern(tuned_ppd_t, tuned_etc_t, tuned_rw_etc_t)
 filetrans_pattern(tuned_ppd_t, tuned_etc_t, tuned_rw_etc_t, file, "ppd_base_profile")
 
-create_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
-write_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
+manage_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
 
 corecmd_exec_bin(tuned_ppd_t)
 dev_read_sysfs(tuned_ppd_t)


### PR DESCRIPTION
Required when the logfile count and logfile size reach log_file_count and log_file_max_size value.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2376487