### PR TITLE
Revert "Allow systemd-coredump signull containers"

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1322,8 +1322,6 @@ allow systemd_coredump_t self:process setcap;
 allow systemd_coredump_t self:unix_stream_socket connectto;
 allow systemd_coredump_t self:user_namespace create;
 
-allow systemd_coredump_t systemd_nspawn_t:process signull;
-
 manage_files_pattern(systemd_coredump_t, systemd_coredump_tmpfs_t, systemd_coredump_tmpfs_t)
 fs_tmpfs_filetrans(systemd_coredump_t, systemd_coredump_tmpfs_t, file )
 
@@ -1349,10 +1347,6 @@ files_mounton_usr(systemd_coredump_t)
 
 fs_read_nsfs_files(systemd_coredump_t)
 fs_mounton_tmpfs(systemd_coredump_t)
-
-optional_policy(`
-	container_signull(systemd_coredump_t)
-')
 
 optional_policy(`
 	logging_send_syslog_msg(systemd_coredump_t)


### PR DESCRIPTION
This reverts commit e86db4292461be81eeb8aab0e6df4a771881bfae which was merged prematurely.