### PR TITLE
Allow iotop stream connect to systemd-userdbd

### DIFF
--- a/policy/modules/contrib/iotop.te
+++ b/policy/modules/contrib/iotop.te
@@ -36,6 +36,8 @@ domain_read_all_domains_state(iotop_t)
 
 corecmd_exec_bin(iotop_t)
 
+init_stream_connectto(iotop_t)
+
 miscfiles_read_localization(iotop_t)
 
 userdom_use_user_terminals(iotop_t)
@@ -44,3 +46,6 @@ optional_policy(`
         libs_exec_ldconfig(iotop_t)
 ')
 
+optional_policy(`
+	systemd_userdbd_stream_connect(iotop_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/25/2025 04:49:34.854:2351) : proctitle=/usr/sbin/iotop -b -n 4 -d 1 type=PATH msg=audit(07/25/2025 04:49:34.854:2351) : item=0 name=/run/systemd/userdb/io.systemd.DynamicUser inode=43 dev=00:1a mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(07/25/2025 04:49:34.854:2351) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DynamicUser } type=SYSCALL msg=audit(07/25/2025 04:49:34.854:2351) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x7 a1=0x7ffd23a98870 a2=0x2d a3=0x56416e3e8010 items=1 ppid=16514 pid=16515 auid=user5367 uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts3 ses=14 comm=iotop exe=/usr/sbin/iotop subj=sysadm_u:sysadm_r:iotop_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(07/25/2025 04:49:34.854:2351) : avc:  denied  { connectto } for  pid=16515 comm=iotop path=/systemd/userdb/io.systemd.DynamicUser scontext=sysadm_u:sysadm_r:iotop_t:s0-s0:c0.c1023 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_stream_socket permissive=0

Resolves: RHEL-105481