### PR TITLE
Allow mdadm the CAP_SYS_PTRACE capability

### DIFF
--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -40,9 +40,9 @@ logging_log_file(mdadm_log_t)
 # Local policy
 #
 
-allow mdadm_t self:capability { dac_read_search dac_override sys_admin ipc_lock };
-dontaudit mdadm_t self:capability { sys_tty_config sys_ptrace };
-dontaudit mdadm_t self:cap_userns { sys_ptrace };
+allow mdadm_t self:capability { dac_read_search dac_override ipc_lock sys_admin sys_ptrace };
+dontaudit mdadm_t self:capability { sys_tty_config };
+allow mdadm_t self:cap_userns { sys_ptrace };
 allow mdadm_t self:process { getsched setsched sigchld sigkill sigstop signull signal };
 allow mdadm_t self:fifo_file rw_fifo_file_perms;
 allow mdadm_t self:netlink_kobject_uevent_socket create_socket_perms;


### PR DESCRIPTION
mdadm executes ps and checks some processes' environ files. This essentially is accessing a part of another process' memory, which the kernel only allows if the current process is allowed to ptrace the target process or has one of CAP_PERFMON or CAP_SYS_ADMIN. In this case the ptrace access check fails, then CAP_PERFMON is tried (unsuccessfully) and then CAP_SYS_ADMIN finally succeeds and allows the operation to proceed. It looks like the ptrace access check fails on uid/gid not being equal + the lack of CAP_SYS_PTRACE capability, which is denied by SELinux without an audit record because of a dontaudit rule.

In this commit, mdadm_t was allowed sys_ptrace (for both capability and cap_userns classes, since the target process might be in a user namespace), and sys_admin was removed.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/05/2025 08:50:30.845:168) : proctitle=ps -ef type=PATH msg=audit(09/05/2025 08:50:30.845:168) : item=0 name=/proc/615/environ inode=14017 dev=00:17 mode=file,400 ouid=systemd-resolve ogid=systemd-resolve rdev=00:00 obj=system_u:system_r:systemd_resolved_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/05/2025 08:50:30.845:168) : arch=x86_64 syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x7ffc661ee4d0 a2=O_RDONLY a3=0x0 items=1 ppid=1932 pid=1933 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=2 comm=ps exe=/usr/bin/ps subj=system_u:system_r:mdadm_t:s0 key=(null) type=AVC msg=audit(09/05/2025 08:50:30.845:168) : avc:  denied  { perfmon } for  pid=1933 comm=ps capability=perfmon  scontext=system_u:system_r:mdadm_t:s0 tcontext=system_u:system_r:mdadm_t:s0 tclass=capability2 permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2379761