### PR TITLE
Remove the lockdown class from the policy

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -1090,12 +1090,6 @@ class perf_event
 	write
 }
 
-class lockdown
-{
-    integrity
-    confidentiality
-}
-
 class io_uring
 {
     override_creds

--- a/policy/flask/flask_documentation.md
+++ b/policy/flask/flask_documentation.md
@@ -1906,16 +1906,6 @@ Used to manage access while attaching BPF programs to tracepoints, perf profilin
 
 ---
 
-## class lockdown
-
-*deprecated*
-
-**integrity**
-
-**confidentiality**
-
----
-
 ## class io\_uring
 
 Used to control the ability to use special io\_uring features by the process. See also [the original kernel commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=740b03414b20e7f1879cd99aae27d8c401bbcbf9) for more details.

--- a/policy/flask/security_classes
+++ b/policy/flask/security_classes
@@ -201,8 +201,6 @@ class mctp_socket
 
 class perf_event
 
-class lockdown
-
 class io_uring
 
 class user_namespace


### PR DESCRIPTION
A comprehensive fix for all the problems caused by the lockdown SELinux class was rejected by Linus and for the lack of a better option, the consensus upstream was to just remove the class entirely and stop checking anything in the lockdown hook.

This commit is a follow-up to the previous commit
12f821c731b2 ("Remove the lockdown-class rules from the policy").