### PR TITLE
Allow NetworkManager list bpf directories

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -204,6 +204,7 @@ dev_getattr_all_chr_files(NetworkManager_t)
 dev_rw_wireless(NetworkManager_t)
 
 fs_getattr_all_fs(NetworkManager_t)
+fs_list_bpf_dirs(NetworkManager_t)
 fs_search_auto_mountpoints(NetworkManager_t)
 fs_read_nsfs_files(NetworkManager_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/18/2026 11:39:17.252:2185) : proctitle=/usr/sbin/NetworkManager --no-daemon type=SYSCALL msg=audit(01/18/2026 11:39:17.252:2185) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f0dfcc0323b a2=O_RDONLY|O_DIRECTORY a3=0x0 items=0 ppid=1 pid=111285 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=NetworkManager exe=/usr/sbin/NetworkManager subj=system_u:system_r:NetworkManager_t:s0 key=(null) type=AVC msg=audit(01/18/2026 11:39:17.252:2185) : avc: denied { read } for pid=111285 comm=NetworkManager name=/ dev="bpf" ino=1 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:bpf_t:s0 tclass=dir permissive=0

Resolves: RHEL-142171