### PR TITLE
Allow kl2tpd create and use netlink_generic_socket

### DIFF
--- a/policy/modules/contrib/l2tp.te
+++ b/policy/modules/contrib/l2tp.te
@@ -29,6 +29,7 @@ files_pid_file(l2tpd_var_run_t)
 allow l2tpd_t self:capability net_admin;
 allow l2tpd_t self:process signal_perms;
 allow l2tpd_t self:fifo_file rw_fifo_file_perms;
+allow l2tpd_t self:netlink_generic_socket create_socket_perms;
 allow l2tpd_t self:netlink_socket create_socket_perms;
 allow l2tpd_t self:rawip_socket create_socket_perms;
 allow l2tpd_t self:socket create_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1765791070.682:251): avc:  denied  { bind } for  pid=4701 comm="kl2tpd" scontext=system_u:system_r:l2tpd_t:s0 tcontext=system_u:system_r:l2tpd_t:s0 tclass=netlink_generic_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2422239