### PR TITLE
Mark svirt_image_t as a logfile to allow rotating VM serial logs

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -199,6 +199,7 @@ type svirt_image_t, virt_image_type, svirt_file_type;
 files_type(svirt_image_t)
 dev_node(svirt_image_t)
 dev_associate_sysfs(svirt_image_t)
+logging_log_file(svirt_image_t)
 
 virt_domain_template(svirt)
 role system_r types svirt_t;


### PR DESCRIPTION
The svirt_image_t type is used for quite a variety of files, including the output of VM serial consoles that have been configured in libvirt to dump to a file.

These outputs are effectively just logs, and it is plausible that users will want to run things like logrotate on them. However, confined tools like logrotate require the log files to be marked with the `logfile` attribute. This made it impossible for a confined logrotate to rotate VM serial logs.

Mark svirt_image_t as a logfile to ensure this works. While it feels a little odd to do this given that not *every* svirt_image_t file is a logfile, that's more of an issue with how overloaded the type already is. We have no choice but to treat it as the union of the things it can be.