### PR TITLE
Allow anaconda-generator get attributes of all filesystems

### DIFF
--- a/policy/modules/contrib/anaconda.te
+++ b/policy/modules/contrib/anaconda.te
@@ -95,6 +95,8 @@ permissive anaconda_generator_t;
 
 kernel_read_proc_files(anaconda_generator_t)
 
+fs_getattr_all_fs(anaconda_generator_t)
+
 optional_policy(`
 	auth_dontaudit_read_passwd_file(anaconda_generator_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1753885860.737:102326): avc:  denied  { getattr } for  pid=18379 comm="anaconda-genera" name="/" dev="nvme0n1p3" ino=2 scontext=system_u:system_r:anaconda_generator_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2385046