### PR TITLE
dist/targeted/modules.conf: enable slrnpull module

### DIFF
--- a/dist/targeted/modules.conf
+++ b/dist/targeted/modules.conf
@@ -2109,7 +2109,7 @@ slpd = module
 #
 # Service for downloading news feeds the slrn newsreader.
 # 
-slrnpull = on
+slrnpull = module
 
 # Layer: services
 # Module: smartmon
@@ -2287,11 +2287,12 @@ thumb = module
 tmpreaper = module
 
 # Layer: contrib
-# Module: glusterd
+# Module: tomcat
 #  
 #  policy for tomcat service
 #
 tomcat = module
+
 # Layer: services
 # Module: tor
 #


### PR DESCRIPTION
The policy Makefile only recognises "base", "module" and "off".  https://github.com/fedora-selinux/selinux-policy/blob/33902770ee27643e1fd5b741ebc6ca514a878f19/Makefile#L297

While at it, fix a module name in comment and formatting.