### PR TITLE
Allow systemd-machined watch cgroup files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -577,6 +577,7 @@ files_write_root_dirs(systemd_machined_t)
 fs_read_nsfs_files(systemd_machined_t)
 fs_read_tmpfs_symlinks(systemd_machined_t)
 fs_cgroup_write_memory_pressure(systemd_machined_t)
+fs_watch_cgroup_files(systemd_machined_t)
 fs_write_tmpfs_socket_files(systemd_machined_t)
 
 init_dbus_chat(systemd_machined_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1760435282.595:245151): avc:  denied  { watch } for  pid=586502 comm="systemd-machine" path="/sys/fs/cgroup/machine.slice/systemd-nspawn@centos9.service/payload/cgroup.events" dev="cgroup2" ino=1335289 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=0

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2909