### PR TITLE
Allow corenet_unconfined_type name_bind to icmp_socket

### DIFF
--- a/policy/modules/kernel/corenetwork.te.in
+++ b/policy/modules/kernel/corenetwork.te.in
@@ -476,7 +476,7 @@ allow corenet_unconfined_type port_type:sctp_socket { send_msg recv_msg name_con
 allow corenet_unconfined_type port_type:udp_socket { send_msg recv_msg };
 
 # Bind to any network address.
-allow corenet_unconfined_type port_type:{ dccp_socket tcp_socket udp_socket rawip_socket sctp_socket} name_bind;
+allow corenet_unconfined_type port_type:{ dccp_socket icmp_socket tcp_socket udp_socket rawip_socket sctp_socket } name_bind;
 allow corenet_unconfined_type node_type:{ dccp_socket icmp_socket tcp_socket udp_socket rawip_socket sctp_socket } node_bind;
 
 # Infiniband


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1759810028.962:6885): avc:  denied  { name_bind } for  pid=43862 comm="nettest" src=12345 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=system_u:object_r:port_t:s0 tclass=icmp_socket permissive=1