### PR TITLE
Allow virtqemud_t get priority of a svirt_t process

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2160,7 +2160,7 @@ allow virtqemud_t self:udp_socket { connect create_socket_perms };
 allow virtqemud_t qemu_var_run_t:{ dir file sock_file } relabelfrom;
 
 allow virtqemud_t svirt_t:netlink_route_socket create_netlink_socket_perms;
-allow virtqemud_t svirt_t:process { getattr getrlimit setrlimit setsched signal signull transition };
+allow virtqemud_t svirt_t:process { getattr getrlimit getsched setrlimit setsched signal signull transition };
 allow virtqemud_t svirt_t:tcp_socket create_stream_socket_perms;
 allow virtqemud_t svirt_t:udp_socket create_socket_perms;
 allow virtqemud_t svirt_t:unix_stream_socket { connectto create_stream_socket_perms };


### PR DESCRIPTION
It can be reproduced with a simple "virsh vcpuinfo" command. The requesting process can be prio-rpc-virtqe or rpc-virtqemud.

The commit addresses the following AVC denial:
ype=PROCTITLE msg=audit(12/04/2024 02:39:12.055:577) : proctitle=/usr/sbin/virtqemud --timeout 120 type=SYSCALL msg=audit(12/04/2024 02:39:12.055:577) : arch=x86_64 syscall=sched_getaffinity success=yes exit=8 a0=0x187e a1=0x8000 a2=0x7fbdd0006ba0 a3=0x7ff items=0 ppid=1 pid=6049 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(12/04/2024 02:39:12.055:577) : avc:  denied  { getsched } for  pid=6049 comm=rpc-virtqemud scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:svirt_tcg_t:s0:c705,c923 tclass=process permissive=1

Resolves: RHEL-69920