### PR TITLE
Allow redis_t to create netlink_rdma_socket

### DIFF
--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -49,6 +49,9 @@ allow redis_t self:netlink_rdma_socket create_socket_perms;
 allow redis_t self:unix_stream_socket create_stream_socket_perms;
 allow redis_t self:tcp_socket create_stream_socket_perms;
 
+# RDMA
+allow redis_t self:netlink_rdma_socket create_socket_perms;
+
 manage_files_pattern(redis_t, redis_conf_t, redis_conf_t)
 
 manage_dirs_pattern(redis_t, redis_log_t, redis_log_t)


### PR DESCRIPTION
Valkey (a Redis fork) attempts to create a netlink RDMA socket during startup or network initialization.

The commit addresses the following AVC denial:
type=SYSCALL msg=audit(03/09/26 07:30:56.695:1051) : arch=x86_64 syscall=socket success=no exit=EACCES(Permission denied) a0=netlink a1=SOCK_RAW a2=hmp a3=0x3 items=0 ppid=1 pid=7795 auid=unset uid=valkey gid=valkey euid=valkey suid=valkey fsuid=valkey egid=valkey sgid=valkey fsgid=valkey tty=(none) ses=unset comm=valkey-server exe=/usr/bin/valkey-server subj=system_u:system_r:redis_t:s0 key=(null) type=AVC msg=audit(03/09/26 07:30:56.695:1051) : avc:  denied  { create } for  pid=7795 comm=valkey-server scontext=system_u:system_r:redis_t:s0 tcontext=system_u:system_r:redis_t:s0 tclass=netlink_rdma_socket permissive=0