### PR TITLE
Allow systemd-coredump mount on tmpfs filesystems

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1301,6 +1301,7 @@ files_mounton_rootfs(systemd_coredump_t)
 files_mounton_usr(systemd_coredump_t)
 
 fs_read_nsfs_files(systemd_coredump_t)
+fs_mounton_tmpfs(systemd_coredump_t)
 
 optional_policy(`
 	logging_send_syslog_msg(systemd_coredump_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1751514063.987:201): avc:  denied  { mounton } for  pid=4828 comm="(sd-parse-elf)" path="/" dev="overlay" ino=2 scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2376018