### PR TITLE
Allow systemd-coredump the sys_chroot capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1280,7 +1280,7 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # sys_ptrace - to read /proc/<pid>/exe of the dumped process
 # setgid setuid - to set own credentials to match the dumped process credentials
 # setpcap - to drop capabilities
-allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_admin sys_ptrace };
+allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_admin sys_chroot sys_ptrace };
 dontaudit systemd_coredump_t self:capability sys_resource;
 allow systemd_coredump_t self:cap_userns { dac_read_search dac_override sys_admin sys_ptrace };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/04/2025 10:02:09.539:833) : proctitle=(sd-coredumpns) type=SYSCALL msg=audit(07/04/2025 10:02:09.539:833) : arch=x86_64 syscall=setns success=no exit=EPERM(Operation not permitted) a0=0xa a1=CLONE_NEWNS a2=0x560a6be81e6a a3=0x560f0b185010 items=0 ppid=11405 pid=11406 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(sd-coredumpns) exe=/usr/lib/systemd/systemd-coredump subj=system_u:system_r:systemd_coredump_t:s0 key=(null) type=AVC msg=audit(07/04/2025 10:02:09.539:833) : avc:  denied  { sys_chroot } for  pid=11406 comm=(sd-coredumpns) capability=sys_chroot  scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=capability permissive=0

Resolves: RHEL-97586