### PR TITLE
Allow systemd-timedated start/stop timemaster services

### DIFF
--- a/policy/modules/contrib/linuxptp.if
+++ b/policy/modules/contrib/linuxptp.if
@@ -181,7 +181,7 @@ ifndef(`phc2sys_rw_shm',`
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	Domain allowed to transition.
+##	Domain allowed access.
 ##	</summary>
 ## </param>
 #
@@ -192,5 +192,45 @@ ifndef(`timemaster_service_status',`
 		')
 
 		allow $1 timemaster_unit_file_t:service status;
+	')
+')
+
+#######################################
+## <summary>
+##	Start timemaster services
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`timemaster_service_start',`
+	interface(`timemaster_service_start',`
+		gen_require(`
+			type timemaster_unit_file_t;
+		')
+
+		allow $1 timemaster_unit_file_t:service { status start };
+	')
+')
+
+#######################################
+## <summary>
+##	Stop timemaster services
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`timemaster_service_stop',`
+	interface(`timemaster_service_stop',`
+		gen_require(`
+			type timemaster_unit_file_t;
+		')
+
+		allow $1 timemaster_unit_file_t:service { status stop };
 	')
 ')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1228,7 +1228,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-	timemaster_service_status(systemd_timedated_t)
+	timemaster_service_start(systemd_timedated_t)
+	timemaster_service_stop(systemd_timedated_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The denial is triggered by "timedatectl set-ntp false", e.g. when using cocpit and attempting to disable time sync and then manually set the time.

The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(06/06/25 20:58:08.670:1060) : pid=1 uid=root auid=unset ses=unset subj=system_u:system_r:init_t:s0 msg='avc:  denied { stop } for auid=unset uid=root gid=root path=/usr/lib/systemd/system/timemaster.service cmdline="/usr/lib/systemd/systemd-timedated" function="bus_unit_method_start_generic" scontext=system_u:system_r:systemd_timedated_t:s0 tcontext=system_u:object_r:timemaster_unit_file_t:s0 tclass=service permissive=0 exe=/usr/lib/systemd/systemd sauid=root hostname=? addr=?  terminal=?'

Resolves: RHEL-95690