### PR TITLE
Allow systemd-machined read virtd process state

### DIFF
--- a/policy/modules/contrib/virt.if
+++ b/policy/modules/contrib/virt.if
@@ -2239,6 +2239,25 @@ interface(`virt_virtqemud_read_state',`
 
 ########################################
 ## <summary>
+##	Read the virtd process state.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_virtd_read_state',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	kernel_search_proc($1)
+	ps_process_pattern($1, virtd_t)
+')
+
+########################################
+## <summary>
 ##	Read the svirt process state.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -632,6 +632,7 @@ optional_policy(`
 	virt_getattr_sandbox_filesystem(systemd_machined_t)
 	virt_read_sandbox_files(systemd_machined_t)
 	virt_svirt_read_state(systemd_machined_t)
+	virt_virtd_read_state(systemd_machined_t)
 ')
 
 #######################################


### PR DESCRIPTION
As a result of systemd commit 119d332d9c2c [1] ("machine: do not allow unprivileged users to register other users' processes as machines"), additional checks for unprivileged users are now performed in machined. [1] https://github.com/systemd/systemd/commit/119d332d9c2c

This is similar to commit 65163609d0f2 ("Allow systemd-machined read svirt process state"), but for the virtd_t domain.

The commit addresses the following AVC denials:
type=AVC msg=audit(10/30/25 17:34:09.467:4630) : avc:  denied  { search } for  pid=8234 comm=systemd-machine name=59740 dev="proc" ino=130755 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:system_r:virtd_t:s0-s0:c0.c1023 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2411970