### PR TITLE
Allow blueman get attributes of filesystems with extended attributes

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -68,6 +68,8 @@ domain_dontaudit_read_all_domains_state(blueman_t)
 files_list_tmp(blueman_t)
 files_dontaudit_write_all_mountpoints(blueman_t)
 
+fs_getattr_xattr_fs(blueman_t)
+
 auth_use_nsswitch(blueman_t)
 
 libs_exec_ldconfig(blueman_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/02/2025 15:55:25.490:3000) : proctitle=/usr/bin/python3 -sPE /usr/libexec/blueman-mechanism type=SYSCALL msg=audit(10/02/2025 15:55:25.490:3000) : arch=x86_64 syscall=fstatfs success=no exit=EACCES(Permission denied) a0=0x5 a1=0x7fc990ffe8e0 a2=0x1 a3=0x5 items=0 ppid=1 pid=117264 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=[pango] fontcon exe=/usr/bin/python3.14 subj=system_u:system_r:blueman_t:s0 key=(null) type=AVC msg=audit(10/02/2025 15:55:25.490:3000) : avc:  denied  { getattr } for  pid=117264 comm=[pango] fontcon name=/ dev="nvme0n1p4" ino=256 scontext=system_u:system_r:blueman_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0