### PR TITLE
Allow stalld map sysfs files

### DIFF
--- a/policy/modules/contrib/stalld.te
+++ b/policy/modules/contrib/stalld.te
@@ -38,6 +38,7 @@ kernel_read_all_proc(stalld_t)
 kernel_setsched(stalld_t)
 
 dev_read_sysfs(stalld_t)
+dev_map_sysfs(stalld_t)
 
 domain_getsched_all_domains(stalld_t)
 domain_read_all_domains_state(stalld_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/27/2025 03:03:16.030:477) : proctitle=/usr/bin/stalld --systemd --backend queue_track -p 1000000000 -r 20000 -d 3 -t 20 --foreground --pidfile /run/stalld/stalld.pid type=MMAP msg=audit(08/27/2025 03:03:16.030:477) : fd=5 flags=MAP_PRIVATE type=SYSCALL msg=audit(08/27/2025 03:03:16.030:477) : arch=x86_64 syscall=mmap success=no exit=EACCES(Permission denied) a0=0x0 a1=0x65a15a a2=PROT_READ a3=MAP_PRIVATE items=0 ppid=1 pid=5952 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stalld exe=/usr/bin/stalld subj=system_u:system_r:stalld_t:s0 key=(null) type=AVC msg=audit(08/27/2025 03:03:16.030:477) : avc:  denied  { map } for  pid=5952 comm=stalld path=/sys/kernel/btf/vmlinux dev="sysfs" ino=870 scontext=system_u:system_r:stalld_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2391234