### PR TITLE
colord: ensure correct labeling for ICC profiles in user home

### DIFF
--- a/policy/modules/contrib/colord.te
+++ b/policy/modules/contrib/colord.te
@@ -144,7 +144,7 @@ optional_policy(`
 
 optional_policy(`
 	gnome_read_home_icc_data_content(colord_t)
-	gnome_filetrans_home_content(colord_t)
+	gnome_manage_home_icc_data_content(colord_t)
 	# Fixes lots of breakage in F16 on upgrade
 	gnome_read_generic_data_home_files(colord_t)
     gnome_map_generic_data_home_files(colord_t)

--- a/policy/modules/contrib/colord.te
+++ b/policy/modules/contrib/colord.te
@@ -144,6 +144,7 @@ optional_policy(`
 
 optional_policy(`
 	gnome_read_home_icc_data_content(colord_t)
+	gnome_filetrans_home_content(colord_t)
 	# Fixes lots of breakage in F16 on upgrade
 	gnome_read_generic_data_home_files(colord_t)
     gnome_map_generic_data_home_files(colord_t)

--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -2309,3 +2309,28 @@ interface(`gnome_initial_setup_filetrans_named_content',`
 
 	files_pid_filetrans($1, gnome_initial_setup_var_run_t, dir, "gnome-initial-setup")
 ')
+
+########################################
+## <summary>
+##	Manage icc data home content.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`gnome_manage_home_icc_data_content',`
+	gen_require(`
+		type data_home_t, gconf_home_t, icc_data_home_t;
+	')
+
+	userdom_search_user_home_dirs($1)
+	allow $1 { data_home_t gconf_home_t }:dir search_dir_perms;
+
+	manage_dirs_pattern($1, icc_data_home_t, icc_data_home_t)
+	manage_files_pattern($1, icc_data_home_t, icc_data_home_t)
+	manage_lnk_files_pattern($1, icc_data_home_t, icc_data_home_t)
+
+	allow $1 icc_data_home_t:file map;
+')


### PR DESCRIPTION
colord: ensure correct labeling for ICC profiles in user home

Previously, this used gnome_filetrans_home_content(colord_t) to
ensure correct labeling of ICC profiles created under
~/.local/share/icc/.

However, that approach granted overly broad home directory file
transition permissions.

Introduce a new, minimal interface
gnome_manage_home_icc_data_content() to allow managing
icc_data_home_t content without requiring file transitions.

Since ~/.local/share/icc is already labeled as icc_data_home_t,
new files inherit the correct type, and only manage permissions
are required.

Update colord_t to use this new interface, aligning with
least-privilege principles.
