### PR TITLE
Recognize /var/home as an alternate path for /home

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -23,8 +23,9 @@
 /var/named/chroot/usr/lib64 /usr/lib
 /var/named/chroot/lib64 /usr/lib
 /var/named/chroot/var  /var
-/home-inst            /home
-/home/home-inst            /home
+/home-inst           /home
+/home/home-inst      /home
+/var/home            /home
 /var/roothome        /root
 /sbin                /usr/bin
 /sysroot/tmp         /tmp

--- a/policy/modules/contrib/fdo.fc
+++ b/policy/modules/contrib/fdo.fc
@@ -24,11 +24,8 @@
 
 /usr/lib/systemd/system/fdo.*.service		--	gen_context(system_u:object_r:fdo_unit_file_t,s0)
 
-/var/home/fdouser(/.*)?					gen_context(system_u:object_r:fdo_home_t,s0) 
+/home/fdouser(/.*)?					gen_context(system_u:object_r:fdo_home_t,s0) 
 
 /var/fdo(/.*)?						gen_context(system_u:object_r:fdo_var_t,s0)
 
 /var/lib/fdo(/.*)?					gen_context(system_u:object_r:fdo_var_lib_t,s0)
-
-
-


### PR DESCRIPTION
Bootc uses /var/home as a persistent path for /home.  This should simplify relabels and restorcon.

https://docs.fedoraproject.org/en-US/bootc/filesystem/#_filesystem_bind_mount_var

I also did some text alignment work I can drop to make the columns look nicer.