### PR TITLE
Gnome remote desktop communicates with tpm2-abrmd over dbus

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -79,6 +79,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tabrmd_dbus_chat(gnome_remote_desktop_t)
+')
+
+optional_policy(`
 	xserver_dbus_chat_xdm(gnome_remote_desktop_t)
 	xserver_read_xdm_state(gnome_remote_desktop_t)
 ')

--- a/policy/modules/contrib/tabrmd.if
+++ b/policy/modules/contrib/tabrmd.if
@@ -1,0 +1,65 @@
+## <summary></summary>
+
+########################################
+## <summary>
+##      Create a tabrmd unix stream socket
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+ifndef(`tabrmd_create_unix_stream_sockets',`
+	interface(`tabrmd_create_unix_stream_sockets',`
+	        gen_require(`
+	                type tabrmd_t;
+	        ')
+
+	        allow $1 tabrmd_t:unix_stream_socket create_stream_socket_perms;
+	')
+')
+
+########################################
+## <summary>
+##      Read and write to
+##      tabrmd unix stream sockets
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+ifndef(`tabrmd_rw_unix_stream_sockets',`
+	interface(`tabrmd_rw_unix_stream_sockets',`
+	        gen_require(`
+	                type tabrmd_t;
+	        ')
+
+	        allow $1 tabrmd_t:unix_stream_socket rw_socket_perms;
+	')
+')
+
+########################################
+## <summary>
+##      Send messages to and from
+##      tabrmd over DBUS.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+ifndef(`tabrmd_dbus_chat',`
+	interface(`tabrmd_dbus_chat',`
+	        gen_require(`
+	                type tabrmd_t;
+	                class dbus send_msg;
+	        ')
+
+	        allow $1 tabrmd_t:dbus send_msg;
+	        allow tabrmd_t $1:dbus send_msg;
+	')
+')


### PR DESCRIPTION
Adding [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd) interface file into the policy for gnome-remote-desktop + TPM for two reasons:

First, gnome-remote-desktop needs to communicate over dbus with tabrmd when working with the TPM (see: https://bugzilla.suse.com/show_bug.cgi?id=1244573) :
```
time->Fri Jun 13 13:10:41 2025
type=USER_AVC msg=audit(1749813041.073:50): pid=1945 uid=498 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:gnome_remote_desktop_t:s0 tcontext=system_u:system_r:tabrmd_t:s0 tclass=dbus permissive=1 exe="/usr/bin/dbus-broker" sauid=498 hostname=? addr=? terminal=?'
```

Second, it is needed for some suse-specific TPM related scripts ([sdbootutils](https://github.com/openSUSE/sdbootutil)).
This includes also an additional interface to allow reading and writing unix sockets because there was no reaction from tabrmd upstream yet: https://github.com/tpm2-software/tpm2-abrmd/pull/851 


Reproducer for gnome-remote-desktop:
1. Install gnome-remote-desktop and tpm2-abrmd
2. start gnome-remote-desktop service