### PR TITLE
RFC: Introduce domain_no_new_privs boolean (bsc#1253047)

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -14,6 +14,14 @@ gen_tunable(domain_fd_use, true)
 
 ## <desc>
 ## <p>
+## Allow all domains to set NoNewPrivs
+## </p>
+## </desc>
+#
+gen_tunable(domain_no_new_privs, false)
+
+## <desc>
+## <p>
 ## Allow all domains to execute in fips_mode
 ## </p>
 ## </desc>
@@ -207,6 +215,10 @@ tunable_policy(`domain_can_mmap_files',`
     allow domain file_type:chr_file map;
     allow domain file_type:blk_file map;
     allow domain file_type:lnk_file map;
+')
+
+tunable_policy(`domain_no_new_privs',`
+    allow domain self:process2 nnp_transition;
 ')
 
 ifdef(`hide_broken_symptoms',`


### PR DESCRIPTION
Allows all domains to do nnp_transition when executing another process.

This is needed for tools that disallow setuid/setgid binaries e.g. https://github.com/thkukuk/account-utils and use NoNewPrivs to accomplish that

default: off

see also: https://www.thkukuk.de/blog/no_new_privs/

--------

RFC 
- main question: is there a reason why NoNewPrivs gets added to systemd daemons manually every time? 
- further explanation: with the account-utils tool all processes that are spawned by some systemd service will also need to be allowed nnp_transition therefor it might be needed to be allowed for all domains (even those which are not having the daemon attribute)

please let me know if there are concerns, thanks :)


