### PR TITLE
Allow thumb_t stream connect to systemd-machined

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -213,6 +213,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_machined_stream_connect(thumb_t)
 	systemd_userdbd_stream_connect(thumb_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1767559989.422:1092): avc:  denied  { connectto } for  pid=244942 comm="blocking-1" path="/run/systemd/userdb/io.systemd.Machine" scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:system_r:systemd_machined_t:s0 tclass=unix_stream_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2427052