### PR TITLE
Define file equivalency for /var/opt

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -35,3 +35,4 @@
 /bin                 /usr/bin
 /usr/etc             /etc
 /usr/sbin            /usr/bin
+/var/opt             /opt

--- a/policy/modules/contrib/antivirus.fc
+++ b/policy/modules/contrib/antivirus.fc
@@ -27,7 +27,6 @@
 /var/lib/clamav(/.*)?				gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/lib/clamav-unofficial-sigs(/.*)?   gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/lib/clamd.*					gen_context(system_u:object_r:antivirus_db_t,s0)
-/var/opt/f-secure(/.*)?				gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/spool/amavisd(/.*)?			gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/virusmails(/.*)?				gen_context(system_u:object_r:antivirus_db_t,s0)
 

--- a/policy/modules/contrib/apache.fc
+++ b/policy/modules/contrib/apache.fc
@@ -129,7 +129,6 @@ ifdef(`distro_suse', `
 /var/lib/moodle(/.*)?		    gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /var/lib/mod_security(/.*)?     gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/nginx(/.*)?            gen_context(system_u:object_r:httpd_var_lib_t,s0)
-/var/opt/rh/rh-nginx18/lib/nginx(/.*)?            gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/php/session(/.*)?		gen_context(system_u:object_r:httpd_var_run_t,s0)
 /var/lib/php/wsdlcache(/.*)?		gen_context(system_u:object_r:httpd_var_run_t,s0)
 
@@ -158,7 +157,7 @@ ifdef(`distro_suse', `
 /var/log/httpd(/.*)?		gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/lighttpd(/.*)?		gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/nginx(/.*)?     gen_context(system_u:object_r:httpd_log_t,s0)
-/var/opt/rh/rh-nginx18/log(/.*)?     gen_context(system_u:object_r:httpd_log_t,s0)
+
 /var/log/php-fpm(/.*)?      gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/roundcubemail(/.*)?	gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/suphp\.log.*	--	gen_context(system_u:object_r:httpd_log_t,s0)
@@ -178,7 +177,6 @@ ifdef(`distro_debian', `
 /run/lighttpd(/.*)?			gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/mod_.*				gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/nginx.*            gen_context(system_u:object_r:httpd_var_run_t,s0)
-/var/opt/rh/rh-nginx18/run/nginx(/.*)?            gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/php-fpm(/.*)?      gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/thttpd\.pid    -- gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/wsgi.*			-s	gen_context(system_u:object_r:httpd_var_run_t,s0)

--- a/policy/modules/contrib/redis.fc
+++ b/policy/modules/contrib/redis.fc
@@ -20,6 +20,3 @@
 
 /run/redis(/.*)?		gen_context(system_u:object_r:redis_var_run_t,s0)
 /run/valkey(/.*)?		gen_context(system_u:object_r:redis_var_run_t,s0)
-
-
-/var/opt/rh/rh-redis32/redis(/.*)?		--	gen_context(system_u:object_r:redis_exec_t,s0)

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -47,8 +47,6 @@ ifdef(`distro_suse', `
 
 /var/ace(/.*)?			gen_context(system_u:object_r:var_auth_t,s0)
 
-/var/opt/quest/vas/vasd(/.*)?	gen_context(system_u:object_r:var_auth_t,s0)
-
 /var/cache/coolkey(/.*)?	gen_context(system_u:object_r:auth_cache_t,s0)
 
 /var/db/shadow.*	--	gen_context(system_u:object_r:shadow_t,s0)


### PR DESCRIPTION
The image mode documentation suggests using /var/opt for /opt, therefore file equivalency is needed.