### PR TITLE
Allow xdm_t create user namespaces

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -450,6 +450,7 @@ allow xdm_t self:socket create_socket_perms;
 allow xdm_t self:appletalk_socket create_socket_perms;
 allow xdm_t self:key { search link write };
 allow xdm_t self:dbus { send_msg acquire_svc };
+allow xdm_t self:user_namespace create;
 
 allow xdm_t xauth_home_t:file manage_file_perms;
 


### PR DESCRIPTION
Required with the update of gdk-pixbuf2 using a new pixbuf loaders provided by glycin which are sandboxed.

The commit addresses the following AVC denial:

type=PROCTITLE msg=audit(07/16/2025 06:40:32.057:1066) : proctitle=bwrap --unshare-all --die-with-parent --chdir / --ro-bind /usr /usr --dev /dev --ro-bind-try /etc/ld.so.cache /etc/ld.so.cache -
type=SYSCALL msg=audit(07/16/2025 06:40:32.057:1066) : arch=x86_64 syscall=clone success=no exit=EACCES(Permission denied) a0=0x7e020011 a1=0x0 a2=CLONE_VM|CLONE_SIGHAND|CLONE_VFORK|CLONE_PARENT|CLONE_NEWNS|CLONE_SYSVSEM|CLONE_UNTRACED|CLONE_CHILD_SETTID|CLONE_NEWUTS a3=0x0 items=0 ppid=3561 pid=4135 auid=unset uid=gdm gid=gdm euid=gdm suid=gdm fsuid=gdm egid=gdm sgid=gdm fsgid=gdm tty=tty1 ses=unset comm=bwrap exe=/usr/bin/bwrap subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(07/16/2025 06:40:32.057:1066) : avc:  denied  { create } for  pid=4135 comm=bwrap scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tclass=user_namespace permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2380069