### PR TITLE
Allow rpcbind get attributes of the pidfs filesystem

### DIFF
--- a/policy/modules/contrib/rpcbind.te
+++ b/policy/modules/contrib/rpcbind.te
@@ -75,6 +75,8 @@ domain_use_interactive_fds(rpcbind_t)
 
 files_read_etc_runtime_files(rpcbind_t)
 
+fs_getattr_pidfs(rpcbind_t)
+
 auth_use_nsswitch(rpcbind_t)
 
 logging_send_syslog_msg(rpcbind_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1764468815.363:708): avc:  denied  { getattr } for  pid=21209 comm="rpcbind" name="/" dev="pidfs" ino=1 scontext=system_u:system_r:rpcbind_t:s0 tcontext=system_u:object_r:pidfs_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2417839