### PR TITLE
Allow kernel_t to read/write all domains' pipes

### DIFF
--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1412,6 +1412,24 @@ interface(`domain_dontaudit_getattr_all_pipes',`
 
 ########################################
 ## <summary>
+##	Read/write all domains' unnamed pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`domain_rw_all_pipes',`
+	gen_require(`
+		attribute domain;
+	')
+
+	allow $1 domain:fifo_file rw_file_perms;
+')
+
+########################################
+## <summary>
 ##	Allow specified type to set context of all
 ##	domains IPSEC associations.
 ## </summary>

--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -391,6 +391,7 @@ domain_signal_all_domains(kernel_t)
 domain_search_all_domains_state(kernel_t)
 domain_connect_all_stream_sockets(kernel_t)
 domain_rw_all_sockets(kernel_t)
+domain_rw_all_pipes(kernel_t)
 # Needed for overlayfs mounter checks
 # (see: https://bugzilla.redhat.com/show_bug.cgi?id=2215454)
 domain_obj_id_change_exemption(kernel_t)


### PR DESCRIPTION
We already allow it to manage all files_type pipes via files_manage_all_files(kernel_t), but pipes can sometimes be labeled with types from the domain attribute, so allow R/W access to those as well.

Resolves: RHEL-124442