### PR TITLE
Dontaudit logrotate perfmon and sys_admin capabilities

### DIFF
--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -64,7 +64,8 @@ files_type(logrotate_var_lib_t)
 
 # Change ownership on log files.
 allow logrotate_t self:capability { chown dac_read_search dac_override kill fsetid fowner setuid setgid sys_resource sys_nice sys_ptrace };
-dontaudit logrotate_t self:capability { sys_resource net_admin };
+dontaudit logrotate_t self:capability { sys_admin sys_resource net_admin };
+dontaudit logrotate_t self:capability2 { perfmon };
 dontaudit logrotate_t self:cap_userns { sys_ptrace };
 
 allow logrotate_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };


### PR DESCRIPTION
pkill/pgrep since procps-ng v4.0.5 and commit 23491ebf ("pgrep: Add match to environment variable") [1] has the ability to match processes on an environment variable. To read other processes' environ file, the perfmon or sys_admin capability is required. It is not necessary for logrotate though as it uses pkill without switches, so the permissions are dontaudited.

[1] https://gitlab.com/procps-ng/procps/-/commit/23491ebf40cd85de4ec62b135da513cbe88632e0

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/15/2026 00:34:51.855:2955) : proctitle=/bin/pkill -HUP sssd_kcm type=PATH msg=audit(03/15/2026 00:34:51.855:2955) : item=0 name=environ inode=628086 dev=00:59 mode=file,400 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:devicekit_power_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/15/2026 00:34:51.855:2955) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=0x5 a1=0x7f59e8991148 a2=O_RDONLY a3=0x0 items=1 ppid=68202 pid=68206 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pkill exe=/usr/bin/pkill subj=system_u:system_r:logrotate_t:s0 key=(null) type=AVC msg=audit(03/15/2026 00:34:51.855:2955) : avc:  denied  { sys_admin } for  pid=68206 comm=pkill capability=sys_admin  scontext=system_u:system_r:logrotate_t:s0 tcontext=system_u:system_r:logrotate_t:s0 tclass=capability permissive=0 type=AVC msg=audit(03/15/2026 00:34:51.855:2955) : avc:  denied  { perfmon } for  pid=68206 comm=pkill capability=perfmon  scontext=system_u:system_r:logrotate_t:s0 tcontext=system_u:system_r:logrotate_t:s0 tclass=capability2 permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2441942