### PR TITLE
Allow insights-client file transition for files in /var/tmp

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -96,7 +96,7 @@ manage_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_t
 #manage_fifo_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 #manage_sock_files_pattern(insights_client_t, insights_client_tmp_t, insights_client_tmp_t)
 #files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file fifo_file sock_file })
-files_tmp_filetrans(insights_client_t, insights_client_tmp_t, dir)
+files_tmp_filetrans(insights_client_t, insights_client_tmp_t, { dir file })
 allow insights_client_t insights_client_tmp_t:sock_file write_sock_file_perms;
 #allow insights_client_t insights_client_tmp_t:dir relabel_dir_perms;
 #allow insights_client_t insights_client_tmp_t:file relabel_dir_perms;
@@ -208,9 +208,7 @@ libs_exec_ldconfig(insights_client_t)
 #')
 
 optional_policy(`
-#	auth_domtrans_chk_passwd(insights_client_t)
-	auth_read_passwd_file(insights_client_t)
-#	auth_rw_lastlog(insights_client_t)
+	auth_domtrans_chk_passwd(insights_client_t)
 ')
 
 #optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/14/2025 06:17:13.290:402) : proctitle=/usr/bin/python3 /usr/lib/python3.9/site-packages/insights_client/run.py type=PATH msg=audit(07/14/2025 06:17:13.290:402) : item=0 name=/var/tmp/ inode=8936678 dev=fd:01 mode=dir,sticky,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:tmp_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/14/2025 06:17:13.290:402) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f3d42de5bd0 a2=O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC a3=0x180 items=1 ppid=6381 pid=6434 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=python3 exe=/usr/bin/python3.9 subj=system_u:system_r:insights_client_t:s0 key=(null) type=AVC msg=audit(07/14/2025 06:17:13.290:402) : avc:  denied  { create } for  pid=6434 comm=python3 name=ppwe038w scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:tmp_t:s0 tclass=file permissive=0