### PR TITLE
Allow system_mail_t read apache system content conditionally

### DIFF
--- a/policy/modules/contrib/mta.te
+++ b/policy/modules/contrib/mta.te
@@ -225,6 +225,7 @@ application_dontaudit_signull(system_mail_t)
 
 optional_policy(`
 	tunable_policy(`httpd_can_sendmail',`
+		apache_read_sys_content(system_mail_t)
 		apache_read_inherited_sys_content_rw_files(system_mail_t)
 	')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/16/2025 04:18:07.589:870) : proctitle=/usr/sbin/sendmail -t -i type=PATH msg=audit(09/16/2025 04:18:07.589:870) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=8604593 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(09/16/2025 04:18:07.589:870) : item=0 name=/usr/sbin/sendmail inode=13047979 dev=fc:02 mode=file,sgid,755 ouid=root ogid=smmsp rdev=00:00 obj=system_u:object_r:sendmail_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(09/16/2025 04:18:07.589:870) : argc=3 a0=/usr/sbin/sendmail a1=-t a2=-i type=SYSCALL msg=audit(09/16/2025 04:18:07.589:870) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55ac475b93e0 a1=0x55ac475b9760 a2=0x55ac475b9420 a3=0x8 items=2 ppid=31529 pid=31851 auid=unset uid=apache gid=apache euid=apache suid=apache fsuid=apache egid=smmsp sgid=smmsp fsgid=smmsp tty=(none) ses=unset comm=sendmail exe=/usr/sbin/sendmail.sendmail subj=system_u:system_r:system_mail_t:s0 key=(null) type=AVC msg=audit(09/16/2025 04:18:07.589:870) : avc:  denied  { read } for  pid=31851 comm=sendmail path=/var/www/html/sendemail.php dev="vda2" ino=10722686 scontext=system_u:system_r:system_mail_t:s0 tcontext=unconfined_u:object_r:httpd_sys_content_t:s0 tclass=file permissive=0

Resolves: RHEL-114970