### PR TITLE
Allow wireguard to setup DNS using dns-hatchet (bsc#1243148)

### DIFF
--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -41,6 +41,33 @@ domain_use_interactive_fds(wireguard_t)
 
 files_read_etc_files(wireguard_t)
 
+# XXX: new DNS piece
+allow wireguard_t self:capability sys_admin;
+
+sysnet_mount_file(wireguard_t)
+
+# use fs_tmpfs_filetrans() instead of chcon on resolv.conf
+# XXX: new dontaudit interface below
+sysnet_dontaudit_file_relabelto(wireguard_t)
+selinux_dontaudit_validate_context(wireguard_t)
+
+sysnet_create_config(wireguard_t)
+sysnet_write_config(wireguard_t)
+
+fs_tmpfs_filetrans(wireguard_t, net_conf_t, file, "resolv.conf")
+
+fs_all_mount_fs_perms_tmpfs(wireguard_t)
+fs_mounton_tmpfs(wireguard_t)
+fs_manage_ramfs_files(wireguard_t)
+storage_rw_fixed_disk_blk_dev(wireguard_t)
+
+optional_policy(`
+	mount_exec(wireguard_t)
+	mount_manage_pid_files(wireguard_t)
+')
+
+files_mounton_rootfs(wireguard_t)
+
 optional_policy(`
 	auth_read_passwd(wireguard_t)
 ')

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -5774,6 +5774,24 @@ interface(`fs_dontaudit_getattr_tmpfs_dirs',`
 
 ########################################
 ## <summary>
+##	Do not audit relabelfrom attempts on files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_relabelfrom_tmpfs_files',`
+	gen_require(`
+		type tmpfs_t;
+	')
+
+	dontaudit $1 tmpfs_t:file relabelfrom;
+')
+
+########################################
+## <summary>
 ##	Set the attributes of tmpfs directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1316,3 +1316,39 @@ interface(`sysnet_filetrans_cloud_net_conf',`
 
 	files_pid_filetrans($1, net_conf_t, dir, "cloud-init")
 ')
+
+#######################################
+## <summary>
+##	Dontaudit relabelto network config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_dontaudit_file_relabelto',`
+	gen_require(`
+		type net_conf_t;
+	')
+
+    dontaudit $1 net_conf_t:file { relabelto };
+')
+
+#######################################
+## <summary>
+##	Mount network config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_mount_file',`
+	gen_require(`
+		type net_conf_t;
+	')
+
+    allow $1 net_conf_t:file mounton;
+')


### PR DESCRIPTION
This is a bit of a contentious change for me and I currently do not find to much time to continue to work on it, but I would like some feedback on one piece: 


There is this code piece in wg-quick[0], which I try to work around here:
```
	printf 'nameserver %s\n' "${DNS[@]}"
		[[ ${#DNS_SEARCH[@]} -eq 0 ]] || printf 'search %s\n' "${DNS_SEARCH[*]}"
		} | unshare -m --propagation shared bash -c "$(cat <<-_EOF
			set -e
			context="\$(stat -c %C /etc/resolv.conf 2>/dev/null)" || unset context
			mount --make-private /dev/shm
			mount -t tmpfs none /dev/shm
			cat > /dev/shm/resolv.conf
			[[ -z \$context || \$context == "?" ]] || chcon "\$context" /dev/shm/resolv.conf 2>/dev/null || true
			mount -o remount,ro /dev/shm
			mount -o bind,ro /dev/shm/resolv.conf /etc/resolv.conf
		_EOF
```

Currently my only good idea is to dontaudit the `chcon` change and setup a file transition for /tmp:
```
fs_tmpfs_filetrans(wireguard_t, net_conf_t, file, "resolv.conf")
```
Which then should mean that `resolv.conf` has the correct label after the mount of  `/dev/shm/resolv.conf ` to `/etc/resolv.conf`.

Not sure if there might be a better option or if that solution might be acceptable in the first place ?

[0] https://git.zx2c4.com/wireguard-tools/tree/contrib/dns-hatchet/hatchet.bash#n27