### PR TITLE
Allow bootupd delete symlinks in the /boot directory

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -45,6 +45,7 @@ dev_read_sysfs(bootupd_t)
 domain_use_interactive_fds(bootupd_t)
 
 files_create_boot_dirs(bootupd_t)
+files_delete_boot_symlinks(bootupd_t)
 files_read_etc_files(bootupd_t)
 files_manage_boot_files(bootupd_t)
 files_read_root_files(bootupd_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -3566,6 +3566,24 @@ interface(`files_rw_boot_symlinks',`
 
 ########################################
 ## <summary>
+##	Delete symlinks in the /boot directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`files_delete_boot_symlinks',`
+	gen_require(`
+		type boot_t;
+	')
+
+	delete_files_pattern($1, boot_t, boot_t)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete symbolic links
 ##	in the /boot directory.
 ## </summary>


### PR DESCRIPTION
src/bios.rs code snippet:
// Remove the real config if it is symlink and will not // if /boot/grub2/grub.cfg is file
if current_config != grub_config {
    println!("Removing {}", current_config);
    grub_config_dir.remove_file_optional(current_config.as_std_path())?;
}

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/08/25 07:01:30.933:36) : proctitle=/usr/bin/bootupctl adopt-and-update --with-static-config type=PATH msg=audit(07/08/25 07:01:30.933:36) : item=1 name=(null) inode=25 dev=fc:02 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:boot_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(07/08/25 07:01:30.933:36) : item=0 name=(null) inode=8194 dev=fc:02 mode=dir,700 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:boot_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/08/25 07:01:30.933:36) : arch=x86_64 syscall=renameat success=yes exit=0 a0=0x7 a1=0x55f559ba7200 a2=0x7 a3=0x55f559ba69c0 items=2 ppid=1 pid=860 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=bootupctl exe=/usr/bin/bootupctl subj=system_u:system_r:bootupd_t:s0 key=(null) type=AVC msg=audit(07/08/25 07:01:30.933:36) : avc:  denied  { unlink } for  pid=860 comm=bootupctl name=grub.cfg dev="vda2" ino=302 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:boot_t:s0 tclass=lnk_file permissive=1

Resolves: RHEL-101155