### PR TITLE
systemd: allow getattrs on fixed devices

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -674,6 +674,9 @@ kernel_rw_net_sysctls(systemd_networkd_t)
 kernel_read_xen_state(systemd_networkd_t)
 kernel_read_network_state(systemd_networkd_t)
 kernel_rw_psi(systemd_networkd_t)
+# Likely from https://github.com/systemd/systemd/blob/f8293452b65551c75534a35af8e6202a45837299/src/network/networkd-manager.c#L173
+# Another option is storage_dontaudit_getattr_fixed_disk_dev(systemd_networkd_t)
+storage_getattr_fixed_disk_dev(systemd_networkd_t)
 
 corenet_rw_tun_tap_dev(systemd_networkd_t)
 corenet_tcp_bind_all_nodes(systemd_networkd_t)


### PR DESCRIPTION
systemd-networkd is trying to monitor hot-plug of network devices, which seems to getattr on the block devices.

I don't know if there are better ways around this:
- make networkd not getattr on fixed disks
- use dont audit rule
- or if some other macro should have covered this but didn't