### PR TITLE
Allow sshd-auth read network sysctls

### DIFF
--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -422,6 +422,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ssh_session_rw_pipes(passwd_t)
+')
+
+optional_policy(`
 	sssd_domtrans(passwd_t)
     sssd_manage_lib_files(passwd_t)
     sssd_manage_public_files(passwd_t)

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -1299,6 +1299,24 @@ interface(`ssh_session_rw_stream_sockets',`
 	allow $1 sshd_session_t:unix_stream_socket rw_stream_socket_perms;
 ')
 
+########################################
+## <summary>
+##	Read and write a sshd-session unnamed pipe.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ssh_session_rw_pipes',`
+	gen_require(`
+		type sshd_session_t;
+	')
+
+	allow $1 sshd_session_t:fifo_file rw_inherited_fifo_file_perms;
+')
+
 #####################################
 ## <summary>
 ##	Allow sshd-session dyntransition to a specified domain.

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -171,6 +171,7 @@ allow sshd_auth_t sshd_t:tcp_socket { getattr read write getopt setopt };
 allow sshd_auth_t sshd_session_t:unix_stream_socket { read write };
 
 kernel_read_proc_files(sshd_auth_t)
+kernel_read_net_sysctls(sshd_auth_t)
 
 optional_policy(`
 	auth_use_nsswitch(sshd_auth_t)

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -164,6 +164,7 @@ domain_dyntrans_type(sshd_auth_t)
 ssh_auth_dyntransition_to(sshd_net_t)
 domtrans_pattern(sshd_session_t, sshd_auth_exec_t, sshd_auth_t)
 
+allow sshd_auth_t self:capability { setgid setuid sys_chroot };
 allow sshd_auth_t self:process { setcurrent setrlimit };
 allow sshd_auth_t self:unix_dgram_socket { create ioctl };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1764365929.570:676): avc:  denied  { getattr } for  pid=82559 comm="sshd-session" path="/proc/sys/net/ipv6/conf/all/disable_ipv6" dev="proc" ino=15563 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2417769