### PR TITLE
Allow init open and read user tmp files

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -420,6 +420,7 @@ miscfiles_filetrans_named_content(init_t)
 udev_manage_rules_files(init_t)
 
 userdom_use_user_ttys(init_t)
+userdom_read_user_tmp_files(init_t)
 userdom_manage_tmp_dirs(init_t)
 userdom_manage_tmp_sockets(init_t)
 userdom_delete_user_tmp_files(init_t)


### PR DESCRIPTION
The commit addresses the following AVC denial, triggered by webui-cockpit-ws accessing /tmp/webui-cockpit-ws.env, previously created by /usr/libexec/anaconda/webui-desktop:
type=AVC msg=audit(1757597103.12:164): avc:  denied  { open } for  pid=1 comm="systemd" path="/tmp/webui-cockpit-ws.env" dev="tmpfs" ino=47 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2394561