### PR TITLE
Allow sshd-net read and write to sshd vsock socket

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -90,6 +90,7 @@ allow sshd_session_t self:netlink_audit_socket { create nlmsg_relay };
 allow sshd_session_t self:netlink_route_socket { bind create getattr nlmsg_read };
 allow sshd_session_t self:udp_socket { connect create getattr };
 
+allow sshd_net_t sshd_t:vsock_socket { read write };
 allow sshd_net_t sshd_session_t:fifo_file write;
 allow sshd_net_t sshd_session_t:unix_stream_socket { read write };
 allow sshd_session_t sshd_t:tcp_socket { getattr getopt read setopt write };


### PR DESCRIPTION
The commit addresses the following AVC denial:
Nov 23 06:17:29 fed43 audit[1604]: AVC avc:  denied  { write } for  pid=1604 comm="sshd-auth" path="socket:[13592]" dev="sockfs" ino=13592 scontext=system_u:system_r:sshd_net_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=vsock_socket permissive=1 Nov 23 06:17:29 fed43 audit[1604]: AVC avc:  denied  { read } for  pid=1604 comm="sshd-auth" path="socket:[13592]" dev="sockfs" ino=13592 scontext=system_u:system_r:sshd_net_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=vsock_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2399770