### PR TITLE
Allow chronyc the setgid and setuid capabilities

### DIFF
--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -255,7 +255,7 @@ optional_policy(`
 # Local policy
 #
 
-allow chronyc_t self:capability { dac_read_search dac_override };
+allow chronyc_t self:capability { dac_read_search dac_override setgid setuid };
 allow chronyc_t self:udp_socket create_socket_perms;
 allow chronyc_t self:unix_dgram_socket create_socket_perms;
 allow chronyc_t self:netlink_route_socket create_netlink_socket_perms;


### PR DESCRIPTION
The latest development code of chrony has a support for dropping root privileges in the chronyc command-line utility to minimize the impact of potential bugs.

  # chronyc -u chrony ntpdata
setgroups() failed : Operation not permitted

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/01/2025 10:39:16.214:559) : proctitle=chronyc -u chrony ntpdata type=SYSCALL msg=audit(09/01/2025 10:39:16.214:559) : arch=x86_64 syscall=setgroups success=no exit=EPERM(Operation not permitted) a0=0x0 a1=0x0 a2=0x0 a3=0x1e1 items=0 ppid=1902 pid=2815 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=4 comm=chronyc exe=/usr/bin/chronyc subj=unconfined_u:unconfined_r:chronyc_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(09/01/2025 10:39:16.214:559) : avc:  denied  { setgid } for  pid=2815 comm=chronyc capability=setgid  scontext=unconfined_u:unconfined_r:chronyc_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:chronyc_t:s0-s0:c0.c1023 tclass=capability permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2387061