### PR TITLE
Allow nfs-generator create and use udp sockets

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1495,11 +1495,7 @@ optional_policy(`
 
 ### nfs generator
 permissive systemd_nfs_generator_t;
-
-#allow nfsd_t nfsd_unit_file_t:file manage_file_perms;
-#systemd_unit_file_filetrans(nfsd_t, nfsd_unit_file_t, file)
-#systemd_create_unit_file_dirs(nfsd_t)
-#systemd_create_unit_file_lnk(nfsd_t)
+allow systemd_nfs_generator_t self:udp_socket create_socket_perms;
 
 ### systemd rc_local generator
 init_exec_script_files(systemd_rc_local_generator_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1756192855.476:472): avc:  denied  { create } for  pid=2848 comm="nfs-server-gene" scontext=system_u:system_r:systemd_nfs_generator_t:s0 tcontext=system_u:system_r:systemd_nfs_generator_t:s0 tclass=udp_socket permissive=0

Resolves: RHEL-111556