### PR TITLE
Label /usr/libexec/postfix/tlsproxy with postfix_smtp_exec_t

### DIFF
--- a/policy/modules/contrib/postfix.fc
+++ b/policy/modules/contrib/postfix.fc
@@ -17,6 +17,7 @@ ifdef(`distro_redhat', `
 /usr/libexec/postfix/bounce --	gen_context(system_u:object_r:postfix_bounce_exec_t,s0)
 /usr/libexec/postfix/pipe --	gen_context(system_u:object_r:postfix_pipe_exec_t,s0)
 /usr/libexec/postfix/virtual --	gen_context(system_u:object_r:postfix_virtual_exec_t,s0)
+/usr/libexec/postfix/tlsproxy -- gen_context(system_u:object_r:postfix_smtp_exec_t,s0)
 ', `
 /usr/lib/postfix/.*	--	gen_context(system_u:object_r:postfix_exec_t,s0)
 /usr/lib/postfix/cleanup --	gen_context(system_u:object_r:postfix_cleanup_exec_t,s0)
@@ -31,6 +32,7 @@ ifdef(`distro_redhat', `
 /usr/lib/postfix/smtpd	--	gen_context(system_u:object_r:postfix_smtpd_exec_t,s0)
 /usr/lib/postfix/bounce	--	gen_context(system_u:object_r:postfix_bounce_exec_t,s0)
 /usr/lib/postfix/pipe	--	gen_context(system_u:object_r:postfix_pipe_exec_t,s0)
+/usr/lib/postfix/tlsproxy --	gen_context(system_u:object_r:postfix_smtp_exec_t,s0)
 ')
 /etc/postfix/postfix-script.* -- gen_context(system_u:object_r:postfix_exec_t,s0)
 /etc/postfix/prng_exch	--	gen_context(system_u:object_r:postfix_prng_t,s0)


### PR DESCRIPTION
The postfix's tlsproxy(8) server implements a two-way TLS proxy. It is used by the postscreen(8) server to talk SMTP-over-TLS with remote SMTP clients that are not allowlisted (including clients whose allowlist status has expired), and by the smtp(8) client to support TLS connection reuse.

The commit addresses the following AVC denial when the executable got the default postfix_exec_t type:
type=AVC msg=audit(1738250195.194:554): avc: denied { read write } for pid=10707 comm="tlsproxy" path="socket:[46554]" dev="sockfs" ino=46554 scontext=system_u:system_r:postfix_master_t:s0 tcontext=system_u:system_r:postfix_smtp_t:s0 tclass=tcp_socket permissive=0 type=SYSCALL msg=audit(1738250195.194:554): arch=x86_64 syscall=recvmsg success=yes exit=EPERM a0=80 a1=7fff3598fa50 a2=0 a3=7fff3598fa8c items=0 ppid=10666 pid=10707 auid=4294967295 uid=89 gid=89 euid=89 suid=89 fsuid=89 egid=89 sgid=89 fsgid=89 tty=(none) ses=4294967295 comm=tlsproxy exe=/usr/libexec/postfix/tlsproxy subj=system_u:system_r:postfix_master_t:s0 key=(null)ARCH=x86_64 SYSCALL=recvmsg AUID=unset UID=postfix GID=postfix EUID=postfix SUID=postfix FSUID=postfix EGID=postfix SGID=postfix FSGID=postfix

Resolves: RHEL-77101