### PR TITLE
Allow virtqemud_t to read state of unconfined services (bsc#1251789)

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2414,6 +2414,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	unconfined_server_read_state(virtqemud_t)
+')
+
+optional_policy(`
 	userdom_manage_tmp_files(virtqemud_t)
 	userdom_manage_tmp_sockets(virtqemud_t)
 	userdom_read_all_users_state(virtqemud_t)


### PR DESCRIPTION
When libvirt is used from unconfined services you see denials like 
```
avc:  denied  { search } for comm="rpc-virtqemud" name="78700" dev="proc" scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=dir permissive=1 
avc:  denied  { read } for comm="rpc-virtqemud" name="stat" dev="proc" scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=file permissive=1 
avc:  denied  { open } for comm="rpc-virtqemud" path="/proc/78700/stat" dev="proc" scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=file permissive=1
```