### PR TITLE
Allow lttng kernel tracing

### DIFF
--- a/policy/modules/contrib/lttng-tools.te
+++ b/policy/modules/contrib/lttng-tools.te
@@ -57,7 +57,13 @@ fs_getattr_tmpfs(lttng_sessiond_t)
 
 auth_use_nsswitch(lttng_sessiond_t)
 
+# Allow lttng-sessiond to load the lttng kernel modules
 modutils_exec_kmod(lttng_sessiond_t)
 modutils_read_module_config(lttng_sessiond_t)
 modutils_read_module_deps_files(lttng_sessiond_t)
 files_read_kernel_modules(lttng_sessiond_t)
+files_load_kernel_modules(lttng_sessiond_t)
+files_map_kernel_modules(lttng_sessiond_t)
+
+# Allow lttng-sessiond to write to '/proc/lttng'
+kernel_write_proc_files(lttng_sessiond_t)


### PR DESCRIPTION
The session daemon can be configured to load the lttng kernel modules by either calling the kmod utilities or by using the libkmod bindings. Add the required rules that were missing for the latter scenario.

The session daemon communicates with the kernel modules by writing to "/proc/lttng", add a rule to allow that.