### PR TITLE
Allow dovecot_deliver_t map its private tmp files

### DIFF
--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -362,6 +362,7 @@ logging_log_filetrans(dovecot_deliver_t, dovecot_var_log_t, { file dir })
 manage_dirs_pattern(dovecot_deliver_t, dovecot_deliver_tmp_t, dovecot_deliver_tmp_t)
 manage_files_pattern(dovecot_deliver_t, dovecot_deliver_tmp_t, dovecot_deliver_tmp_t)
 files_tmp_filetrans(dovecot_deliver_t, dovecot_deliver_tmp_t, { file dir })
+allow dovecot_deliver_t dovecot_deliver_tmp_t:file map;
 
 allow dovecot_deliver_t dovecot_var_run_t:fifo_file write_fifo_file_perms;
 allow dovecot_deliver_t dovecot_var_run_t:dir list_dir_perms;


### PR DESCRIPTION
Dovecot 2.4 in F43 has an updated system for dovecot-lda that uses doveconf to load it's configuration.
When postfix (main.cf) is configured to use dovecot-lda: mailbox_command = /usr/libexec/dovecot/dovecot-lda -f "$SENDER" -a "$RECIPIENT" -d "$USER"

it results in errors in journal such as:
postfix/local[4314]: 0BBC120773: to=<XXX>, orig_to=<XXX>, relay=local, delay=0.03, delays=0/0/0/0.03, dsn=5.3.0, status=bounced (Command died with status 89: "/usr/libexec/dovecot/dovecot-lda -f "$SENDER" -a "$RECIPIENT" -d "$USER"". Command output: doveconf: Fatal: Failed to read config: mmap((temp config file)) failed: Permission denied )

The commit addresses this problem and the following AVC denial: type=AVC msg=audit(27.2.2026 20:16:55.997:245) : avc:  denied  { map } for  pid=4315 comm=doveconf path=/tmp/doveconf.56828550d8e6941a (deleted) dev="tmpfs" ino=56 scontext=system_u:system_r:dovecot_deliver_t:s0 tcontext=system_u:object_r:dovecot_deliver_tmp_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2443408