### PR TITLE
Allow power-profiles-daemon get attributes of filesystems with extend…

### DIFF
--- a/policy/modules/contrib/powerprofiles.te
+++ b/policy/modules/contrib/powerprofiles.te
@@ -25,6 +25,8 @@ kernel_read_proc_files(powerprofiles_t)
 dev_rw_sysfs(powerprofiles_t)
 dev_watch_sysfs_dirs(powerprofiles_t)
 
+fs_getattr_xattr_fs(powerprofiles_t)
+
 optional_policy(`
 	dbus_connect_system_bus(powerprofiles_t)
 	dbus_system_bus_client(powerprofiles_t)


### PR DESCRIPTION
…ed attributes

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/30/2025 16:31:09.073:240) : proctitle=/usr/libexec/power-profiles-daemon type=SYSCALL msg=audit(06/30/2025 16:31:09.073:240) : arch=x86_64 syscall=fstatfs success=yes exit=0 a0=0x9 a1=0x7ffd0e282f70 a2=0x1 a3=0x1b6 items=0 ppid=1 pid=2059 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=power-profiles- exe=/usr/libexec/power-profiles-daemon subj=system_u:system_r:powerprofiles_t:s0 key=(null) type=AVC msg=audit(06/30/2025 16:31:09.073:240) : avc:  denied  { getattr } for  pid=2059 comm=power-profiles- name=/ dev="vda2" ino=128 scontext=system_u:system_r:powerprofiles_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1

Resolves: RHEL-100718