### PR TITLE
Label /var/lib/cosmic-greeter with xdm_var_lib_t

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -149,6 +149,7 @@ ifndef(`distro_debian',`
 
 /var/[xgkw]dm(/.*)?		gen_context(system_u:object_r:xserver_log_t,s0)
 
+/var/lib/cosmic-greeter(/.*)?	gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/gdm(3)?(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/sddm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/lxdm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1762480004.270:144): avc:  denied  { unlink } for  pid=1763 comm="cosmic-greeter" name="last_user" dev="nvme0n1p3" ino=2178764 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_lib_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2413280