### PR TITLE
Allow nfs generator create and use netlink and udp sockets

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1496,6 +1496,7 @@ optional_policy(`
 ### nfs generator
 permissive systemd_nfs_generator_t;
 allow systemd_nfs_generator_t self:udp_socket create_socket_perms;
+allow systemd_nfs_generator_t self:netlink_route_socket { create_netlink_socket_perms };
 
 ### systemd rc_local generator
 init_exec_script_files(systemd_rc_local_generator_t)


### PR DESCRIPTION
The commit addresses the following AVC denial example: AVC avc:  denied  { create } for  pid=179463 comm="nfs-server-gene" scontext=system_u:system_r:systemd_nfs_generator_t:s0 tcontext=system_u:system_r:systemd_nfs_generator_t:s0 tclass=netlink_route_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2394936