### PR TITLE
Revert "Allow virt_domain write to virt_image_t files" for c10s branch

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1093,7 +1093,7 @@ manage_dirs_pattern(virt_domain, virt_cache_t, virt_cache_t)
 manage_files_pattern(virt_domain, virt_cache_t, virt_cache_t)
 files_var_filetrans(virt_domain, virt_cache_t, { file dir })
 
-rw_files_pattern(virt_domain, virt_image_t, virt_image_t)
+read_files_pattern(virt_domain, virt_image_t, virt_image_t)
 read_lnk_files_pattern(virt_domain, virt_image_t, virt_image_t)
 
 manage_dirs_pattern(virt_domain, svirt_image_t, svirt_image_t)


### PR DESCRIPTION
The orginal fix https://github.com/fedora-selinux/selinux-policy/commit/f8ac78ff7e319be9f2b137589fe70868e614d269.patch is missing in c10s branch. Please fix it