### PR TITLE
Allow valkey-server create and use netlink_rdma_socket

### DIFF
--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -45,6 +45,7 @@ systemd_unit_file(redis_unit_file_t)
 
 allow redis_t self:process { setrlimit signal_perms };
 allow redis_t self:fifo_file rw_fifo_file_perms;
+allow redis_t self:netlink_rdma_socket create_socket_perms;
 allow redis_t self:unix_stream_socket create_stream_socket_perms;
 allow redis_t self:tcp_socket create_stream_socket_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/02/2025 16:38:25.052:10016) : proctitle=/usr/bin/valkey-server 127.0.0.1:6379 type=SYSCALL msg=audit(10/02/2025 16:38:25.052:10016) : arch=x86_64 syscall=socket success=no exit=EACCES(Permission denied) a0=netlink a1=SOCK_RAW a2=hmp a3=0x50 items=0 ppid=1 pid=448721 auid=unset uid=valkey gid=valkey euid=valkey suid=valkey fsuid=valkey egid=valkey sgid=valkey fsgid=valkey tty=(none) ses=unset comm=valkey-server exe=/usr/bin/valkey-server subj=system_u:system_r:redis_t:s0 key=(null) type=AVC msg=audit(10/02/2025 16:38:25.052:10016) : avc:  denied  { create } for  pid=448721 comm=valkey-server scontext=system_u:system_r:redis_t:s0 tcontext=system_u:system_r:redis_t:s0 tclass=netlink_rdma_socket permissive=0