### PR TITLE
ci: Restrict permissions for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,34 @@
 name: build
+permissions: {}
 on: [push, pull_request]
+
 jobs:
   build:
+    name: Build policy
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # to check out repository contents
+
     container:
       image: quay.io/fedora/fedora:rawhide
       options: --security-opt seccomp=unconfined
+
     steps:
-      - uses: actions/checkout@v4
-      - run: dnf install --nogpgcheck -y git-core checkpolicy policycoreutils-devel make m4 findutils
-      - run: git clone --depth=1 https://github.com/containers/container-selinux.git /tmp/container-selinux
-      - run: cp /tmp/container-selinux/container.* policy/modules/contrib
-      - run: cp dist/targeted/modules.conf policy
-      - run: make -j $(nproc) policy
-      - run: make -j $(nproc) validate
-      - run: make -j $(nproc) container.pp
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          dnf install --nogpgcheck -y git-core checkpolicy policycoreutils-devel make m4 findutils
+
+      - name: Build policy
+        run: |
+          git clone --depth=1 https://github.com/containers/container-selinux.git /tmp/container-selinux
+          cp /tmp/container-selinux/container.* policy/modules/contrib/
+          cp dist/targeted/modules.conf policy/
+          make -j "$(nproc)" policy
+          make -j "$(nproc)" validate
+          make -j "$(nproc)" container.pp


### PR DESCRIPTION
As recommended by Zizmor, restrict permissions for the build.yml workflow to read-only access to the repository, and do not persist credentials for the repository checkout action.

Additionally, update `actions/checkout` to the latest version and pin it by a commit hash, and improve workflow formatting for clarity.