### PR TITLE
Allow tlp get the attributes of the pidfs filesystem

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -64,6 +64,8 @@ files_read_kernel_modules(tlp_t)
 files_map_kernel_modules(tlp_t)
 files_load_kernel_modules(tlp_t)
 
+fs_getattr_pidfs(tlp_t)
+
 init_status(tlp_t)
 init_stream_connectto(tlp_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1760526474.843:188): avc:  denied  { getattr } for  pid=5843 comm="systemctl" name="/" dev="pidfs" ino=1 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:object_r:pidfs_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2404140