### PR TITLE
Fix kernel_secretmem_use() and add kernel_secretmem_use_inherited()

### DIFF
--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -4749,6 +4749,24 @@ interface(`kernel_secretmem_domtrans',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain to use the secretmem API
+##	via an inherited file descriptor.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kernel_secretmem_use_inherited',`
+	gen_require(`
+		type secretmem_t;
+	')
+	allow $1 secretmem_t:anon_inode { getattr read write map };
+')
+
+########################################
+## <summary>
 ##	Allow the domain to use the secretmem API.
 ## </summary>
 ## <param name="domain">
@@ -4761,6 +4779,8 @@ interface(`kernel_secretmem_use',`
 	gen_require(`
 		type secretmem_t;
 	')
+
+	kernel_secretmem_use_inherited($1)
 	allow $1 secretmem_t:anon_inode create;
 ')
 


### PR DESCRIPTION
Fix the existing kernel_secretmem_use() interface content so that it matches other anon_inode types related interfaces and add kernel_secretmem_use_inherited().