### PR TITLE
Allow KDE Plasma Login Manager to function as a display manager

### DIFF
--- a/policy/modules/kernel/corecommands.fc
+++ b/policy/modules/kernel/corecommands.fc
@@ -61,6 +61,11 @@ ifdef(`distro_redhat',`
 /etc/lxdm/Pre.*			--	gen_context(system_u:object_r:bin_t,s0)
 /etc/lxdm/Xsession		--	gen_context(system_u:object_r:bin_t,s0)
 
+/etc/plasmalogin/Xsession		--	gen_context(system_u:object_r:bin_t,s0)
+/etc/plasmalogin/wayland-session		--	gen_context(system_u:object_r:bin_t,s0)
+/etc/plasmalogin/Xsetup		--	gen_context(system_u:object_r:bin_t,s0)
+/etc/plasmalogin/Xstop		--	gen_context(system_u:object_r:bin_t,s0)
+
 /etc/sddm/Xsession		--	gen_context(system_u:object_r:bin_t,s0)
 /etc/sddm/wayland-session		--	gen_context(system_u:object_r:bin_t,s0)
 /etc/sddm/Xsetup		--	gen_context(system_u:object_r:bin_t,s0)

--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -102,6 +102,12 @@ HOME_DIR/\.dmrc.*	--	gen_context(system_u:object_r:xdm_home_t,s0)
 /usr/bin/nodm	--	gen_context(system_u:object_r:xdm_exec_t,s0)
 /usr/bin/[mxgkw]dm	--	gen_context(system_u:object_r:xdm_exec_t,s0)
 
+/usr/bin/plasmalogin			--	gen_context(system_u:object_r:xdm_exec_t,s0)
+/usr/bin/plasma-login-wallpaper		--	gen_context(system_u:object_r:xdm_exec_t,s0)
+/usr/bin/startplasma-login-wayland	--	gen_context(system_u:object_r:xdm_exec_t,s0)
+/usr/libexec/plasma-login-greeter	--	gen_context(system_u:object_r:xdm_exec_t,s0)
+/usr/libexec/plasmalogin-helper.*	--	gen_context(system_u:object_r:xdm_exec_t,s0)
+
 /usr/bin/sddm         	--	gen_context(system_u:object_r:xdm_exec_t,s0)
 /usr/bin/sddm-greeter  	--	gen_context(system_u:object_r:xdm_exec_t,s0)
 /usr/bin/gpe-dm		--	gen_context(system_u:object_r:xdm_exec_t,s0)
@@ -151,6 +157,7 @@ ifndef(`distro_debian',`
 
 /var/lib/cosmic-greeter(/.*)?	gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/gdm(3)?(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
+/var/lib/plasmalogin(/.*)?	gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/sddm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/lxdm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
 /var/lib/lightdm(/.*)?		gen_context(system_u:object_r:xdm_var_lib_t,s0)
@@ -186,6 +193,7 @@ ifndef(`distro_debian',`
 /run/slim.*			gen_context(system_u:object_r:xdm_var_run_t,s0)
 /run/xauth(/.*)?		gen_context(system_u:object_r:xdm_var_run_t,s0)
 /run/xdmctl(/.*)?		gen_context(system_u:object_r:xdm_var_run_t,s0)
+/run/plasmalogin(/.*)?	gen_context(system_u:object_r:xdm_var_run_t,s0)
 /run/sddm(/.*)?		gen_context(system_u:object_r:xdm_var_run_t,s0)
 
 /run/video.rom	--	gen_context(system_u:object_r:xserver_var_run_t,s0)


### PR DESCRIPTION
Plasma Login Manager is the new display manager from the KDE community for KDE Plasma. It is forked from SDDM and largely behaves the same way.