### PR TITLE
Update sssd_dontaudit_read_public_files()

### DIFF
--- a/policy/modules/contrib/sssd.if
+++ b/policy/modules/contrib/sssd.if
@@ -210,6 +210,7 @@ interface(`sssd_dontaudit_read_public_files',`
 		type sssd_public_t;
 	')
 
+	dontaudit $1 sssd_public_t:dir search_dir_perms;
 	dontaudit $1 sssd_public_t:file read_file_perms;
 ')
 


### PR DESCRIPTION
Update sssd_dontaudit_read_public_files() interface so that it also dontaudits directory search.

The commit addresses the following AVC denial:
type=AVC msg=audit(1751705091.535:439): avc:  denied  { search } for  pid=5031 comm="bootc-systemd-g" name="mc" dev="sda3" ino=446687 scontext=system_u:system_r:systemd_bootc_generator_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2376505