### PR TITLE
Allow userdomain write to systemd-oomd socket runtime files

### DIFF
--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -3224,3 +3224,25 @@ interface(`systemd_cache_filetrans',`
 
 	filetrans_pattern($1, systemd_cache_t, $2, $3, $4)
 ')
+
+########################################
+## <summary>
+##	Allow the specified domain to connect to
+##	systemd-oomd over a unix socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_oomd_stream_connect',`
+	gen_require(`
+		type systemd_oomd_t;
+		type systemd_oomd_var_run_t;
+	')
+
+	allow $1 systemd_oomd_t:unix_stream_socket connectto;
+	allow $1 systemd_oomd_var_run_t:sock_file write;
+	files_search_pids($1)
+')

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -213,6 +213,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_oomd_stream_connect(userdomain)
 	systemd_userdbd_stream_connect(userdomain)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/21/2025 16:08:46.670:9440) : proctitle=(systemd) type=PATH msg=audit(07/21/2025 16:08:46.670:9440) : item=0 name=/run/systemd/oom/io.systemd.ManagedOOM inode=846 dev=00:1b mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_oomd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(07/21/2025 16:08:46.670:9440) : saddr={ saddr_fam=local path=/run/systemd/oom/io.systemd.ManagedOOM } type=SYSCALL msg=audit(07/21/2025 16:08:46.670:9440) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x1d a1=0x7fffdaafa700 a2=0x29 a3=0x0 items=1 ppid=1 pid=384718 auid=user17594 uid=user17594 gid=user17594 euid=user17594 suid=user17594 fsuid=user17594 egid=user17594 sgid=user17594 fsgid=user17594 tty=(none) ses=134 comm=systemd exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(07/21/2025 16:08:46.670:9440) : avc:  denied  { write } for  pid=384718 comm=systemd name=io.systemd.ManagedOOM dev="tmpfs" ino=846 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_oomd_var_run_t:s0 tclass=sock_file permissive=0