### PR TITLE
Allow lttng-sessiond to use sd_notify

### DIFF
--- a/policy/modules/contrib/lttng-tools.te
+++ b/policy/modules/contrib/lttng-tools.te
@@ -28,7 +28,15 @@ allow lttng_sessiond_t self:capability2 block_suspend;
 allow lttng_sessiond_t self:process { setrlimit signal_perms };
 allow lttng_sessiond_t self:fifo_file rw_fifo_file_perms;
 allow lttng_sessiond_t self:tcp_socket listen;
+allow lttng_sessiond_t self:unix_dgram_socket create;
 allow lttng_sessiond_t self:unix_stream_socket { create_stream_socket_perms connectto };
+
+# FIXME: this is required because of systemd's notify socket is created while
+# in the initramfs, hence as kernel_t. Once SELinux permits relabeling socket
+# objects created before the policy is loaded, this should be removed and
+# systemd fixed to relabel the socket appropriately.
+# Tracked by [systemd PR](https://github.com/systemd/systemd/pull/31336).
+kernel_dgram_send(lttng_sessiond_t)
 
 manage_dirs_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)
 manage_files_pattern(lttng_sessiond_t, lttng_sessiond_var_run_t, lttng_sessiond_var_run_t)


### PR DESCRIPTION
The next version of lttng-tools will use the SD_NOTIFY protocol to signal readiness of the daemon to systemd. This is currently blocked by the policy:

----
time->Fri Jan 30 16:16:23 2026
type=AVC msg=audit(1769807783.178:120): avc:  denied  { create } for  pid=1330 comm="lttng-sessiond" scontext=system_u:system_r:lttng_sessiond_t:s0 tcontext=system_u:system_r:lttng_sessiond_t:s0 tclass=unix_dgram_socket permissive=1 ----
time->Fri Jan 30 16:16:23 2026
type=AVC msg=audit(1769807783.178:121): avc:  denied  { sendto } for  pid=1330 comm="lttng-sessiond" path="/systemd/notify" scontext=system_u:system_r:lttng_sessiond_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=1