### PR TITLE
Add support for socket activated polkit helper agent

### DIFF
--- a/policy/modules/contrib/policykit.fc
+++ b/policy/modules/contrib/policykit.fc
@@ -20,3 +20,4 @@
 /var/lib/PolicyKit-public(/.*)?			gen_context(system_u:object_r:policykit_var_lib_t,s0)
 /run/PolicyKit(/.*)?			gen_context(system_u:object_r:policykit_var_run_t,s0)
 /run/polkit-1(/.*)?			gen_context(system_u:object_r:policykit_var_run_t,s0)
+/run/polkit(/.*)?			gen_context(system_u:object_r:policykit_var_run_t,s0)

--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -15,6 +15,7 @@ init_nnp_daemon_domain(policykit_t)
 type policykit_auth_t, policykit_domain;
 type policykit_auth_exec_t;
 init_daemon_domain(policykit_auth_t, policykit_auth_exec_t)
+init_nnp_daemon_domain(policykit_auth_t)
 
 type policykit_grant_t, policykit_domain;
 type policykit_grant_exec_t;
@@ -209,6 +210,7 @@ fs_dontaudit_append_ecryptfs_files(policykit_auth_t)
 auth_rw_var_auth(policykit_auth_t)
 auth_use_nsswitch(policykit_auth_t)
 auth_domtrans_chk_passwd(policykit_auth_t)
+auth_nnp_domtrans_chkpwd(policykit_auth_t)
 
 logging_send_syslog_msg(policykit_auth_t)
 

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -490,6 +490,23 @@ interface(`auth_domtrans_chkpwd',`
 
 ########################################
 ## <summary>
+##	Allow caller to transition to chkpwd_t with NoNewPrivileges
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`auth_nnp_domtrans_chkpwd',`
+	gen_require(`
+		type chkpwd_t;
+	')
+	allow $1 chkpwd_t:process2 nnp_transition;
+')
+
+########################################
+## <summary>
 ##  Execute chkpwd in the caller domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The next polkit version is moving from setuid polkit-helper-agent to a socket activated version.

The socket is placed in a separate location under /run/polkit/.

polkit change:

https://github.com/polkit-org/polkit/commit/c007940054392b67b84b6044dda8a215040d8eb5