### PR TITLE
Introduce systemd_cryptsetup_generator_var_run_t file type (bsc#1244459)

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1404,6 +1404,15 @@ optional_policy(`
 
 #manage_files_pattern(systemd_cryptsetup_generator_t, systemd_fstab_generator_unit_file_t, systemd_fstab_generator_unit_file_t)
 
+type systemd_cryptsetup_generator_var_run_t;
+files_type(systemd_cryptsetup_generator_var_run_t)
+
+init_pid_filetrans(systemd_cryptsetup_generator_t, systemd_cryptsetup_generator_var_run_t, dir, "cryptsetup")
+
+allow systemd_cryptsetup_generator_t systemd_cryptsetup_generator_var_run_t:dir manage_dir_perms;
+allow systemd_cryptsetup_generator_t systemd_cryptsetup_generator_var_run_t:file manage_file_perms;
+allow systemd_cryptsetup_generator_t systemd_cryptsetup_generator_var_run_t:lnk_file manage_lnk_file_perms;
+
 ### debug generator
 fs_read_tmpfs_files(systemd_debug_generator_t)
 


### PR DESCRIPTION
When the key material is on a USB stick this currently doesn't work since cryptsetup will create a directory with a generic type

Solves avc:  denied  { associate } for  pid=16385 comm="systemd-cryptse" name="cryptsetup" scontext=system_u:object_r:systemd_cryptsetup_generator_var_run_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0