### PR TITLE
Allow named_filetrans_domain filetrans flatpak homedir (bsc#1253682)

### DIFF
--- a/policy/modules/contrib/flatpak.if
+++ b/policy/modules/contrib/flatpak.if
@@ -1,0 +1,23 @@
+## <summary></summary>
+
+#########################################
+## <summary>
+##	Transition to flatpak named content in user home
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`flatpak_named_filetrans_home_content',`
+	interface(`flatpak_named_filetrans_home_content',`
+		gen_require(`
+			type flatpak_home_t;
+		')
+	
+		optional_policy(`
+			gnome_data_filetrans($1, flatpak_home_t, dir, "flatpak")
+		')
+	')
+')

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -353,6 +353,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+    flatpak_named_filetrans_home_content(named_filetrans_domain)
+')
+
+optional_policy(`
     ipa_filetrans_named_content(named_filetrans_domain)
 ')
 


### PR DESCRIPTION
Depends on: https://github.com/flatpak/flatpak/pull/6437

Fixes:
```
Would relabel /home/foo/.local/share/flatpak/app/org.gnome.Builder/x86_64/stable/327753f4701dbb9046bfb0c0c9c05b16edea0fbd8df7f368525c461d8d30b5a4/files/lib/python3.13/site-packages/sphinx_rtd_theme/static/css/fonts from unconfined_u:object_r:user_fonts_t:s0 to unconfined_u:object_r:data_home_t:s0
Would relabel /home/foo/.local/share/flatpak/app/org.gnome.Builder/x86_64/stable/327753f4701dbb9046bfb0c0c9c05b16edea0fbd8df7f368525c461d8d30b5a4/files/lib/systemd from unconfined_u:object_r:systemd_home_t:s0 to unconfined_u:object_r:data_home_t:s0
Would relabel /home/foo/.local/share/flatpak/app/org.gnome.Builder/x86_64/stable/327753f4701dbb9046bfb0c0c9c05b16edea0fbd8df7f368525c461d8d30b5a4/files/lib/systemd/user from unconfined_u:object_r:systemd_home_t:s0 to unconfined_u:object_r:data_home_t:s0
Would relabel /home/foo/.local/share/flatpak/app/org.gnome.Builder/x86_64/stable/327753f4701dbb9046bfb0c0c9c05b16edea0fbd8df7f368525c461d8d30b5a4/files/lib/systemd/user/vte-spawn-.scope.d from unconfined_u:object_r:systemd_home_t:s0 to unconfined_u:object_r:data_home_t:s0
Would relabel /home/foo/.local/share/flatpak/app/org.gnome.Builder/x86_64/stable/327753f4701dbb9046bfb0c0c9c05b16edea0fbd8df7f368525c461d8d30b5a4/files/share/doc/gnome-builder/en/_static/css/fonts from unconfined_u:object_r:user_fonts_t:s0 to unconfined_u:object_r:data_home_t:s0
Would relabel /home/foo/.local/share/flatpak/app/org.gnome.Builder/x86_64/stable/327753f4701dbb9046bfb0c0c9c05b16edea0fbd8df7f368525c461d8d30b5a4/files/share/gnome-builder/fonts from unconfined_u:object_r:user_fonts_t:s0 to unconfined_u:object_r:data_home_t:s0
```