### PR TITLE
Allow logwatch domain transition on rpm execution

### DIFF
--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -182,6 +182,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rpm_domtrans(logwatch_t)
+')
+
+optional_policy(`
 	samba_read_log(logwatch_t)
 	samba_read_share_files(logwatch_t)
 ')

--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -191,6 +191,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sendmail_rw_unix_stream_sockets(logwatch_t)
 	sendmail_stream_connect(logwatch_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/13/2025 10:00:47.549:213) : proctitle=/usr/bin/perl /usr/share/logwatch/scripts/services/dnf5 type=PATH msg=audit(10/13/2025 10:00:47.549:213) : item=0 name=/usr/bin/dnf inode=146331 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:rpm_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/13/2025 10:00:47.549:213) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x555d30633a90 a1=0x555d30638250 a2=0x555d2facf650 a3=0x8 items=1 ppid=1360 pid=1363 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=perl exe=/usr/bin/perl subj=system_u:system_r:logwatch_t:s0 key=(null) type=AVC msg=audit(10/13/2025 10:00:47.549:213) : avc:  denied  { execute } for  pid=1363 comm=perl name=dnf5 dev="vda2" ino=146331 scontext=system_u:system_r:logwatch_t:s0 tcontext=system_u:object_r:rpm_exec_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2388720