### PR TITLE
Allow mdadm use modprobe (bsc#1257793)

### DIFF
--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -121,6 +121,8 @@ fs_search_all(mdadm_t)
 mls_file_read_all_levels(mdadm_t)
 mls_file_write_all_levels(mdadm_t)
 
+modutils_domtrans_kmod(mdadm_t)
+
 storage_dev_filetrans_fixed_disk(mdadm_t)
 storage_manage_fixed_disk(mdadm_t)
 storage_read_scsi_generic(mdadm_t)


### PR DESCRIPTION
mdadm needs permissions to execute modprobe:
https://github.com/md-raid-utilities/mdadm/blob/43d5b7866827ccb645d5eaa92aeba96fa85571c6/util.c#L2615

Leads to a failed boot otherwise:
https://bugzilla.suse.com/show_bug.cgi?id=1257793

Fixes:
Feb 02 08:05:31 workstation kernel: audit: type=1400 audit(1770015931.612:4): avc:  denied  { getattr } for  pid=1161 comm="sh" path="/usr/bin/kmod" dev="dm-0" ino=1739916 scontext=system_u:system_r:mdadm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:kmod_exec_t:s0 tclass=file permissive=0