### PR TITLE
Allow ras-mc-ctl get attributes of the kmod executable

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -42,7 +42,7 @@ fs_manage_tracefs_dirs(rasdaemon_t)
 fs_mount_tracefs(rasdaemon_t)
 fs_unmount_tracefs(rasdaemon_t)
 
-modutils_dontaudit_exec_kmod(rasdaemon_t) # more info here #1030277
+modutils_getattr_kmod_exec(rasdaemon_t)
 
 auth_use_nsswitch(rasdaemon_t)
 

--- a/policy/modules/system/modutils.if
+++ b/policy/modules/system/modutils.if
@@ -200,6 +200,25 @@ interface(`modutils_domtrans_kmod',`
 
 ########################################
 ## <summary>
+##	Get attributes of the kmod executable.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`modutils_getattr_kmod_exec',`
+	gen_require(`
+		type kmod_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	allow $1 kmod_exec_t:file getattr;
+')
+
+########################################
+## <summary>
 ##	Unconditionally execute insmod in the insmod domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/27/2025 12:14:38.392:194) : proctitle=/usr/bin/perl -w /usr/bin/ras-mc-ctl --register-labels type=PATH msg=audit(10/27/2025 12:14:38.392:194) : item=0 name=/usr/bin/modprobe inode=141795 dev=fd:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:kmod_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10/27/2025 12:14:38.392:194) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55af7d932ce0 a2=0x55af7d8f8228 a3=0x0 items=1 ppid=1 pid=3240 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=ras-mc-ctl exe=/usr/bin/perl subj=system_u:system_r:rasdaemon_t:s0 key=(null) type=AVC msg=audit(10/27/2025 12:14:38.392:194) : avc:  denied  { getattr } for  pid=3240 comm=ras-mc-ctl path=/usr/bin/kmod dev="vda2" ino=141795 scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:kmod_exec_t:s0 tclass=file permissive=0

Resolves: RHEL-102535