### PR TITLE
Allow gnome-remote-desktop read sssd public files

### DIFF
--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -70,6 +70,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sssd_read_public_files(gnome_remote_desktop_t)
+')
+
+optional_policy(`
 	sysnet_read_config(gnome_remote_desktop_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1762431526.77:934): avc:  denied  { read } for  pid=62388 comm=52445020736F636B65742074687265 path="/var/lib/sss/pubconf/krb5.include.d" dev="dm-5" ino=537158989 scontext=system_u:system_r:gnome_remote_desktop_t:s0 tcontext=system_u:object_r:sssd_public_t:s0 tclass=dir permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2413082