### PR TITLE
Support coreos installation methods

### DIFF
--- a/policy/modules/contrib/coreos_installer.fc
+++ b/policy/modules/contrib/coreos_installer.fc
@@ -10,3 +10,4 @@
 /usr/lib/systemd/system/coreos-installer.*			--	gen_context(system_u:object_r:coreos_installer_unit_file_t,s0)
 
 /run/coreos-installer-reboot	--	gen_context(system_u:object_r:coreos_installer_var_run_t,s0)
+/run/ostree-live	--	gen_context(system_u:object_r:coreos_installer_var_run_t,s0)

--- a/policy/modules/contrib/coreos_installer.te
+++ b/policy/modules/contrib/coreos_installer.te
@@ -67,6 +67,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fstools_domtrans(coreos_installer_t)
+')
+
+optional_policy(`
 	miscfiles_read_localization(coreos_installer_t)
 ')
 
@@ -132,6 +136,10 @@ optional_policy(`
 
 optional_policy(`
 	sssd_read_public_files(coreos_installer_generator_t)
+')
+
+optional_policy(`
+	systemd_manage_unit_symlinks(coreos_installer_generator_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1468,7 +1468,7 @@ interface(`systemd_manage_unit_dirs',`
 #
 interface(`systemd_manage_unit_symlinks',`
 	gen_require(`
-		attribute systemd_unit_file_type;
+		type systemd_unit_file_t;
 	')
 
 	manage_lnk_files_pattern($1, systemd_unit_file_t, systemd_unit_file_t)


### PR DESCRIPTION
The commit addresses the following AVC denial example: Jul 17 07:58:19 localhost kernel: audit: type=1400 audit(1752739097.953:5): avc:  denied  { getattr } for  pid=1018 comm="coreos-boot-mou" path="/run/ostree-live" dev="tmpfs" ino=31 scontext=system_u:system_r:coreos_boot_mount_generator_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2305385