### PR TITLE
Allow systemd-machined read svirt process state

### DIFF
--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -2239,6 +2239,25 @@ interface(`virt_virtqemud_read_state',`
 
 ########################################
 ## <summary>
+##	Read the svirt process state.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_svirt_read_state',`
+	gen_require(`
+		type svirt_t;
+	')
+
+	kernel_search_proc($1)
+	ps_process_pattern($1, svirt_t)
+')
+
+########################################
+## <summary>
 ##	Execute virsh in the caller domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -631,6 +631,7 @@ optional_policy(`
 	virt_rw_svirt_dev(systemd_machined_t)
 	virt_getattr_sandbox_filesystem(systemd_machined_t)
 	virt_read_sandbox_files(systemd_machined_t)
+	virt_svirt_read_state(systemd_machined_t)
 ')
 
 #######################################


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=AVC msg=audit(1761761320.303:568): avc:  denied  { search } for  pid=1490 comm="systemd-machine" name="19272" dev="proc" ino=31558 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:system_r:svirt_t:s0:c825,c980 tclass=dir permissive=0 type=AVC msg=audit(1761787546.949:757): avc:  denied  { open } for  pid=1075 comm="systemd-machine" path="/proc/32908/stat" dev="proc" ino=169265 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:system_r:svirt_t:s0:c274,c314 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2407206