### PR TITLE
Allow sssd get the attributes of the pidfs filesystem

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -371,6 +371,7 @@ files_dontaudit_search_var(session_bus_type)
 files_watch_usr_dirs(session_bus_type)
 files_watch_var_lib_dirs(session_bus_type)
 
+fs_getattr_pidfs(session_bus_type)
 fs_getattr_romfs(session_bus_type)
 fs_getattr_xattr_fs(session_bus_type)
 fs_dontaudit_list_nfs(session_bus_type)

--- a/policy/modules/contrib/pcscd.te
+++ b/policy/modules/contrib/pcscd.te
@@ -61,6 +61,8 @@ dev_read_sysfs(pcscd_t)
 
 files_read_etc_runtime_files(pcscd_t)
 
+fs_getattr_pidfs(pcscd_t)
+
 term_use_unallocated_ttys(pcscd_t)
 term_dontaudit_getattr_pty_dirs(pcscd_t)
 

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -132,6 +132,7 @@ files_watch_lib_dirs(sssd_t)
 
 fs_getattr_cgroup(sssd_t)
 fs_search_cgroup_dirs(sssd_t)
+fs_getattr_pidfs(sssd_t)
 fs_getattr_tmpfs(sssd_t)
 fs_getattr_xattr_fs(sssd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/01/2025 22:51:08.802:4919) : proctitle=/usr/libexec/sssd/sssd_kcm --logger=files type=SYSCALL msg=audit(12/01/2025 22:51:08.802:4919) : arch=x86_64 syscall=fstatfs success=no exit=EACCES(Permission denied) a0=0xe a1=0x7ffd4cbc8050 a2=0x50494446 a3=0x0 items=0 ppid=1 pid=196257 auid=unset uid=sssd gid=sssd euid=sssd suid=sssd fsuid=sssd egid=sssd sgid=sssd fsgid=sssd tty=(none) ses=unset comm=sssd_kcm exe=/usr/libexec/sssd/sssd_kcm subj=system_u:system_r:sssd_t:s0 key=(null) type=AVC msg=audit(12/01/2025 22:51:08.802:4919) : avc:  denied  { getattr } for  pid=196257 comm=sssd_kcm name=/ dev="pidfs" ino=1 scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:object_r:pidfs_t:s0 tclass=filesystem permissive=0