### PR TITLE
Allow mdadm to use CAP_BPF during RAID monitoring

### DIFF
--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -41,6 +41,7 @@ logging_log_file(mdadm_log_t)
 
 allow mdadm_t self:capability { dac_read_search dac_override sys_admin ipc_lock };
 dontaudit mdadm_t self:capability { sys_tty_config sys_ptrace };
+allow mdadm_t self:capability2 { bpf };
 dontaudit mdadm_t self:cap_userns { sys_ptrace };
 allow mdadm_t self:process { getsched setsched sigchld sigkill sigstop signull signal };
 allow mdadm_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
mdadm_t should be permitted to use CAP_BPF if required for legitimate RAID monitoring operations

Steps to reproduce the AVC denial:
- Install RHEL 9.7 with SELinux enforcing.
- Create one or more software RAID arrays using mdadm.
- Ensure /etc/mdadm.conf exists and contains array definitions.
- Allow systemd to start RAID monitoring services (or reboot).
- Check audit logs:  ausearch -m avc -ts recent | grep mdadm

Fixes: https://issues.redhat.com/browse/RHEL-135764