### PR TITLE
Allow sysadm_sudo_t connect to systemd-logind over a unix socket

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -112,6 +112,7 @@ template(`sudo_role_template',`
 
 	optional_policy(`
 		systemd_domtrans_systemctl($1_sudo_t, $3)
+		systemd_logind_stream_connect($1_sudo_t)
 		systemd_systemctl_entrypoint($3)
 	')
 

--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -101,6 +101,10 @@ template(`sudo_role_template',`
 	')
 
 	optional_policy(`
+		iotop_domtrans($1_sudo_t)
+	')
+
+	optional_policy(`
 	    	kerberos_manage_host_rcache($1_sudo_t)
 		kerberos_read_config($1_sudo_t)
 	')

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -800,6 +800,7 @@ interface(`systemd_mounton_inhibit_dir',`
 interface(`systemd_logind_stream_connect',`
 	gen_require(`
 		type systemd_logind_t;
+		type systemd_logind_var_run_t;
 	')
 
 	allow $1 systemd_logind_t:unix_stream_socket connectto;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/16/2025 09:32:35.952:692) : proctitle=sudo -r sysadm_r dmidecode type=PATH msg=audit(09/16/2025 09:32:35.952:692) : item=0 name=/run/systemd/io.systemd.Login inode=1596 dev=00:1b mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_logind_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(09/16/2025 09:32:35.952:692) : saddr={ saddr_fam=local path=/run/systemd/io.systemd.Login } type=SYSCALL msg=audit(09/16/2025 09:32:35.952:692) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x14 a1=0x7ffc7130e510 a2=0x20 a3=0x0 items=1 ppid=7420 pid=7451 auid=sysadm-user uid=sysadm-user gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts3 ses=14 comm=sudo exe=/usr/bin/sudo subj=sysadm_u:sysadm_r:sysadm_sudo_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(09/16/2025 09:32:35.952:692) : avc:  denied  { write } for  pid=7451 comm=sudo name=io.systemd.Login dev="tmpfs" ino=1596 scontext=sysadm_u:sysadm_r:sysadm_sudo_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_logind_var_run_t:s0 tclass=sock_file permissive=0