### PR TITLE
Allow systemd-hostnamed to manage its Varlink socket

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1049,6 +1049,8 @@ init_delete_pid_dir_entry(systemd_hostnamed_t)
 init_status(systemd_hostnamed_t)
 init_stream_connect(systemd_hostnamed_t)
 
+init_create_pid_socket(systemd_hostnamed_t)
+
 logging_send_syslog_msg(systemd_hostnamed_t)
 
 systemd_read_efivarfs(systemd_hostnamed_t)


### PR DESCRIPTION
The commit addresses the following AVC denial when systemd-hostnamed attempts to create its Varlink socket at /run/systemd/io.systemd.Hostname (introduced in systemd 257+):

1499:[Tue Dec 30 08:10:57 2025] audit: type=1400 audit(1767082257.400:5): avc:  denied  { create } for  pid=5377 comm="systemd-hostnam" name="io.systemd.Hostname" scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=sock_file permissive=0

This prevents setting the hostname via kickstart during bootc installations on RHEL 10 / CentOS Stream 10 systems with SELinux enforcing.

Resolves: RHEL-139385