### PR TITLE
Allow kmscon to read netlink_kobject_uevent_socket

### DIFF
--- a/policy/modules/contrib/kmscon.te
+++ b/policy/modules/contrib/kmscon.te
@@ -37,7 +37,7 @@ dontaudit kmscon_t self:capability2 block_suspend;
 domain_dontaudit_read_all_domains_state(kmscon_t)
 
 # Create an udev monitor
-allow kmscon_t self:netlink_kobject_uevent_socket { bind create getopt setopt getattr };
+allow kmscon_t self:netlink_kobject_uevent_socket { bind create getopt read setopt getattr };
 
 allow kmscon_t kmscon_devpts_t:chr_file { rw_chr_file_perms setattr_chr_file_perms };
 term_create_pty(kmscon_t, kmscon_devpts_t)


### PR DESCRIPTION
https://discussion.fedoraproject.org/t/f44-change-proposal-usekmsconvtconsole-systemwide/172602/18

Fixes:

time->Sat Nov 15 19:13:29 2025
type=AVC msg=audit(1763244809.103:36160): avc:  denied  { read } for  pid=3419 comm="kmscon" scontext=system_u:system_r:kmscon_t:s0 tcontext=system_u:system_r:kmscon_t:s0 tclass=netlink_kobject_uevent_socket permissive=0