### PR TITLE
Allow init watch/watch_reads systemd-machined user ptys

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -579,6 +579,8 @@ optional_policy(`
     systemd_hostnamed_delete_config(init_t)
 	systemd_manage_conf_files(init_t)
 	systemd_rw_networkd_tmpfs_files(init_t)
+	systemd_machined_watch_user_ptys(init_t)
+	systemd_machined_watch_reads_user_ptys(init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2558,6 +2558,42 @@ interface(`systemd_machined_rw_devpts_chr_files',`
 
 ########################################
 ## <summary>
+##	Watch systemd-machined user pty.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_machined_watch_user_ptys',`
+	gen_require(`
+		type systemd_machined_devpts_t;
+	')
+
+	allow $1 systemd_machined_devpts_t:chr_file watch_chr_file_perms;
+')
+
+########################################
+## <summary>
+##	Watch_reads systemd-machined user pty.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_machined_watch_reads_user_ptys',`
+	gen_require(`
+		type systemd_machined_devpts_t;
+	')
+
+	allow $1 systemd_machined_devpts_t:chr_file watch_reads_chr_file_perms;
+')
+
+########################################
+## <summary>
 ##	Allow the specified domain to connect to
 ##	systemd_machined with a unix socket.
 ## </summary>


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1760123095.197:297): avc:  denied  { watch watch_reads } for  pid=1809 comm="(agetty)" path="/dev/pts/1" dev="devpts" ino=4 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:systemd_machined_devpts_t:s0 tclass=chr_file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2403174