### PR TITLE
Allow virtqemud_t send kill signal to svirt_tcg_t

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2165,7 +2165,7 @@ allow virtqemud_t svirt_t:tcp_socket create_stream_socket_perms;
 allow virtqemud_t svirt_t:udp_socket create_socket_perms;
 allow virtqemud_t svirt_t:unix_stream_socket { connectto create_stream_socket_perms };
 allow virtqemud_t svirt_socket_t:unix_stream_socket connectto;
-allow virtqemud_t svirt_tcg_t:process { getrlimit getsched setsched signal signull transition };
+allow virtqemud_t svirt_tcg_t:process { getrlimit getsched setsched sigkill signal signull transition };
 allow virtqemud_t svirt_tcg_t:unix_stream_socket { connectto create_stream_socket_perms };
 
 allow virtqemud_t svirt_devpts_t:chr_file open;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/11/2025 11:17:26.626:172) : proctitle=/usr/sbin/virtqemud --timeout 120 type=OBJ_PID msg=audit(02/11/2025 11:17:26.626:172) : opid=1479 oauid=unset ouid=qemu oses=-1 obj=system_u:system_r:svirt_tcg_t:s0:c185,c466 ocomm=qemu-kvm type=SYSCALL msg=audit(02/11/2025 11:17:26.626:172) : arch=x86_64 syscall=kill success=yes exit=0 a0=0x5c7 a1=SIGKILL a2=0x7fd083755cba a3=0x7fd0807fc750 items=0 ppid=1 pid=817 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(02/11/2025 11:17:26.626:172) : avc:  denied  { sigkill } for  pid=817 comm=rpc-virtqemud scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:svirt_tcg_t:s0:c185,c466 tclass=process permissive=1

Resolves: RHEL-69913