### PR TITLE
Logwatch fixes (bsc#1255862)

### DIFF
--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -143,6 +143,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	auth_login_pgm_signull(logwatch_t)
+')
+
+optional_policy(`
 	bind_read_config(logwatch_t)
 	bind_read_zone(logwatch_t)
 ')

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -2600,6 +2600,24 @@ interface(`auth_login_pgm_sigchld',`
 
 ########################################
 ## <summary>
+##	Send a SIGNULL signal to login programs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_login_pgm_signull',`
+	gen_require(`
+		attribute login_pgm;
+	')
+
+	allow $1 login_pgm:process signull;
+')
+
+########################################
+## <summary>
 ##	Manage the keyrings of all login programs
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
see: https://bugzilla.suse.com/show_bug.cgi?id=1255862

- Add auth_login_pgm_signull interface (bsc#1255862)
```
"uptime" uses read_utmp, which in turn reads the systemd sessions, which
give information about the log in sessions.

Then it sends a signull to the pid to determine if the processes
are still there.

So processes running in domains and using "uptime" need this
permission.

https://github.com/coreutils/gnulib/blob/master/lib/readutmp.c#L192
```

- Logwatch zz-runtime uses uptime (bsc#1255862)
  - see https://sourceforge.net/p/logwatch/git/ci/a9ee060fb7d34d6fb1e15b7199cabb0ab92043be/tree/scripts/services/zz-runtime

- DROPPED ~Allow logwatch to getattr nsfs_t (bsc#1255862)~
```
logwatch uses df, which in turn checks also /run/docker/netns.
this is labelled nsfs_t and is category "file", so allowing it

Adresses:

----
time->Fri Jan  2 00:00:02 2026
type=AVC msg=audit(1767340802.125:199): avc:  denied  { getattr } for  pid=2616 comm="df" path="/run/docker/netns/ffa9bcf0358e" dev="nsfs" ino=4026532554 scontext=system_u:system_r:logwatch_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=0

```