### PR TITLE
Allow stap server read virtual memory sysctls

### DIFF
--- a/policy/modules/contrib/stapserver.te
+++ b/policy/modules/contrib/stapserver.te
@@ -66,6 +66,7 @@ fs_tmpfs_filetrans(stapserver_t, stapserver_tmpfs_t, { file dir })
 
 kernel_read_system_state(stapserver_t)
 kernel_read_kernel_sysctls(stapserver_t)
+kernel_read_vm_sysctls(stapserver_t)
 kernel_read_fs_sysctls(stapserver_t)
 files_list_kernel_modules(stapserver_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/11/2025 02:21:50.972:311) : proctitle=/usr/bin/stap -r5.14.0-611.el9.x86_64 -a x86_64 --tmpdir=/tmp/stap-server.mplsCp/response/stap000000 --client-options -v -eprobe type=PATH msg=audit(09/11/2025 02:21:50.972:311) : item=0 name=/proc/sys/vm/nr_hugepages inode=36353 dev=00:14 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysctl_vm_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/11/2025 02:21:50.972:311) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f7781d63348 a2=O_RDONLY a3=0x0 items=1 ppid=9564 pid=9859 auid=unset uid=stap-server gid=stap-server euid=stap-server suid=stap-server fsuid=stap-server egid=stap-server sgid=stap-server fsgid=stap-server tty=(none) ses=unset comm=stap exe=/usr/bin/stap subj=system_u:system_r:stapserver_t:s0 key=(null) type=AVC msg=audit(09/11/2025 02:21:50.972:311) : avc:  denied  { read } for  pid=9859 comm=stap name=nr_hugepages dev="proc" ino=36353 scontext=system_u:system_r:stapserver_t:s0 tcontext=system_u:object_r:sysctl_vm_t:s0 tclass=file permissive=0

Resolves: RHEL-114157