### PR TITLE
Allow gpg-agent create insights-client lib sock files

### DIFF
--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -358,7 +358,7 @@ optional_policy(`
 	insights_client_setattr_lib_dirs(gpg_agent_t)
 	insights_client_watch_lib_dirs(gpg_agent_t)
 	insights_client_manage_lib_files(gpg_agent_t)
-#	insights_client_manage_lib_sock_files(gpg_agent_t)
+	insights_client_create_lib_sock_files(gpg_agent_t)
 	insights_client_manage_tmp_sock_files(gpg_agent_t)
 ')
 

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -247,6 +247,63 @@ interface(`insights_client_manage_lib_files',`
 
 ########################################
 ## <summary>
+##	Read insights_client lib socket files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_read_lib_sock_files',`
+	gen_require(`
+		type insights_client_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_sock_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Write insights_client lib socket files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_write_lib_sock_files',`
+	gen_require(`
+		type insights_client_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	write_sock_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Create insights_client lib socket files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`insights_client_create_lib_sock_files',`
+	gen_require(`
+		type insights_client_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	create_sock_files_pattern($1, insights_client_var_lib_t, insights_client_var_lib_t)
+')
+
+########################################
+## <summary>
 ##	Create insights_client lib dirs.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/05/25 16:42:05.503:155) : proctitle=gpg-agent --homedir /var/lib/insights/tmpgwfdzd9w --use-standard-socket --daemon type=SYSCALL msg=audit(08/05/25 16:42:05.503:155) : arch=x86_64 syscall=bind success=no exit=EACCES(Permission denied) a0=0x3 a1=0x5606da6316e0 a2=0x2b a3=0x0 items=0 ppid=1888 pid=1889 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=gpg-agent exe=/usr/bin/gpg-agent subj=system_u:system_r:gpg_agent_t:s0 key=(null) type=AVC msg=audit(08/05/25 16:42:05.503:155) : avc:  denied  { create } for  pid=1889 comm=gpg-agent name=S.gpg-agent scontext=system_u:system_r:gpg_agent_t:s0 tcontext=system_u:object_r:insights_client_var_lib_t:s0 tclass=sock_file permissive=0

Resolves: RHEL-107589