### PR TITLE
Allow httpds to connect to fcgiwrap

### DIFF
--- a/policy/modules/contrib/apache.fc
+++ b/policy/modules/contrib/apache.fc
@@ -73,6 +73,7 @@ HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?	gen_context(system_u:objec
 /usr/bin/rotatelogs		--	gen_context(system_u:object_r:httpd_rotatelogs_exec_t,s0)
 /usr/bin/suexec		--	gen_context(system_u:object_r:httpd_suexec_exec_t,s0)
 /usr/bin/thttpd        -- gen_context(system_u:object_r:httpd_exec_t,s0)
+/usr/bin/fcgiwrap		--	gen_context(system_u:object_r:httpd_exec_t,s0)
 
 ifdef(`distro_suse', `
 /usr/bin/httpd2-.*		--	gen_context(system_u:object_r:httpd_exec_t,s0)


### PR DESCRIPTION
Prior to f31, nginx (and other processes running with httpd_t) were able to connect to fcgiwrap's FastCGI UNIX socket, with fcgiwrap running with unconfined_service_t, with policy:

    $ sudo sesearch -A -s httpd_t -t unconfined_service_t -c unix_stream_socket
    allow domain unconfined_service_t:unix_stream_socket { connectto getattr };

This policy no longer exists in f31, I presume via 936db96bc, and the connection is denied:

    type=AVC msg=audit(1771851421.922:190): avc:  denied  { connectto } for  pid=938 comm="nginx" path="/run/fcgiwrap/fcgiwrap-nginx.sock" scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=unix_stream_socket permissive=0

Applying httpd_exec_t to fcgiwrap, similar to php-fpm (another FastCGI application that nginx and other covered httpds connect to), reenables this connection.

Discussion at https://bugzilla.redhat.com/show_bug.cgi?id=2441936

Do I need to file a separate bug here or one for selinux-policy on Bugzilla?

I intend to backport to c{9,10}s if this is merged.