### PR TITLE
Allow switcheroo-control the sys_admin capability

### DIFF
--- a/policy/modules/contrib/switcheroo.te
+++ b/policy/modules/contrib/switcheroo.te
@@ -15,6 +15,7 @@ permissive switcheroo_control_t;
 # Policy for switcheroo_control_t
 #
 
+allow switcheroo_control_t self:capability sys_admin;
 allow switcheroo_control_t self:capability2 bpf;
 allow switcheroo_control_t self:netlink_kobject_uevent_socket create_socket_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/26/2025 22:03:18.651:8979) : proctitle=/usr/libexec/switcheroo-control type=SYSCALL msg=audit(11/26/2025 22:03:18.651:8979) : arch=aarch64 syscall=setsockopt success=yes exit=0 a0=0x3 a1=SOL_SOCKET a2=SO_ATTACH_FILTER a3=0xfffff35b7788 items=0 ppid=1 pid=556061 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=switcheroo-cont exe=/usr/libexec/switcheroo-control subj=system_u:system_r:switcheroo_control_t:s0 key=(null) type=AVC msg=audit(11/26/2025 22:03:18.651:8979) : avc:  denied  { sys_admin } for  pid=556061 comm=switcheroo-cont capability=sys_admin  scontext=system_u:system_r:switcheroo_control_t:s0 tcontext=system_u:system_r:switcheroo_control_t:s0 tclass=capability permissive=0