### PR TITLE
Allow virtlogd_t dac_override (bsc#1253389)

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -961,7 +961,7 @@ optional_policy(`
 #
 # virtlogd local policy
 #
-allow virtlogd_t self:capability kill;
+allow virtlogd_t self:capability { dac_override kill };
 allow virtlogd_t virt_image_t:dir search_dir_perms;
 allow virtlogd_t svirt_t:process signal;
 


### PR DESCRIPTION
When lock_manager is set to lockd this causes AVCs like
`avc:  denied  { dac_override } for  pid=37829 comm="virtlockd" capability=1 scontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tclass=capability permissive=0`

Reason is that the VM images are owned by a non-root user: 
`-rw-------. 1 qemu qemu system_u:object_r:svirt_image_t:s0:c254,c534 16G Nov 13 16:57 /var/lib/libvirt/images/opensuse16.0.qcow2`