### PR TITLE
Update gpg_role() interface with unix_stream_socket permissions

### DIFF
--- a/policy/modules/contrib/gpg.if
+++ b/policy/modules/contrib/gpg.if
@@ -64,7 +64,9 @@ interface(`gpg_role',`
 		gpg_pinentry_dbus_chat($2)
 	')
 
-	allow $2 gpg_agent_t:unix_stream_socket { rw_socket_perms connectto };
+	allow $2 gpg_agent_t:unix_stream_socket { connectto create_stream_socket_perms };
+	allow gpg_agent_t $2:unix_stream_socket { getattr ioctl };
+
 	ifdef(`hide_broken_symptoms',`
 		#Leaked File Descriptors
 		dontaudit gpg_t $2:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(11/14/2025 08:48:24.365:670) : proctitle=(systemd) type=SYSCALL msg=audit(11/14/2025 08:48:24.365:670) : arch=x86_64 syscall=socket success=yes exit=34 a0=local a1=SOCK_STREAM a2=ip a3=0x5631765be010 items=0 ppid=1 pid=6097 auid=staff-user uid=staff-user gid=staff-user euid=staff-user suid=staff-user fsuid=staff-user egid=staff-user sgid=staff-user fsgid=staff-user tty=(none) ses=13 comm=systemd exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(11/14/2025 08:48:24.365:670) : avc:  denied  { create } for  pid=6097 comm=systemd scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:gpg_agent_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

type=PROCTITLE msg=audit(11/14/2025 08:48:24.365:671) : proctitle=(systemd)
type=SYSCALL msg=audit(11/14/2025 08:48:24.365:671) : arch=x86_64 syscall=listen success=yes exit=0 a0=0x22 a1=0x7fffffff a2=0x23 a3=0x7ffebe1c9360 items=0 ppid=1 pid=6097 auid=staff-user uid=staff-user gid=staff-user euid=staff-user suid=staff-user fsuid=staff-user egid=staff-user sgid=staff-user fsgid=staff-user tty=(none) ses=13 comm=systemd exe=/usr/lib/systemd/systemd subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(11/14/2025 08:48:24.365:671) : avc:  denied  { listen } for  pid=6097 comm=systemd path=/run/user/1000/gnupg/S.gpg-agent scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:gpg_agent_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

type=PROCTITLE msg=audit(11/14/2025 08:48:24.388:672) : proctitle=/usr/bin/gpg-agent --supervised
type=SYSCALL msg=audit(11/14/2025 08:48:24.388:672) : arch=x86_64 syscall=fstat success=yes exit=0 a0=0x1 a1=0x7fff12dbb3a0 a2=0x88 a3=0x7 items=0 ppid=6097 pid=6150 auid=staff-user uid=staff-user gid=staff-user euid=staff-user suid=staff-user fsuid=staff-user egid=staff-user sgid=staff-user fsgid=staff-user tty=(none) ses=13 comm=gpg-agent exe=/usr/bin/gpg-agent subj=staff_u:staff_r:gpg_agent_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(11/14/2025 08:48:24.388:672) : avc:  denied  { getattr } for  pid=6150 comm=gpg-agent path=socket:[21927] dev="sockfs" ino=21927 scontext=staff_u:staff_r:gpg_agent_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

type=PROCTITLE msg=audit(11/14/2025 08:48:24.391:673) : proctitle=/usr/bin/gpg-agent --supervised
type=SYSCALL msg=audit(11/14/2025 08:48:24.391:673) : arch=x86_64 syscall=ioctl success=no exit=ENOTTY(Inappropriate ioctl for device) a0=0x1 a1=TCGETS a2=0x7fff12dbb160 a3=0x55670c3df010 items=0 ppid=6097 pid=6150 auid=staff-user uid=staff-user gid=staff-user euid=staff-user suid=staff-user fsuid=staff-user egid=staff-user sgid=staff-user fsgid=staff-user tty=(none) ses=13 comm=gpg-agent exe=/usr/bin/gpg-agent subj=staff_u:staff_r:gpg_agent_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(11/14/2025 08:48:24.391:673) : avc:  denied  { ioctl } for  pid=6150 comm=gpg-agent path=socket:[21927] dev="sockfs" ino=21927 ioctlcmd=TCGETS scontext=staff_u:staff_r:gpg_agent_t:s0-s0:c0.c1023 tcontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

Resolves: RHEL-128555