### PR TITLE
Allow systemd-homework to remove ~/.identity-blob

### DIFF
--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -189,6 +189,7 @@ files_create_home_dir(systemd_homework_t)
 files_delete_home_dir(systemd_homework_t)
 files_search_home(systemd_homework_t)
 files_home_filetrans(systemd_homework_t, systemd_homed_crypto_luks_t, file)
+delete_files_pattern(systemd_homework_t, systemd_homed_record_t, systemd_homed_record_t)
 
 # unlabeled home directories
 files_manage_isid_type_dirs(systemd_homework_t)


### PR DESCRIPTION
This PR addresses the following AVC denial:
`type=AVC msg=audit(1763025211.718:1480): avc:  denied  { rmdir } for  pid=13456 comm="systemd-homewor" name=".identity-blob" dev="dm-1" ino=266 scontext=system_u:system_r:systemd_homework_t:s0 tcontext=unconfined_u:object_r:systemd_homed_record_t:s0 tclass=dir permissive=0`


I have this policy change laying around for some time, but I sadly didn't find the time to set up a rawhide VM for testing yet. However, this should fix the AVC denial I experienced.