### PR TITLE
Support using bubblewrap for confined users

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -196,6 +196,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	miscfiles_mounton_fonts_cache_dirs(thumb_t)
+')
+
+optional_policy(`
 	nscd_dontaudit_write_sock_file(thumb_t)
 ')
 

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -44,6 +44,10 @@ files_dontaudit_read_all_symlinks(staff_t)
 files_dontaudit_manage_boot_dirs(staff_t)
 fs_read_tmpfs_files(staff_t)
 fs_read_binfmt_misc(staff_t)
+fs_mount_tmpfs(staff_t)
+fs_unmount_tmpfs(staff_t)
+fs_remount_xattr_fs(staff_t)
+fs_unmount_xattr_fs(staff_t)
 
 dev_read_cpuid(staff_t)
 dev_read_kmsg(staff_t)
@@ -58,6 +62,8 @@ domain_getattr_all_domains(staff_t)
 domain_obj_id_change_exemption(staff_t)
 
 files_read_kernel_modules(staff_t)
+files_mounton_rootfs(staff_t)
+files_mounton_generic_tmp_dirs(staff_t)
 
 seutil_read_module_store(staff_t)
 seutil_run_newrole(staff_t, staff_r)
@@ -67,6 +73,7 @@ seutil_read_login_config(staff_t)
 storage_read_scsi_generic(staff_t)
 storage_write_scsi_generic(staff_t)
 
+term_mount_pty_fs(staff_t)
 term_use_unallocated_ttys(staff_t)
 term_use_generic_ptys(staff_t)
 
@@ -235,6 +242,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	miscfiles_mounton_fonts_cache_dirs(staff_t)
+')
+
+optional_policy(`
 	mock_role(staff_r, staff_t)
 ')
 
@@ -313,6 +324,7 @@ optional_policy(`
 	sysadm_role_change(staff_r)
 	userdom_dontaudit_use_user_terminals(staff_t)
     userdom_dontaudit_read_admin_home_files(staff_t)
+	userdom_mounton_tmp_files(staff_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -396,6 +396,24 @@ interface(`miscfiles_setattr_fonts_dirs',`
 
 ########################################
 ## <summary>
+##	Mount on fonts cache directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`miscfiles_mounton_fonts_cache_dirs', `
+	gen_require(`
+		type fonts_cache_t;
+	')
+
+	allow $1 fonts_cache_t:dir mounton;
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to set the attributes
 ##	on a fonts directory.
 ## </summary>

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -461,7 +461,7 @@ interface(`userdom_manage_tmp_dirs',`
 
 #######################################
 ## <summary>
-##	Manage user temporary directories
+##	Mounton user temporary directories
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -476,6 +476,25 @@ interface(`userdom_mounton_tmp_dirs',`
 	')
 
     allow $1 user_tmp_t:dir mounton;
+')
+
+#######################################
+## <summary>
+##	Mounton user temporary files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolebase/>
+#
+interface(`userdom_mounton_tmp_files',`
+	gen_require(`
+		type user_tmp_t;
+	')
+
+	allow $1 user_tmp_t:file mounton;
 ')
 
 #######################################


### PR DESCRIPTION
In graphical environments, bubblewrap is used for sandboxing user applications which requires additional SELinux permissions, especially for mount namespacing.

The commit addresses a set of AVC denials like this: type=PROCTITLE msg=audit(2.2.2026 10:05:21.897:540) : proctitle=bwrap --unshare-all --die-with-parent --chdir / --ro-bind /usr /usr --dev /dev --ro-bind-try /etc/ld.so.cache /etc/ld.so.cache - type=PATH msg=audit(2.2.2026 10:05:21.897:540) : item=0 name=/tmp inode=1 dev=00:2b mode=dir,sticky,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:tmp_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(2.2.2026 10:05:21.897:540) : arch=x86_64 syscall=mount success=yes exit=0 a0=0x5627c2a87f64 a1=0x5627c2a87f4f a2=0x5627c2a87f64 a3=MS_NOSUID|MS_NODEV items=1 ppid=29441 pid=29442 auid=username uid=username gid=username euid=username suid=username fsuid=username egid=username sgid=username fsgid=username tty=(none) ses=3 comm=bwrap exe=/usr/bin/bwrap subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(2.2.2026 10:05:21.897:540) : avc:  denied  { mount } for  pid=29442 comm=bwrap name=/ dev="tmpfs" ino=1 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=1 type=AVC msg=audit(2.2.2026 10:05:21.897:540) : avc:  denied  { mounton } for  pid=29442 comm=bwrap path=/tmp dev="tmpfs" ino=1 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2435751