### PR TITLE
Allow virtstoraged create qemu /var/run files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2158,7 +2158,7 @@ allow virtqemud_t self:udp_socket { connect create_socket_perms };
 allow virtqemud_t qemu_var_run_t:{ dir file sock_file } relabelfrom;
 
 allow virtqemud_t svirt_t:netlink_route_socket create_netlink_socket_perms;
-allow virtqemud_t svirt_t:process { getattr getrlimit setsched signal signull transition };
+allow virtqemud_t svirt_t:process { getattr getrlimit setrlimit setsched signal signull transition };
 allow virtqemud_t svirt_t:tcp_socket create_stream_socket_perms;
 allow virtqemud_t svirt_t:udp_socket create_socket_perms;
 allow virtqemud_t svirt_t:unix_stream_socket { connectto create_stream_socket_perms };
@@ -2219,6 +2219,7 @@ filetrans_pattern(virtqemud_t, virt_var_run_t, qemu_var_run_t, dir, "qemu")
 
 allow virtqemud_t svirt_image_t:file map;
 allow virtqemud_t svirt_image_t:blk_file setattr;
+allow virtqemud_t svirt_image_t:chr_file unlink;
 rw_blk_files_pattern(virtqemud_t, svirt_image_t, svirt_image_t)
 rw_chr_files_pattern(virtqemud_t, svirt_image_t, svirt_image_t)
 setattr_chr_files_pattern(virtqemud_t, svirt_image_t, svirt_image_t)
@@ -2279,6 +2280,7 @@ dev_setattr_sev(virtqemud_t)
 dev_setattr_urand(virtqemud_t)
 dev_setattr_userfaultfd(virtqemud_t)
 dev_unmount_fs(virtqemud_t)
+dev_unlink_vfio_dev(virtqemud_t)
 
 files_mounton_non_security(virtqemud_t)
 files_read_all_symlinks(virtqemud_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2462,6 +2462,7 @@ manage_files_pattern(virtstoraged_t, virt_var_lib_t, virt_var_lib_t)
 manage_lnk_files_pattern(virtstoraged_t, virt_etc_rw_t, virt_etc_rw_t)
 
 write_files_pattern(virtstoraged_t, qemu_var_run_t, qemu_var_run_t)
+create_files_pattern(virtstoraged_t, qemu_var_run_t, qemu_var_run_t)
 
 kernel_get_sysvipc_info(virtstoraged_t)
 kernel_io_uring_use(virtstoraged_t)

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -6180,6 +6180,24 @@ interface(`dev_rw_vfio_dev',`
 
 ########################################
 ## <summary>
+##	Unlink the VFIO devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dev_unlink_vfio_dev',`
+	gen_require(`
+		type device_t, vfio_device_t;
+	')
+
+	delete_chr_files_pattern($1, device_t, vfio_device_t)
+')
+
+########################################
+## <summary>
 ##	Allow read/write the vhost net device
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Triggered when cloning a vm with nvram.

The commit addresses the following AVC denial:
type=AVC msg=audit(1752811278.985:12625): avc:  denied  { write } for  pid=1645349 comm="rpc-virtstorage" name="nvram" dev="dm-0" ino=203603940 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:qemu_var_run_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1752811278.985:12625): avc:  denied  { add_name } for  pid=1645349 comm="rpc-virtstorage" name="test1_VARS.fd" scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:qemu_var_run_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1752811278.985:12625): avc:  denied  { create } for  pid=1645349 comm="rpc-virtstorage" name="test1_VARS.fd" scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:qemu_var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(1752811278.985:12625): avc:  denied  { write } for  pid=1645349 comm="rpc-virtstorage" path="/var/lib/libvirt/qemu/nvram/test1_VARS.fd" dev="dm-0" ino=203413165 scontext=system_u:system_r:virtstoraged_t:s0 tcontext=system_u:object_r:qemu_var_run_t:s0 tclass=file permissive=1

Resolves: RHEL-104344