### PR TITLE
fix: unbreak thumbnailing for Thunar/tumblerd

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -99,6 +99,7 @@ files_map_non_security_files(thumb_t)
 files_mounton_rootfs(thumb_t)
 files_watch_etc_dirs(thumb_t)
 files_watch_usr_dirs(thumb_t)
+files_mounton_generic_tmp_dirs(thumb_t)
 
 fs_getattr_all_fs(thumb_t)
 fs_read_dos_files(thumb_t)
@@ -108,6 +109,7 @@ fs_mmap_removable_files(thumb_t)
 fs_dontaudit_getattr_nsfs_files(thumb_t)
 fs_mounton_tmpfs(thumb_t)
 fs_all_mount_fs_perms_xattr_fs(thumb_t)
+fs_all_mount_fs_perms_tmpfs(thumb_t)
 
 auth_read_passwd(thumb_t)
 
@@ -134,6 +136,7 @@ sysnet_read_config(thumb_t)
 
 
 term_dontaudit_use_unallocated_ttys(thumb_t)
+term_mount_pty_fs(thumb_t)
 
 userdom_dontaudit_setattr_user_tmp(thumb_t)
 userdom_read_user_tmp_files(thumb_t)


### PR DESCRIPTION
Thumbnailing on Thunar is currently broken on a fresh, up-to-date Fedora Sway 43 VM: https://bugzilla.redhat.com/show_bug.cgi?id=2418633