### PR TITLE
Allow sudodomain connect to gkeyringd over a unix stream socket

### DIFF
--- a/policy/modules/admin/sudo.te
+++ b/policy/modules/admin/sudo.te
@@ -135,6 +135,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gnome_stream_connect_gkeyringd(sudodomain)
+')
+
+optional_policy(`
 	ssh_signull(sudodomain)
 ')
 


### PR DESCRIPTION
These permissions are needed to support using pam_ssh_agent_auth for staff_u users that can transition to sudodomain using sudo.

Resolves: RHEL-121158