### PR TITLE
Allow NM nvme dispatcher script start systemd services

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -708,6 +708,7 @@ optional_policy(`
 	systemd_status_systemd_services(NetworkManager_dispatcher_ddclient_t)
 	systemd_start_systemd_services(NetworkManager_dispatcher_sendmail_t)
 	systemd_status_systemd_services(NetworkManager_dispatcher_sendmail_t)
+	systemd_start_systemd_services(NetworkManager_dispatcher_nvme_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(1756420336.221:48): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=n/a uid=0 gid=0 path="/usr/lib/systemd/system/nvmf-connect-nbft.service" cmdline="" function="bus_unit_method_start_generic" scontext=system_u:system_r:NetworkManager_dispatcher_nvme_t:s0 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=service permissive=0 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'

Resolves: RHEL-111946