### PR TITLE
Label /run/audit with auditd_var_run_t

### DIFF
--- a/policy/modules/system/logging.fc
+++ b/policy/modules/system/logging.fc
@@ -65,6 +65,7 @@ ifdef(`distro_redhat',`
 /var/spool/postfix/dev/log -s	gen_context(system_u:object_r:devlog_t,s0)
 ')
 
+/run/audit(/.*)?		gen_context(system_u:object_r:auditd_var_run_t,mls_systemhigh)
 /run/audit_events	-s	gen_context(system_u:object_r:auditd_var_run_t,mls_systemhigh)
 /run/audispd_events	-s	gen_context(system_u:object_r:audisp_var_run_t,mls_systemhigh)
 /run/auditd\.pid	--	gen_context(system_u:object_r:auditd_var_run_t,mls_systemhigh)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -225,7 +225,7 @@ logging_log_filetrans(auditd_t, auditd_log_t, dir, "audit")
 
 manage_files_pattern(auditd_t, auditd_var_run_t, auditd_var_run_t)
 manage_sock_files_pattern(auditd_t, auditd_var_run_t, auditd_var_run_t)
-files_pid_filetrans(auditd_t, auditd_var_run_t, { file sock_file })
+files_pid_filetrans(auditd_t, auditd_var_run_t, { dir file sock_file })
 
 manage_files_pattern(auditd_t, auditd_tmp_t, auditd_tmp_t)
 manage_dirs_pattern(auditd_t, auditd_tmp_t, auditd_tmp_t)


### PR DESCRIPTION
Since audit commit 4ade1466f91d ("Use configures runstatedir to locate audit.pid, auditd.state, and other run time files") [1], audit uses /run/audit to store the daemon pid file, state file, and other runtime files.

[1] https://github.com/linux-audit/audit-userspace/commit/4ade1466f91dad3c33b2d92596ef8385f3bc5571