### PR TITLE
Allow systemd_homework_t transition pid files to lvm_var_run_t (bsc#1240883)

### DIFF
--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -259,6 +259,7 @@ optional_policy(`
 
 optional_policy(`
     lvm_manage_var_run(systemd_homework_t)
+    lvm_var_run_filetrans(systemd_homework_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Adresses:
----
time->Wed Sep  3 13:43:50 2025
type=AVC msg=audit(1756899830.225:396): avc:  denied  { create } for  pid=3802 comm="systemd-homewor" name="cryptsetup" scontext=system_u:system_r:systemd_homework_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=dir permissive=0

Reproducer:
1. remove regular cryptsetup (important! this way it uses systemd internal cryptsetup)
2. systemctl start systemd-homed
3. homectl create foo --disk-size=500M

> systemd-homework[1416]: Failed to create directory cryptsetup in /run (13: Permission denied).
> systemd-homework[1416]: Cannot format device /dev/loop1.