### PR TITLE
Allow openvpn create and use generic netlink socket

### DIFF
--- a/policy/modules/contrib/openvpn.te
+++ b/policy/modules/contrib/openvpn.te
@@ -71,6 +71,7 @@ allow openvpn_t self:unix_dgram_socket sendto;
 allow openvpn_t self:unix_stream_socket { accept connectto listen };
 allow openvpn_t self:tcp_socket server_stream_socket_perms;
 allow openvpn_t self:tun_socket { create_socket_perms relabelfrom relabelto };
+allow openvpn_t self:netlink_generic_socket create_socket_perms;
 allow openvpn_t self:netlink_route_socket nlmsg_write;
 
 dontaudit openvpn_t self:capability2  block_suspend ;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1756218769.705:22736): avc:  denied  { create } for  pid=11149 comm="openvpn" scontext=system_u:system_r:openvpn_t:s0 tcontext=system_u:system_r:openvpn_t:s0 tclass=netlink_generic_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2391164