### PR TITLE
Update su_domain_type policy for kerberized su

### DIFF
--- a/policy/modules/admin/su.te
+++ b/policy/modules/admin/su.te
@@ -83,8 +83,17 @@ optional_policy(`
 ')
 
 optional_policy(`
+	userdom_tmp_filetrans_user_tmp(su_domain_type, file)
+	userdom_manage_user_tmp_files(su_domain_type)
+')
+
+optional_policy(`
 	# used when the password has expired
 	usermanage_read_crack_db(su_domain_type)
+')
+
+optional_policy(`
+	ssh_signull(su_domain_type)
 ')
 
 # Modify .Xauthority file (via xauth program).

--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -59,7 +59,7 @@ template(`sudo_role_template',`
 	allow $1_sudo_t $3:file read_file_perms;;
 	allow $1_sudo_t $3:key search;
 
-	allow $1_sudo_t $1_t:unix_stream_socket { connectto read write };
+	allow $1_sudo_t $1_t:unix_stream_socket { getattr connectto ioctl read write };
 
 	# Enter this derived domain from the user domain
 	domtrans_pattern($3, sudo_exec_t, $1_sudo_t)
@@ -112,6 +112,10 @@ template(`sudo_role_template',`
 	optional_policy(`
 		netutils_domtrans($1_sudo_t)
 		netutils_run_traceroute($1_sudo_t, $2)
+	')
+
+	optional_policy(`
+		ssh_agent_stream_connect($1_sudo_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -812,6 +812,25 @@ interface(`ssh_agent_signal',`
 
 ########################################
 ## <summary>
+##	Connect to ssh_agent_type over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ssh_agent_stream_connect',`
+	gen_require(`
+		type ssh_agent_tmp_t;
+		attribute ssh_agent_type;
+	')
+
+	stream_connect_pattern($1, ssh_agent_tmp_t, ssh_agent_tmp_t, ssh_agent_type)
+')
+
+########################################
+## <summary>
 ##	Getattr ssh home directory
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Required when ksu, the kerberized super-user command, is used for the sysadm SELinux user.

The commit addresses the following AVC denial:
type=AVC msg=audit(1751981394.509:158515): avc:  denied  { create } for  pid=1765961 comm="ksu" name="krb5cc_95326.TfGdXaPG" scontext=sysadm_u:sysadm_r:sysadm_su_t:s0-s0:c0.c1023 tcontext=sysadm_u:object_r:tmp_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(1751981394.509:158515): arch=x86_64 syscall=openat success=no exit=EACCES a0=ffffff9c a1=55efb5a2df20 a2=800c2 a3=180 items=1 ppid=1765836 pid=1765961 auid=98840 uid=95326 gid=95326 euid=95326 suid=95326 fsuid=95326 egid=95326 sgid=95326 fsgid=95326 tty=pts4 ses=4 comm=ksu exe=/usr/bin/ksu subj=sysadm_u:sysadm_r:sysadm_su_t:s0-s0:c0.c1023 key="perm_access"ARCH=x86_64 SYSCALL=openat AUID=nwallwoz UID=nwallwo GID=nwallwo EUID=nwallwo SUID=nwallwo FSUID=nwallwo EGID=nwallwo SGID=nwallwo FSGID=nwallwo type=PATH msg=audit(1751981394.509:158515): item=0 name=/tmp/ inode=64 dev=fd:05 mode=041777 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:tmp_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0OUID=root OGID=root

Resolves: RHEL-104237