### PR TITLE
Allow aide get attributes of tmpfs and devtmpfs filesystems

### DIFF
--- a/policy/modules/contrib/aide.te
+++ b/policy/modules/contrib/aide.te
@@ -37,6 +37,7 @@ logging_log_filetrans(aide_t, aide_log_t, file)
 
 dev_getattr_all_blk_files(aide_t)
 dev_getattr_all_chr_files(aide_t)
+dev_getattr_fs(aide_t)
 dev_read_rand(aide_t)
 dev_read_urand(aide_t)
 
@@ -46,6 +47,7 @@ files_read_all_symlinks(aide_t)
 files_getattr_all_pipes(aide_t)
 files_getattr_all_sockets(aide_t)
 
+fs_getattr_tmpfs(aide_t)
 fs_getattr_xattr_fs(aide_t)
 
 init_stream_connectto(aide_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(01/14/2026 02:30:01.626:369) : proctitle=/usr/sbin/aide --config=/etc/aide.conf --init type=SYSCALL msg=audit(01/14/2026 02:30:01.626:369) : arch=x86_64 syscall=fstatfs success=yes exit=0 a0=0x5 a1=0x7f82503e6510 a2=0x3 a3=0x0 items=0 ppid=45619 pid=45620 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=aide exe=/usr/sbin/aide subj=system_u:system_r:aide_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(01/14/2026 02:30:01.626:369) : avc:  denied  { getattr } for  pid=45620 comm=aide name=/ dev="devtmpfs" ino=1 scontext=system_u:system_r:aide_t:s0-s0:c0.c1023 tcontext=system_u:object_r:device_t:s0 tclass=filesystem permissive=1

type=PROCTITLE msg=audit(01/14/2026 02:30:01.626:370) : proctitle=/usr/sbin/aide --config=/etc/aide.conf --init
type=SYSCALL msg=audit(01/14/2026 02:30:01.626:370) : arch=x86_64 syscall=fstatfs success=yes exit=0 a0=0x5 a1=0x7f82503e6510 a2=0x3 a3=0x0 items=0 ppid=45619 pid=45620 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=aide exe=/usr/sbin/aide subj=system_u:system_r:aide_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(01/14/2026 02:30:01.626:370) : avc:  denied  { getattr } for  pid=45620 comm=aide name=/ dev="tmpfs" ino=1 scontext=system_u:system_r:aide_t:s0-s0:c0.c1023 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=1

Resolves: RHEL-121480