### PR TITLE
Allow systemd-ssh-issue read kernel sysctls

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1154,6 +1154,7 @@ manage_files_pattern(systemd_ssh_issue_t, systemd_ssh_issue_var_run_t, systemd_s
 files_pid_filetrans(systemd_ssh_issue_t, systemd_ssh_issue_var_run_t, dir)
 
 kernel_dgram_send(systemd_ssh_issue_t)
+kernel_read_sysctl(systemd_ssh_issue_t)
 
 dev_read_sysfs(systemd_ssh_issue_t)
 dev_read_vsock(systemd_ssh_issue_t);


### PR DESCRIPTION
This permission request appears only on the s390x architecture.

The commit addresses the following AVC denial:
Nov 18 10:06:59 s390x-kvm-123.lab.eng.rdu2.redhat.com audit[815]: AVC avc:  denied  { read } for  pid=815 comm="systemd-ssh-iss" name="sysinfo" dev="proc" ino=4026531943 scontext=system_u:system_r:systemd_ssh_issue_t:s0 tcontext=system_u:object_r:sysctl_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2415644