### PR TITLE
Allow openvswitch read virtqemud process state

### DIFF
--- a/policy/modules/contrib/openvswitch.te
+++ b/policy/modules/contrib/openvswitch.te
@@ -162,6 +162,7 @@ optional_policy(`
     virt_rw_svirt_image(openvswitch_t)
     virt_stream_connect_svirt(openvswitch_t)
     virt_rw_stream_sockets_svirt(openvswitch_t)
+    virt_virtqemud_read_state(openvswitch_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -2221,6 +2221,24 @@ interface(`virt_rw_stream_sockets_virtqemud',`
 
 ########################################
 ## <summary>
+##	Read the virtqemud process state
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_virtqemud_read_state',`
+	gen_require(`
+		type virtqemud_t;
+	')
+
+	ps_process_pattern($1, virtqemud_t)
+')
+
+########################################
+## <summary>
 ##	Execute virsh in the caller domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/11/2025 05:50:24.918:1021) : proctitle=ovs-vsctl --timeout=5 -- --may-exist add-port ovsbr0 vnet1 -- set Port vnet1 other_config:transient=true -- set Interface vnet1 type=PATH msg=audit(08/11/2025 05:50:24.918:1021) : item=0 name=/proc/33963/cmdline inode=58176 dev=00:16 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:virtqemud_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/11/2025 05:50:24.918:1021) : arch=x86_64 syscall=openat success=yes exit=7 a0=AT_FDCWD a1=0x55ec1c8e7ac0 a2=O_RDONLY a3=0x0 items=1 ppid=33963 pid=34207 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ovs-vsctl exe=/usr/bin/ovs-vsctl subj=system_u:system_r:openvswitch_t:s0 key=(null) type=AVC msg=audit(08/11/2025 05:50:24.918:1021) : avc:  denied  { open } for  pid=34207 comm=ovs-vsctl path=/proc/33963/cmdline dev="proc" ino=58176 scontext=system_u:system_r:openvswitch_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=file permissive=1 type=AVC msg=audit(08/11/2025 05:50:24.918:1021) : avc:  denied  { read } for  pid=34207 comm=ovs-vsctl name=cmdline dev="proc" ino=58176 scontext=system_u:system_r:openvswitch_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=file permissive=1 type=AVC msg=audit(08/11/2025 05:50:24.918:1021) : avc:  denied  { search } for  pid=34207 comm=ovs-vsctl name=33963 dev="proc" ino=57255 scontext=system_u:system_r:openvswitch_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=dir permissive=1

Resolves: RHEL-65322