### PR TITLE
Allow sshd_auth_t getopt/setopt on tcp_socket (bsc#1252992)

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -166,7 +166,7 @@ domtrans_pattern(sshd_session_t, sshd_auth_exec_t, sshd_auth_t)
 allow sshd_auth_t self:process { setcurrent setrlimit };
 allow sshd_auth_t self:unix_dgram_socket { create ioctl };
 
-allow sshd_auth_t sshd_t:tcp_socket { getattr read write };
+allow sshd_auth_t sshd_t:tcp_socket { getattr read write getopt setopt };
 allow sshd_auth_t sshd_session_t:unix_stream_socket { read write };
 
 kernel_read_proc_files(sshd_auth_t)


### PR DESCRIPTION
Fixes following AVC:
type=AVC msg=audit(1762236864.490:486): avc:  denied  { getopt } for  pid=2794 comm="sshd-auth" laddr=::1 lport=22 faddr=::1 fport=46614 scontext=system_u:system_r:sshd_auth_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=tcp_socket permissive=1
type=AVC msg=audit(1762236864.494:487): avc:  denied  { setopt } for  pid=2794 comm="sshd-auth" laddr=::1 lport=22 faddr=::1 fport=46614 scontext=system_u:system_r:sshd_auth_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=tcp_socket permissive=1