### PR TITLE
Allow tlshd the net_admin capability

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -11,6 +11,7 @@ init_daemon_domain(ktlshd_t, ktlshd_exec_t)
 
 permissive ktlshd_t;
 
+allow ktlshd_t self:capability net_admin;
 allow ktlshd_t self:key write;
 allow ktlshd_t self:netlink_generic_socket create_socket_perms;
 allow ktlshd_t self:netlink_route_socket r_netlink_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1762977517.566:973): avc:  denied  { net_admin } for  pid=4638 comm="tlshd" capability=12  scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:system_r:ktlshd_t:s0 tclass=capability permissive=0

Resolves: RHEL-127023