### PR TITLE
Allow cloud init to domtrans into ssh keygen (bsc#1249964)

### DIFF
--- a/policy/modules/contrib/cloudform.te
+++ b/policy/modules/contrib/cloudform.te
@@ -159,8 +159,9 @@ optional_policy(`
 ')
 
 optional_policy(`
-    ssh_exec_keygen(cloud_init_t)
     ssh_read_user_home_files(cloud_init_t)
+    ssh_domtrans_keygen(cloud_init_t)
+
 ')
 
 optional_policy(`


### PR DESCRIPTION
Ohterwise creating ssh keys via cloud init will result in type etc_t for the key files