### PR TITLE
Allow boinc to be executed in a container

### DIFF
--- a/policy/modules/contrib/boinc.te
+++ b/policy/modules/contrib/boinc.te
@@ -92,6 +92,7 @@ optional_policy(`
 #
 
 allow boinc_t self:process { setsched setpgid signull sigkill };
+allow boinc_t self:cap_userns sys_ptrace;
 
 allow boinc_t self:unix_stream_socket create_stream_socket_perms;
 allow boinc_t self:tcp_socket create_stream_socket_perms;
@@ -170,6 +171,10 @@ xserver_stream_connect(boinc_t)
 
 tunable_policy(`boinc_execmem',`
 	allow boinc_t self:process { execstack execmem };
+')
+
+optional_policy(`
+	container_runtime_domtrans(boinc_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Boinc detects if a container engine (docker, podman) is installed.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/24/2025 19:41:30.140:2983) : proctitle=sh -c --  podman --version 2>/dev/null type=PATH msg=audit(10/24/2025 19:41:30.140:2983) : item=0 name=/usr/bin/podman inode=3826 dev=00:22 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:container_runtime_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(10/24/2025 19:41:30.140:2983) : cwd=/var/lib/boinc type=SYSCALL msg=audit(10/24/2025 19:41:30.140:2983) : arch=x86_64 syscall=access success=no exit=EACCES(Permission denied) a0=0x555b7051c980 a1=X_OK a2=0x3d4 a3=0x0 items=1 ppid=124405 pid=124567 auid=unset uid=boinc gid=boinc euid=boinc suid=boinc fsuid=boinc egid=boinc sgid=boinc fsgid=boinc tty=(none) ses=unset comm=sh exe=/usr/bin/bash subj=system_u:system_r:boinc_t:s0 key=(null) type=AVC msg=audit(10/24/2025 19:41:30.140:2983) : avc:  denied  { execute } for  pid=124567 comm=sh name=podman dev="nvme0n1p4" ino=3826 scontext=system_u:system_r:boinc_t:s0 tcontext=system_u:object_r:container_runtime_exec_t:s0 tclass=file permissive=0