### PR TITLE
Allow login_userdomain read lastlog

### DIFF
--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -383,8 +383,6 @@ tunable_policy(`deny_bluetooth',`',`
 kernel_watch_unlabeled_dirs(login_userdomain)
 kernel_read_psi(login_userdomain)
 
-auth_watch_passwd(login_userdomain)
-
 corecmd_watch_bin_dirs(login_userdomain)
 
 dev_watch_generic_dirs(login_userdomain)
@@ -421,6 +419,11 @@ miscfiles_watch_localization_symlinks(login_userdomain)
 mount_watch_pid_dirs(login_userdomain)
 mount_watch_pid_files(login_userdomain)
 mount_watch_reads_pid_files(login_userdomain)
+
+optional_policy(`
+	auth_read_lastlog(login_userdomain)
+	auth_watch_passwd(login_userdomain)
+')
 
 optional_policy(`
 	init_mmap_read_var_lib_files(login_userdomain)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/01/2025 14:10:33.651:418) : proctitle=lastlog type=PATH msg=audit(08/01/2025 14:10:33.651:418) : item=0 name=/var/log/lastlog inode=33858567 dev=fd:00 mode=file,664 ouid=root ogid=utmp rdev=00:00 obj=system_u:object_r:lastlog_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/01/2025 14:10:33.651:418) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x5608767fa835 a2=O_RDONLY a3=0x0 items=1 ppid=2085 pid=2238 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=(none) ses=11 comm=lastlog exe=/usr/bin/lastlog subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(08/01/2025 14:10:33.651:418) : avc: denied { read } for pid=2238 comm=lastlog name=lastlog dev="dm-0" ino=33858567 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:lastlog_t:s0 tclass=file permissive=0

Resolves: RHEL-119686