### PR TITLE
Allow systemd-coredumpd capabilities in the user namespace

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1283,7 +1283,7 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # setpcap - to drop capabilities
 allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_admin sys_chroot sys_ptrace };
 dontaudit systemd_coredump_t self:capability sys_resource;
-allow systemd_coredump_t self:cap_userns { dac_read_search dac_override sys_admin sys_ptrace };
+allow systemd_coredump_t self:cap_userns { dac_read_search dac_override setgid setuid sys_admin sys_chroot sys_ptrace };
 
 # To set its capability set
 allow systemd_coredump_t self:process setcap;


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(08/11/2025 06:41:51.410:1058) : proctitle=(sd-coredumpns) type=PATH msg=audit(08/11/2025 06:41:51.410:1058) : item=0 name=. inode=20972076 dev=fc:02 mode=dir,555 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:root_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(08/11/2025 06:41:51.410:1058) : cwd=/ type=SYSCALL msg=audit(08/11/2025 06:41:51.410:1058) : arch=x86_64 syscall=chroot success=yes exit=0 a0=0x7f3171561676 a1=0x10000000 a2=0x5632e17de08c a3=0x563782056010 items=1 ppid=34352 pid=34353 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(sd-coredumpns) exe=/usr/lib/systemd/systemd-coredump subj=system_u:system_r:systemd_coredump_t:s0 key=(null) type=AVC msg=audit(08/11/2025 06:41:51.410:1058) : avc:  denied  { sys_chroot } for  pid=34353 comm=(sd-coredumpns) capability=sys_chroot  scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=cap_userns permissive=1 type=PROCTITLE msg=audit(08/11/2025 06:41:51.410:1059) : proctitle=(sd-coredumpns) type=SYSCALL msg=audit(08/11/2025 06:41:51.410:1059) : arch=x86_64 syscall=setgroups success=yes exit=0 a0=0x0 a1=0x0 a2=0x0 a3=0x563782056010 items=0 ppid=34352 pid=34353 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=(sd-coredumpns) exe=/usr/lib/systemd/systemd-coredump subj=system_u:system_r:systemd_coredump_t:s0 key=(null) type=AVC msg=audit(08/11/2025 06:41:51.410:1059) : avc:  denied  { setgid } for  pid=34353 comm=(sd-coredumpns) capability=setgid  scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=cap_userns permissive=1 type=PROCTITLE msg=audit(08/11/2025 06:41:51.410:1060) : proctitle=(sd-coredumpns) type=SYSCALL msg=audit(08/11/2025 06:41:51.410:1060) : arch=x86_64 syscall=setresuid success=yes exit=0 a0=root a1=root a2=root a3=0x563782056010 items=0 ppid=34352 pid=34353 auid=unset uid=vu-test-0 gid=vg-test-0 euid=vu-test-0 suid=vu-test-0 fsuid=vu-test-0 egid=vg-test-0 sgid=vg-test-0 fsgid=vg-test-0 tty=(none) ses=unset comm=(sd-coredumpns) exe=/usr/lib/systemd/systemd-coredump subj=system_u:system_r:systemd_coredump_t:s0 key=(null) type=AVC msg=audit(08/11/2025 06:41:51.410:1060) : avc:  denied  { setuid } for  pid=34353 comm=(sd-coredumpns) capability=setuid  scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=cap_userns permissive=1

Resolves: RHEL-97586