### PR TITLE
Allow sshd-auth get attributes of sshd vsock socket

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -169,6 +169,8 @@ allow sshd_auth_t self:process { setcurrent setrlimit };
 allow sshd_auth_t self:unix_dgram_socket { create ioctl };
 
 allow sshd_auth_t sshd_t:tcp_socket { getattr read write getopt setopt };
+allow sshd_auth_t sshd_t:vsock_socket getattr;
+
 allow sshd_auth_t sshd_session_t:unix_stream_socket { read write };
 
 kernel_read_proc_files(sshd_auth_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1765241721.016:79): avc:  denied  { getattr } for  pid=944 comm="sshd-auth" scontext=system_u:system_r:sshd_auth_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=vsock_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2406423