### PR TITLE
Allow svirt read virtqemud fifo files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -501,6 +501,7 @@ allow svirt_t virtlogd_t:fifo_file write;
 allow svirt_t virtlogd_t:unix_stream_socket connectto;
 
 allow svirt_t virtqemud_t:tun_socket attach_queue;
+allow svirt_t virtqemud_t:fifo_file read;
 allow svirt_t virtqemud_var_run_t:file write;
 
 read_files_pattern(svirt_t, virtqemud_t, virtqemud_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/16/2025 11:00:03.191:937) : proctitle=/usr/bin/swtpm socket --ctrl type=unixio,path=/run/libvirt/qemu/swtpm/1-avocado-vt-vm1-swtpm.sock,mode=0600 --tpmstate dir=/var/ type=AVC msg=audit(07/16/2025 11:00:03.191:937) : avc:  denied  { read } for  pid=38059 comm=swtpm path=pipe:[14964] dev="pipefs" ino=14964 scontext=system_u:system_r:svirt_t:s0:c371,c986 tcontext=system_u:system_r:virtqemud_t:s0 tclass=fifo_file permissive=0 type=AVC msg=audit(07/16/2025 11:00:03.191:937) : avc:  denied  { read } for  pid=38059 comm=swtpm path=pipe:[14966] dev="pipefs" ino=14966 scontext=system_u:system_r:svirt_t:s0:c371,c986 tcontext=system_u:system_r:virtqemud_t:s0 tclass=fifo_file permissive=0 type=SYSCALL msg=audit(07/16/2025 11:00:03.191:937) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7f543403e110 a1=0x7f543404c7d0 a2=0x7ffcf8274438 a3=0x2 items=0 ppid=1 pid=38059 auid=unset uid=tss gid=tss euid=tss suid=tss fsuid=tss egid=tss sgid=tss fsgid=tss tty=(none) ses=unset comm=swtpm exe=/usr/bin/swtpm subj=system_u:system_r:svirt_t:s0:c371,c986 key=(null) type=EXECVE msg=audit(07/16/2025 11:00:03.191:937) : argc=14 a0=/usr/bin/swtpm a1=socket a2=--ctrl a3=type=unixio,path=/run/libvirt/qemu/swtpm/1-avocado-vt-vm1-swtpm.sock,mode=0600 a4=-tpmstate a5=dir=/var/lib/libvirt/swtpm/fa56e914-81ca-43a2-889d-2351a66e4b7a/tpm2,mode=0600 a6=log a7=file=/var/log/swtpm/libvirt/qemu/avocado-vt-vm1-swtpm.log a8=terminate a9=tpm2 a10=key a11=pwdfd=27,mode=aes-256-cbc a12=-migration-key a13=pwdfd=29,mode=aes-256-cbc

Resolves: RHEL-104069