### PR TITLE
Allow apcupsd get attributes of the /dev/shm filesystem

### DIFF
--- a/policy/modules/contrib/apcupsd.te
+++ b/policy/modules/contrib/apcupsd.te
@@ -98,6 +98,7 @@ files_manage_etc_runtime_files(apcupsd_t)
 files_etc_filetrans_etc_runtime(apcupsd_t, file, "nologin")
 
 fs_getattr_cgroup(apcupsd_t)
+fs_getattr_tmpfs(apcupsd_t)
 
 term_use_all_terms(apcupsd_t)
 term_use_usb_ttys(apcupsd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
avc:  denied  { getattr } for  pid=1769889 comm="mail" name="/" dev="tmpfs" ino=1 scontext=system_u:system_r:apcupsd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2388133