### PR TITLE
Allow "hostapd_cli ping" run as a systemd service

### DIFF
--- a/policy/modules/contrib/hostapd.te
+++ b/policy/modules/contrib/hostapd.te
@@ -9,6 +9,9 @@ type hostapd_t;
 type hostapd_exec_t;
 init_daemon_domain(hostapd_t, hostapd_exec_t)
 
+type hostapd_tmp_t;
+files_tmp_file(hostapd_tmp_t)
+
 type hostapd_var_run_t;
 files_pid_file(hostapd_var_run_t)
 
@@ -26,6 +29,9 @@ allow hostapd_t self:netlink_socket create_socket_perms;
 allow hostapd_t self:netlink_generic_socket create_socket_perms;
 allow hostapd_t self:netlink_route_socket create_netlink_socket_perms;
 allow hostapd_t self:packet_socket create_socket_perms;
+
+manage_sock_files_pattern(hostapd_t, hostapd_tmp_t, hostapd_tmp_t)
+files_tmp_filetrans(hostapd_t, hostapd_tmp_t, sock_file)
 
 manage_dirs_pattern(hostapd_t, hostapd_var_run_t, hostapd_var_run_t)
 manage_files_pattern(hostapd_t, hostapd_var_run_t, hostapd_var_run_t)
@@ -58,4 +64,5 @@ userdom_write_user_tmp_sockets(hostapd_t)
 
 optional_policy(`
 	unconfined_dgram_send(hostapd_t)
+	unconfined_server_dgram_send(hostapd_t)
 ')

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -393,6 +393,24 @@ interface(`unconfined_server_create_unix_sockets',`
 
 ########################################
 ## <summary>
+##	Create unconfined_service_t UNIX sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_server_dgram_send',`
+	gen_require(`
+		type unconfined_service_t;
+	')
+
+	allow $1 unconfined_service_t:unix_dgram_socket sendto;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read and write
 #	unconfined service domain unnamed pipes.
 ## </summary>


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/20/2024 08:57:32.118:559) : proctitle=/usr/sbin/hostapd /etc/hostapd/hostapd.conf -P /run/hostapd.pid -B type=PATH msg=audit(09/20/2024 08:57:32.118:559) : item=0 name=/tmp/wpa_ctrl_36103-1 inode=618191 dev=fd:01 mode=socket,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(09/20/2024 08:57:32.118:559) : saddr={ saddr_fam=local path=/tmp/wpa_ctrl_36103-1 } type=SYSCALL msg=audit(09/20/2024 08:57:32.118:559) : arch=x86_64 syscall=sendto success=yes exit=5 a0=0xb a1=0x560b04ca7100 a2=0x5 a3=0x0 items=1 ppid=1 pid=35561 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=hostapd exe=/usr/sbin/hostapd subj=system_u:system_r:hostapd_t:s0 key=(null) type=AVC msg=audit(09/20/2024 08:57:32.118:559) : avc:  denied  { sendto } for  pid=35561 comm=hostapd path=/tmp/wpa_ctrl_36103-1 scontext=system_u:system_r:hostapd_t:s0 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=unix_dgram_socket permissive=1 type=AVC msg=audit(09/20/2024 08:57:32.118:559) : avc:  denied  { write } for  pid=35561 comm=hostapd name=wpa_ctrl_36103-1 dev="vda1" ino=618191 scontext=system_u:system_r:hostapd_t:s0 tcontext=system_u:object_r:tmp_t:s0 tclass=sock_file permissive=1

Resolves: RHEL-59683