### PR TITLE
Allow virtqemud read/write inherited dri devices

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2264,7 +2264,7 @@ dev_delete_urand(virtqemud_t)
 dev_getattr_fs(virtqemud_t)
 dev_read_cpuid(virtqemud_t)
 dev_rw_sysfs(virtqemud_t)
-
+dev_rw_inherited_dri(virtqemud_t)
 dev_read_urand(virtqemud_t)
 dev_rw_sgx_vepc(virtqemud_t)
 dev_rw_vfio_dev(virtqemud_t)


### PR DESCRIPTION
This issue manifests when a vm with 3D acceleration is started. The file path is /dev/dri/renderD128.

The commit addresses the following AVC denial:
type=AVC msg=audit(1747877884.388:417): avc:  denied  { read write } for  pid=55883 comm="rpc-virtqemud" name="renderD128" dev="tmpfs" ino=10 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:dri_device_t:s0 tclass=chr_file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2367923