### PR TITLE
Allow systemd-oomd watch tmpfs dirs

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1970,6 +1970,8 @@ kernel_stream_connect(systemd_oomd_t)
 domain_read_all_domains_state(systemd_oomd_t)
 domain_kill_all_domains(systemd_oomd_t)
 
+files_watch_tmpfs_dirs(systemd_oomd_t)
+
 fs_list_cgroup_dirs(systemd_oomd_t)
 fs_setattr_cgroup_dirs(systemd_oomd_t)
 fs_write_cgroup_dirs(systemd_oomd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
Jul 27 03:22:55 audit: PROCTITLE proctitle="/usr/lib/systemd/systemd-oomd" Jul 27 03:22:55 audit[1134]: AVC avc:  denied  { watch } for  pid=1134 comm="systemd-oomd" path="/" dev="overlay" ino=2 scontext=system_u:system_r:systemd_oomd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir permissive=1 Jul 27 03:22:55 audit[1134]: SYSCALL arch=c000003e syscall=254 success=yes exit=1 a0=7 a1=7f542920c82b a2=180 a3=556eb90ed6c0 items=0 ppid=1 pid=1134 auid=4294967295 uid=999 gid=999 euid=999 suid=999 fsuid=999 egid=999 sgid=999 fsgid=999 tty=(none) ses=4294967295 comm="systemd-oomd" exe="/usr/lib/systemd/systemd-oomd" subj=system_u:system_r:systemd_oomd_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2383684