### PR TITLE
Allow rtkit-daemon dbus chat with systemd-logind

### DIFF
--- a/policy/modules/contrib/rtkit.te
+++ b/policy/modules/contrib/rtkit.te
@@ -36,4 +36,7 @@ optional_policy(`
 	optional_policy(`
 		policykit_dbus_chat(rtkit_daemon_t)
 	')
+	optional_policy(`
+		systemd_dbus_chat_logind(rtkit_daemon_t)
+	')
 ')


### PR DESCRIPTION
The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(03/02/2026 09:54:12.771:71) : pid=857 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:rtkit_daemon_t:s0 tcontext=system_u:system_r:systemd_logind_t:s0 tclass=dbus permissive=0 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'