### PR TITLE
Allow samba-bgqd send to smbd over a unix datagram socket

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1386,6 +1386,7 @@ optional_policy(`
 allow smbd_t samba_dcerpcd_t:process noatsecure;
 allow smbd_t samba_dcerpcd_t:unix_stream_socket connectto;
 allow winbind_t samba_dcerpcd_t:unix_stream_socket connectto;
+allow samba_bgqd_t smbd_t: unix_dgram_socket sendto;
 allow samba_dcerpcd_t samba_bgqd_t:unix_dgram_socket sendto;
 allow samba_dcerpcd_t nmbd_t:unix_dgram_socket sendto;
 allow samba_dcerpcd_t smbd_t:unix_dgram_socket sendto;


### PR DESCRIPTION
samba-bgqd needs to access the /var/lib/samba/private/msg.sock/PID socket to report that it is ready.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/23/2025 00:32:13.142:11912) : proctitle=/usr/libexec/samba/samba-bgqd --foreground --no-process-group type=PATH msg=audit(05/23/2025 00:32:13.142:11912) : item=0 name=/var/lib/samba/private/msg.sock/668534 inode=981924 dev=fd:00 mode=socket,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:samba_var_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(05/23/2025 00:32:13.142:11912) : saddr={ saddr_fam=local path=/var/lib/samba/private/msg.sock/668534 } type=SYSCALL msg=audit(05/23/2025 00:32:13.142:11912) : arch=ppc64le syscall=connect success=no exit=EACCES(Permission denied) a0=0x15 a1=0x7fffd63baeca a2=0x6e a3=0x100387ed items=1 ppid=1 pid=668503 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=samba-bgqd exe=/usr/libexec/samba/samba-bgqd subj=system_u:system_r:samba_bgqd_t:s0 key=(null) type=AVC msg=audit(05/23/2025 00:32:13.142:11912) : avc:  denied  { sendto } for  pid=668503 comm=samba-bgqd path=/var/lib/samba/private/msg.sock/668534 scontext=system_u:system_r:samba_bgqd_t:s0 tcontext=system_u:system_r:smbd_t:s0 tclass=unix_dgram_socket permissive=0

Resolves: RHEL-93731