### PR TITLE
Allow sshd noatsecure on sshd-session execution

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -90,6 +90,7 @@ allow sshd_session_t self:netlink_audit_socket { create nlmsg_relay };
 allow sshd_session_t self:netlink_route_socket { bind create getattr nlmsg_read };
 allow sshd_session_t self:udp_socket { connect create getattr };
 
+allow sshd_t sshd_session_t:process noatsecure;
 allow sshd_net_t sshd_t:vsock_socket { read write };
 allow sshd_net_t sshd_session_t:fifo_file write;
 allow sshd_net_t sshd_session_t:unix_stream_socket { ioctl read write };


### PR DESCRIPTION
By default, AT_SECURE (secure mode environment cleansing) is enabled by the SELinux LSM on a domain transition and dontaudited in the policy.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/13/2026 12:57:23.736:9601) : proctitle=/usr/libexec/openssh/sshd-session -D -R type=PATH msg=audit(01/13/2026 12:57:23.736:9601) : item=1 name=/lib/ld64.so.1 inode=96503 dev=fd:00 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:lib_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(01/13/2026 12:57:23.736:9601) : item=0 name=/usr/libexec/openssh/sshd-session inode=134915705 dev=fd:00 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sshd_session_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=EXECVE msg=audit(01/13/2026 12:57:23.736:9601) : argc=3 a0=/usr/libexec/openssh/sshd-session a1=-D a2=-R type=SYSCALL msg=audit(01/13/2026 12:57:23.736:9601) : arch=s390x syscall=execve success=yes exit=0 a0=0x2aa028f58a0 a1=0x2aa0290adb0 a2=0x2aa028a2340 a3=0x0 items=2 ppid=257959 pid=258060 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(01/13/2026 12:57:23.736:9601) : avc:  denied  { siginh } for  pid=258060 comm=sshd-session scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tclass=process permissive=0 type=AVC msg=audit(01/13/2026 12:57:23.736:9601) : avc:  denied  { rlimitinh } for  pid=258060 comm=sshd-session scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tclass=process permissive=0 type=AVC msg=audit(01/13/2026 12:57:23.736:9601) : avc:  denied  { noatsecure } for  pid=258060 comm=sshd scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tclass=process permissive=0

Resolves: RHEL-138247