### PR TITLE
Allow sshd-session get attributes of sshd vsock socket

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -94,6 +94,7 @@ allow sshd_net_t sshd_session_t:fifo_file write;
 allow sshd_net_t sshd_session_t:unix_stream_socket { read write };
 allow sshd_session_t sshd_t:tcp_socket { getattr getopt read setopt write };
 allow sshd_session_t sshd_t:unix_stream_socket { read write };
+allow sshd_session_t sshd_t:vsock_socket { getattr };
 
 allow sshd_session_t ssh_home_t:dir relabelto;
 allow sshd_session_t ssh_home_t:file relabelto;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1758904368.073:420): avc:  denied  { getattr } for  pid=2205 comm="sshd-session" scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=vsock_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2399770