### PR TITLE
Allow systemd-coredump signull containers

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1322,6 +1322,8 @@ allow systemd_coredump_t self:process setcap;
 allow systemd_coredump_t self:unix_stream_socket connectto;
 allow systemd_coredump_t self:user_namespace create;
 
+allow systemd_coredump_t systemd_nspawn_t:process signull;
+
 manage_files_pattern(systemd_coredump_t, systemd_coredump_tmpfs_t, systemd_coredump_tmpfs_t)
 fs_tmpfs_filetrans(systemd_coredump_t, systemd_coredump_tmpfs_t, file )
 
@@ -1347,6 +1349,10 @@ files_mounton_usr(systemd_coredump_t)
 
 fs_read_nsfs_files(systemd_coredump_t)
 fs_mounton_tmpfs(systemd_coredump_t)
+
+optional_policy(`
+	container_signull(systemd_coredump_t)
+')
 
 optional_policy(`
 	logging_send_syslog_msg(systemd_coredump_t)


### PR DESCRIPTION
When coredump forwarding (CoredumpReceive) is enabled, systemd-coredump checks if the container leader is alive and listens on the coredump socket.

The commit addresses the following AVC denial:
type=AVC msg=audit(1764684762.061:465): avc:  denied  { signull } for  pid=8570 comm="systemd-coredum" scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:container_t:s0:c96,c446 tclass=process permissive=0

and similar for systemd-nspawn.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2418343