### PR TITLE
Allow iptables manage its private fifo_files in /tmp

### DIFF
--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -68,7 +68,8 @@ files_lock_filetrans(iptables_t, iptables_lock_t, file)
 
 allow iptables_t iptables_tmp_t:dir manage_dir_perms;
 allow iptables_t iptables_tmp_t:file manage_file_perms;
-files_tmp_filetrans(iptables_t, iptables_tmp_t, { file dir })
+allow iptables_t iptables_tmp_t:fifo_file manage_file_perms;
+files_tmp_filetrans(iptables_t, iptables_tmp_t, { dir file fifo_file })
 
 kernel_request_load_module(iptables_t)
 kernel_read_system_state(iptables_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/17/25 12:12:47.095:1509) : proctitle=nft -j -f - type=EXECVE msg=audit(03/17/25 12:12:47.095:1509) : argc=4 a0=nft a1=-j a2=-f a3=- type=SYSCALL msg=audit(03/17/25 12:12:47.095:1509) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7f97e2882d70 a1=0x560887444100 a2=0x7ffdee1af598 a3=0x8 items=0 ppid=13726 pid=13733 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=16 comm=nft exe=/usr/sbin/nft subj=unconfined_u:unconfined_r:iptables_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(03/17/25 12:12:47.095:1509) : avc:  denied  { write } for  pid=13733 comm=nft path=/tmp/podman_bats.vMhYNp/podman-kill-fifo.CMSpDDvE0M dev="xvda3" ino=377487601 scontext=unconfined_u:unconfined_r:iptables_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=fifo_file permissive=0

Resolves: RHEL-83775