### PR TITLE
Use kernel_dgram_send() for systemd_notify_t

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -925,7 +925,7 @@ allow systemd_notify_t self:unix_dgram_socket create_socket_perms;
 # objects created before the policy is loaded, this should be removed and
 # systemd fixed to relabel the socket appropriately.
 # Tracked by [systemd PR](https://github.com/systemd/systemd/pull/31336).
-allow systemd_notify_t kernel_t:unix_dgram_socket sendto;
+kernel_dgram_send(systemd_notify_t)
 
 dev_write_kmsg(systemd_notify_t)
 


### PR DESCRIPTION
Use the proper kernel_dgram_send() for systemd_notify_t instead of direct reference to a type outside the current module.

Credits to Michael Jeanson for spotting this.