### PR TITLE
Allow nfsidmapd search virt lib directories

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -477,3 +477,7 @@ optional_policy(`
 optional_policy(`
 	systemd_homed_stream_connect(nfsidmap_t)
 ')
+
+optional_policy(`
+	virt_search_lib(nfsidmap_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/22/2024 03:05:50.060:994) : proctitle=nfsidmap 886959952 uid:SYSTEM@NT AUTHORITY type=AVC msg=audit(11/22/2024 03:05:50.060:994) : avc:  denied  { search } for  pid=29683 comm=nfsidmap name=libvirt dev="dm-0" ino=67923547 scontext=system_u:system_r:nfsidmap_t:s0 tcontext=system_u:object_r:virt_var_lib_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(11/22/2024 03:05:50.060:994) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fe2a91d0033 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=0 ppid=17616 pid=29683 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=nfsidmap exe=/usr/sbin/nfsidmap subj=system_u:system_r:nfsidmap_t:s0 key=(null)

Resolves: RHEL-68722