### PR TITLE
Update ktls policy

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -11,6 +11,7 @@ init_daemon_domain(ktlshd_t, ktlshd_exec_t)
 
 permissive ktlshd_t;
 
+allow ktlshd_t self:capability net_admin;
 allow ktlshd_t self:key write;
 allow ktlshd_t self:netlink_generic_socket create_socket_perms;
 allow ktlshd_t self:netlink_route_socket r_netlink_socket_perms;
@@ -18,7 +19,9 @@ allow ktlshd_t self:udp_socket create_socket_perms;
 allow ktlshd_t self:unix_dgram_socket create_socket_perms;
 
 kernel_read_net_sysctls(ktlshd_t)
+kernel_read_network_state_symlinks(ktlshd_t)
 kernel_read_proc_files(ktlshd_t)
+kernel_rw_key(ktlshd_t)
 
 domain_read_view_all_domains_keyrings(ktlshd_t)
 
@@ -32,6 +35,7 @@ optional_policy(`
 
 optional_policy(`
 	miscfiles_read_generic_certs(ktlshd_t)
+	miscfiles_map_generic_certs(ktlshd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
tlshd's primary function is to perform TLS handshakes on sockets on behalf of the kernel. In order to do that, it needs CAP_NET_ADMIN.

Part of the handshake process involves verifying the peer's TLS certificates. In order to do that, tlshd needs to be able to mmap certificates in the system trust store.

tlshd sometimes stores certificates and private keys in kernel keyrings, so it needs to be able to read and write keys.

Authored-by: Scott Mayhew <smayhew@redhat.com>
Resolves: RHEL-127023