### PR TITLE
Allow domain read sysfs files

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -152,6 +152,7 @@ allow domain self:process { getcap fork getsched signal_perms };
 
 # Use trusted objects in /dev
 dev_read_cpu_online(domain)
+dev_read_sysfs(domain)
 dev_rw_null(domain)
 dev_rw_zero(domain)
 term_use_controlling_term(domain)


### PR DESCRIPTION
glibc 2.42.9000-16 contains the following change:
- malloc: Enable 2MB THP by default on Aarch64 (Dev Jain)

which means any running process may want to read
/sys/kernel/mm/transparent_hugepage/enabled

The commit addresses the following AVC denial:
type=AVC msg=audit(1766480461.358:217): avc:  denied  { read } for  pid=1120 comm="unix_chkpwd" name="enabled" dev="sysfs" ino=1212 scontext=system_u:system_r:chkpwd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2424556