### PR TITLE
Dontaudit systemd-generator connect to sssd over a unix stream socket

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1408,8 +1408,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sssd_dontaudit_read_public_files(systemd_generator)
-	sssd_dontaudit_search_lib(systemd_generator)
+	sssd_dontaudit_stream_connect(systemd_generator)
 ')
 
 ### Rules for individual systemd generator domains


### PR DESCRIPTION
The previous dontaudit rules for accessing files and dirs were removed as these permissions are actually allowed by other rules.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2393707