### PR TITLE
Allow ras-mc-ctl write to sysfs files

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -31,7 +31,7 @@ kernel_read_system_state(rasdaemon_t)
 kernel_manage_debugfs(rasdaemon_t)
 
 dev_read_raw_memory(rasdaemon_t)
-dev_read_sysfs(rasdaemon_t)
+dev_rw_sysfs(rasdaemon_t)
 dev_read_urand(rasdaemon_t)
 dev_rw_cpu_microcode(rasdaemon_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:

type=AVC msg=audit(1735686000.621:305): avc:  denied  { write } for  pid=4494 comm="ras-mc-ctl" name="dimm_label" dev="sysfs" ino=60664 scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
type=SYSCALL msg=audit(1735686000.621:305): arch=x86_64 syscall=openat success=yes exit=ESRCH a0=ffffff9c a1=556391175920 a2=80241 a3=1b6 items=0 ppid=1 pid=4494 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=ras-mc-ctl exe=/usr/bin/perl subj=system_u:system_r:rasdaemon_t:s0 key=(null)

The device name matches the
/sys/devices/system/edac/mc/mc*/(dimm|rank)*/dimm_label pattern, e.g.  /sys/devices/system/edac/mc/mc0/rank0/dimm_label

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2335134