### PR TITLE
Set temporary no-stub resolv.conf file from NetworkManager as net_conf_t

### DIFF
--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1198,6 +1198,7 @@ interface(`sysnet_filetrans_named_content',`
 
 	optional_policy(`
 		networkmanager_pid_filetrans($1, net_conf_t, file, "no-stub-resolv.conf")
+		networkmanager_pid_filetrans($1, net_conf_t, file, "no-stub-resolv.conf.tmp")
 		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf")
 		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
 	')


### PR DESCRIPTION
Currently NetworkManager writes
`/run/NetworkManager/no-stub-resolv.conf `by using `mkstemp()`, which creates a temporary file name with a random suffix and then renames it. The policy doesn't handle this, and the file gets wrongly labeled as `NetworkManager_var_run_t`.

NetworkManager is being updated to write the file with a fixed ".tmp" suffix here:

  https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/2298

Adapt the policy accordingly.