### PR TITLE
Allow virtqemud handle virt_content_t chr files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2167,6 +2167,8 @@ allow virtqemud_t svirt_tmpfs_t:file { map write };
 
 allow virtqemud_t virt_cache_t:file { relabelfrom relabelto };
 
+allow virtqemud_t virt_content_t:chr_file { rw_chr_file_perms setattr };
+
 allow virtqemud_t virt_driver_domain:unix_stream_socket connectto;
 
 allow virtqemud_t virt_var_lib_t:file relabelfrom;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1737691046.008:9001): avc:  denied  { open } for  pid=338050 comm="rpc-virtqemud" path="/dev/sg1" dev="tmpfs" ino=6 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:virt_content_t:s0 tclass=chr_file permissive=1

Resolves: RHEL-76104