### PR TITLE
Allow bluez dbus api pass sockets over dbus

### DIFF
--- a/policy/modules/contrib/bluetooth.if
+++ b/policy/modules/contrib/bluetooth.if
@@ -86,6 +86,26 @@ interface(`bluetooth_stream_connect',`
 
 ########################################
 ## <summary>
+##	Allow read and write bluetooth domain stream.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bluetooth_rw_stream',`
+	gen_require(`
+		type bluetooth_t;
+	')
+
+	tunable_policy(`deny_bluetooth',`',`
+		allow $1 bluetooth_t:unix_stream_socket { read write };
+	')
+')
+
+########################################
+## <summary>
 ##	Execute bluetooth in the bluetooth domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/bluetooth.te
+++ b/policy/modules/contrib/bluetooth.te
@@ -194,6 +194,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_rw_stream(bluetooth_t)
+')
+
+optional_policy(`
 	ppp_domtrans(bluetooth_t)
 ')
 

--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -386,6 +386,24 @@ interface(`unconfined_dontaudit_rw_pipes',`
 
 ########################################
 ## <summary>
+##	Allow read and write unconfined domain stream.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`unconfined_rw_stream',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:unix_stream_socket { read write };
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read and write
 ##	unconfined domain stream.
 ## </summary>


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=AVC msg=audit(16.11.2022 18:32:57.441:509) : avc:  denied  { read write } for  pid=762 comm=dbus-broker path=socket:[29888] dev="sockfs" ino=29888 scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:bluetooth_t:s0 tclass=unix_stream_socket permissive=1

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/1458