### PR TITLE
Allow systemd create symlinks in /run/varlink/registry

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -579,8 +579,10 @@ optional_policy(`
     systemd_hostnamed_delete_config(init_t)
 	systemd_manage_conf_files(init_t)
 	systemd_rw_networkd_tmpfs_files(init_t)
+	systemd_machined_create_pid_lnk_files(init_t)
 	systemd_machined_watch_user_ptys(init_t)
 	systemd_machined_watch_reads_user_ptys(init_t)
+	systemd_varlink_registry_create_lnk_files(init_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -167,6 +167,10 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_run_t,s0)
 /run/systemd/zram-generator.conf	--	gen_context(system_u:object_r:systemd_zram_generator_conf_t,s0)
 
+/run/varlink			-d	gen_context(system_u:object_r:systemd_varlink_t,s0)
+/run/varlink/registry		-d	gen_context(system_u:object_r:systemd_varlink_registry_t,s0)
+/run/varlink/registry/.+	-l	gen_context(system_u:object_r:systemd_varlink_registry_t,s0)
+
 /run/log/bootchart.*	--	gen_context(system_u:object_r:systemd_bootchart_var_run_t,s0)
 
 /run/systemd/units(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -160,6 +160,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/machines.lock	--	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/oom(/.*)?		gen_context(system_u:object_r:systemd_oomd_var_run_t,s0)
 /run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)
+/run/systemd/resolve\.hook/io\.systemd\.Machine	-s	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
+/run/systemd/resolve\.hook/io\.systemd\.Network	-s	gen_context(system_u:object_r:systemd_networkd_var_run_t,s0)
 /run/systemd/netif(/.*)?	gen_context(system_u:object_r:systemd_networkd_var_run_t,s0)
 /run/systemd/import(/.*)?		gen_context(system_u:object_r:systemd_importd_var_run_t,s0)
 /run/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_run_t,s0)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -2423,6 +2423,25 @@ interface(`systemd_machined_manage_pid_files',`
 	manage_files_pattern($1, systemd_machined_var_run_t, systemd_machined_var_run_t)
 ')
 
+########################################
+## <summary>
+##	Create systemd-machined PID symlinks
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_machined_create_pid_lnk_files',`
+	gen_require(`
+		type systemd_machined_var_run_t;
+	')
+
+	files_search_pids($1)
+	create_lnk_files_pattern($1, systemd_machined_var_run_t, systemd_machined_var_run_t)
+')
+
 ######################################
 ## <summary>
 ##	List systemd-machined PID files.
@@ -3337,4 +3356,23 @@ interface(`systemd_oomd_stream_connect',`
 	allow $1 systemd_oomd_t:unix_stream_socket connectto;
 	allow $1 systemd_oomd_var_run_t:sock_file write;
 	files_search_pids($1)
+')
+
+########################################
+## <summary>
+##	Create /run/varlink/registry symlinks
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_varlink_registry_create_lnk_files',`
+	gen_require(`
+		type systemd_varlink_registry_t;
+	')
+
+	files_search_pids($1)
+	create_lnk_files_pattern($1, systemd_varlink_registry_t, systemd_varlink_registry_t)
 ')

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -332,6 +332,12 @@ files_pid_file(systemd_oomd_var_run_t)
 systemd_domain_template(systemd_pcrextend)
 systemd_domain_template(systemd_pcrlock)
 
+# /run/varlink{,/registry}
+type systemd_varlink_t;
+files_pid_file(systemd_varlink_t)
+type systemd_varlink_registry_t;
+files_pid_file(systemd_varlink_registry_t)
+
 #######################################
 #
 # Systemd_logind local policy

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -601,7 +601,9 @@ init_status(systemd_machined_t)
 init_start(systemd_machined_t)
 init_stop(systemd_machined_t)
 init_manage_config_transient_files(systemd_machined_t)
+init_create_pid_dirs(systemd_machined_t)
 init_named_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, file, "machines.lock")
+init_named_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, sock_file, "io.systemd.Machine")
 
 logging_dgram_send(systemd_machined_t)
 
@@ -708,6 +710,8 @@ fs_cgroup_write_memory_pressure(systemd_networkd_t)
 dev_read_sysfs(systemd_networkd_t)
 dev_write_kmsg(systemd_networkd_t)
 
+init_create_pid_dirs(systemd_networkd_t)
+init_named_pid_filetrans(systemd_networkd_t, systemd_networkd_var_run_t, sock_file, "io.systemd.Network")
 init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "netif")
 
 sysnet_manage_config(systemd_networkd_t)
@@ -1651,6 +1655,7 @@ init_pid_filetrans(systemd_resolved_t, systemd_resolved_var_run_t, dir)
 
 list_dirs_pattern(systemd_resolved_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 read_files_pattern(systemd_resolved_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
+allow systemd_resolved_t systemd_networkd_var_run_t:sock_file write;
 allow systemd_resolved_t systemd_networkd_var_run_t:dir watch_dir_perms;
 
 kernel_dgram_send(systemd_resolved_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(03/09/2026 04:15:40.897:59) : avc:  denied  { create } for  pid=1 comm=systemd name=io.systemd.Login scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=lnk_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2443593