### PR TITLE
Dontaudit firewalld dac_read_search capability

### DIFF
--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -37,7 +37,7 @@ systemd_unit_file(firewalld_unit_file_t)
 #
 
 allow firewalld_t self:capability { net_admin net_raw setpcap };
-dontaudit firewalld_t self:capability { dac_override sys_tty_config };
+dontaudit firewalld_t self:capability { dac_override dac_read_search sys_tty_config };
 allow firewalld_t self:process setcap;
 allow firewalld_t self:fifo_file rw_fifo_file_perms;
 allow firewalld_t self:unix_stream_socket { accept listen };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/15/2025 19:02:21.884:334) : proctitle=/usr/bin/python3 -sP /usr/bin/firewalld --nofork --nopid type=PATH msg=audit(10/15/2025 19:02:21.884:334) : item=0 name=/root/.cache nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/15/2025 19:02:21.884:334) : arch=x86_64 syscall=mkdir success=no exit=EACCES(Permission denied) a0=0x55db85e7b760 a1=0700 a2=0x55ded84c244c a3=0x4 items=1 ppid=1 pid=2636 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=firewalld exe=/usr/bin/python3.13 subj=system_u:system_r:firewalld_t:s0 key=(null) type=AVC msg=audit(10/15/2025 19:02:21.884:334) : avc:  denied  { dac_read_search } for  pid=2636 comm=firewalld capability=dac_read_search  scontext=system_u:system_r:firewalld_t:s0 tcontext=system_u:system_r:firewalld_t:s0 tclass=capability permissive=0