### PR TITLE
Allow systemd create lastlog entries

### DIFF
--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -1023,9 +1023,15 @@ interface(`auth_create_lastlog',`
 		type lastlog_t;
 	')
 
+	# util-linux <= 2.40
 	logging_search_logs($1)
 	allow $1 lastlog_t:file create;
 	logging_log_named_filetrans($1, lastlog_t, file, "lastlog")
+
+	# util-linux >= 2.41
+	files_search_var_lib($1)
+	create_files_pattern($1, lastlog_t, lastlog_t)
+	delete_files_pattern($1, lastlog_t, lastlog_t)
 ')
 
 ########################################

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -621,9 +621,7 @@ manage_files_pattern(login_pgm, auth_home_t, auth_home_t)
 auth_filetrans_admin_home_content(login_pgm)
 auth_filetrans_home_content(login_pgm)
 auth_filetrans_auth_home_content(login_pgm)
-
-allow login_pgm lastlog_t:dir manage_dir_perms;
-allow login_pgm lastlog_t:file manage_file_perms;
+auth_create_lastlog(login_pgm)
 
 # needed for afs - https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=253321
 kernel_search_network_sysctl(login_pgm)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -715,6 +715,7 @@ term_relabel_ptys_dirs(init_t)
 
 auth_relabel_login_records(init_t)
 auth_relabel_pam_console_data_dirs(init_t)
+auth_create_lastlog(init_t)
 auth_manage_faillog(init_t)
 
 clock_read_adjtime(init_t)


### PR DESCRIPTION
Can be invoked e.g. when admin checks user systemd manager, systemctl --user --machine=user1@.host list-units

The commit addresses the following AVC denials:
type=AVC msg=audit(1756271659.887:1077): avc:  denied  { add_name } for  pid=132384 comm="(o-bridge)" name="lastlog2.db-journal" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:lastlog_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1756271659.887:1077): avc:  denied  { create } for  pid=132384 comm="(o-bridge)" name="lastlog2.db-journal" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:lastlog_t:s0 tclass=file permissive=1 type=SYSCALL msg=audit(1756271659.887:1077): arch=x86_64 syscall=openat success=yes exit=EBADF a0=ffffffffffffff9c a1=56066a68c6c2 a2=a0042 a3=1a4 items=2 ppid=1 pid=132384 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=7 comm=(o-bridge) exe=/usr/lib/systemd/systemd-executor subj=system_u:system_r:init_t:s0 key=(null) type=PATH msg=audit(1756271659.887:1077): item=0 name=/var/lib/lastlog/ inode=153686313 dev=00:23 mode=040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:lastlog_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(1756271659.887:1077): item=1 name=/var/lib/lastlog/lastlog2.db-journal inode=173875823 dev=00:23 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:lastlog_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2391226