### PR TITLE
Allow geoclue read NetworkManager pid files

### DIFF
--- a/policy/modules/contrib/geoclue.te
+++ b/policy/modules/contrib/geoclue.te
@@ -86,6 +86,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	networkmanager_read_pid_files(geoclue_t)
+')
+
+optional_policy(`
 	pcscd_stream_connect(geoclue_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1754360186.558:694): avc:  denied  { read } for  pid=135323 comm="pool-1" name="no-stub-resolv.conf" dev="tmpfs" ino=6508 scontext=system_u:system_r:geoclue_t:s0 tcontext=system_u:object_r:NetworkManager_var_run_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2386477