### PR TITLE
Allow plasma login manager stop login services

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -458,7 +458,7 @@ allow xdm_t xserver_unconfined_type:process { signull };
 
 allow xdm_t x_domain:system { status reload };
 
-allow xdm_t xdm_unit_file_t:service { status start };
+allow xdm_t xdm_unit_file_t:service { status start stop };
 
 allow xdm_t xconsole_device_t:fifo_file { getattr_fifo_file_perms setattr_fifo_file_perms };
 manage_dirs_pattern(xdm_t, xkb_var_lib_t, xkb_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
Jan 11 20:42:41 hostname systemd[63615]: selinux: avc:  denied  { stop } for auid=n/a uid=965 gid=965 path="/usr/lib/systemd/user/plasma-login-wayland.target" cmdline="/usr/bin/startplasma-login-wayland" function="bus_unit_method_start_generic" scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xdm_unit_file_t:s0 tclass=service permissive=0 Jan 11 20:42:41 hostname systemd[63615]: SELinux access check scon=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcon=system_u:object_r:xdm_unit_file_t:s0 tclass=service perm=stop state=enforcing function=bus_unit_method_start_generic path=/usr/lib/systemd/user/plasma-login-wayland.target cmdline=/usr/bin/startplasma-login-wayland: Permission denied

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2428612