### PR TITLE
Grant systemd_generic_generator_t sys_resource capability (bsc#1257754)

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1571,6 +1571,8 @@ manage_files_pattern(systemd_fstab_generator_t, systemd_cryptsetup_generator_uni
 create_lnk_files_pattern(systemd_zram_generator_t, systemd_fstab_generator_unit_file_t, systemd_fstab_generator_unit_file_t)
 
 ### a generic generator
+allow systemd_generic_generator_t self:capability sys_resource;
+
 permissive systemd_generic_generator_t;
 
 


### PR DESCRIPTION
My first exposure to these generators. Found by automatic internal testing on ppc64le.

Fixes the following AVC:
```
audit(..): avc:  denied  { sys_resource } for  pid=532 comm="ln" capability=24  scontext=system_u:system_r:systemd_generic_generator_t:s0 tcontext=system_u:system_r:systemd_generic_generator_t:s0 tclass=capability permissive=1
```