### PR TITLE
Allow logwatch stream connect to opensmtpd

### DIFF
--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -187,7 +187,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sendmail_write_pid_files(logwatch_t)
+	sendmail_stream_connect(logwatch_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/sendmail.if
+++ b/policy/modules/contrib/sendmail.if
@@ -347,13 +347,13 @@ interface(`sendmail_manage_tmp_files',`
 ##	</summary>
 ## </param>
 #
-interface(`sendmail_write_pid_files',`
+interface(`sendmail_stream_connect',`
 	gen_require(`
-		type sendmail_var_run_t;
+		type sendmail_t, sendmail_var_run_t;
 	')
 
 	files_search_pids($1)
-	allow $1 sendmail_var_run_t:file write_sock_file_perms;
+	stream_connect_pattern($1, sendmail_var_run_t, sendmail_var_run_t, sendmail_t)
 ')
 
 ########################################


### PR DESCRIPTION
This is a follow-up commit to 791e4eb8c1ac ("Allow logwatch work with opensmtpd") which turned out to be insufficient.

The commit addresses the following AVC denial:
type=AVC msg=audit(1754378223.221:205740): avc:  denied  { connectto } for  pid=2191906 comm="sendmail" path="/run/smtpd.sock" scontext=system_u:system_r:logwatch_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sendmail_t:s0 tclass=unix_stream_socket permissive=0 type=SYSCALL msg=audit(1754378223.221:205740): arch=x86_64 syscall=connect success=no exit=EACCES a0=3 a1=7ffc64e36c90 a2=6e a3=0 items=1 ppid=2191813 pid=2191906 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=917 sgid=917 fsgid=917 tty=(none) ses=4294967295 comm=sendmail exe=/usr/bin/smtpctl subj=system_u:system_r:logwatch_t:s0-s0:c0.c1023 key=(null) type=PATH msg=audit(1754378223.221:205740): item=0 name=/var/run/smtpd.sock inode=52492 dev=00:1b mode=0140666 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:sendmail_var_run_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2342843