### PR TITLE
Allow login to getattr pidfs

### DIFF
--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -114,6 +114,7 @@ files_create_home_dir(local_login_t)
 fs_search_auto_mountpoints(local_login_t)
 fs_getattr_cgroup(local_login_t)
 fs_getattr_tmpfs(local_login_t)
+fs_getattr_pidfs(local_login_t)
 fs_getattr_xattr_fs(local_login_t)
 
 storage_dontaudit_getattr_fixed_disk_dev(local_login_t)


### PR DESCRIPTION
podman fails to create a session with:
podman001.test.openqa.fedoraproject.org audit[242038]: AVC avc:  denied  { getattr } for  pid=242038 comm="login"
  name="/" dev="pidfs" ino=1
  scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023
  tcontext=system_u:object_r:pidfs_t:s0
  tclass=filesystem permissive=0
podman001.test.openqa.fedoraproject.org audit[242038]: AVC avc:  denied  { getattr } for  pid=242038 comm="login"
  name="/" dev="pidfs" ino=1
  scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023
  tcontext=system_u:object_r:pidfs_t:s0
  tclass=filesystem permissive=0
podman001.test.openqa.fedoraproject.org login[242038]: pam_systemd(login:session): Failed to register session: (null) podman001.test.openqa.fedoraproject.org login[242038]: pam_unix(login:session): session opened for user testman(uid=1001) by testman(uid=0)