### PR TITLE
Allow systemd-oomd watch dbus pid sock files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1956,6 +1956,7 @@ optional_policy(`
     dbus_acquire_svc_system_dbusd(systemd_oomd_t)
     dbus_read_pid_sock_files(systemd_oomd_t)
     dbus_watch_pid_dir_path(systemd_oomd_t)
+    dbus_watch_pid_sock_files(systemd_oomd_t)
 ')
 
 permissive systemd_oomd_t;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1753342150.425:57): avc:  denied  { watch } for  pid=803 comm="systemd-oomd" path="/run/dbus/system_bus_socket" dev="tmpfs" ino=2758 scontext=system_u:system_r:systemd_oomd_t:s0 tcontext=system_u:object_r:system_dbusd_var_run_t:s0 tclass=sock_file permissive=1