### PR TITLE
Add a new type for systemd-ssh-issue PID files

### DIFF
--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -113,6 +113,8 @@ locallogin_domtrans(getty_t)
 
 logging_send_syslog_msg(getty_t)
 
+# access to /run/issue.d/50-ssh-vsock.issue
+systemd_ssh_issue_read_pid_files(getty_t)
 
 ifdef(`distro_gentoo',`
 	# Gentoo default /etc/issue makes agetty

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -123,6 +123,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/lib/private/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_lib_t,s0)
 /usr/lib/systemd/resolv.*   --   gen_context(system_u:object_r:lib_t,s0)
 
+/run/issue.d(/.*)?	gen_context(system_u:object_r:systemd_ssh_issue_var_run_t,s0)
+
 /run/systemd/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
 /run/systemd/.+\.conf\.d	-d	gen_context(system_u:object_r:systemd_conf_t,s0)
 /run/systemd/.+\.conf\.d/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -485,6 +485,26 @@ interface(`systemd_resolved_pid_filetrans',`
 
 ######################################
 ## <summary>
+##	Read systemd_ssh_issue PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_ssh_issue_read_pid_files',`
+	gen_require(`
+		type systemd_ssh_issue_var_run_t;
+	')
+
+	files_search_pids($1)
+	list_dirs_pattern($1, systemd_ssh_issue_var_run_t, systemd_ssh_issue_var_run_t)
+	read_files_pattern($1, systemd_ssh_issue_var_run_t, systemd_ssh_issue_var_run_t)
+')
+
+######################################
+## <summary>
 ##	Read systemd_login PID files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1142,7 +1142,15 @@ optional_policy(`
 
 permissive systemd_ssh_issue_t;
 
+type systemd_ssh_issue_var_run_t;
+files_pid_file(systemd_ssh_issue_var_run_t)
+
 allow systemd_ssh_issue_t self:vsock_socket create_socket_perms;
+
+# /run/issue.d/50-ssh-vsock.issue
+manage_dirs_pattern(systemd_ssh_issue_t, systemd_ssh_issue_var_run_t, systemd_ssh_issue_var_run_t)
+manage_files_pattern(systemd_ssh_issue_t, systemd_ssh_issue_var_run_t, systemd_ssh_issue_var_run_t)
+files_pid_filetrans(systemd_ssh_issue_t, systemd_ssh_issue_var_run_t, dir)
 
 kernel_dgram_send(systemd_ssh_issue_t)
 


### PR DESCRIPTION
systemd-ssh-issue creates /run/issue.d/50-ssh-vsock.issue, which is then read by agetty.