### PR TITLE
Dontaudit ps to read proc (bsc#1257527)

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -69,7 +69,7 @@ dev_rw_wireless(tlp_t)
 # tlp uses ps aux to check the process list and then
 # greps for only tuned-ppd, power-profiles-daemon and
 # tlp-pd. Dontauditing the rest.
-domain_dontaudit_search_all_domains_state(tlp_t)
+domain_dontaudit_read_all_domains_state(tlp_t)
 
 files_read_kernel_modules(tlp_t)
 files_map_kernel_modules(tlp_t)


### PR DESCRIPTION
Followup for https://github.com/fedora-selinux/selinux-policy/pull/3070
There were some additional AVCs that were not caught

Adresses:
----
time->Wed Mar 11 09:14:13 2026
type=AVC msg=audit(1773216853.669:772): avc:  denied  { read } for  pid=15667 comm="ps" name="3015" dev="proc" ino=23852 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dir permissive=0 ----
time->Wed Mar 11 09:14:13 2026
type=AVC msg=audit(1773216853.669:773): avc:  denied  { read } for  pid=15667 comm="ps" name="3017" dev="proc" ino=15269 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:system_r:init_t:s0 tclass=dir permissive=0 ----
time->Wed Mar 11 09:14:13 2026
type=AVC msg=audit(1773216853.669:774): avc:  denied  { read } for  pid=15667 comm="ps" name="3087" dev="proc" ino=25649 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dir permissive=0 ----
time->Wed Mar 11 09:14:13 2026
type=AVC msg=audit(1773216853.669:775): avc:  denied  { read } for  pid=15667 comm="ps" name="3088" dev="proc" ino=15331 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:system_r:kernel_t:s0 tclass=dir permissive=0 ----
time->Wed Mar 11 09:14:13 2026
type=AVC msg=audit(1773216853.669:776): avc:  denied  { read } for  pid=15667 comm="ps" name="3153" dev="proc" ino=25677 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:system_r:postfix_master_t:s0 tclass=dir permissive=0 ----
time->Wed Mar 11 09:14:13 2026
type=AVC msg=audit(1773216853.669:777): avc:  denied  { read } for  pid=15667 comm="ps" name="3155" dev="proc" ino=15332 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:system_r:postfix_pickup_t:s0 tclass=dir permissive=0 ----
time->Wed Mar 11 09:14:13 2026
type=AVC msg=audit(1773216853.669:778): avc:  denied  { read } for  pid=15667 comm="ps" name="3156" dev="proc" ino=15333 scontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:system_r:postfix_qmgr_t:s0 tclass=dir permissive=0