### PR TITLE
Allow auditd manage its private run dirs

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -223,6 +223,7 @@ manage_files_pattern(auditd_t, auditd_log_t, auditd_log_t)
 manage_lnk_files_pattern(auditd_t, auditd_log_t, auditd_log_t)
 logging_log_filetrans(auditd_t, auditd_log_t, dir, "audit")
 
+manage_dirs_pattern(auditd_t, auditd_var_run_t, auditd_var_run_t)
 manage_files_pattern(auditd_t, auditd_var_run_t, auditd_var_run_t)
 manage_sock_files_pattern(auditd_t, auditd_var_run_t, auditd_var_run_t)
 files_pid_filetrans(auditd_t, auditd_var_run_t, { dir file sock_file })


### PR DESCRIPTION
Since bbdd1f0b6559 ("Label /run/audit with auditd_var_run_t") commit, audit is allowed a file transition for the audit directory, but it has not been allowed to manage such directories.

The commit addresses the following AVC denial:
Sep 01 19:32:37 localhost audit[685]: AVC avc:  denied  { create } for  pid=685 comm="auditd" name="audit" scontext=system_u:system_r:auditd_t:s0 tcontext=system_u:object_r:auditd_var_run_t:s0 tclass=dir permissive=0 Sep 01 19:32:37 localhost audit[685]: SYSCALL arch=c000003e syscall=83 success=no exit=-13 a0=55edc73a436f a1=1ed a2=ffffffffffffffa0 a3=0 items=0 ppid=684 pid=685 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="auditd" exe="/usr/bin/auditd" subj=system_u:system_r:auditd_t:s0 key=(null) Sep 01 19:32:37 localhost audit: PROCTITLE proctitle="/usr/bin/auditd" Sep 01 19:32:37 localhost auditd[685]: Cannot create run directory /run/audit (Permission denied)