### PR TITLE
Allow systemd-coredump the kill capability in the user namespace

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1316,7 +1316,7 @@ systemd_read_efivarfs(systemd_sysctl_t)
 # setpcap - to drop capabilities
 allow systemd_coredump_t self:capability { dac_read_search net_admin setgid setpcap setuid sys_admin sys_chroot sys_ptrace };
 dontaudit systemd_coredump_t self:capability sys_resource;
-allow systemd_coredump_t self:cap_userns { dac_read_search dac_override setgid setuid sys_admin sys_chroot sys_ptrace };
+allow systemd_coredump_t self:cap_userns { dac_read_search dac_override kill setgid setuid sys_admin sys_chroot sys_ptrace };
 
 # To set its capability set
 allow systemd_coredump_t self:process setcap;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1764740444.595:818): avc:  denied  { kill } for  pid=181196 comm="systemd-coredum" capability=5  scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=cap_userns permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2418563