### PR TITLE
ecryptfs uses /home/.ecryptfs for full homedir encryption (bsc#1258350)

### DIFF
--- a/policy/modules/kernel/filesystem.fc
+++ b/policy/modules/kernel/filesystem.fc
@@ -1,6 +1,7 @@
 # ecryptfs does not support xattr
 HOME_DIR/\.ecryptfs(/.*)?	gen_context(system_u:object_r:ecryptfs_t,s0)
 HOME_DIR/\.Private(/.*)?	gen_context(system_u:object_r:ecryptfs_t,s0)
+HOME_ROOT/\.ecryptfs(/.*)?	gen_context(system_u:object_r:ecryptfs_t,s0)
 
 /dev/hugepages		-d	gen_context(system_u:object_r:hugetlbfs_t,s0)
 /dev/hugepages(/.*)?		<<none>>


### PR DESCRIPTION
ecryptfs uses /home/.ecryptfs for full homedir encryption

see: https://bugzilla.suse.com/show_bug.cgi?id=1258350
i think there was also one for fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1757228

Fixes:

```
type=AVC msg=audit(1771406494.908:115): avc:  denied  { read } for  pid=1107 comm="(systemd)" name=".ecryptfs" dev="vda3" ino=274 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=lnk_file permissive=0
type=AVC msg=audit(1771407174.388:115): avc:  denied  { read } for  pid=958 comm="(systemd)" name=".ecryptfs" dev="vda3" ino=274 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=lnk_file permissive=0
type=AVC msg=audit(1771408136.620:102): avc:  denied  { getattr } for  pid=802 comm="login" path="/home/.ecryptfs/foo/.ecryptfs/auto-mount" dev="vda3" ino=279 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408136.621:103): avc:  denied  { read } for  pid=958 comm="login" name="wrapped-passphrase" dev="vda3" ino=281 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408136.621:104): avc:  denied  { read } for  pid=958 comm="login" name="wrapped-passphrase" dev="vda3" ino=281 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408136.775:118): avc:  denied  { getattr } for  pid=982 comm="login" path="/home/.ecryptfs/foo/.ecryptfs/auto-mount" dev="vda3" ino=279 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408326.761:125): avc:  denied  { getattr } for  pid=802 comm="login" path="/home/.ecryptfs/foo/.ecryptfs/Private.sig" dev="vda3" ino=282 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408361.958:92): avc:  denied  { getattr } for  pid=797 comm="login" path="/home/.ecryptfs/foo/.ecryptfs/auto-mount" dev="vda3" ino=279 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408361.959:93): avc:  denied  { read } for  pid=797 comm="login" name="Private.mnt" dev="vda3" ino=283 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408361.960:94): avc:  denied  { read } for  pid=907 comm="login" name="wrapped-passphrase" dev="vda3" ino=281 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408361.960:95): avc:  denied  { read } for  pid=907 comm="login" name="wrapped-passphrase" dev="vda3" ino=281 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
type=AVC msg=audit(1771408362.106:109): avc:  denied  { getattr } for  pid=797 comm="login" path="/home/.ecryptfs/foo/.ecryptfs/Private.sig" dev="vda3" ino=282 scontext=system_u:system_r:local_login_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0
```