### PR TITLE
Allow rasdaemon_t to list pstore (bsc#1259742)

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -37,6 +37,7 @@ dev_rw_cpu_microcode(rasdaemon_t)
 
 corecmd_exec_bin(rasdaemon_t)
 
+fs_list_pstore(rasdaemon_t)
 fs_rw_tracefs_files(rasdaemon_t)
 fs_manage_tracefs_dirs(rasdaemon_t)
 fs_mount_tracefs(rasdaemon_t)


### PR DESCRIPTION
Fixes
type=AVC msg=audit(..): avc:  denied  { search } for  pid=1067 comm="rasdaemon" name="/" dev="pstore" ino=226 scontext=system_u:system_r:rasdaemon_t:s0 tcontext=system_u:object_r:pstore_t:s0 tclass=dir permissive=0