### PR TITLE
Allow geoclue get attributes of the /dev/shm filesystem

### DIFF
--- a/policy/modules/contrib/geoclue.te
+++ b/policy/modules/contrib/geoclue.te
@@ -52,6 +52,7 @@ dev_read_urand(geoclue_t)
 files_watch_etc_dirs(geoclue_t)
 
 fs_getattr_cgroup(geoclue_t)
+fs_getattr_tmpfs(geoclue_t)
 fs_getattr_xattr_fs(geoclue_t)
 
 init_dbus_chat(geoclue_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1756104782.300:568): avc:  denied  { getattr } for  pid=11732 comm="pool-2" name="/" dev="tmpfs" ino=1 scontext=system_u:system_r:geoclue_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2390668