### PR TITLE
Allow mdadm to use CAP_BPF during RAID monitoring

### DIFF
--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -42,6 +42,7 @@ logging_log_file(mdadm_log_t)
 
 allow mdadm_t self:capability { dac_read_search dac_override ipc_lock sys_admin sys_ptrace };
 dontaudit mdadm_t self:capability { sys_tty_config };
+allow mdadm_t self:capability2 { bpf };
 allow mdadm_t self:cap_userns { sys_ptrace };
 allow mdadm_t self:process { getsched setsched sigchld sigkill sigstop signull signal };
 allow mdadm_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
mdadm_t should be permitted to use CAP_BPF if required for legitimate RAID monitoring operations

Fixes: https://issues.redhat.com/browse/RHEL-135764