### PR TITLE
allow abrt_dump_oops to write to init sockets

### DIFF
--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -591,6 +591,8 @@ logging_watch_journal_dir(abrt_dump_oops_t)
 
 init_read_var_lib_files(abrt_dump_oops_t)
 
+init_write_pid_socket(abrt_dump_oops_t)
+
 optional_policy(`
 	samba_stream_connect_winbind(abrt_dump_oops_t)
 ')


### PR DESCRIPTION
The abrt-dump-journal-core utility requires write
access to the NamespaceResource socket located
at /run/systemd/userdb/io.systemd.NamespaceResource

resolves: bz2283201