### PR TITLE
Allow systemd homed getattr all tmpfs files (bsc#1240883)

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -10280,6 +10280,24 @@ interface(`files_delete_tmpfs_files',`
 
 ########################################
 ## <summary>
+##	Allow getattr all tmpfs files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`files_getattr_tmpfs_files',`
+	gen_require(`
+		attribute tmpfsfile;
+	')
+
+	allow $1 tmpfsfile:file getattr;
+')
+
+########################################
+## <summary>
 ##	Allow read write all tmpfs files
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -75,6 +75,7 @@ files_list_spool(systemd_homed_t)
 files_list_var(systemd_homed_t)
 
 # /dev/shm
+files_getattr_tmpfs_files(systemd_homed_t)
 fs_getattr_tmpfs(systemd_homed_t)
 
 fs_getattr_nsfs_files(systemd_homed_t)


### PR DESCRIPTION
there can be more than just tmpfs_t in /dev/shm, e.g. entropyd_tmpfs_t

systemd homed fails to create if it can not stat things in /dev/shm: `systemd-homed[2606]: Failed to stat() POSIX shared memory segment /dev/shm/sem.haveged_sem: Permission denied`

so might be better to allow getattr on the whole tmpfsfile attribute

Adresses:
` ` ` 
----
time->Wed Sep  3 11:11:29 2025
type=AVC msg=audit(1756890689.789:234): avc:  denied  { getattr } for  pid=2606 comm="systemd-homed" path="/dev/shm/sem.haveged_sem" dev="tmpfs" ino=2 scontext=system_u:system_r:systemd_homed_t:s0 tcontext=system_u:object_r:entropyd_tmpfs_t:s0 tclass=file permissive=0
` ` ` 