### PR TITLE
Revert "Allow virt_domain write to virt_image_t files"

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1096,7 +1096,7 @@ manage_dirs_pattern(virt_domain, virt_cache_t, virt_cache_t)
 manage_files_pattern(virt_domain, virt_cache_t, virt_cache_t)
 files_var_filetrans(virt_domain, virt_cache_t, { file dir })
 
-rw_files_pattern(virt_domain, virt_image_t, virt_image_t)
+read_files_pattern(virt_domain, virt_image_t, virt_image_t)
 read_lnk_files_pattern(virt_domain, virt_image_t, virt_image_t)
 
 manage_dirs_pattern(virt_domain, svirt_image_t, svirt_image_t)


### PR DESCRIPTION
This reverts commit e74d7dddf1bbbe63e36cc3886db007e2c82b71d8. The original issue turned out not to be caused by selinux, in fact selinux did the right thing to block the image. The bug is in libvirt's qcow2 header parser, which isn't able to parse (due to mishandling of padding in the header) more than 1 qcow2 header extension. The 'dataFile' filename is the second extension in case the file also has a backing file.

Libvirt thus thought that /var/lib/libvirt/images/datastore.qcow2 does not have any data file and thus also didn't apply any selinux labels to /var/lib/libvirt/images/datastore_2. Selinux policy correctly blocked the attempt by qemu.

The patch that was added breaks s-virt protections as it allows arbitrary qemu processes to write to images which are currently not in use. The patch thus must be reverted.

Resolves: RHEL-93773