### PR TITLE
Drop redundant miscfiles_read_generic_certs(nsswitch_domain)

### DIFF
--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -498,10 +498,6 @@ tunable_policy(`authlogin_nsswitch_use_ldap',`
 	sysnet_read_config(nsswitch_domain)
 ')
 
-tunable_policy(`authlogin_nsswitch_use_ldap',`
-	miscfiles_read_generic_certs(nsswitch_domain)
-')
-
 optional_policy(`
 	tunable_policy(`authlogin_nsswitch_use_ldap',`
 		dirsrv_stream_connect(nsswitch_domain)


### PR DESCRIPTION
This is allowed elsewhere.

```
$ sesearch -A --source syslogd_t --target cert_t --perm read
allow nsswitch_domain cert_t:dir { getattr ioctl lock open read search };
allow nsswitch_domain cert_t:file { getattr ioctl lock map open read };
allow nsswitch_domain cert_t:lnk_file { getattr read };
allow syslogd_t non_security_file_type:dir { getattr ioctl lock open read search }; [ logging_syslogd_list_non_security_dirs ]:True

$ getsebool logging_syslogd_list_non_security_dirs
logging_syslogd_list_non_security_dirs --> off
```