### PR TITLE
Allow wireguard to setup DNS using dns_hatchet

### DIFF
--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -41,6 +41,32 @@ domain_use_interactive_fds(wireguard_t)
 
 files_read_etc_files(wireguard_t)
 
+# DNS hatchet part
+allow wireguard_t self:capability sys_admin;
+
+sysnet_create_config(wireguard_t)
+sysnet_mount_file(wireguard_t)
+sysnet_write_config(wireguard_t)
+
+# DNS hatchet: masking a chcon call in favor of fs_tmpfs_filetrans() for proper file context on resolv.conf
+sysnet_dontaudit_file_relabelto(wireguard_t)
+fs_dontaudit_relabelfrom_tmpfs_files(wireguard_t)
+selinux_dontaudit_validate_context(wireguard_t)
+fs_tmpfs_filetrans(wireguard_t, net_conf_t, file, "resolv.conf")
+
+files_mounton_rootfs(wireguard_t)
+
+fs_all_mount_fs_perms_tmpfs(wireguard_t)
+fs_mounton_tmpfs(wireguard_t)
+fs_manage_tmpfs_files(wireguard_t)
+fs_search_cgroup_dirs(wireguard_t)
+storage_rw_fixed_disk_blk_dev(wireguard_t)
+
+optional_policy(`
+	mount_exec(wireguard_t)
+	mount_manage_pid_files(wireguard_t)
+')
+
 optional_policy(`
 	auth_read_passwd(wireguard_t)
 ')

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -5774,6 +5774,24 @@ interface(`fs_dontaudit_getattr_tmpfs_dirs',`
 
 ########################################
 ## <summary>
+##	Do not audit relabelfrom attempts on files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`fs_dontaudit_relabelfrom_tmpfs_files',`
+	gen_require(`
+		type tmpfs_t;
+	')
+
+	dontaudit $1 tmpfs_t:file relabelfrom;
+')
+
+########################################
+## <summary>
 ##	Set the attributes of tmpfs directories.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1335,3 +1335,21 @@ interface(`sysnet_filetrans_cloud_net_conf',`
 
 	files_pid_filetrans($1, net_conf_t, dir, "cloud-init")
 ')
+
+#######################################
+## <summary>
+##	Mount network config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_mount_file',`
+	gen_require(`
+		type net_conf_t;
+	')
+
+    allow $1 net_conf_t:file mounton;
+')

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -332,6 +332,24 @@ interface(`sysnet_relabelfrom_dhcpc_state',`
 
 #######################################
 ## <summary>
+##	Dontaudit relabelto network config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysnet_dontaudit_file_relabelto',`
+	gen_require(`
+		type net_conf_t;
+	')
+
+    dontaudit $1 net_conf_t:file { relabelto };
+')
+
+#######################################
+## <summary>
 ##	Manage the dhcp client state files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
(successor of an earlier [draft PR](https://github.com/fedora-selinux/selinux-policy/pull/2840))

The change allows the user to use the DNS config line with wireguard, example config and  usage for context/reproduction:

```sh
$ cat /etc/wireguard/wg0.conf 
[Interface]
PrivateKey = [cut]
Address = 240.0.0.1/24
DNS = 8.8.8.8
$ systemctl start wg-quick@wg0
[..]
$ systemctl stop wg-quick@wg0
[..]
```

The last line in the config file (`DNS =`) would cause problems without the changes in this PR.

What made this change complicated for me was the workaround about the `chcon` [call](https://git.zx2c4.com/wireguard-tools/tree/contrib/dns-hatchet/hatchet.bash#n27) in `wg-quick`. Already [discussed](https://github.com/fedora-selinux/selinux-policy/pull/2840#issuecomment-3224512990) before as well.

To summarize: I work around chcon with a couple of new dontaudit interfaces and use a filetrans for the proper context on `resolv.conf`.