### PR TITLE
Allow spamc read aliases file

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -371,6 +371,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mta_read_aliases(spamc_t)
+')
+
+optional_policy(`
 	milter_manage_spamass_state(spamc_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/16/2025 09:14:14.653:466) : proctitle=/usr/bin/perl -T -w /usr/bin/spamassassin type=PATH msg=audit(10/16/2025 09:14:14.653:466) : item=2 name=/lib64/ld-linux-x86-64.so.2 inode=8609969 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(10/16/2025 09:14:14.653:466) : item=1 name=/usr/bin/perl inode=9353935 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:bin_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(10/16/2025 09:14:14.653:466) : item=0 name=/usr/bin/spamassassin inode=9825767 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:spamc_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(10/16/2025 09:14:14.653:466) : cwd=/home/user25788/mail type=EXECVE msg=audit(10/16/2025 09:14:14.653:466) : argc=3 a0=/usr/bin/perl a1=-T -w a2=/usr/bin/spamassassin type=SYSCALL msg=audit(10/16/2025 09:14:14.653:466) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55bec3000ab0 a1=0x55bec3003e10 a2=0x55bec3003cb0 a3=0x8 items=3 ppid=7664 pid=7665 auid=unset uid=user25788 gid=user25788 euid=user25788 suid=user25788 fsuid=user25788 egid=user25788 sgid=user25788 fsgid=user25788 tty=(none) ses=unset comm=spamassassin exe=/usr/bin/perl subj=system_u:system_r:spamc_t:s0 key=(null) type=AVC msg=audit(10/16/2025 09:14:14.653:466) : avc:  denied  { read } for  pid=7665 comm=spamassassin path=/etc/aliases.lmdb dev="vda2" ino=4343186 scontext=system_u:system_r:spamc_t:s0 tcontext=system_u:object_r:etc_aliases_t:s0 tclass=file permissive=0