### PR TITLE
auditd: don't grant write as implied by manage_files_pattern for logs

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -219,7 +219,7 @@ allow auditd_t auditd_etc_t:file { read_file_perms map };
 allow auditd_t audisp_remote_t:process { noatsecure signal };
 
 manage_dirs_pattern(auditd_t, auditd_log_t, auditd_log_t)
-manage_files_pattern(auditd_t, auditd_log_t, auditd_log_t)
+allow auditd_t auditd_log_t:file { append_file_perms create_file_perms link read_file_perms rename_file_perms setattr_file_perms unlink };
 manage_lnk_files_pattern(auditd_t, auditd_log_t, auditd_log_t)
 logging_log_filetrans(auditd_t, auditd_log_t, dir, "audit")
 


### PR DESCRIPTION
auditd doesn't actually need to be able to write logs, only create, append, read, rename, and setattr them. Given that great lengths are already taken to ensure audit log confidentiality and integrity (e.g. marking as mls_systemhigh and granting cap_sys_nice to prioritise over other processes to not miss audit events), it makes sense to not grant an unnecessary permission which would allow a comprimised audit daemon to tamper with the audit logs.