### PR TITLE
Allow qemu-ga to skip authentication

### DIFF
--- a/policy/modules/contrib/virt_supplementary.te
+++ b/policy/modules/contrib/virt_supplementary.te
@@ -42,6 +42,7 @@ gen_tunable(virt_qemu_ga_run_unconfined, false)
 
 gen_require(`
     class passwd passwd;
+    class passwd rootok;
 ')
 
 type virt_qmf_t;
@@ -160,6 +161,7 @@ optional_policy(`
 allow virt_qemu_ga_t self:capability { dac_override dac_read_search sys_admin sys_time sys_tty_config };
 
 allow virt_qemu_ga_t self:passwd passwd;
+allow virt_qemu_ga_t self:passwd rootok;
 
 allow virt_qemu_ga_t self:fifo_file rw_fifo_file_perms;
 allow virt_qemu_ga_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
This allow qemu-ga to skip authentication in PAM module pam_rootok, which is required when qemu-ga is executing chpasswd.

The commit addresses the following AVC denials:
type=USER_AVC msg=audit(1766271436.494:151): pid=3619 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:passwd_t:s0 msg='avc:  denied  { rootok } for  scontext=system_u:system_r:virt_qemu_ga_t:s0 tcontext=system_u:system_r:virt_qemu_ga_t:s0 tclass=passwd permissive=0 exe="/usr/sbin/chpasswd" sauid=0 hostname=? addr=? terminal=?'