### PR TITLE
Update files_search_base_file_types()

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1291,6 +1291,7 @@ interface(`files_search_base_file_types',`
 	')
 
 	allow $1 base_file_type:dir search_dir_perms;
+	allow $1 base_file_type:lnk_file read_lnk_file_perms;
 ')
 
 ########################################


### PR DESCRIPTION
Update the files_search_base_file_types() interface to include reading of base_file_type symlinks.

The commit addresses the following AVC denial:
type=AVC msg=audit(1756322581.289:872): avc:  denied  { read } for  pid=17624 comm="sshd-session" name="lock" dev="nvme0n1p3" ino=204794 scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_lock_t:s0 tclass=lnk_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2391344