### PR TITLE
Allow setroubleshoot-fixit get attributes of xattr fs

### DIFF
--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -226,6 +226,8 @@ dev_read_rand(setroubleshoot_fixit_t)
 dev_read_sysfs(setroubleshoot_fixit_t)
 dev_read_urand(setroubleshoot_fixit_t)
 
+fs_getattr_xattr_fs(setroubleshoot_fixit_t)
+
 selinux_read_policy(setroubleshoot_fixit_t)
 
 seutil_domtrans_setfiles(setroubleshoot_fixit_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1762970857.901:791): avc:  denied  { getattr } for  pid=20682 comm=5B70616E676F5D20666F6E74636F6E name="/" dev="nvme0n1p3" ino=256 scontext=system_u:system_r:setroubleshoot_fixit_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2414618