### PR TITLE
Allow thumb_t stream connect to systemd-homed

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -217,5 +217,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_homed_stream_connect(thumb_t)
+')
+
+optional_policy(`
 	xserver_stream_connect_xdm(thumb_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1769172801.969:611): avc:  denied  { connectto } for  pid=145773 comm="blocking-1" path="/run/systemd/userdb/io.systemd.Home" scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:system_r:systemd_homed_t:s0 tclass=unix_stream_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2431014