### PR TITLE
Support gdm as a user account provider

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -611,6 +611,7 @@ optional_policy(`
 
 optional_policy(`
 	xserver_exec(abrt_dump_oops_t)
+	xserver_stream_connect_xdm(abrt_dump_oops_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2421,6 +2421,10 @@ optional_policy(`
 	userdom_relabelfrom_user_tmp_sock_files(virtqemud_t)
 ')
 
+optional_policy(`
+	xserver_stream_connect_xdm(virtqemud_t)
+')
+
 #######################################
 #
 # virtsecretd local policy

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -824,8 +824,25 @@ interface(`xserver_manage_xdm_spool_files',`
 
 ########################################
 ## <summary>
-##	Connect to XDM over a unix domain
-##	stream socket.
+##	Connect to XDM over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xserver_stream_connectto_xdm',`
+	gen_require(`
+		type xdm_t;
+	')
+
+	allow $1 xdm_t:unix_stream_socket connectto;
+')
+
+########################################
+## <summary>
+##	Stream connect to XDM over a unix domain stream socket.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -756,6 +756,7 @@ systemd_hwdb_mmap_config(xdm_t)
 systemd_hwdb_read_config(xdm_t)
 systemd_coredump_domtrans(xdm_t)
 systemd_login_watch_session_dirs(xdm_t)
+systemd_userdbd_named_runtime_filetrans(xdm_t, xdm_var_run_t, sock_file, "org.gnome.DisplayManager")
 
 userdom_dontaudit_use_unpriv_user_fds(xdm_t)
 userdom_create_all_users_keys(xdm_t)

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -718,6 +718,9 @@ auth_manage_pam_console_data(xdm_t)
 auth_signal_pam(xdm_t)
 auth_rw_faillog(xdm_t)
 auth_write_login_records(xdm_t)
+auth_filetrans_named_content_pwd_lock(xdm_t)
+auth_create_passwd(xdm_t)
+auth_write_passwd(xdm_t)
 
 # Run telinit->init to shutdown.
 init_telinit(xdm_t)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2230,6 +2230,24 @@ interface(`auth_filetrans_named_content',`
 
 ########################################
 ## <summary>
+##	Transition to authlogin named content: /etc/.pwd.lock
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_filetrans_named_content_pwd_lock',`
+	gen_require(`
+		type passwd_file_t;
+	')
+
+	files_etc_filetrans($1, passwd_file_t, file, ".pwd.lock")
+')
+
+########################################
+## <summary>
 ##	Get the attributes of the passwd passwords file.
 ## </summary>
 ## <param name="domain">
@@ -2391,6 +2409,44 @@ interface(`auth_manage_passwd',`
 	files_etc_filetrans($1, passwd_file_t, file, ".pwd.lock")
 	files_etc_filetrans($1, passwd_file_t, file, "passwd.lock")
 	files_etc_filetrans($1, passwd_file_t, file, "group.lock")
+')
+
+########################################
+## <summary>
+##	Create the passwd passwords file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_create_passwd',`
+	gen_require(`
+		type passwd_file_t;
+	')
+
+	files_search_etc($1)
+	allow $1 passwd_file_t:file create_file_perms;
+')
+
+########################################
+## <summary>
+##	Write the passwd passwords file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_write_passwd',`
+	gen_require(`
+		type passwd_file_t;
+	')
+
+	files_search_etc($1)
+	allow $1 passwd_file_t:file write_file_perms;
 ')
 
 ########################################

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -587,6 +587,10 @@ optional_policy(`
     virt_read_lib_files(nsswitch_domain)
 ')
 
+optional_policy(`
+	xserver_stream_connect_xdm(nsswitch_domain)
+')
+
 #######################################
 #
 # Login Program local policy

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2980,6 +2980,41 @@ interface(`systemd_userdbd_runtime_filetrans',`
 
 #######################################
 ## <summary>
+##	Create objects in /run/systemd/userdbd directory
+##	with an automatic type transition to a specified private type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="private_type">
+##	<summary>
+##	The type of the object to create.
+##	</summary>
+## </param>
+## <param name="object_class">
+##	<summary>
+##	The class of the object to be created.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`systemd_userdbd_named_runtime_filetrans',`
+	gen_require(`
+		type systemd_userdbd_runtime_t;
+	')
+
+	files_search_pids($1)
+	filetrans_pattern($1, systemd_userdbd_runtime_t, $2, $3, $4)
+')
+
+#######################################
+## <summary>
 ##	Read systemd-userdbd data symlinks.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
Aug 18 16:49:46 fedora audit[3213]: AVC avc: denied { connectto } for pid=3213 comm="systemd-userwor" path="/run/systemd/userdb/org.gnome.DisplayManager" scontext=system_u:system_r:systemd_userdbd_t:s0 tcontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1 Aug 18 16:49:46 fedora audit[3308]: AVC avc: denied { connectto } for pid=3308 comm="(systemd)" path="/run/systemd/userdb/org.gnome.DisplayManager" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2390023