### PR TITLE
Allow systemd-importd create and unlink init pid socket

### DIFF
--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2964,6 +2964,42 @@ interface(`init_write_pid_socket',`
     allow $1 init_var_run_t:sock_file write;
 ')
 
+#######################################
+## <summary>
+##	Allow the specified domain to create init sock file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_create_pid_socket',`
+	gen_require(`
+		type init_var_run_t;
+	')
+
+	allow $1 init_var_run_t:sock_file create;
+')
+
+#######################################
+## <summary>
+##	Allow the specified domain to unlink init sock file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_unlink_pid_socket',`
+	gen_require(`
+		type init_var_run_t;
+	')
+
+	allow $1 init_var_run_t:sock_file unlink;
+')
+
 ########################################
 ## <summary>
 ##	Send a message to init over a unix domain

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1790,6 +1790,8 @@ corenet_tcp_connect_http_port(systemd_importd_t)
 fs_getattr_xattr_fs(systemd_importd_t)
 
 init_read_state(systemd_importd_t)
+init_create_pid_socket(systemd_importd_t)
+init_unlink_pid_socket(systemd_importd_t)
 
 logging_send_syslog_msg(systemd_importd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/19/2025 04:15:19.643:521) : proctitle=/usr/lib/systemd/systemd-importd type=PATH msg=audit(06/19/2025 04:15:19.643:521) : item=1 name=/run/systemd/io.systemd.Import inode=2007 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(06/19/2025 04:15:19.643:521) : item=0 name=/run/systemd/ inode=2 dev=00:1a mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:init_var_run_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(06/19/2025 04:15:19.643:521) : saddr={ saddr_fam=local path=/run/systemd/io.systemd.Import } type=SYSCALL msg=audit(06/19/2025 04:15:19.643:521) : arch=x86_64 syscall=bind success=yes exit=0 a0=0xb a1=0x7ffe32b0e160 a2=0x21 a3=0x5592a510f500 items=2 ppid=1 pid=5530 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-importd exe=/usr/lib/systemd/systemd-importd subj=system_u:system_r:systemd_importd_t:s0 key=(null) type=AVC msg=audit(06/19/2025 04:15:19.643:521) : avc:  denied  { create } for  pid=5530 comm=systemd-importd name=io.systemd.Import scontext=system_u:system_r:systemd_importd_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=sock_file permissive=1

Resolves: RHEL-98490