### PR TITLE
Allow fs_write_tmpfs_files for systemd_sleep_t

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1909,6 +1909,7 @@ dev_rw_sysfs(systemd_sleep_t)
 dev_write_kmsg(systemd_sleep_t)
 
 fs_manage_efivarfs_files(systemd_sleep_t)
+fs_rw_tmpfs_files(systemd_sleep_t)
 
 fstools_rw_swap_files(systemd_sleep_t)
 


### PR DESCRIPTION
The NVIDIA driver [uses `filp_open()`](https://github.com/NVIDIA/open-gpu-kernel-modules/blob/590.48.01/kernel-open/nvidia/os-interface.c#L1840) to create an anonymous temporary file during system suspend, which it uses to temporarily store the contents of GPU video memory when video memory preservation is enabled. This anonymous file is created in the filesystem backing `/tmp` by default, but the path can be configured with the
[`NVreg_TemporaryFilePath=` kernel module parameter](https://download.nvidia.com/XFree86/Linux-x86_64/590.48.01/README/powermanagement.html). A future version of the driver is planned to switch to using an anonymous shmem (tmpfs) file by default instead.

Currently, the code to do this is triggered by a write to `/proc/driver/nvidia/suspend`, which comes from the `nvidia-sleep.sh` script that is run by the `nvidia-suspend.service` systemd unit. This service runs in `unconfined_service_t`.

A future version of the NVIDIA driver will instead run this code in response to `systemd-sleep`'s write to `/sys/power/state`, which runs in the very restrictive `systemd_sleep_t` context, which blocks this filesystem access, causing suspend to fail.

Fix this problem by allowing tmpfs access in `systemd_sleep_t`.