### PR TITLE
Question/RFC: pid 1 with no_new_privs implementation

### DIFF
--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -101,6 +101,9 @@ interface(`cron_role',`
 
     tunable_policy(`cron_userdomain_transition',`
         allow crond_t $2_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+	        allow crond_t $2_t:process2 nnp_transition;
+	')
         allow crond_t $2_t:fd use;
         allow crond_t $2_t:key manage_key_perms;
 
@@ -113,6 +116,9 @@ interface(`cron_role',`
         ps_process_pattern($2_t, cronjob_t)
     ',`
         dontaudit crond_t $2_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+	        dontaudit crond_t $2_t:process2 nnp_transition;
+	')
         dontaudit crond_t $2_t:fd use;
         dontaudit crond_t $2_t:key manage_key_perms;
 
@@ -191,6 +197,9 @@ interface(`cron_unconfined_role',`
 
     tunable_policy(`cron_userdomain_transition',`
         allow crond_t $2_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+	        allow crond_t $2_t:process2 nnp_transition;
+	')
         allow crond_t $2_t:fd use;
         allow crond_t $2_t:key manage_key_perms;
 
@@ -199,6 +208,9 @@ interface(`cron_unconfined_role',`
         allow $2_t crond_t:fifo_file rw_fifo_file_perms;
     ',`
         dontaudit crond_t $2_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+	        dontaudit crond_t $2_t:process2 nnp_transition;
+	')
         dontaudit crond_t $2_t:fd use;
         dontaudit crond_t $2_t:key manage_key_perms;
 
@@ -282,6 +294,9 @@ interface(`cron_admin_role',`
 
     tunable_policy(`cron_userdomain_transition',`
         allow crond_t $2_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+	        allow crond_t $2_t:process2 nnp_transition;
+	')
         allow crond_t $2_t:fd use;
         allow crond_t $2_t:key manage_key_perms;
 
@@ -293,6 +308,9 @@ interface(`cron_admin_role',`
         ps_process_pattern($2_t, cronjob_t)
     ',`
         dontaudit crond_t $2_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+	        dontaudit crond_t $2_t:process2 nnp_transition;
+	')
         dontaudit crond_t $2_t:fd use;
         dontaudit crond_t $2_t:key manage_key_perms;
 

--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -432,6 +432,9 @@ tunable_policy(`cron_system_cronjob_use_shares',`
 # via setexeccon.  There is no way to set up an automatic
 # transition, since crontabs are configuration files, not executables.
 allow crond_t system_cronjob_t:process transition;
+ifdef(`init_server_no_new_privs',`
+	allow crond_t system_cronjob_t:process2 nnp_transition;
+')
 dontaudit crond_t system_cronjob_t:process { noatsecure siginh rlimitinh };
 allow crond_t system_cronjob_t:fd use;
 allow system_cronjob_t crond_t:fd use;
@@ -730,6 +733,9 @@ allow cronjob_t user_cron_spool_t:file entrypoint;
 # via setexeccon.  There is no way to set up an automatic
 # transition, since crontabs are configuration files, not executables.
 allow crond_t cronjob_t:process transition;
+ifdef(`init_server_no_new_privs',`
+	allow crond_t cronjob_t:process2 nnp_transition;
+')
 dontaudit crond_t cronjob_t:process { noatsecure siginh rlimitinh };
 allow crond_t cronjob_t:fd use;
 allow cronjob_t crond_t:fd use;
@@ -900,10 +906,16 @@ dontaudit crond_t unconfined_cronjob_t:process { noatsecure siginh rlimitinh };
 
 tunable_policy(`cron_userdomain_transition',`
 	dontaudit crond_t unconfined_cronjob_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+		dontaudit crond_t unconfined_cronjob_t:process2 nnp_transition;
+	')
 	dontaudit crond_t unconfined_cronjob_t:fd use;
 	dontaudit crond_t unconfined_cronjob_t:key manage_key_perms;
 ',`
 	allow crond_t unconfined_cronjob_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+		allow crond_t unconfined_cronjob_t:process2 nnp_transition;
+	')
 	allow crond_t unconfined_cronjob_t:fd use;
 	allow crond_t unconfined_cronjob_t:key manage_key_perms;
 ')

--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -1841,6 +1841,9 @@ interface(`gnome_transition_gkeyringd',`
 	')
 
 	allow $1 gkeyringd_domain:process transition;
+	ifdef(`init_server_no_new_privs',`
+		allow $1 gkeyringd_domain:process2 nnp_transition;
+	')
 	dontaudit $1 gkeyringd_domain:process { noatsecure siginh rlimitinh };
 	allow gkeyringd_domain $1:process { sigchld signull };
 	allow gkeyringd_domain $1:fifo_file rw_inherited_fifo_file_perms;

--- a/policy/modules/contrib/rpm.if
+++ b/policy/modules/contrib/rpm.if
@@ -1001,6 +1001,9 @@ interface(`rpm_transition_script',`
 
 	typeattribute $1 rpm_transition_domain;
 	allow $1 rpm_script_t:process transition;
+	ifdef(`init_server_no_new_privs',`
+		allow $1 rpm_script_t:process2 nnp_transition;
+	')
 	roleattribute $2 rpm_script_roles;
 
 	allow $1 rpm_script_t:fd use;

--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -1331,6 +1331,9 @@ interface(`virt_transition_svirt',`
 	')
 
 	allow $1 virt_domain:process transition;
+	ifdef(`init_server_no_new_privs',`
+		allow $1 virt_domain:process2 nnp_transition;
+	')
 	role $2 types virt_domain;
 	role $2 types svirt_socket_t;
 	optional_policy(`

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2582,6 +2582,10 @@ allow virt_domain svirt_socket_t:unix_stream_socket { connectto create_stream_so
 tunable_policy(`virt_transition_userdomain',`
 	userdom_transition(virtd_t)
 	userdom_transition(virtd_lxc_t)
+	ifdef(`init_server_no_new_privs',`
+		userdom_nnp_transition(virtd_t)
+		userdom_nnp_transition(virtd_lxc_t)
+	')
 ')
 
 ########################################

--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1818,6 +1818,24 @@ interface(`domain_transition_all',`
 
 ########################################
 ## <summary>
+##	Allow caller to nnp_transition to any domain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`domain_nnp_transition_all',`
+	gen_require(`
+		attribute domain;
+	')
+
+	allow $1 domain:process2 nnp_transition;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to access check /proc
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -94,6 +94,9 @@ systemd_config_all_services(unconfined_t)
 unconfined_domain_noaudit(unconfined_t)
 domain_named_filetrans(unconfined_t)
 domain_transition_all(unconfined_t)
+ifdef(`init_server_no_new_privs',`
+	domain_nnp_transition_all(unconfined_t)
+')
 
 usermanage_run_passwd(unconfined_t, unconfined_r)
 

--- a/policy/modules/services/postgresql.te
+++ b/policy/modules/services/postgresql.te
@@ -534,10 +534,16 @@ allow sepgsql_client_type user_sepgsql_blob_t:db_blob { create drop getattr seta
 type_transition sepgsql_client_type sepgsql_database_type:db_blob user_sepgsql_blob_t;
 
 allow sepgsql_client_type sepgsql_ranged_proc_t:process transition;
+ifdef(`init_server_no_new_privs',`
+	allow sepgsql_client_type sepgsql_ranged_proc_t:process2 nnp_transition;
+')
 type_transition sepgsql_client_type sepgsql_ranged_proc_exec_t:process sepgsql_ranged_proc_t;
 allow sepgsql_ranged_proc_t sepgsql_client_type:process dyntransition;
 
 allow sepgsql_client_type sepgsql_trusted_proc_t:process transition;
+ifdef(`init_server_no_new_privs',`
+	allow sepgsql_client_type sepgsql_trusted_proc_t:process2 nnp_transition;
+')
 type_transition sepgsql_client_type sepgsql_trusted_proc_exec_t:process sepgsql_trusted_proc_t;
 
 tunable_policy(`postgresql_selinux_users_ddl',`

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1988,6 +1988,9 @@ role system_r types daemon;
 #')
 
 allow initrc_domain daemon:process transition;
+ifdef(`init_server_no_new_privs',`
+	allow initrc_domain daemon:process2 nnp_transition;
+')
 allow daemon initrc_domain:fd use;
 allow daemon initrc_domain:fifo_file rw_inherited_fifo_file_perms;
 allow daemon initrc_domain:process sigchld;
@@ -1998,6 +2001,9 @@ allow systemprocess initrc_domain:fifo_file rw_inherited_fifo_file_perms;
 allow systemprocess initrc_domain:process sigchld;
 allow initrc_domain systemprocess_entry:file { getattr open read execute map };
 allow initrc_domain systemprocess:process transition;
+ifdef(`init_server_no_new_privs',`
+	allow initrc_domain systemprocess:process2 nnp_transition;
+')
 
 optional_policy(`
 	systemd_getattr_unit_dirs(daemon)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -6778,6 +6778,24 @@ interface(`userdom_transition',`
 
 ########################################
 ## <summary>
+##	Allow caller to nnp_transition to any userdomain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`userdom_nnp_transition',`
+	gen_require(`
+		attribute userdomain;
+	')
+
+	allow $1 userdomain:process2 nnp_transition;
+')
+
+########################################
+## <summary>
 ##	Allow caller to nnp_transition to login userdomain.
 ## </summary>
 ## <param name="domain">

--- a/policy/support/misc_patterns.spt
+++ b/policy/support/misc_patterns.spt
@@ -4,6 +4,9 @@
 define(`domain_transition_pattern',`
 	allow $1 $2:file mmap_exec_file_perms;
 	allow $1 $3:process transition;
+	ifdef(`init_server_no_new_privs',`
+		allow $1 $3:process2 nnp_transition;
+	')
 #	dontaudit $1 $3:process { noatsecure siginh rlimitinh };
 ')
 


### PR DESCRIPTION
Context: There is some push to disable setuid binaries by starting pid 1 (systemd) with no_new_privs, which will lead subsequent processes to also need no_new_privs and so on.  I am not sure if you have something like this on the fedora end as well.

https://www.thkukuk.de/blog/no_new_privs/
https://lore.kernel.org/selinux/CAEjxPJ4eE_gau==Fj6fytyQb=jciQo+x391iDUh4EbJUMfrGKw@mail.gmail.com/T/#t

Question:
So the problem is for me, that I have found no clean and simple way to implement support for this in SELinux.

Ideas that I had and why it did not implement them:
- trace all `process transition`s from `init_t` and its children and add `nnp_transition` to them: would be likely really, really big patch. I am not sure, would you be interested in taking something like that?

The current implementation:
- adding it to all domtrans that use the `domain_transition_pattern` and manually add it to all that don't use the pattern. this is broader, but a smaller patch
- it is hidden behind a compile time flag, because it is not possible to have a `gen_tunable` inside of `domain_transition_pattern` as the pattern can be used inside of other `gen_tunable`, which will generate nested if(), which does not work with the macro processor. I tried to rewrite the `gen_tunable` as well, but then I keep hitting issues with `gen_bool`

I do not like this implementation myself, so my question is, do you by chance have a better idea? And would you want to have this in the fedora policy or should we better just keep this downstream until you have the need?


