### PR TITLE
Allow rpc.mountd setuid and setgid capabilities

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -237,7 +237,7 @@ optional_policy(`
 # NFSD local policy
 #
 
-allow nfsd_t self:capability { dac_read_search dac_override sys_admin sys_chroot sys_rawio sys_resource };
+allow nfsd_t self:capability { dac_read_search dac_override setgid setuid sys_admin sys_chroot sys_rawio sys_resource };
 
 allow nfsd_t self:process { setcap };
 


### PR DESCRIPTION
The capabilities are now required because of a newly introduced setresuid() syscall.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(5.2.2026 09:16:27.810:311) : proctitle=/usr/sbin/rpc.mountd type=SYSCALL msg=audit(5.2.2026 09:16:27.810:311) : arch=x86_64 syscall=setresuid success=yes exit=0 a0=unset a1=root a2=unset a3=0x7fff6f5d81c8 items=0 ppid=1 pid=6910 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc.mountd exe=/usr/sbin/rpc.mountd subj=system_u:system_r:nfsd_t:s0 key=(null)