### PR TITLE
Label /usr/lib/systemd/user/graphical-session-pre.target with xdm_uni…

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -91,6 +91,7 @@ HOME_DIR/\.dmrc.*	--	gen_context(system_u:object_r:xdm_home_t,s0)
 #
 
 /usr/lib/systemd/user/.*gnome.*\.(service|target)		--	gen_context(system_u:object_r:xdm_unit_file_t,s0)
+/usr/lib/systemd/user/graphical-session-pre.target		--	gen_context(system_u:object_r:xdm_unit_file_t,s0)
 /usr/lib/systemd/user/plasma-.*\.(service|target)		--	gen_context(system_u:object_r:xdm_unit_file_t,s0)
 
 /usr/bin/mdm-binary	--	gen_context(system_u:object_r:xdm_exec_t,s0)


### PR DESCRIPTION
…t_file_t

The commit addresses the following error reported in the journal: Oct 20 15:58:28 localhost-live systemd[1305]: selinux: avc:  denied  { status } for auid=n/a uid=60578 gid=977 path="/usr/lib/systemd/user/graphical-session-pre.target" cmdline="/usr/libexec/gnome-session-init-worker gnome-initial-setup" function="reply_unit_path" scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=service permissive=0 Oct 20 15:58:28 localhost-live systemd[1305]: SELinux access check scon=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcon=system_u:object_r:systemd_unit_file_t:s0 tclass=service perm=status state=enforcing function=reply_unit_path path=/usr/lib/systemd/user/graphical-session-pre.target cmdline=/usr/libexec/gnome-session-init-worker gnome-initial-setup: Permission denied Oct 20 15:58:28 localhost-live gnome-session-i[1340]: Could not get unit for graphical-session-pre.target: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: SELinux policy denies access: Permission denied

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2402621