### PR TITLE
Allow systemd-networkd to create leases directory

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -651,7 +651,7 @@ allow systemd_networkd_t self:tun_socket { relabelfrom relabelto create_socket_p
 
 allow init_t systemd_networkd_t:netlink_route_socket create_netlink_socket_perms;
 
-allow systemd_networkd_t systemd_networkd_var_lib_t:dir list_dir_perms;
+allow systemd_networkd_t systemd_networkd_var_lib_t:dir {create_dir_perms list_dir_perms};
 create_files_pattern(systemd_networkd_t, systemd_networkd_var_lib_t, systemd_networkd_var_lib_t)
 
 manage_files_pattern(systemd_networkd_t, systemd_networkd_tmpfs_t, systemd_networkd_tmpfs_t)


### PR DESCRIPTION
As reported in https://bugzilla.redhat.com/show_bug.cgi?id=2371297, systemd-networkd fails to write a lease file with:
```
audit[1946]: AVC avc:  denied  { create } for  pid=1946 comm="systemd-network"
    name="dhcp-server-lease"
    scontext=system_u:system_r:systemd_networkd_t:s0
    tcontext=system_u:object_r:systemd_networkd_var_lib_t:s0
    tclass=dir permissive=0
```
and indeed, 'create' is not listed:
```console
$ sesearch -A -s systemd_networkd_t -t systemd_networkd_var_lib_t -c dir allow systemd_networkd_t systemd_networkd_var_lib_t:dir
    { add_name getattr ioctl lock open read search write };
```
https://bugzilla.redhat.com/show_bug.cgi?id=2371297
https://issues.redhat.com/browse/FC-1900