### PR TITLE
Set correct labels for files in bwrap sandbox (bsc#1253682) 

### DIFF
--- a/policy/modules/contrib/gnome.fc
+++ b/policy/modules/contrib/gnome.fc
@@ -1,5 +1,6 @@
 HOME_DIR/\.cache(/.*)?	gen_context(system_u:object_r:cache_home_t,s0)
 HOME_DIR/\.cache/dconf(/.*)?	gen_context(system_u:object_r:config_home_t,s0)
+HOME_DIR/\.cache/gnome-desktop-thumbnailer/gstreamer-.*(/.*)?	gen_context(system_u:object_r:gstreamer_home_t,s0)
 HOME_DIR/\.color/icc(/.*)?	gen_context(system_u:object_r:icc_data_home_t,s0)
 HOME_DIR/\.dbus(/.*)?	gen_context(system_u:object_r:dbus_home_t,s0)
 HOME_DIR/\.config(/.*)?	gen_context(system_u:object_r:config_home_t,s0)

--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -2,6 +2,7 @@
 # HOME_DIR
 #
 HOME_DIR/\.cache/fontconfig(/.*)?		gen_context(system_u:object_r:user_fonts_cache_t,s0)
+HOME_DIR/\.cache/glycin/usr/libexec/glycin-loaders/.+/glycin-svg/fontconfig(/.*)?	gen_context(system_u:object_r:user_fonts_cache_t,s0)
 HOME_DIR/\.config/fontconfig(/.*)?		gen_context(system_u:object_r:user_fonts_config_t,s0)
 HOME_DIR/\.fonts\.conf	--	gen_context(system_u:object_r:user_fonts_config_t,s0)
 HOME_DIR/\.fonts\.d(/.*)?	gen_context(system_u:object_r:user_fonts_config_t,s0)


### PR DESCRIPTION
Fixes:
```
Would relabel /home/<user>/.cache/gnome-desktop-thumbnailer/gstreamer-1.0 from unconfined_u:object_r:gstreamer_home_t:s0 to unconfined_u:object_r:cache_home_t:s0
Would relabel /home/<user>/.cache/glycin/usr/libexec/glycin-loaders/2+/glycin-svg/fontconfig from unconfined_u:object_r:user_fonts_cache_t:s0 to unconfined_u:object_r:cache_home_t:s0
```