### PR TITLE
Allow systemd-mountfsd the perfmon capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2011,6 +2011,7 @@ optional_policy(`
 #
 
 allow systemd_mountfsd_t self:capability { sys_ptrace sys_resource };
+allow systemd_mountfsd_t self:capability2 { perfmon };
 allow systemd_mountfsd_t systemd_mountfsd_exec_t:file execute_no_trans;
 
 permissive systemd_mountfsd_t;


### PR DESCRIPTION
This capability is required to get content of the PID1's environ file.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/06/2026 19:47:05.990:9394) : proctitle=/usr/lib/systemd/systemd-mountfsd type=PATH msg=audit(03/06/2026 19:47:05.990:9394) : item=0 name=/proc/1/environ inode=513009 dev=00:41 mode=file,400 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:init_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/06/2026 19:47:05.990:9394) : arch=x86_64 syscall=openat success=yes exit=4 a0=AT_FDCWD a1=0x7ffcd49bfdc0 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=379325 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-mountfs exe=/usr/lib/systemd/systemd-mountfsd subj=system_u:system_r:systemd_mountfsd_t:s0 key=(null) type=AVC msg=audit(03/06/2026 19:47:05.990:9394) : avc:  denied  { perfmon } for  pid=379325 comm=systemd-mountfs capability=perfmon  scontext=system_u:system_r:systemd_mountfsd_t:s0 tcontext=system_u:system_r:systemd_mountfsd_t:s0 tclass=capability2 permissive=1