### PR TITLE
Update kmscon policy module to kmscon version 9 (bsc#1238137)

### DIFF
--- a/dist/targeted/modules.conf
+++ b/dist/targeted/modules.conf
@@ -1247,6 +1247,13 @@ keystone = module
 # 
 kismet = module
 
+# Layer: contrib
+# Module: kmscon
+#
+# Linux KMS/DRM based virtual Console Emulator
+#
+kmscon = module
+
 # Layer: services
 # Module: ksmtuned
 #

--- a/policy/modules/contrib/kmscon.te
+++ b/policy/modules/contrib/kmscon.te
@@ -31,9 +31,13 @@ term_tty(kmscon_devpts_t)
 allow kmscon_t self:capability {sys_admin sys_tty_config};
 
 dontaudit kmscon_t self:capability2 block_suspend;
+# kmscon tries to read /proc/<pid_of_login_process>/cgroup
+# preliminarily dontaudit this since there is some discussion upstream
+# https://github.com/Aetf/kmscon/pull/105
+domain_dontaudit_read_all_domains_state(kmscon_t)
 
 # Create an udev monitor
-allow kmscon_t self:netlink_kobject_uevent_socket { bind create setopt getattr };
+allow kmscon_t self:netlink_kobject_uevent_socket { bind create getopt setopt getattr };
 
 allow kmscon_t kmscon_devpts_t:chr_file { rw_chr_file_perms setattr_chr_file_perms };
 term_create_pty(kmscon_t, kmscon_devpts_t)
@@ -44,6 +48,11 @@ read_files_pattern(kmscon_t, kmscon_conf_t, kmscon_conf_t)
 kernel_read_system_state(kmscon_t)
 
 auth_read_passwd(kmscon_t)
+
+# because it is a shell script https://github.com/Aetf/kmscon/pull/7/files
+corecmd_exec_shell(kmscon_t)
+# for dbus-send in the shell script
+corecmd_exec_bin(kmscon_t)
 
 dev_rw_dri(kmscon_t)
 dev_read_sysfs(kmscon_t)
@@ -63,6 +72,13 @@ miscfiles_manage_fonts_cache(kmscon_t)
 term_use_unallocated_ttys(kmscon_t)
 
 optional_policy(`
+    # Allow domtrans to agetty using --login
+    # see https://github.com/Aetf/kmscon/commit/21cf668c58867a100272adea6f323cd56fc73e78
+    getty_domtrans(kmscon_t)
+    getty_systemctl(kmscon_t)
+')
+
+optional_policy(`
     # Learn about the input devices
     udev_read_db(kmscon_t)
 ')
@@ -77,11 +93,17 @@ optional_policy(`
     init_dbus_chat(kmscon_t)
 
     optional_policy(`
+	systemd_dbus_chat_localed(kmscon_t)
         systemd_dbus_chat_logind(kmscon_t)
 
         # List seats
         systemd_login_list_pid_dirs(kmscon_t)
         systemd_login_read_pid_files(kmscon_t)
+	# Watch seat dirs /run/systemd/seats
+	systemd_login_watch_pid_dirs(kmscon_t)
+	# Watch and read /run/systemd/sessions
+	systemd_read_logind_sessions_files(kmscon_t)
+	systemd_login_watch_session_dirs(kmscon_t)
 
         kmscon_systemctl(systemd_logind_t)
     ')


### PR DESCRIPTION
We have some downstream commits in the opensuse selinux policy regarding kmscon, after a developer notified us that
the development will be continued in a fork: https://github.com/Aetf/kmscon
So maybe you want to have the kmscon commits from us as well so that they can take it?

Because: I saw that they also added a custom module for fedora 42, maybe it would make sense to ask them to take this kmscon module instead....
see: https://github.com/Aetf/kmscon/pull/109/files

Also we are enabling the module downstream in openSUSE, let me know if i should add this commit as well.
(not sure what fedoras plans are with kmscon, i think it is dropped https://src.fedoraproject.org/rpms/kmscon)

If it is not needed, feel free to close :) 