### PR TITLE
Allow iptables read firewalld process state

### DIFF
--- a/policy/modules/contrib/firewalld.if
+++ b/policy/modules/contrib/firewalld.if
@@ -122,6 +122,26 @@ interface(`firewalld_read_pid_files',`
 
 ########################################
 ## <summary>
+##	Read firewalld process state files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`firewalld_read_state',`
+	gen_require(`
+		type firewalld_t;
+	')
+
+	allow $1 firewalld_t:dir { search_dir_perms read };
+	allow $1 firewalld_t:file read_file_perms;
+	allow $1 firewalld_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Dontaudit read and write leaked firewalld file descriptors 
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -145,6 +145,7 @@ optional_policy(`
 
 optional_policy(`
 	firewalld_read_config(iptables_t)
+	firewalld_read_state(iptables_t)
 	firewalld_read_pid_files(iptables_t)
 	firewalld_dontaudit_write_tmp_files(iptables_t)
 	firewalld_dontaudit_leaks(iptables_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10.12.2025 09:21:21.749:6362) : proctitle=/usr/bin/nft list ruleset type=PATH msg=audit(10.12.2025 09:21:21.749:6362) : item=0 name=/proc/908938/fd/ inode=9543722 dev=00:18 mode=dir,500 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:firewalld_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(10.12.2025 09:21:21.749:6362) : arch=x86_64 syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x7ffeb3abcef0 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=1286515 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=nft exe=/usr/bin/nft subj=system_u:system_r:iptables_t:s0 key=(null) type=AVC msg=audit(10.12.2025 09:21:21.749:6362) : avc:  denied  { read open } for  pid=1286515 comm=nft path=/proc/908938/fd dev="proc" ino=9543722 scontext=system_u:system_r:iptables_t:s0 tcontext=system_u:system_r:firewalld_t:s0 tclass=dir permissive=1 type=AVC msg=audit(10.12.2025 09:21:21.749:6362) : avc:  denied  { search } for  pid=1286515 comm=nft name=908938 dev="proc" ino=9543721 scontext=system_u:system_r:iptables_t:s0 tcontext=system_u:system_r:firewalld_t:s0 tclass=dir permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2374075