### PR TITLE
Allow thumb_t stream connect to systemd-userdbd

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -109,6 +109,7 @@ tunable_policy(`selinuxuser_execmod',`
 ')
 
 init_append_stream_sockets(thumb_t)
+init_stream_connectto(thumb_t)
 
 libs_dontaudit_setattr_lib_dirs(thumb_t)
 
@@ -199,4 +200,8 @@ tunable_policy(`nis_enabled',`
 
 optional_policy(`
     storage_getattr_fixed_disk_dev(thumb_t)
+')
+
+optional_policy(`
+	systemd_userdbd_stream_connect(thumb_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=AVC msg=audit(1762189264.579:2369): avc:  denied  { connectto } for  pid=70744 comm="blocking-1" path="/run/systemd/userdb/io.systemd.DynamicUser" scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=0 type=AVC msg=audit(1762345883.190:455): avc:  denied  { write } for  pid=116974 comm="blocking-1" name="io.systemd.DynamicUser" dev="tmpfs" ino=1482 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=sock_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2408906