### PR TITLE
Allow tlshd write generic certificate dirs

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -37,6 +37,7 @@ optional_policy(`
 	miscfiles_read_generic_certs(ktlshd_t)
 	miscfiles_map_generic_certs(ktlshd_t)
 	miscfiles_write_generic_certs(ktlshd_t)
+	miscfiles_write_generic_cert_dirs(ktlshd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -167,6 +167,24 @@ interface(`miscfiles_write_generic_certs',`
 
 ########################################
 ## <summary>
+##	Write generic SSL certificate dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`miscfiles_write_generic_cert_dirs',`
+	gen_require(`
+		type cert_t;
+	')
+
+	allow $1 cert_t:dir write;
+')
+
+########################################
+## <summary>
 ##	Manage generic SSL certificates.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(1770124993.122:3505): proctitle="/usr/sbin/tlshd" type=SYSCALL msg=audit(1770124993.122:3505): arch=c000003e syscall=21 success=no exit=-13 a0=561ac94d3ef0 a1=2 a2=0 a3=0 items=0 ppid=16233 pid=17706 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="tlshd" exe="/usr/sbin/tlshd" subj=system_u:system_r:ktlshd_t:s0 key=(null) type=AVC msg=audit(1770124993.122:3505): avc:  denied  { write } for pid=17706 comm="tlshd" name="source" dev="dm-0" ino=150995736 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=0

Resolves: RHEL-123737