### PR TITLE
Allow tlshd write generic certificates

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -36,6 +36,7 @@ optional_policy(`
 optional_policy(`
 	miscfiles_read_generic_certs(ktlshd_t)
 	miscfiles_map_generic_certs(ktlshd_t)
+	miscfiles_write_generic_certs(ktlshd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -147,6 +147,26 @@ interface(`miscfiles_dontaudit_map_generic_certs',`
 
 ########################################
 ## <summary>
+##	Write generic SSL certificates.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`miscfiles_write_generic_certs',`
+	gen_require(`
+		type cert_t;
+	')
+
+	allow $1 cert_t:dir list_dir_perms;
+	write_files_pattern($1, cert_t, cert_t)
+')
+
+########################################
+## <summary>
 ##	Manage generic SSL certificates.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1761275393.108:359): avc:  denied  { write } for  pid=28727 comm="tlshd" name="source" dev="dm-0" ino=150996217 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=1 type=SYSCALL msg=audit(1761275393.108:359): arch=x86_64 syscall=access success=yes exit=0 a0=55fc5db65b20 a1=2 a2=0 a3=0 items=0 ppid=28715 pid=28727 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=tlshd exe=/usr/sbin/tlshd subj=system_u:system_r:ktlshd_t:s0 key=(null)ARCH=x86_64 SYSCALL=access AUID=unset UID=root GID=root EUID=root SUID=root FSUID=root EGID=root SGID=root FSGID=root

Resolves: RHEL-123737