### PR TITLE
xenstored_t needs CAP_SYS_ADMIN for XENSTORETYPE=domain (bsc#1247875)

### DIFF
--- a/policy/modules/contrib/xen.te
+++ b/policy/modules/contrib/xen.te
@@ -24,6 +24,13 @@ gen_tunable(xend_run_qemu, true)
 
 ## <desc>
 ## <p>
+## Allow xenstored to use XENSTORETYPE "domain"
+## </p>
+## </desc>
+gen_tunable(xenstored_use_store_type_domain, false)
+
+## <desc>
+## <p>
 ## Allow xen to manage nfs files
 ## </p>
 ## </desc>
@@ -421,6 +428,13 @@ optional_policy(`
 #
 # Xen store local policy
 #
+tunable_policy(`xenstored_use_store_type_domain',`
+	allow xenstored_t self:capability sys_admin;
+	# init-xenstore-domain runs as xenstored_t
+	# and writes userdata-*.libxl-json and
+	# handles userdata lock files in /var/lib/xen
+	manage_files_pattern(xenstored_t, xend_var_lib_t, xend_var_lib_t)
+')
 
 allow xenstored_t self:capability { dac_read_search  ipc_lock sys_resource };
 allow xenstored_t self:process setrlimit;
@@ -448,11 +462,6 @@ manage_dirs_pattern(xenstored_t, xenstored_var_lib_t, xenstored_var_lib_t)
 manage_files_pattern(xenstored_t, xenstored_var_lib_t, xenstored_var_lib_t)
 manage_sock_files_pattern(xenstored_t, xenstored_var_lib_t, xenstored_var_lib_t)
 files_var_lib_filetrans(xenstored_t, xenstored_var_lib_t, { file dir sock_file })
-
-# init-xenstore-domain runs as xenstored_t
-# and writes userdata-*.libxl-json and
-# handles userdata lock files in /var/lib/xen
-manage_files_pattern(xenstored_t, xend_var_lib_t, xend_var_lib_t)
 
 stream_connect_pattern(xenstored_t, evtchnd_var_run_t, evtchnd_var_run_t, evtchnd_t)
 


### PR DESCRIPTION
That is not the default in fedora, so adding it behind a boolean `xenstored_use_store_type_domain`.
Basically you can configure xenstored to use the `XENSTORETYPE=domain` (opensuse default) in `/etc/sysconfig/xencommons` instead of `XENSTORETYPE=daemon` (fedora default)

Reasoning for `sys_admin` capability:
1. `/usr/lib/systemd/system/xenstored.service` starts `/etc/xen/scripts/launch-xenstore` as `xenstored_t`
2. which in turn starts `/usr/lib/xen/bin/init-xenstore-domain `(also running as `xenstored_t`)
3. init-xenstore-domain opens `/dev/xen/xenbus_backend`: https://github.com/xen-project/xen/blame/b99227347230281699b5d8b5e677829f91c6e199/tools/helpers/init-xenstore-domain.c#L102
4. this requires CAP_SYS_ADMIN: https://github.com/torvalds/linux/blob/320475fbd590dc94a0a3d9173f81e0797ee1a232/drivers/xen/xenbus/xenbus_dev_backend.c#L24
5. therefor allow xenstored_t sys_admin capabilities

Also moved rule from a previous commit by myself inside the boolean to have it grouped there for this use case.

Adresses:
```
type=AVC msg=audit(1757596406.536:40): avc:  denied  { sys_admin } for  pid=1385 comm="init-xenstore-d" capability=21  scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:system_r:xenstored_t:s0 tclass=capability permissive=0
```

With full auditing:
```
----
type=PROCTITLE msg=audit(09/12/2025 11:05:27.943:50) : proctitle=/usr/lib/xen/bin/init-xenstore-domain --kernel /usr/lib/xen/boot/xenstore-stubdom.gz --memory 32 --maxmem 1/100 
type=PATH msg=audit(09/12/2025 11:05:27.943:50) : item=0 name=/dev/xen/xenbus_backend inode=89 dev=00:06 mode=character,600 ouid=root ogid=root rdev=0a:103 obj=system_u:object_r:xen_device_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 
type=CWD msg=audit(09/12/2025 11:05:27.943:50) : cwd=/ 
type=SYSCALL msg=audit(09/12/2025 11:05:27.943:50) : arch=x86_64 syscall=openat success=no exit=EPERM(Operation not permitted) a0=AT_FDCWD a1=0x55b97a9050a1 a2=O_RDWR a3=0x0 items=1 ppid=1025 pid=1044 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=init-xenstore-d exe=/usr/lib/xen/bin/init-xenstore-domain subj=system_u:system_r:xenstored_t:s0 key=(null) 
type=AVC msg=audit(09/12/2025 11:05:27.943:50) : avc:  denied  { sys_admin } for  pid=1044 comm=init-xenstore-d capability=sys_admin  scontext=system_u:system_r:xenstored_t:s0 tcontext=system_u:system_r:xenstored_t:s0 tclass=capability permissive=0
```
see also: https://bugzilla.suse.com/show_bug.cgi?id=1247875