### PR TITLE
Dontaudit nft (iptables_t) read/write on dma device

### DIFF
--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -2178,6 +2178,24 @@ interface(`dev_rw_dma_dev',`
 
 ########################################
 ## <summary>
+##	Dontaudit read and write on the dma device.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`dev_dontaudit_rw_dma_dev',`
+	gen_require(`
+		type dma_device_t;
+	')
+
+	dontaudit $1 dma_device_t:chr_file rw_chr_file_perms;
+')
+
+########################################
+## <summary>
 ##	getattr the dri devices.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -90,6 +90,7 @@ corenet_dontaudit_rw_tun_tap_dev(iptables_t)
 dev_read_sysfs(iptables_t)
 dev_read_urand(iptables_t)
 dev_read_rand(iptables_t)
+dev_dontaudit_rw_dma_dev(iptables_t)
 
 fs_getattr_xattr_fs(iptables_t)
 fs_search_auto_mountpoints(iptables_t)


### PR DESCRIPTION
## Summary

`nft` inherits an open file descriptor for `/dev/udmabuf` from its parent process, causing SELinux AVC denials when it transitions to `iptables_t`. Since `nft` has no legitimate need to access the DMA buffer device, this adds a `dontaudit` rule to suppress the noise.

## Changes

- **`policy/modules/kernel/devices.if`**: Add new `dev_dontaudit_rw_dma_dev()` interface (matching the existing `dev_dontaudit_rw_dri()` pattern)
- **`policy/modules/system/iptables.te`**: Apply `dev_dontaudit_rw_dma_dev(iptables_t)`

## AVC Denial

```
type=AVC msg=audit(1770803370.309:309): avc:  denied  { read write } for  pid=50487 comm="nft" path="/dev/udmabuf" dev="devtmpfs" ino=224 scontext=unconfined_u:unconfined_r:iptables_t:s0-s0:c0.c1023 tcontext=system_u:object_r:dma_device_t:s0 tclass=chr_file permissive=0
```

## Environment

- **Fedora**: 43
- **Kernel**: 6.18.8-200.fc43.x86_64
- **SELinux policy**: selinux-policy-targeted-42.23-1.fc43.noarch

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/3060