### PR TITLE
Allow tlshd communication to unconfined_t over a tcp socket

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -41,3 +41,7 @@ optional_policy(`
 optional_policy(`
 	sysnet_read_config(ktlshd_t)
 ')
+
+optional_policy(`
+	unconfined_connected_tcp_sockets(ktlshd_t)
+')

--- a/policy/modules/roles/unconfineduser.if
+++ b/policy/modules/roles/unconfineduser.if
@@ -442,6 +442,25 @@ interface(`unconfined_stream_connect',`
 
 ########################################
 ## <summary>
+##	Read/write/other permissions from connected_socket_perms
+##	to unconfined domain tcp sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`unconfined_connected_tcp_sockets',`
+	gen_require(`
+		type unconfined_t;
+	')
+
+	allow $1 unconfined_t:tcp_socket connected_socket_perms;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read or write
 ##	unconfined domain tcp sockets.
 ## </summary>


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=AVC msg=audit(1769645908.709:1095): avc:  denied  { setopt } for  pid=73592 comm="tlshd" laddr=127.0.0.1 lport=58822 faddr=127.0.0.1 fport=4420 scontext=system_u:system_r:ktlshd_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=tcp_socket permissive=1

Resolves: RHEL-125106