### PR TITLE
fix: permit accountsd_t to read kde systemsettings tmp file

### DIFF
--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -48,6 +48,7 @@ dev_read_sysfs(accountsd_t)
 files_read_mnt_files(accountsd_t)
 files_read_usr_files(accountsd_t)
 files_watch_etc_dirs(accountsd_t)
+files_read_generic_tmp_files(accountsd_t)
 
 fs_getattr_cgroup(accountsd_t)
 fs_getattr_xattr_fs(accountsd_t)


### PR DESCRIPTION
```
type=AVC msg=audit(1757818031.750:619): avc:  denied  { open } for  pid=3899 comm="cat" path="/tmp/systemsettings.TrlEAv" dev="tmpfs" ino=56 scontext=system_u:system_r:accountsd_t:s0 tcontext=unconfined_u:object_r:tmp_t:s0 tclass=file permissive=0
```

This is required to update the profile picture for users