### PR TITLE
Remove vfio_device_t label from /dev/sclp[0-9]* and /dev/vmcp[0-9]*

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -168,8 +168,6 @@ ifdef(`distro_suse', `
 /dev/vc-mem		-c	gen_context(system_u:object_r:memory_device_t,mls_systemhigh)
 /dev/vfio/(vfio)?[0-9]*	-c	gen_context(system_u:object_r:vfio_device_t,s0)
 /dev/clp[0-9]*            -c  gen_context(system_u:object_r:vfio_device_t,s0)
-/dev/sclp[0-9]*            -c  gen_context(system_u:object_r:vfio_device_t,s0)
-/dev/vmcp[0-9]*     -c  gen_context(system_u:object_r:vfio_device_t,s0)
 /dev/vhost-net		-c	gen_context(system_u:object_r:vhost_device_t,s0)
 /dev/vhost-vdpa-[0-9]+		-c	gen_context(system_u:object_r:vhost_device_t,s0)
 /dev/vhost-vsock		-c	gen_context(system_u:object_r:vhost_device_t,s0)


### PR DESCRIPTION
/dev/sclp[0-9]* and /dev/vmcp[0-9]* are s390x-specific character devices which are unrelated to VFIO. Therefore, change the label back to device_t.

Fixes: 61939dae5285 ("Add support for /dev/vmcp and /dev/sclp")

Related issue: https://github.com/fedora-selinux/selinux-policy/issues/2864