### PR TITLE
Condition ptrace permission on deny_trace boolean

### DIFF
--- a/policy/modules/contrib/lockdev.if
+++ b/policy/modules/contrib/lockdev.if
@@ -55,7 +55,10 @@ interface(`lockdev_role',`
 
 	domtrans_pattern($2, lockdev_exec_t, lockdev_t)
 
-	allow $2 lockdev_t:process { ptrace signal_perms };
+	allow $2 lockdev_t:process signal_perms;
+	tunable_policy(`deny_ptrace',`',`
+		allow $2 lockdev_t:process ptrace;
+	')
 	ps_process_pattern($2, lockdev_t)
 
 	allow lockdev_t $2:process signull;

--- a/policy/modules/contrib/pcm.te
+++ b/policy/modules/contrib/pcm.te
@@ -14,7 +14,10 @@ permissive pcmsensor_t;
 allow pcmsensor_t self:capability { sys_rawio sys_resource };
 allow pcmsensor_t self:capability2 perfmon;
 allow pcmsensor_t self:perf_event { cpu kernel open read };
-allow pcmsensor_t self:process { ptrace setrlimit setsched };
+allow pcmsensor_t self:process { setrlimit setsched };
+tunable_policy(`deny_ptrace',`',`
+	allow pcmsensor_t self:process ptrace;
+')
 allow pcmsensor_t self:tcp_socket create_stream_socket_perms;
 
 kernel_read_proc_files(pcmsensor_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -494,7 +494,9 @@ files_mountpoint(container_ro_file_t)
 #
 
 allow svirt_t self:capability sys_rawio;
-allow svirt_t self:process ptrace;
+tunable_policy(`deny_ptrace',`',`
+	allow svirt_t self:process ptrace;
+')
 
 allow svirt_t self:netlink_rdma_socket create_socket_perms;
 # it was a part of auth_use_nsswitch

--- a/policy/modules/contrib/wireshark.if
+++ b/policy/modules/contrib/wireshark.if
@@ -26,7 +26,10 @@ interface(`wireshark_role',`
 
 	domtrans_pattern($2, wireshark_exec_t, wireshark_t)
 
-	allow $2 wireshark_t:process { ptrace signal_perms };
+	allow $2 wireshark_t:process signal_perms;
+	tunable_policy(`deny_ptrace',`',`
+		allow $2 wireshark_t:process ptrace;
+	')
 	ps_process_pattern($2, wireshark_t)
 
 	allow $2 { wireshark_tmp_t wireshark_home_t wireshark_tmpfs_t }:dir { manage_dir_perms relabel_dir_perms };


### PR DESCRIPTION
The `ptrace` permission is conditioned on `deny_ptrace` being set to false everywhere except in these few instances. This makes these parts of the policy consistent with the rest.