### PR TITLE
waydroid, iptables: dontaudit nft attempts to read waydroid FDs

### DIFF
--- a/policy/modules/contrib/waydroid.if
+++ b/policy/modules/contrib/waydroid.if
@@ -1,0 +1,19 @@
+## <summary>The waydroid domain.</summary>
+
+########################################
+## <summary>
+##    Dontaudit read the process state (/proc/pid) of waydroid
+## </summary>
+## <param name="domain">
+##    <summary>
+##    Domain allowed access.
+##    </summary>
+## </param>
+# 
+interface(`waydroid_dontaudit_read_state',`
+    gen_require(`
+        type waydroid_t;
+    ')
+    dontaudit $1 waydroid_t:file read;
+    dontaudit $1 waydroid_t:lnk_file read;
+')

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -216,3 +216,6 @@ optional_policy(`
 	wireguard_read_fifo_files(iptables_t)
 ')
 
+optional_policy(`
+	waydroid_dontaudit_read_state(iptables_t)
+')


### PR DESCRIPTION
Resolves bz#2360313.