### PR TITLE
fix: bz2279215 Allow speech-dispatcher access to user home/cache files

### DIFF
--- a/policy/modules/contrib/speech-dispatcher.te
+++ b/policy/modules/contrib/speech-dispatcher.te
@@ -43,6 +43,7 @@ allow speech_dispatcher_t self:fifo_file rw_fifo_file_perms;
 allow speech_dispatcher_t self:unix_stream_socket create_stream_socket_perms;
 allow speech_dispatcher_t self:tcp_socket create_socket_perms;
 
+
 manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
 manage_files_pattern(speech_dispatcher_t, speech_dispatcher_log_t, speech_dispatcher_log_t)
 logging_log_filetrans(speech_dispatcher_t, speech_dispatcher_log_t, { dir })
@@ -52,6 +53,7 @@ files_tmp_filetrans(speech_dispatcher_t, speech_dispatcher_tmp_t, { file })
 
 manage_files_pattern(speech_dispatcher_t, speech_dispatcher_tmpfs_t, speech_dispatcher_tmpfs_t)
 fs_tmpfs_filetrans(speech_dispatcher_t, speech_dispatcher_tmpfs_t, { file })
+allow speech_dispatcher_t speech_dispatcher_tmpfs_t:file map;
 
 manage_files_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
 manage_dirs_pattern(speech_dispatcher_t, speech_dispatcher_home_t, speech_dispatcher_home_t)
@@ -66,3 +68,19 @@ corenet_tcp_connect_pdps_port(speech_dispatcher_t)
 
 dev_read_urand(speech_dispatcher_t)
 
+
+files_manage_generic_tmp_dirs(speech_dispatcher_t)
+
+libs_exec_lib_files(speech_dispatcher_t)
+
+optional_policy(`
+	gnome_create_home_config_dirs(speech_dispatcher_t)
+	gnome_create_generic_cache_dir(speech_dispatcher_t)
+	gnome_manage_generic_cache_files(speech_dispatcher_t)
+	gnome_manage_generic_cache_sockets(speech_dispatcher_t)
+')
+
+optional_policy(`
+	pulseaudio_manage_home_dirs(speech_dispatcher_t)
+	pulseaudio_manage_home_symlinks(speech_dispatcher_t)
+')


### PR DESCRIPTION
Speech-dispatcherd fails with AVC denials when configured to run as an unprivileged user (User=testuser) for a user session, as it requires access to the user's homedirectory contexts for PID files, logs, sockets, and PulseAudio configuration. speech-dispatcher requires to work with cache and pulse-audio

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2279215