### PR TITLE
Allow setroubleshoot_fixit to write Python cache in /usr/share

### DIFF
--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -235,6 +235,8 @@ seutil_domtrans_setsebool(setroubleshoot_fixit_t)
 seutil_read_module_store(setroubleshoot_fixit_t)
 
 files_list_tmp(setroubleshoot_fixit_t)
+files_manage_usr_files(setroubleshoot_fixit_t)
+files_rw_usr_dirs(setroubleshoot_fixit_t)
 
 auth_use_nsswitch(setroubleshoot_fixit_t)
 


### PR DESCRIPTION
The setroubleshoot fixit domain was denied the ability to create and write Python bytecode cache files (e.g., cpython-313.pyc) in the /usr/share directory, which is labeled usr_t.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2298271