### PR TITLE
Allow NetworkManager-dispatcher-winbind get pidfs attributes

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -617,6 +617,8 @@ domain_read_all_domains_state(NetworkManager_dispatcher_dnssec_t)
 
 files_manage_etc_files(NetworkManager_dispatcher_console_t)
 
+fs_getattr_pidfs(NetworkManager_dispatcher_winbind_t)
+
 init_status(NetworkManager_dispatcher_cloud_t)
 init_status(NetworkManager_dispatcher_ddclient_t)
 init_append_stream_sockets(networkmanager_dispatcher_plugin)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1756272333.532:400): avc:  denied  { getattr } for  pid=15003 comm="systemctl" name="/" dev="pidfs" ino=1 scontext=system_u:system_r:NetworkManager_dispatcher_winbind_t:s0 tcontext=system_u:object_r:pidfs_t:s0 tclass=filesystem permissive=1 type=SYSCALL msg=audit(1756272333.532:400): arch=x86_64 syscall=fstatfs success=yes exit=0 a0=3 a1=7fff83cbc320 a2=7fff83cbc320 a3=0 items=0 ppid=15002 pid=15003 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=systemctl exe=/usr/bin/systemctl subj=system_u:system_r:NetworkManager_dispatcher_winbind_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2391225