### PR TITLE
Allow logwatch work with opensmtpd

### DIFF
--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -160,6 +160,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mta_rw_spool(logwatch_t)
+')
+
+optional_policy(`
 	ntp_domtrans(logwatch_t)
 ')
 
@@ -180,6 +184,10 @@ optional_policy(`
 optional_policy(`
 	samba_read_log(logwatch_t)
 	samba_read_share_files(logwatch_t)
+')
+
+optional_policy(`
+	sendmail_write_pid_files(logwatch_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/sendmail.if
+++ b/policy/modules/contrib/sendmail.if
@@ -339,6 +339,25 @@ interface(`sendmail_manage_tmp_files',`
 
 ########################################
 ## <summary>
+##	Write to sendmail pid files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sendmail_write_pid_files',`
+	gen_require(`
+		type sendmail_var_run_t;
+	')
+
+	files_search_pids($1)
+	allow $1 sendmail_var_run_t:file write_sock_file_perms;
+')
+
+########################################
+## <summary>
 ##	Set the attributes of sendmail pid files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PATH msg=audit(02/14/2025 16:18:03.070:27334) : item=0 name=/var/run/smtpd.sock inode=5339 dev=00:1b mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sendmail_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(02/14/2025 16:18:03.070:27334) : arch=unknown-elf-type(x86_64) syscall=read success=no exit=EACCES a0=0x3 a1=0x7fff3f878790 a2=0x6e a3=0x55fc6e981790 items=1 ppid=264760 pid=264850 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=unknown(917) sgid=unknown(917) fsgid=unknown(917) tty=(none) ses=unset comm=sendmail exe=/usr/sbin/smtpctl subj=system_u:system_r:logwatch_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/14/2025 16:18:03.070:27334) : avc:  denied  { write } for  pid=264850 comm=sendmail name=smtpd.sock dev="tmpfs" ino=5339 scontext=system_u:system_r:logwatch_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sendmail_var_run_t:s0 tclass=sock_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2342843