### PR TITLE
Allow nfsd_t domain setuid and setgid capability for rpc.mountd

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -237,7 +237,7 @@ optional_policy(`
 # NFSD local policy
 #
 
-allow nfsd_t self:capability { dac_read_search dac_override sys_admin sys_chroot sys_rawio sys_resource };
+allow nfsd_t self:capability { dac_read_search dac_override setgid setuid sys_admin sys_chroot sys_rawio sys_resource };
 
 allow nfsd_t self:process { setcap };
 


### PR DESCRIPTION
This commit addresses the following AVC denial:

type=AVC msg=audit(1770654443.859:310): avc:  denied  { setgid } for  pid=2689 comm="rpc.mountd" capability=6  scontext=system_u:system_r:nfsd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=capability permissive=0
type=SYSCALL msg=audit(1770654443.859:310): arch=c000003e syscall=116 success=no exit=-1 a0=1 a1=55d30809b370 a2=0 a3=0 items=0 ppid=1 pid=2689 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="rpc.mountd" exe="/usr/sbin/rpc.mountd" subj=system_u:system_r:nfsd_t:s0 key=(null)ARCH=x86_64 SYSCALL=setgroups AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
type=PROCTITLE msg=audit(1770654443.859:310): proctitle="/usr/sbin/rpc.mountd"

Signed-off-by: Scott Mayhew <smayhew@redhat.com>

Resolves: RHEL-148247