### PR TITLE
Allow thumb_t create permission in the user namespace

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -64,7 +64,7 @@ userdom_user_tmp_filetrans(thumb_t, thumb_tmp_t, { file dir sock_file })
 manage_dirs_pattern(thumb_t, thumb_tmpfs_t, thumb_tmpfs_t)
 manage_files_pattern(thumb_t, thumb_tmpfs_t, thumb_tmpfs_t)
 fs_tmpfs_filetrans(thumb_t, thumb_tmpfs_t, { dir file })
-allow thumb_t thumb_tmpfs_t:file execute;
+allow thumb_t thumb_tmpfs_t:file { execute mounton };
 
 can_exec(thumb_t, thumb_exec_t)
 

--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -43,6 +43,7 @@ allow thumb_t self:udp_socket create_socket_perms;
 allow thumb_t self:tcp_socket create_socket_perms;
 allow thumb_t self:shm create_shm_perms;
 allow thumb_t self:sem create_sem_perms;
+allow thumb_t self:user_namespace create;
 
 manage_dirs_pattern(thumb_t, thumb_home_t, thumb_home_t)
 manage_files_pattern(thumb_t, thumb_home_t, thumb_home_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1756101205.607:223): avc:  denied  { create } for  pid=2865 comm="bwrap" scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tclass=user_namespace permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2390663