### PR TITLE
Remove 8 permissive domains

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -11,8 +11,6 @@ domain_type(gnome_remote_desktop_t)
 domain_entry_file(gnome_remote_desktop_t, gnome_remote_desktop_exec_t)
 role system_r types gnome_remote_desktop_t;
 
-permissive gnome_remote_desktop_t;
-
 type gnome_remote_desktop_var_lib_t;
 files_type(gnome_remote_desktop_var_lib_t)
 

--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -9,8 +9,6 @@ type ktlshd_t;
 type ktlshd_exec_t;
 init_daemon_domain(ktlshd_t, ktlshd_exec_t)
 
-permissive ktlshd_t;
-
 allow ktlshd_t self:capability net_admin;
 allow ktlshd_t self:key write;
 allow ktlshd_t self:netlink_generic_socket create_socket_perms;

--- a/policy/modules/contrib/pcm.te
+++ b/policy/modules/contrib/pcm.te
@@ -9,8 +9,6 @@ type pcmsensor_t;
 type pcmsensor_exec_t;
 init_daemon_domain(pcmsensor_t, pcmsensor_exec_t)
 
-permissive pcmsensor_t;
-
 allow pcmsensor_t self:capability { sys_admin sys_rawio sys_resource };
 allow pcmsensor_t self:capability2 perfmon;
 allow pcmsensor_t self:perf_event { cpu kernel open read };

--- a/policy/modules/contrib/powerprofiles.te
+++ b/policy/modules/contrib/powerprofiles.te
@@ -13,8 +13,6 @@ init_nnp_daemon_domain(powerprofiles_t)
 type powerprofiles_var_lib_t;
 files_type(powerprofiles_var_lib_t);
 
-permissive powerprofiles_t;
-
 allow powerprofiles_t self:capability2 bpf;
 allow powerprofiles_t self:netlink_kobject_uevent_socket create_socket_perms;
 

--- a/policy/modules/contrib/qgs.te
+++ b/policy/modules/contrib/qgs.te
@@ -9,8 +9,6 @@ type qgs_t;
 type qgs_exec_t;
 init_daemon_domain(qgs_t, qgs_exec_t)
 
-permissive qgs_t;
-
 type qgs_var_lib_t;
 files_type(qgs_var_lib_t);
 

--- a/policy/modules/contrib/redfish-finder.te
+++ b/policy/modules/contrib/redfish-finder.te
@@ -14,8 +14,6 @@ init_daemon_domain(redfish_finder_t, redfish_finder_exec_t)
 # redfish-finder local policy
 #
 
-permissive redfish_finder_t;
-
 corecmd_exec_bin(redfish_finder_t)
 dev_read_sysfs(redfish_finder_t)
 

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -316,8 +316,6 @@ optional_policy(`
 # samba-bgqd local policy
 #
 
-permissive samba_bgqd_t;
-
 allow samba_bgqd_t self:netlink_route_socket r_netlink_socket_perms;
 allow samba_bgqd_t self:tcp_socket create_stream_socket_perms;
 allow samba_bgqd_t self:udp_socket create_socket_perms;

--- a/policy/modules/contrib/switcheroo.te
+++ b/policy/modules/contrib/switcheroo.te
@@ -8,7 +8,6 @@ policy_module(switcheroo, 1.0)
 type switcheroo_control_t;
 type switcheroo_control_exec_t;
 init_daemon_domain(switcheroo_control_t, switcheroo_control_exec_t)
-permissive switcheroo_control_t;
 
 #################################
 #

--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -177,8 +177,6 @@ optional_policy(`
 #
 # tuned-ppd local policy
 #
-permissive tuned_ppd_t;
-
 allow tuned_ppd_t tuned_exec_t:file getattr;
 
 allow tuned_ppd_t tuned_rw_etc_t:file create;

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -76,7 +76,6 @@ ssh_server_template(sshd_session)
 #role system_r types sshd_session_t;
 type sshd_session_exec_t;
 corecmd_executable_file(sshd_session_exec_t)
-permissive sshd_session_t;
 domain_type(sshd_session_t);
 domain_entry_file(sshd_session_t, sshd_session_exec_t)
 domain_dyntrans_type(sshd_session_t)
@@ -169,7 +168,6 @@ term_relabelto_all_ptys(sshd_session_t)
 type sshd_auth_t;
 role system_r types sshd_auth_t;
 type sshd_auth_exec_t;
-permissive sshd_auth_t;
 domain_type(sshd_auth_t);
 corecmd_executable_file(sshd_auth_exec_t)
 domain_entry_file(sshd_auth_t, sshd_auth_exec_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2044,8 +2044,6 @@ allow systemd_mountfsd_t self:capability { sys_ptrace sys_resource };
 allow systemd_mountfsd_t self:capability2 { perfmon };
 allow systemd_mountfsd_t systemd_mountfsd_exec_t:file execute_no_trans;
 
-permissive systemd_mountfsd_t;
-
 kernel_dgram_send(systemd_mountfsd_t)
 
 ########################################
@@ -2078,8 +2076,6 @@ optional_policy(`
     dbus_watch_pid_dir_path(systemd_oomd_t)
     dbus_watch_pid_sock_files(systemd_oomd_t)
 ')
-
-permissive systemd_oomd_t;
 
 ########################################
 #
@@ -2133,8 +2129,6 @@ permissive systemd_pcrlock_t;
 #
 # systemd_user_runtimedir local policy
 #
-
-permissive systemd_user_runtimedir_t;
 
 allow systemd_user_runtimedir_t self:capability { dac_override dac_read_search fowner sys_admin };
 allow systemd_user_runtimedir_t self:netlink_selinux_socket create_socket_perms;


### PR DESCRIPTION
The following domains which were temporarily put into permissive mode have the setting changed now:
- gnome_remote_desktop_t
- ktlshd_t
- pcmsensor_t
- powerprofiles_t
- samba_bgqd_t
- switcheroo_control_t
- tuned_ppd_t
- systemd_user_runtimedir_t