### PR TITLE
Allow virtnodedev_t the perfmon capability

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2025,6 +2025,7 @@ optional_policy(`
 # virtnodedevd local policy
 #
 allow virtnodedevd_t self:capability { net_admin sys_admin };
+allow virtnodedevd_t self:capability2 perfmon;
 allow virtnodedevd_t self:netlink_generic_socket create_socket_perms;
 allow virtnodedevd_t self:process { setsched };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1758004239.291:546): avc:  denied  { perfmon } for  pid=7547 comm="nodev-device-ev" capability=38  scontext=system_u:system_r:virtnodedevd_t:s0 tcontext=system_u:system_r:virtnodedevd_t:s0 tclass=capability2 permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2395647