### PR TITLE
Allow dovecoth-auth to connect to systemd-logind over a unix socket

### DIFF
--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -279,6 +279,7 @@ files_read_usr_symlinks(dovecot_auth_t)
 files_read_var_lib_files(dovecot_auth_t)
 files_search_tmp(dovecot_auth_t)
 
+fs_getattr_pidfs(dovecot_auth_t)
 fs_getattr_xattr_fs(dovecot_auth_t)
 
 init_rw_utmp(dovecot_auth_t)
@@ -328,6 +329,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_logind_stream_connect(dovecot_auth_t)
 	systemd_private_tmp(dovecot_auth_tmp_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
audit[500854]: AVC avc:  denied  { write } for  pid=500854 comm="auth" name="io.systemd.Login" dev="tmpfs" ino=4112 scontext=system_u:system_r:dovecot_auth_t:s0 tcontext=system_u:object_r:systemd_logind_var_run_t:s0 tclass=sock_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2426971