### PR TITLE
Allow kdump search kdumpctl_tmp_t directories

### DIFF
--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -149,6 +149,7 @@ manage_lnk_files_pattern(kdumpctl_t, kdumpctl_tmp_t, kdumpctl_tmp_t)
 manage_fifo_files_pattern(kdumpctl_t, kdumpctl_tmp_t, kdumpctl_tmp_t)
 files_tmp_filetrans(kdumpctl_t, kdumpctl_tmp_t, { file dir lnk_file })
 can_exec(kdumpctl_t, kdumpctl_tmp_t)
+allow kdump_t kdumpctl_tmp_t:dir search_dir_perms;
 
 manage_dirs_pattern(kdumpctl_t, kdump_crash_t, kdump_crash_t)
 manage_files_pattern(kdumpctl_t, kdump_crash_t, kdump_crash_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1755188034.816:416): avc:  denied  { open } for  pid=6206 comm="kexec" path="/tmp/kdump.pizl/vmlinuz" dev="tmpfs" ino=91 scontext=system_u:system_r:kdump_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(1755188034.816:416): arch=x86_64 syscall=openat success=no exit=EACCES a0=ffffffffffffff9c a1=7ffee3595e7d a2=0 a3=0 items=1 ppid=6204 pid=6206 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=kexec exe=/usr/bin/kexec subj=system_u:system_r:kdump_t:s0 key=(null) type=PATH msg=audit(1755188034.816:416): item=0 name=/tmp/kdump.pizl/vmlinuz inode=91 dev=00:2d mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:kdumpctl_tmp_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0