### PR TITLE
Allow create kerberos files in postgresql db home

### DIFF
--- a/policy/modules/contrib/kerberos.if
+++ b/policy/modules/contrib/kerberos.if
@@ -635,6 +635,10 @@ interface(`kerberos_filetrans_named_content',`
 	kerberos_tmp_filetrans_host_rcache($1, "ldapmap1_0")
 	kerberos_tmp_filetrans_host_rcache($1, "ldap_487")
 	kerberos_tmp_filetrans_host_rcache($1, "ldap_55")
+
+	postgresql_db_filetrans($1, krb5_home_t, file, ".k5identity")
+	postgresql_db_filetrans($1, krb5_home_t, file, ".k5login")
+	postgresql_db_filetrans($1, krb5_home_t, file, ".k5users")
 ')
 
 ########################################

--- a/policy/modules/services/postgresql.fc
+++ b/policy/modules/services/postgresql.fc
@@ -35,6 +35,10 @@ ifdef(`distro_redhat', `
 /var/lib/postgres(ql)?(/.*)? 		gen_context(system_u:object_r:postgresql_db_t,s0)
 
 /var/lib/pgsql(/.*)?			gen_context(system_u:object_r:postgresql_db_t,s0)
+/var/lib/pgsql/\.k5identity		gen_context(system_u:object_r:krb5_home_t,s0)
+/var/lib/pgsql/\.k5login		gen_context(system_u:object_r:krb5_home_t,s0)
+/var/lib/pgsql/\.k5users		gen_context(system_u:object_r:krb5_home_t,s0)
+
 /var/lib/pgsql/logfile(/.*)?		gen_context(system_u:object_r:postgresql_log_t,s0)
 /var/lib/pgsql/.*\.log			gen_context(system_u:object_r:postgresql_log_t,s0)
 /var/lib/pgsql/data/pg_log(/.*)?	gen_context(system_u:object_r:postgresql_log_t,s0)

--- a/policy/modules/services/postgresql.if
+++ b/policy/modules/services/postgresql.if
@@ -490,6 +490,39 @@ interface(`postgresql_filetrans_named_content',`
 
 ########################################
 ## <summary>
+##	Create private objects at postgresql db directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="private type">
+##	<summary>
+##	The type of the object to be created.
+##	</summary>
+## </param>
+## <param name="object">
+##	<summary>
+##	The object class of the object being created.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`postgresql_db_filetrans',`
+	gen_require(`
+		type postgresql_db_t;
+	')
+
+	filetrans_pattern($1, postgresql_db_t, $2, $3, $4)
+')
+
+########################################
+## <summary>
 ##	All of the rules required to administrate an postgresql environment
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The pgsql user has its home in the /var/lib/pgsql directory labeled with the postgresql_db_t type.