### PR TITLE
Allow unconfined_domain_type cap2_userns capabilities

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -267,29 +267,39 @@ optional_policy(`
 # is handled in the interface as typeattribute cannot
 # be used on an attribute.
 
+# Write access is for setting attributes under /proc/self/attr.
+allow unconfined_domain_type self:file manage_file_perms;
+allow unconfined_domain_type self:dir rw_dir_perms;
+allow unconfined_domain_type self:fifo_file { manage_fifo_file_perms relabelfrom relabelto };
+allow unconfined_domain_type self:lnk_file setattr;
+
 # allow special io_uring features
 allow unconfined_domain_type domain:io_uring { cmd override_creds };
 allow unconfined_domain_type self:io_uring sqpoll;
 dev_io_uring_cmd_on_all_dev_nodes(unconfined_domain_type)
 files_io_uring_cmd_on_all_files(unconfined_domain_type)
 
-# allow using the user_namespace class
+# Use any Linux capability
+allow unconfined_domain_type self:capability ~{ sys_module };
+allow unconfined_domain_type self:capability2 ~{ mac_admin mac_override };
+
+# Use namespace capabilities
 allow unconfined_domain_type self:user_namespace create;
+allow unconfined_domain_type self:cap_userns all_cap_userns_perms;
+allow unconfined_domain_type self:cap2_userns { bpf perfmon syslog wake_alarm };
 
 # Use bpf tools
 allow unconfined_domain_type domain:bpf { map_create map_read map_write prog_load prog_run };
 
-allow unconfined_domain_type self:lnk_file setattr;
-
 # Use/sendto/connectto sockets created by any domain.
-allow unconfined_domain_type self:cap_userns all_cap_userns_perms;
 allow unconfined_domain_type domain:{ socket_class_set socket key_socket } *;
-
 allow unconfined_domain_type domain:system all_system_perms;
+
 # Use descriptors and pipes created by any domain.
 allow unconfined_domain_type domain:fd use;
 allow unconfined_domain_type domain:fifo_file rw_file_perms;
 
+# Use dbus
 allow unconfined_domain_type unconfined_domain_type:dbus send_msg;
 
 # Act upon any other process.

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -70,10 +70,6 @@ dontaudit unconfined_t self:capability sys_module;
 
 allow unconfined_t file_type:system module_load;
 
-allow unconfined_t self:cap_userns all_cap_userns_perms;
-
-allow unconfined_t self:bpf { map_create map_read map_write prog_load prog_run };
-
 kernel_rw_unlabeled_socket(unconfined_t)
 kernel_rw_unlabeled_rawip_socket(unconfined_t)
 kernel_rw_unlabeled_smc_socket(unconfined_t)

--- a/policy/modules/system/unconfined.if
+++ b/policy/modules/system/unconfined.if
@@ -17,18 +17,8 @@ interface(`unconfined_domain_noaudit',`
 		class passwd all_passwd_perms;
 	')
 
-	# Use any Linux capability.
-
-	allow $1 self:capability ~{ sys_module };
-	allow $1 self:capability2 ~{ mac_admin mac_override };
-	allow $1 self:fifo_file { manage_fifo_file_perms relabelfrom relabelto };
-
 	# Transition to myself, to make get_ordered_context_list happy.
 	allow $1 self:process { dyntransition transition };
-
-	# Write access is for setting attributes under /proc/self/attr.
-	allow $1 self:file manage_file_perms;
-	allow $1 self:dir rw_dir_perms;
 
 	# Userland object managers
 	allow $1 self:nscd all_nscd_perms;


### PR DESCRIPTION
Also move permissions for individual domain to the interface or all domains in unconfined_domain_type.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(1748139125.344:173921): proctitle="./test_progs-cpuv4" type=SYSCALL msg=audit(1748139125.344:173921): arch=c000003e syscall=321 success=no exit=-1 a0=24 a1=7ffe86c803e0 a2=8 a3=64 items=0 ppid=21056 pid=24806 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="new_name" exe="/usr/libexec/kselftests/bpf/test_progs-cpuv4" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(1748139125.344:173921): avc:  denied  { bpf } for  pid=24806 comm="new_name" capability=39  scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=cap2_userns permissive=0

Resolves: RHEL-93656