### PR TITLE
Update dovecot policy for dovecot 2.4.1

### DIFF
--- a/policy/modules/contrib/dovecot.fc
+++ b/policy/modules/contrib/dovecot.fc
@@ -35,11 +35,14 @@ ifdef(`distro_redhat', `
 ')
 
 #
-# /var
+# /run
 #
 /run/dovecot(-login)?(/.*)?		gen_context(system_u:object_r:dovecot_var_run_t,s0)
 /run/dovecot/login/ssl-parameters.dat -- gen_context(system_u:object_r:dovecot_var_lib_t,s0)
 
+#
+# /var
+#
 /var/lib/dovecot(/.*)?			gen_context(system_u:object_r:dovecot_var_lib_t,s0)
 
 /var/log/dovecot(/.*)?			gen_context(system_u:object_r:dovecot_var_log_t,s0)

--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -115,6 +115,7 @@ allow dovecot_t dovecot_keytab_t:file read_file_perms;
 manage_dirs_pattern(dovecot_t, dovecot_tmp_t, dovecot_tmp_t)
 manage_files_pattern(dovecot_t, dovecot_tmp_t, dovecot_tmp_t)
 files_tmp_filetrans(dovecot_t, dovecot_tmp_t, { file dir })
+allow dovecot_t dovecot_tmp_t:file map;
 
 # Allow dovecot to create and read SSL parameters file
 manage_files_pattern(dovecot_t, dovecot_var_lib_t, dovecot_var_lib_t)
@@ -136,6 +137,7 @@ manage_lnk_files_pattern(dovecot_t, dovecot_var_run_t, dovecot_var_run_t)
 manage_sock_files_pattern(dovecot_t, dovecot_var_run_t, dovecot_var_run_t)
 manage_fifo_files_pattern(dovecot_t, dovecot_var_run_t, dovecot_var_run_t)
 files_pid_filetrans(dovecot_t, dovecot_var_run_t, { dir file fifo_file sock_file })
+allow dovecot_t dovecot_var_run_t:file map;
 
 kernel_read_security_state(dovecot_t)
 
@@ -251,6 +253,7 @@ read_files_pattern(dovecot_auth_t, dovecot_etc_t, dovecot_etc_t)
 read_lnk_files_pattern(dovecot_auth_t, dovecot_etc_t, dovecot_etc_t)
 
 manage_files_pattern(dovecot_auth_t, dovecot_var_run_t, dovecot_var_run_t)
+allow dovecot_auth_t dovecot_var_run_t:file map;
 
 manage_dirs_pattern(dovecot_auth_t, dovecot_auth_tmp_t, dovecot_auth_tmp_t)
 manage_files_pattern(dovecot_auth_t, dovecot_auth_tmp_t, dovecot_auth_tmp_t)


### PR DESCRIPTION
The commit addresses the following AVC denial examples: type=AVC msg=audit(06/03/2025 15:53:24.872:546) : avc:  denied  { map } for  pid=2436 comm=doveconf path=/tmp/doveconf.c6c591808abd8b09 (deleted) dev="tmpfs" ino=51 scontext=system_u:system_r:dovecot_t:s0 tcontext=system_u:object_r:dovecot_tmp_t:s0 tclass=file permissive=1 type=AVC msg=audit(06/03/2025 15:53:24.941:549) : avc:  denied  { map } for  pid=2438 comm=anvil path=/run/dovecot/dovecot.conf.binary dev="tmpfs" ino=2248 scontext=system_u:system_r:dovecot_t:s0 tcontext=system_u:object_r:dovecot_var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(06/03/2025 15:58:17.996:559) : avc:  denied  { map } for  pid=2485 comm=auth path=/run/dovecot/dovecot.conf.binary dev="tmpfs" ino=2248 scontext=system_u:system_r:dovecot_auth_t:s0 tcontext=system_u:object_r:dovecot_var_run_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2370124