### PR TITLE
Allow sshd-session read network sysctls

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -104,6 +104,7 @@ manage_dirs_pattern(sshd_session_t, ssh_home_t, ssh_home_t)
 manage_files_pattern(sshd_session_t, ssh_home_t, ssh_home_t)
 
 kernel_stream_connect(sshd_session_t)
+kernel_read_net_sysctls(sshd_session_t)
 
 fs_getattr_all_fs(sshd_session_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1769945906.568:934): avc:  denied  { getattr } for  pid=41964 comm="sshd-session" path="/proc/sys/net/ipv6/conf/all/disable_ipv6" dev="proc" ino=12547 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2435755