### PR TITLE
Allow kdump search and read EFI System Partition (vfat/dosfs)

### DIFF
--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -157,6 +157,7 @@ manage_lnk_files_pattern(kdumpctl_t, kdump_crash_t, kdump_crash_t)
 files_var_filetrans(kdumpctl_t, kdump_crash_t, dir, "crash")
 
 read_files_pattern(kdumpctl_t, kdump_etc_t, kdump_etc_t)
+fs_read_dos_files(kdump_t)
 
 kernel_read_system_state(kdumpctl_t)
 kernel_stream_connect(kdumpctl_t)


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHEL-116041

The commit addresses the following AVC denials:

type=AVC msg=audit(1764732322.800:356): avc:  denied  { search } for  pid=7942 comm="kexec" name="/" dev="sda1" ino=1 scontext=system_u:system_r:kdump_t:s0 tcontext=system_u:object_r:dosfs_t:s0 tclass=dir permissive=0
type=SYSCALL msg=audit(1764732322.800:356): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=7fff37b04eb6 a2=0 a3=0 items=0 ppid=7505 pid=7942 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="kexec" exe="/usr/sbin/kexec" subj=system_u:system_r:kdump_t:s0 key=(null)ARCH=x86_64 SYSCALL=openat AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"

type=AVC msg=audit(1764732890.807:2659): avc:  denied  { read } for  pid=9693 comm="kexec" name="ffffffffffffffffffffffffffffffff-6.12.0-165.el10.x86_64.efi" dev="sda1" ino=11 scontext=system_u:system_r:kdump_t:s0 tcontext=system_u:object_r:dosfs_t:s0 tclass=file permissive=0
type=SYSCALL msg=audit(1764732890.807:2659): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=7ffc896deeb6 a2=0 a3=0 items=0 ppid=9256 pid=9693 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="kexec" exe="/usr/sbin/kexec" subj=system_u:system_r:kdump_t:s0 key=(null)ARCH=x86_64 SYSCALL=openat AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"

Follow-up: 2f424aa098ccf2f811a6bcfdb0f3867a5e5346ef