### PR TITLE
Allow vdagent get attributes of the pidfs filesystem

### DIFF
--- a/policy/modules/contrib/vdagent.te
+++ b/policy/modules/contrib/vdagent.te
@@ -49,6 +49,7 @@ dev_dontaudit_write_mtrr(vdagent_t)
 
 fs_getattr_cgroup(vdagent_t)
 fs_search_cgroup_dirs(vdagent_t)
+fs_getattr_pidfs(vdagent_t)
 fs_getattr_tmpfs(vdagent_t)
 
 term_use_virtio_console(vdagent_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1770077831.929:149): avc:  denied  { getattr } for  pid=2293 comm="spice-vdagentd" name="/" dev="pidfs" ino=1 scontext=system_u:system_r:vdagent_t:s0 tcontext=system_u:object_r:pidfs_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2436158