### PR TITLE
tuned: allow managing tuned_etc_t files

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -45,7 +45,7 @@ allow tuned_t self:netlink_socket create_socket_perms;
 allow tuned_t self:udp_socket create_socket_perms;
 allow tuned_t self:socket create_socket_perms;
 
-read_files_pattern(tuned_t, tuned_etc_t, tuned_etc_t)
+manage_files_pattern(tuned_t, tuned_etc_t, tuned_etc_t)
 exec_files_pattern(tuned_t, tuned_etc_t, tuned_etc_t)
 
 manage_files_pattern(tuned_t, tuned_etc_t, tuned_rw_etc_t)


### PR DESCRIPTION
tuned regularly called _save_base_profile on profile changes, which writes to PPD_BASE_PROFILE_FILE, /etc/tuned/ppd_base_profile in Fedora.

Use manage_file_pattern as if /etc/tuned/ppd_base_profile does not exist, it may be created by tuned on a write, and considering the tuned daemon is the thing responsible for managing that file, it is logical to grant it such permissions.

audit[1575]: AVC avc:  denied  { write } for  pid=1575 comm="tuned-ppd" name="ppd_base_profile" dev="dm-0" ino=56904266 scon text=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:tuned_etc_t:s0 tclass=file permissive=1