### PR TITLE
Allow nut_upsdrvctl_t the sys_ptrace capability

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -127,7 +127,7 @@ optional_policy(`
 # Local policy for upsdrvctl
 #
 
-allow nut_upsdrvctl_t self:capability { kill };
+allow nut_upsdrvctl_t self:capability { kill sys_ptrace };
 allow nut_upsdrvctl_t self:fd use;
 allow nut_upsdrvctl_t self:unix_dgram_socket { create_socket_perms sendto };
 allow nut_upsdrvctl_t self:udp_socket create_socket_perms;


### PR DESCRIPTION
Required when upsdrvctl wants to access the usbhid-ups process's proc data.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(15.09.2025 15:47:49.220:31475) : proctitle=/usr/bin/upsdrvctl stop cyberpower type=PATH msg=audit(15.09.2025 15:47:49.220:31475) : item=0 name=/proc/1806/exe inode=17787 dev=00:18 mode=link,777 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:nut_upsdrvctl_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(15.09.2025 15:47:49.220:31475) : arch=x86_64 syscall=readlink success=no exit=EACCES a0=0x7ffc8cb386f0 a1=0x5558f66174d0 a2=0x201 a3=0x5558f6618630 items=1 ppid=1 pid=75444 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=upsdrvctl exe=/usr/bin/upsdrvctl subj=system_u:system_r:nut_upsdrvctl_t:s0 key=(null) type=AVC msg=audit(15.09.2025 15:47:49.220:31475) : avc:  denied  { sys_ptrace } for  pid=75444 comm=upsdrvctl capability=sys_ptrace  scontext=system_u:system_r:nut_upsdrvctl_t:s0 tcontext=system_u:system_r:nut_upsdrvctl_t:s0 tclass=capability permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2394937