### PR TITLE
TLP Fixes (bsc#1257527) 

### DIFF
--- a/policy/modules/contrib/powerprofiles.if
+++ b/policy/modules/contrib/powerprofiles.if
@@ -1,1 +1,19 @@
 ## <summary>Power profiles handling over D-Bus</summary>
+
+########################################
+## <summary>
+##	Allow the domain to read powerprofiles state files in /proc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`powerprofiles_read_state',`
+	gen_require(`
+		type powerprofiles_t;
+	')
+
+	ps_process_pattern($1, powerprofiles_t)
+')

--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -60,6 +60,11 @@ dev_manage_sysfs(tlp_t)
 dev_rw_cpu_microcode(tlp_t)
 dev_rw_wireless(tlp_t)
 
+# tlp uses ps aux to check the process list and then
+# greps for only tuned-ppd, power-profiles-daemon and
+# tlp-pd. Dontauditing the rest.
+domain_dontaudit_search_all_domains_state(tlp_t)
+
 files_read_kernel_modules(tlp_t)
 files_map_kernel_modules(tlp_t)
 files_load_kernel_modules(tlp_t)
@@ -106,6 +111,10 @@ ifdef(`snappy_search_lib',`
 ')
 
 optional_policy(`
+	powerprofiles_read_state(tlp_t)
+')
+
+optional_policy(`
     sssd_read_public_files(tlp_t)
     sssd_stream_connect(tlp_t)
 ')
@@ -119,5 +128,14 @@ optional_policy(`
 ')
 
 optional_policy(`
+	tuned_ppd_read_state(tlp_t)
+')
+
+optional_policy(`
 	udev_domtrans(tlp_t)
+')
+
+optional_policy(`
+	# tlp-pd is not confined ATM
+	unconfined_server_read_state(tlp_t)
 ')

--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -29,6 +29,12 @@ allow tlp_t self:udp_socket create_socket_perms;
 allow tlp_t self:unix_dgram_socket create_socket_perms;
 allow tlp_t self:netlink_generic_socket create_socket_perms;
 
+# tlp uses ps aux to check the process list and then
+# greps for only tuned-ppd, power-profiles-daemon and
+# tlp-pd. ps does not need those two necessarily to work:
+dontaudit tlp_t self:cap_userns sys_ptrace;
+dontaudit tlp_t self:capability2 perfmon;
+
 allow tlp_t tlp_unit_file_t:file read_file_perms;
 
 manage_dirs_pattern(tlp_t, tlp_var_run_t, tlp_var_run_t)

--- a/policy/modules/contrib/tuned.if
+++ b/policy/modules/contrib/tuned.if
@@ -199,3 +199,21 @@ interface(`tuned_dbus_chat_ppd',`
 	allow $1 tuned_ppd_t:dbus send_msg;
 	allow tuned_ppd_t $1:dbus send_msg;
 ')
+
+########################################
+## <summary>
+##	Allow the domain to read tuned state files in /proc.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tuned_ppd_read_state',`
+	gen_require(`
+		type tuned_ppd_t;
+	')
+
+	ps_process_pattern($1, tuned_ppd_t)
+')


### PR DESCRIPTION
see https://bugzilla.suse.com/show_bug.cgi?id=1257527

TLP uses `ps aux | grep ...` to check for different running services such as tuned-ppd or power-profiles-daemon and sets different profiles depending on it.

see for example:
https://github.com/linrunner/TLP/blob/700c4caf8b8139e292e9ef44335a897587a2c035/tlp-func-base.in#L470

So dontaudit generally and allow only tuned, ppd and unconfined_service_t (for tlp-pd, which not confined ATM in openSUSE)
Also dontaudit ps permissions that tlp_t does not need

FYI, in openSUSE the tlp package has a `Conflicts:` with power-profiles-daemon and tuned, so this scenario where both are running is very unlikely (so the `ps aux | grep` check is likely always false). In fedora rawhide it seems only tuned and ppd are conflicting in the package spec file, but when I tested installng `tlp` and then `power-profiles-daemon`, it gives conflicting files, so that combination is also not installable.