### PR TITLE
Allow sshd-session inherit limits from its parent process

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -85,7 +85,7 @@ domtrans_pattern(sshd_t, sshd_session_exec_t, sshd_session_t)
 ssh_session_dyntransition_to(sshd_net_t)
 
 allow sshd_session_t self:capability { audit_write chown dac_read_search setgid setuid sys_resource };
-allow sshd_session_t self:process { setcurrent setexec setkeycreate setrlimit setsched };
+allow sshd_session_t self:process { rlimitinh setcurrent setexec setkeycreate setrlimit setsched };
 allow sshd_session_t self:netlink_audit_socket { create nlmsg_relay };
 allow sshd_session_t self:netlink_route_socket { bind create getattr nlmsg_read };
 allow sshd_session_t self:udp_socket { connect create getattr };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/17/2025 15:04:16.398:510) : proctitle=/usr/libexec/openssh/sshd-session -D -R type=PATH msg=audit(12/17/2025 15:04:16.398:510) : item=1 name=/lib64/ld-linux-x86-64.so.2 inode=85632 dev=00:20 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:ld_so_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(12/17/2025 15:04:16.398:510) : item=0 name=/usr/libexec/openssh/sshd-session inode=29754 dev=00:20 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sshd_session_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(12/17/2025 15:04:16.398:510) : argc=3 a0=/usr/libexec/openssh/sshd-session a1=-D a2=-R type=SYSCALL msg=audit(12/17/2025 15:04:16.398:510) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x55b89ad03490 a1=0x55b89ad18900 a2=0x55b89acb3090 a3=0x8 items=2 ppid=860 pid=87694 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(12/17/2025 15:04:16.398:510) : avc:  denied  { rlimitinh } for  pid=87694 comm=sshd-session scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tclass=process permissive=0

Resolves: RHEL-136673