### PR TITLE
Allow sshd-session read cockpit pid files

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -120,6 +120,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cockpit_read_pid_files(sshd_session_t)
+')
+
+optional_policy(`
 	systemd_dbus_chat_hostnamed(sshd_session_t)
 	systemd_userdbd_stream_connect(sshd_session_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/25/2025 07:35:45.926:110) : proctitle=sshd-session: root [priv] type=PATH msg=audit(09/25/2025 07:35:45.926:110) : item=0 name=/etc/motd.d/cockpit inode=1571 dev=00:1a mode=file,640 ouid=root ogid=wheel rdev=00:00 obj=system_u:object_r:cockpit_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/25/2025 07:35:45.926:110) : arch=x86_64 syscall=openat success=yes exit=6 a0=AT_FDCWD a1=0x555d141e8cf0 a2=O_RDONLY a3=0x0 items=1 ppid=842 pid=981 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=2 comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(09/25/2025 07:35:45.926:110) : avc:  denied  { open } for  pid=981 comm=sshd-session path=/run/cockpit/inactive.issue dev="tmpfs" ino=1571 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:object_r:cockpit_var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(09/25/2025 07:35:45.926:110) : avc:  denied  { read } for  pid=981 comm=sshd-session name=inactive.issue dev="tmpfs" ino=1571 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:object_r:cockpit_var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(09/25/2025 07:35:45.926:110) : avc:  denied  { read } for  pid=981 comm=sshd-session name=issue dev="tmpfs" ino=1573 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:object_r:cockpit_var_run_t:s0 tclass=lnk_file permissive=1