### PR TITLE
Allow rhsmcertd read anaconda run files

### DIFF
--- a/policy/modules/contrib/anaconda.if
+++ b/policy/modules/contrib/anaconda.if
@@ -185,3 +185,21 @@ interface(`anaconda_fd_use',`
 
 	allow $1 install_t:fd use;
 ')
+
+#######################################
+## <summary>
+##      Allow a domain read install /run files.
+## </summary>
+## <param name="domain">
+## <summary>
+##      Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`install_read_var_run_files',`
+        gen_require(`
+                type install_var_run_t;
+        ')
+
+        allow $1 install_var_run_t:file read_file_perms;
+')

--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -171,6 +171,10 @@ optional_policy(`
 #')
 
 optional_policy(`
+	install_read_var_run_files(rhsmcertd_t)
+')
+
+optional_policy(`
 	kpatch_domtrans(rhsmcertd_t)
 	kpatch_read_lib_files(rhsmcertd_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial, expecting that /run/ostree-booted file was assigned the install_var_run_t type: type=PROCTITLE msg=audit(15.1.2026 18:53:57.588:539) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-package-profile-uploader --force-upload type=AVC msg=audit(15.1.2026 18:53:57.588:539) : avc:  denied  { read } for  pid=6024 comm=rhsm-package-pr name=ostree-booted dev="tmpfs" ino=558 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(15.1.2026 18:53:57.588:539) : avc:  denied  { open } for  pid=6024 comm=rhsm-package-pr path=/run/ostree-booted dev="tmpfs" ino=558 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=1 type=SYSCALL msg=audit(15.1.2026 18:53:57.588:539) : arch=x86_64 syscall=openat success=yes exit=8 a0=AT_FDCWD a1=0x7f1f842b598b a2=O_RDONLY|O_CLOEXEC a3=0x0 items=0 ppid=3858 pid=6024 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-package-pr exe=/usr/bin/python3.12 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)

Resolves: RHEL-141391