### PR TITLE
Allow samba-dcerpcd send sigkills to passwd

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -549,6 +549,7 @@ tunable_policy(`samba_domain_controller',`
 	allow smbd_t self:passwd passwd;
 
 	usermanage_domtrans_passwd(samba_dcerpcd_t)
+	usermanage_kill_passwd(samba_dcerpcd_t)
 	allow samba_dcerpcd_t self:passwd passwd;
 ')
 


### PR DESCRIPTION
strace snippet shows the following code path:
436 DEBUG(3, ("chat_with_program: Child failed to change password: %s\n", pass->pw_name)); 437 kill(pid, SIGKILL); /* be sure to end this process */

Note this permission is now allowed only when the
samba_domain_controller tunable is on.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/30/2025 20:38:26.556:3188) : proctitle=/usr/libexec/samba/rpcd_lsad --configfile=/etc/samba/smb.conf --worker-group=2 --worker-index=0 --debuglevel=0 type=OBJ_PID msg=audit(05/30/2025 20:38:26.556:3188) : opid=239220 oauid=unset ouid=root oses=-1 obj=system_u:system_r:passwd_t:s0 ocomm=passwd type=SYSCALL msg=audit(05/30/2025 20:38:26.556:3188) : arch=ppc64le syscall=kill success=no exit=EACCES(Permission denied) a0=0x3a674 a1=SIGKILL a2=0x125751 a3=0x125674ef1 items=0 ppid=239206 pid=239216 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpcd_lsad exe=/usr/libexec/samba/rpcd_lsad subj=system_u:system_r:winbind_rpcd_t:s0 key=(null) type=AVC msg=audit(05/30/2025 20:38:26.556:3188) : avc:  denied  { sigkill } for  pid=239216 comm=rpcd_lsad scontext=system_u:system_r:winbind_rpcd_t:s0 tcontext=system_u:system_r:passwd_t:s0 tclass=process permissive=0

Resolves: RHEL-100032