### PR TITLE
Allow irqbalance create and use netlink generic socket

### DIFF
--- a/policy/modules/contrib/irqbalance.te
+++ b/policy/modules/contrib/irqbalance.te
@@ -37,6 +37,7 @@ files_pid_file(irqbalance_var_run_t)
 allow irqbalance_t self:capability { setpcap net_admin };
 dontaudit irqbalance_t self:capability sys_tty_config;
 allow irqbalance_t self:cap_userns setpcap;
+allow irqbalance_t self:netlink_generic_socket create_socket_perms;
 allow irqbalance_t self:process { getcap getsched setcap signal_perms };
 allow irqbalance_t self:udp_socket create_socket_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1766065085.970:80): avc:  denied  { create } for  pid=1519 comm="irqbalance" scontext=system_u:system_r:irqbalance_t:s0 tcontext=system_u:system_r:irqbalance_t:s0 tclass=netlink_generic_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2423556