### PR TITLE
RFC: Mark configfs_t as mountpoint (bsc#1246080)

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -113,6 +113,7 @@ files_type(cgroup_memory_pressure_t)
 
 type configfs_t;
 fs_type(configfs_t)
+files_mountpoint(configfs_t)
 genfscon configfs / gen_context(system_u:object_r:configfs_t,s0)
 
 type cpusetfs_t;


### PR DESCRIPTION
Mark configfs_t as mountpoint so that it will be covered by files_dontaudit_list_all_mountpoints()

Because:
zypper does a search through all directories in /sys when detecting hardware searching for hardware related files:
https://github.com/openSUSE/libzypp/blame/6b385649d18269fcba8d80ed356adb8100be920d/zypp/target/modalias/Modalias.cc#L121

While it does that, it will also listdir /sys/kernel/config, which is labelled configfs_t and is a mountpoint:
```
$ mount | grep configfs
configfs on /sys/kernel/config type configfs (rw,nosuid,nodev,noexec,relatime)
```

This is fine if not running inside a container, however when run inside a container, it will put out the following denial: 
```
type=AVC msg=audit(1752072462.135:477): avc:  denied  { read } for  pid=7142 comm="Zypp-main" name="/" dev="configfs" ino=3600 scontext=system_u:system_r:container_t:s0:c152,c335 tcontext=system_u:object_r:configfs_t:s0 tclass=dir permissive=0
```

I think containers should likely not be able to access /sys/kernel/config, and there is already a dontaudit rule for mountpoints in general: https://github.com/fedora-selinux/selinux-policy/blob/949ce783b718d33baa5bbf9ba45eea5428aae408/policy/modules/contrib/virt.te#L1739

I think adding mountpoint attribute to configfs_t probably should be done, but i am not 100% sure if there was a reason that it is not there. Also please let me know if you disagree and the denial should be visible. 
Thanks!

Quick reproducer:
```
### as root                                   
--> install podman (e.g. dnf in podman)                        
--> create regular user
curl https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-opensuse/ecee72060e095157c8dd376745fe8d3b587518de/data/containers/registries.conf -o /etc/containers/registries.conf    
                                              
### as user
podman pull registry.opensuse.org/opensuse/tumbleweed:latest  
mkdir -p /var/tmp/containerapp/BuildTest      
curl https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-opensuse/ecee72060e095157c8dd376745fe8d3b587518de/data/containers/Dockerfile -o /var/tmp/containerapp/BuildTest/Dockerfile    
--> set baseimage_var in  /var/tmp/containerapp/BuildTest/Dockerfile to registry.opensuse.org/opensuse/tumbleweed:latest  
curl https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-opensuse/ecee72060e095157c8dd376745fe8d3b587518de/data/containers/index.html -o /var/tmp/containerapp/BuildTest/index.html    
timeout  600 podman build -f /var/tmp/containerapp/BuildTest/Dockerfile /var/tmp/containerapp/BuildTest  
--> check avcs
``` 