### PR TITLE
Allow thumbnailer connect to abrt over a unix stream socket

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -157,6 +157,10 @@ xserver_stream_connect(thumb_t)
 xserver_use_user_fonts(thumb_t)
 
 optional_policy(`
+	abrt_stream_connect(thumb_t)
+')
+
+optional_policy(`
     bumblebee_stream_connect(thumb_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1769534549.819:253): avc:  denied  { write } for  pid=12587 comm="exe-thumbnailer" name="abrt.socket" dev="tmpfs" ino=3187 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:object_r:abrt_var_run_t:s0 tclass=sock_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2433446