### PR TITLE
Allow bluez dbus API passing unix domain sockets - contd.

### DIFF
--- a/policy/modules/contrib/bluetooth.if
+++ b/policy/modules/contrib/bluetooth.if
@@ -86,6 +86,26 @@ interface(`bluetooth_stream_connect',`
 
 ########################################
 ## <summary>
+##	Allow read and write bluetooth domain stream.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bluetooth_rw_stream',`
+	gen_require(`
+		type bluetooth_t;
+	')
+
+	tunable_policy(`deny_bluetooth',`',`
+		allow $1 bluetooth_t:unix_stream_socket { read write };
+	')
+')
+
+########################################
+## <summary>
 ##	Execute bluetooth in the bluetooth domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/bluetooth.te
+++ b/policy/modules/contrib/bluetooth.te
@@ -194,6 +194,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_rw_stream(bluetooth_t)
+')
+
+optional_policy(`
 	ppp_domtrans(bluetooth_t)
 ')
 

--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -183,6 +183,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	bluetooth_rw_stream(system_dbusd_t)
+')
+
+optional_policy(`
     boltd_write_var_run_pipes(system_dbusd_t)
 ')
 

--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -386,6 +386,24 @@ interface(`unconfined_dontaudit_rw_pipes',`
 
 ########################################
 ## <summary>
+##	Allow read and write unconfined domain stream.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`unconfined_rw_stream',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:unix_stream_socket { read write };
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read and write
 ##	unconfined domain stream.
 ## </summary>


### PR DESCRIPTION
Continued from #2898 -- add missing `bluetooth_rw_stream(system_dbusd_t)`.

Tested RPMs built from this, Pipewire BLE MIDI works with them on Fedora 43.