### PR TITLE
Allow mdadm search filesystem_type directories

### DIFF
--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -115,6 +115,7 @@ fs_dontaudit_list_tmpfs(mdadm_t)
 fs_manage_cgroup_files(mdadm_t)
 fs_read_efivarfs_files(mdadm_t)
 fs_read_tmpfs_files(mdadm_t)
+fs_search_all(mdadm_t)
 
 mls_file_read_all_levels(mdadm_t)
 mls_file_write_all_levels(mdadm_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1764133209.590:19110): avc:  denied  { search } for  pid=1898232 comm="mdadm" name="/" dev="binder" ino=1 scontext=system_u:system_r:mdadm_t:s0 tcontext=system_u:object_r:binderfs_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2417293