### PR TITLE
Allow gnome-remote-desktop connect to unreserved ports

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -41,6 +41,7 @@ files_read_etc_files(gnome_remote_desktop_t)
 files_watch_etc_dirs(gnome_remote_desktop_t)
 
 corenet_tcp_bind_generic_node(gnome_remote_desktop_t)
+corenet_tcp_connect_unreserved_ports(gnome_remote_desktop_t)
 dev_read_sysfs(gnome_remote_desktop_t)
 files_watch_usr_dirs(gnome_remote_desktop_t)
 fs_getattr_cgroup(gnome_remote_desktop_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1749025962.758:118): avc:  denied  { name_connect } for  pid=1312 comm="gnome-remote-de" dest=2321 scontext=system_u:system_r:gnome_remote_desktop_t:s0 tcontext=system_u:object_r:unreserved_port_t:s0 tclass=tcp_socket permissive=1 type=SYSCALL msg=audit(1749025962.758:118): arch=x86_64 syscall=connect success=no exit=ECONNREFUSED a0=a a1=556c15320d90 a2=1c a3=0 items=0 ppid=1 pid=1312 auid=4294967295 uid=972 gid=972 euid=972 suid=972 fsuid=972 egid=972 sgid=972 fsgid=972 tty=(none) ses=4294967295 comm=gnome-remote-de exe=/usr/libexec/gnome-remote-desktop-daemon subj=system_u:system_r:gnome_remote_desktop_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2370210