### PR TITLE
Revert "Allow kl2tpd create and use netlink_generic_socket"

### DIFF
--- a/policy/modules/contrib/l2tp.te
+++ b/policy/modules/contrib/l2tp.te
@@ -29,7 +29,6 @@ files_pid_file(l2tpd_var_run_t)
 allow l2tpd_t self:capability net_admin;
 allow l2tpd_t self:process signal_perms;
 allow l2tpd_t self:fifo_file rw_fifo_file_perms;
-allow l2tpd_t self:netlink_generic_socket create_socket_perms;
 allow l2tpd_t self:netlink_socket create_socket_perms;
 allow l2tpd_t self:rawip_socket create_socket_perms;
 allow l2tpd_t self:socket create_socket_perms;


### PR DESCRIPTION
This reverts commit 5c417de12f90 in favor of another one with more information.