### PR TITLE
Dontaudit tlshd write generic certificate dirs

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -37,7 +37,7 @@ optional_policy(`
 	miscfiles_read_generic_certs(ktlshd_t)
 	miscfiles_map_generic_certs(ktlshd_t)
 	miscfiles_write_generic_certs(ktlshd_t)
-	miscfiles_write_generic_cert_dirs(ktlshd_t)
+	miscfiles_dontaudit_write_generic_cert_dirs(ktlshd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -185,6 +185,24 @@ interface(`miscfiles_write_generic_cert_dirs',`
 
 ########################################
 ## <summary>
+##	Do not audit attempts to write generic SSL certificate dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`miscfiles_dontaudit_write_generic_cert_dirs',`
+	gen_require(`
+		type cert_t;
+	')
+
+	dontaudit $1 cert_t:dir write;
+')
+
+########################################
+## <summary>
 ##	Manage generic SSL certificates.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
This is a follow-up to (or a partial revert of) the b99bb0d1e029 ("Allow tlshd write generic certificate dirs") commit as it turned out dir-write permission is not actually needed for tlshd, but the raised denial is just an effect of access(W_OK) executed in the init phase of p11-kit-trust to decide if the library will enable read-only or read-write mode. It is dontaudited instead.

Resolves: RHEL-127023