### PR TITLE
Allow cupsd to manage cupsd_rw_etc_t lnk_files

### DIFF
--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -160,6 +160,7 @@ can_exec(cupsd_t, cupsd_interface_t)
 
 manage_dirs_pattern(cupsd_t, cupsd_etc_t, cupsd_rw_etc_t)
 manage_files_pattern(cupsd_t, cupsd_etc_t, cupsd_rw_etc_t)
+manage_lnk_files_pattern(cupsd_t, cupsd_etc_t, cupsd_rw_etc_t)
 filetrans_pattern(cupsd_t, cupsd_etc_t, cupsd_rw_etc_t, file)
 files_var_filetrans(cupsd_t, cupsd_rw_etc_t, { dir file })
 cups_filetrans_named_content(cupsd_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:

> `avc:  denied  { read } for  pid=1593 comm="cupsd" name="dbg.file.ppd" dev="nvme1n1p3" ino=1880287 scontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:cupsd_rw_etc_t:s0 tclass=lnk_file permissive=1`

Fixes bsc#1252122