### PR TITLE
Revert "Allow NM nvme dispatcher script start systemd services"

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -694,7 +694,6 @@ optional_policy(`
 	systemd_status_systemd_services(NetworkManager_dispatcher_ddclient_t)
 	systemd_start_systemd_services(NetworkManager_dispatcher_sendmail_t)
 	systemd_status_systemd_services(NetworkManager_dispatcher_sendmail_t)
-	systemd_start_systemd_services(NetworkManager_dispatcher_nvme_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This reverts commit c78b2e210a6451b90b34563135142c8e970f7fca because the affected type does not exist in RHEL 9.

Resolves: RHEL-111946