### PR TITLE
Allow thumb_t connect to XDM over a unix domain stream socket

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -215,3 +215,7 @@ optional_policy(`
 optional_policy(`
 	systemd_userdbd_stream_connect(thumb_t)
 ')
+
+optional_policy(`
+	xserver_stream_connect_xdm(thumb_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1765095884.414:741): avc:  denied  { write } for  pid=55950 comm="blocking-2" name="org.gnome.DisplayManager" dev="tmpfs" ino=3504 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xdm_var_run_t:s0 tclass=sock_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2419755