### PR TITLE
Allow systemd-resolved connect to systemd-networkd over a unix stream…

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1662,6 +1662,7 @@ init_pid_filetrans(systemd_resolved_t, systemd_resolved_var_run_t, dir)
 list_dirs_pattern(systemd_resolved_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 read_files_pattern(systemd_resolved_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 allow systemd_resolved_t systemd_networkd_var_run_t:sock_file write;
+allow systemd_resolved_t systemd_networkd_t:unix_stream_socket connectto;
 allow systemd_resolved_t systemd_networkd_var_run_t:dir watch_dir_perms;
 
 kernel_dgram_send(systemd_resolved_t)


### PR DESCRIPTION
… socket

The commit addresses the following AVC denial:
-
type=PROCTITLE msg=audit(03/10/2026 14:00:32.644:154) : proctitle=/usr/lib/systemd/systemd-resolved type=PATH msg=audit(03/10/2026 14:00:32.644:154) : item=0 name=/run/systemd/resolve.hook/io.systemd.Network inode=769 dev=00:1c mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_networkd_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(03/10/2026 14:00:32.644:154) : cwd=/ type=SOCKADDR msg=audit(03/10/2026 14:00:32.644:154) : saddr={ saddr_fam=local path=/run/systemd/resolve.hook/io.systemd.Network } type=SYSCALL msg=audit(03/10/2026 14:00:32.644:154) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x19 a1=0x7ffde773d360 a2=0x2f a3=0x0 items=1 ppid=1 pid=700 auid=unset uid=systemd-resolve gid=systemd-resolve euid=systemd-resolve suid=systemd-resolve fsuid=systemd-resolve egid=systemd-resolve sgid=systemd-resolve fsgid=systemd-resolve tty=(none) ses=unset comm=systemd-resolve exe=/usr/lib/systemd/systemd-resolved subj=system_u:system_r:systemd_resolved_t:s0 key=(null) type=AVC msg=audit(03/10/2026 14:00:32.644:154) : avc:  denied  { connectto } for  pid=700 comm=systemd-resolve path=/run/systemd/resolve.hook/io.systemd.Network scontext=system_u:system_r:systemd_resolved_t:s0 tcontext=system_u:system_r:systemd_networkd_t:s0 tclass=unix_stream_socket permissive=0