### PR TITLE
Allow sblim-sfcbd execute dnsdomainname

### DIFF
--- a/policy/modules/contrib/sblim.te
+++ b/policy/modules/contrib/sblim.te
@@ -121,6 +121,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_read_logind_sessions_files(sblim_gatherd_t)
+')
+
+optional_policy(`
 	virt_read_config(sblim_gatherd_t)
 	virt_stream_connect(sblim_gatherd_t)
 	virt_getattr_exec(sblim_gatherd_t)
@@ -201,6 +205,10 @@ optional_policy(`
 
 optional_policy(`
 	ssh_signull(sblim_sfcbd_t)
+')
+
+optional_policy(`
+	systemd_read_logind_sessions_files(sblim_sfcbd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/sblim.te
+++ b/policy/modules/contrib/sblim.te
@@ -154,7 +154,7 @@ miscfiles_read_certs(sblim_reposd_t)
 # Sfcbd local policy
 #
 
-allow sblim_sfcbd_t self:capability { setgid setuid sys_ptrace sys_rawio};
+allow sblim_sfcbd_t self:capability { dac_read_search setgid setuid sys_ptrace sys_rawio};
 dontaudit sblim_sfcbd_t self:cap_userns sys_ptrace;
 allow sblim_sfcbd_t self:process signal;
 allow sblim_sfcbd_t self:unix_stream_socket connectto;

--- a/policy/modules/contrib/sblim.te
+++ b/policy/modules/contrib/sblim.te
@@ -184,6 +184,8 @@ domain_use_interactive_fds(sblim_sfcbd_t)
 
 files_getattr_non_auth_dirs(sblim_sfcbd_t)
 
+hostname_exec(sblim_sfcbd_t)
+
 init_read_utmp(sblim_sfcbd_t)
 
 logging_send_audit_msgs(sblim_sfcbd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/13/2025 07:17:04.911:891) : proctitle=sh -c /bin/dnsdomainname >/tmp/SBLIMDgEdHt type=PATH msg=audit(06/13/2025 07:17:04.911:891) : item=0 name=/bin/dnsdomainname inode=16799621 dev=ca:03 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:hostname_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/13/2025 07:17:04.911:891) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x558d9b3c9910 a1=0x558d9b3c9a30 a2=0x558d9b3c7d70 a3=0x1b6 items=1 ppid=27144 pid=27145 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sh exe=/usr/bin/bash subj=system_u:system_r:sblim_sfcbd_t:s0 key=(null) type=AVC msg=audit(06/13/2025 07:17:04.911:891) : avc: denied { execute } for pid=27145 comm=sh name=hostname dev="xvda3" ino=16799621 scontext=system_u:system_r:sblim_sfcbd_t:s0 tcontext=system_u:object_r:hostname_exec_t:s0 tclass=file permissive=0

Resolves: RHEL-98287