### PR TITLE
Allow aide get attributes of a filesystem with extended attributes

### DIFF
--- a/policy/modules/contrib/aide.te
+++ b/policy/modules/contrib/aide.te
@@ -46,6 +46,8 @@ files_read_all_symlinks(aide_t)
 files_getattr_all_pipes(aide_t)
 files_getattr_all_sockets(aide_t)
 
+fs_getattr_xattr_fs(aide_t)
+
 init_stream_connectto(aide_t)
 
 mls_file_read_to_clearance(aide_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(10/15/2025 07:56:01.578:173240) : proctitle=/usr/sbin/aide --config=/etc/aide.conf --init type=SYSCALL msg=audit(10/15/2025 07:56:01.578:173240) : arch=x86_64 syscall=fstatfs success=yes exit=0 a0=0x5 a1=0x7f0b796df590 a2=0x3 a3=0x0 items=0 ppid=25397 pid=25398 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=aide exe=/usr/sbin/aide subj=system_u:system_r:aide_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(10/15/2025 07:56:01.578:173240) : avc:  denied  { getattr } for  pid=25398 comm=aide name=/ dev="vda2" ino=128 scontext=system_u:system_r:aide_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1

Resolves: RHEL-121479