### PR TITLE
Label /var/lib/lastlog with lastlog_t

### DIFF
--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -54,6 +54,7 @@ ifdef(`distro_suse', `
 /var/db/shadow.*	--	gen_context(system_u:object_r:shadow_t,s0)
 
 /var/lib/abl(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
+/var/lib/lastlog(/.*)?		gen_context(system_u:object_r:lastlog_t,s0)
 /var/lib/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
 /var/lib/pam_shield(/.*)?	gen_context(system_u:object_r:var_auth_t,s0)
 /var/lib/google-authenticator(/.*)?	gen_context(system_u:object_r:var_auth_t,s0)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -622,6 +622,9 @@ auth_filetrans_admin_home_content(login_pgm)
 auth_filetrans_home_content(login_pgm)
 auth_filetrans_auth_home_content(login_pgm)
 
+allow login_pgm lastlog_t:dir manage_dir_perms;
+allow login_pgm lastlog_t:file manage_file_perms;
+
 # needed for afs - https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=253321
 kernel_search_network_sysctl(login_pgm)
 kernel_rw_afs_state(login_pgm)


### PR DESCRIPTION
With the [1] Fedora change in place, lastlog database has a new path: /var/lib/lastlog instead of /var/log/lastlog.

[1] https://fedoraproject.org/wiki/Changes/Migrate_to_lastlog2