### PR TITLE
Allow irqbalance search sssd lib directories

### DIFF
--- a/policy/modules/contrib/irqbalance.te
+++ b/policy/modules/contrib/irqbalance.te
@@ -77,6 +77,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_search_lib(irqbalance_t)
+')
+
+optional_policy(`
 	udev_read_db(irqbalance_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/25/2025 08:26:55.169:498) : proctitle=sh -c exec /usr/libexec/irqbalance/irq_policy.sh /sys 12 type=PATH msg=audit(07/25/2025 08:26:55.169:498) : item=0 name=/var/lib/sss/pipes/nss nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(07/25/2025 08:26:55.169:498) : saddr={ saddr_fam=local path=/var/lib/sss/pipes/nss } type=SYSCALL msg=audit(07/25/2025 08:26:55.169:498) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x3 a1=0x7ffc248205f0 a2=0x6e a3=0x100 items=1 ppid=7934 pid=7993 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sh exe=/usr/bin/bash subj=system_u:system_r:irqbalance_t:s0 key=(null) type=AVC msg=audit(07/25/2025 08:26:55.169:498) : avc:  denied  { search } for  pid=7993 comm=sh name=sss dev="vda2" ino=1105030 scontext=system_u:system_r:irqbalance_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=dir permissive=0

Resolves: RHEL-1556