### PR TITLE
Allow virtnodedevd the dac_read_search capability

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2024,7 +2024,7 @@ optional_policy(`
 #
 # virtnodedevd local policy
 #
-allow virtnodedevd_t self:capability { net_admin sys_admin };
+allow virtnodedevd_t self:capability { dac_read_search net_admin sys_admin };
 allow virtnodedevd_t self:capability2 perfmon;
 allow virtnodedevd_t self:netlink_generic_socket create_socket_perms;
 allow virtnodedevd_t self:process { setsched };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01-12-25 05:41:56.864:230) : proctitle=/usr/bin/virtnodedevd --timeout 120 type=PATH msg=audit(01-12-25 05:41:56.864:230) : item=0 name=/proc/self/fd/20 inode=68864 dev=00:19 mode=file,200 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:sysfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01-12-25 05:41:56.864:230) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f10297f8e50 a2=O_RDONLY|O_NOCTTY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=5621 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=udev-event exe=/usr/bin/virtnodedevd subj=system_u:system_r:virtnodedevd_t:s0 key=(null) type=AVC msg=audit(01-12-25 05:41:56.864:230) : avc:  denied  { dac_override } for  pid=5621 comm=udev-event capability=dac_override  scontext=system_u:system_r:virtnodedevd_t:s0 tcontext=system_u:system_r:virtnodedevd_t:s0 tclass=capability permissive=0 type=AVC msg=audit(01-12-25 05:41:56.864:230) : avc:  denied  { dac_read_search } for  pid=5621 comm=udev-event capability=dac_read_search  scontext=system_u:system_r:virtnodedevd_t:s0 tcontext=system_u:system_r:virtnodedevd_t:s0 tclass=capability permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2394805