### PR TITLE
Allow unconfined user a file transition for creating sudo log directory

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -196,4 +196,5 @@ interface(`sudo_filetrans_named_content_log',`
 	')
 
 	logging_log_filetrans($1, sudo_log_t, file, "sudo.log")
+	logging_log_filetrans($1, sudo_log_t, dir, "sudo-io")
 ')


### PR DESCRIPTION
When "Defaults log_input" or "Defaults log_output" is specified in sudoers configuration along with the documentation, users allowed to run sudo need to have a named file transition defined to create the log directory (iolog_dir) with the proper type. So far it was defined for members of the sudodomain attribute only (refer to db7cdfa58f, "Allow sysadm_t and staff_t domains to use sudo io logging").

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2278988