### PR TITLE
Allow rtkit-daemon write systemd inhibit pipes

### DIFF
--- a/policy/modules/contrib/rtkit.te
+++ b/policy/modules/contrib/rtkit.te
@@ -40,3 +40,7 @@ optional_policy(`
 		systemd_dbus_chat_logind(rtkit_daemon_t)
 	')
 ')
+
+optional_policy(`
+	systemd_write_inhibit_pipes(rtkit_daemon_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/05/2026 15:58:55.938:5942) : proctitle=/usr/libexec/rtkit-daemon type=SYSCALL msg=audit(03/05/2026 15:58:55.938:5942) : arch=x86_64 syscall=recvmsg success=yes exit=76 a0=0x4 a1=0x7ffed347c290 a2=MSG_CMSG_CLOEXEC a3=0x0 items=0 ppid=1 pid=213566 auid=unset uid=rtkit gid=rtkit euid=rtkit suid=rtkit fsuid=rtkit egid=rtkit sgid=rtkit fsgid=rtkit tty=(none) ses=unset comm=rtkit-daemon exe=/usr/libexec/rtkit-daemon subj=system_u:system_r:rtkit_daemon_t:s0 key=(null) type=AVC msg=audit(03/05/2026 15:58:55.938:5942) : avc:  denied  { write } for  pid=213566 comm=rtkit-daemon path=/run/systemd/inhibit/17.ref dev="tmpfs" ino=4930 scontext=system_u:system_r:rtkit_daemon_t:s0 tcontext=system_u:object_r:systemd_logind_inhibit_var_run_t:s0 tclass=fifo_file permissive=0