### PR TITLE
Allow sshd-session read, write, and map ica tmpfs files

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -126,6 +126,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ica_rw_map_tmpfs_files(sshd_session_t)
+')
+
+optional_policy(`
 	systemd_dbus_chat_hostnamed(sshd_session_t)
 	systemd_userdbd_stream_connect(sshd_session_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(01/02/2026 14:32:12.885:6174) : proctitle=/usr/libexec/openssh/sshd-session -D -R type=AVC msg=audit(01/02/2026 14:32:12.885:6174) : avc:  denied  { read write } for  pid=201123 comm=sshd-session name=icastats_0 dev="tmpfs" ino=4 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:ica_tmpfs_t:s0 tclass=file permissive=1 type=SYSCALL msg=audit(01/02/2026 14:32:12.885:6174) : arch=s390x syscall=openat success=yes exit=6 a0=AT_FDCWD a1=0x3ffc6ef85f3 a2=O_RDWR|O_NOFOLLOW|O_CLOEXEC a3=0x0 items=0 ppid=200897 pid=201123 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 key=(null) type=PROCTITLE msg=audit(01/02/2026 14:32:12.885:6175) : proctitle=/usr/libexec/openssh/sshd-session -D -R type=AVC msg=audit(01/02/2026 14:32:12.885:6175) : avc:  denied  { map } for  pid=201123 comm=sshd-session path=/dev/shm/icastats_0 dev="tmpfs" ino=4 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:ica_tmpfs_t:s0 tclass=file permissive=1 type=SYSCALL msg=audit(01/02/2026 14:32:12.885:6175) : arch=s390x syscall=mmap success=yes exit=4396067848192 a0=0x3ffc6ef86d0 a1=0xe60 a2=PROT_READ|PROT_WRITE a3=MAP_SHARED items=0 ppid=200897 pid=201123 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 key=(null)

Resolves: RHEL-138247