### PR TITLE
Allow sshd_net_t ioctl on unix_stream_socket of sshd_session_t

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -92,7 +92,7 @@ allow sshd_session_t self:udp_socket { connect create getattr };
 
 allow sshd_net_t sshd_t:vsock_socket { read write };
 allow sshd_net_t sshd_session_t:fifo_file write;
-allow sshd_net_t sshd_session_t:unix_stream_socket { read write };
+allow sshd_net_t sshd_session_t:unix_stream_socket { ioctl read write };
 allow sshd_session_t sshd_t:tcp_socket { getattr getopt read setopt write };
 allow sshd_session_t sshd_t:unix_stream_socket { read write };
 allow sshd_session_t sshd_t:vsock_socket { getattr };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(12/01/2025 07:14:11.840:1835) : proctitle=sshd-session: [net] type=SYSCALL msg=audit(12/01/2025 07:14:11.840:1835) : arch=s390x syscall=ioctl success=no exit=ENOTTY(Inappropriate ioctl for device) a0=0x6 a1=0xc0007a05 a2=0x3fff99f9350 a3=0x3fff99f92d0 items=0 ppid=36697 pid=36699 auid=unset uid=sshd gid=sshd euid=sshd suid=sshd fsuid=sshd egid=sshd sgid=sshd fsgid=sshd tty=(none) ses=unset comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sshd_net_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(12/01/2025 07:14:11.840:1835) : avc:  denied  { ioctl } for  pid=36699 comm=sshd-session path=socket:[64742] dev="sockfs" ino=64742 ioctlcmd=0x7a05 scontext=system_u:system_r:sshd_net_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

Resolves: RHEL-127721