### PR TITLE
Allow tuned_t use its private tmpfs files

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -28,6 +28,9 @@ logging_log_file(tuned_log_t)
 type tuned_tmp_t;
 files_tmp_file(tuned_tmp_t)
 
+type tuned_tmpfs_t;
+files_tmpfs_file(tuned_tmpfs_t)
+
 type tuned_var_run_t;
 files_pid_file(tuned_var_run_t)
 
@@ -63,6 +66,10 @@ manage_dirs_pattern(tuned_t, tuned_tmp_t, tuned_tmp_t)
 manage_files_pattern(tuned_t, tuned_tmp_t, tuned_tmp_t)
 files_tmp_filetrans(tuned_t, tuned_tmp_t, { file dir })
 can_exec(tuned_t, tuned_tmp_t)
+
+manage_files_pattern(tuned_t, tuned_tmpfs_t, tuned_tmpfs_t)
+fs_tmpfs_filetrans(tuned_t, tuned_tmpfs_t, file)
+allow tuned_t tuned_tmpfs_t:file map;
 
 manage_files_pattern(tuned_t, tuned_var_run_t, tuned_var_run_t)
 manage_dirs_pattern(tuned_t, tuned_var_run_t, tuned_var_run_t)


### PR DESCRIPTION
strace snippet of "tuned-adm list":
72557 memfd_create("libffi", MFD_CLOEXEC) = 5</memfd:libffi>(deleted) 72557 write(5</memfd:libffi>(deleted), "\x00\x00\x00\x00\x0... 72557 mmap(NULL, 4096, PROT_READ|PROT_EXEC, MAP_SHARED, 5</memfd:libffi>(deleted), 0) = 0x7f2c12455000