### PR TITLE
Add aliases.lmdb to mta_filetrans_named_content()

### DIFF
--- a/policy/modules/contrib/mta.fc
+++ b/policy/modules/contrib/mta.fc
@@ -8,6 +8,7 @@ HOME_DIR/.maildir(/.*)?		gen_context(system_u:object_r:mail_home_rw_t,s0)
 
 /etc/aliases		--	gen_context(system_u:object_r:etc_aliases_t,s0)
 /etc/aliases\.db	--	gen_context(system_u:object_r:etc_aliases_t,s0)
+/etc/aliases\.cdb	--	gen_context(system_u:object_r:etc_aliases_t,s0)
 /etc/aliases\.lmdb	--	gen_context(system_u:object_r:etc_aliases_t,s0)
 /etc/mail(/.*)?			gen_context(system_u:object_r:etc_mail_t,s0)
 /etc/mail/aliases.*	--	gen_context(system_u:object_r:etc_aliases_t,s0)

--- a/policy/modules/contrib/mta.if
+++ b/policy/modules/contrib/mta.if
@@ -1321,6 +1321,7 @@ interface(`mta_filetrans_named_content',`
 	#filetrans_pattern($1, etc_mail_t, etc_aliases_t, { dir file })
 	mta_etc_filetrans_aliases($1, "aliases")
 	mta_etc_filetrans_aliases($1, "aliases.db")
+	mta_etc_filetrans_aliases($1, "aliases.lmdb")
 	mta_etc_filetrans_aliases($1, "aliasesdb-stamp")
 	mta_etc_filetrans_aliases($1, "__db.aliases.db")
     mta_etc_filetrans_aliases($1, "virtusertable.db")

--- a/policy/modules/contrib/mta.if
+++ b/policy/modules/contrib/mta.if
@@ -1321,6 +1321,7 @@ interface(`mta_filetrans_named_content',`
 	#filetrans_pattern($1, etc_mail_t, etc_aliases_t, { dir file })
 	mta_etc_filetrans_aliases($1, "aliases")
 	mta_etc_filetrans_aliases($1, "aliases.db")
+	mta_etc_filetrans_aliases($1, "aliases.cdb")
 	mta_etc_filetrans_aliases($1, "aliases.lmdb")
 	mta_etc_filetrans_aliases($1, "aliasesdb-stamp")
 	mta_etc_filetrans_aliases($1, "__db.aliases.db")


### PR DESCRIPTION
The mta_filetrans_named_content() interface contains list of filenames which type should transition to private types like etc_aliases_t on the file creation.

In the bb522ec186 ("Label /etc/aliases.lmdb with etc_aliases_t") commit, aliases.lmdb was assigned a label, but it was not backed by an automated file transition.

Resolves: RHEL-140884