### PR TITLE
Allow hostapd write to socket files in /tmp

### DIFF
--- a/policy/modules/contrib/hostapd.te
+++ b/policy/modules/contrib/hostapd.te
@@ -53,6 +53,7 @@ dev_rw_wireless(hostapd_t)
 domain_use_interactive_fds(hostapd_t)
 
 files_read_etc_files(hostapd_t)
+files_write_generic_tmp_sock_files(hostapd_t)
 
 auth_use_nsswitch(hostapd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/30/2025 08:37:27.908:577) : proctitle=/usr/sbin/hostapd /etc/hostapd/hostapd.conf -P /run/hostapd.pid -B type=PATH msg=audit(07/30/2025 08:37:27.908:577) : item=0 name=/tmp/wpa_ctrl_51140-1 inode=741016 dev=fd:01 mode=socket,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(07/30/2025 08:37:27.908:577) : saddr={ saddr_fam=local path=/tmp/wpa_ctrl_51140-1 } type=SYSCALL msg=audit(07/30/2025 08:37:27.908:577) : arch=x86_64 syscall=sendto success=no exit=EACCES(Permission denied) a0=0xb a1=0x55d5dc575d00 a2=0x5 a3=0x0 items=1 ppid=1 pid=49912 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=hostapd exe=/usr/sbin/hostapd subj=system_u:system_r:hostapd_t:s0 key=(null) type=AVC msg=audit(07/30/2025 08:37:27.908:577) : avc:  denied  { write } for  pid=49912 comm=hostapd name=wpa_ctrl_51140-1 dev="vda1" ino=741016 scontext=system_u:system_r:hostapd_t:s0 tcontext=system_u:object_r:tmp_t:s0 tclass=sock_file permissive=0

Resolves: RHEL-59683