### PR TITLE
Allow sys_resource on execution of generic executables conditionally

### DIFF
--- a/policy/global_tunables
+++ b/policy/global_tunables
@@ -153,3 +153,10 @@ gen_tunable(use_virtualbox, false)
 ## </p>
 ## </desc>
 gen_tunable(deny_bluetooth,false)
+
+## <desc>
+## <p>
+## Allow the sys_resource capability to all domains allowed to execute bin_t
+## </p>
+## </desc>
+gen_tunable(corecmd_bin_sys_resource, false)

--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -254,7 +254,7 @@ corenet_sctp_bind_generic_node(traceroute_t)
 corenet_icmp_bind_generic_node(traceroute_t)
 corenet_rawip_bind_unreserved_port(traceroute_t)
 
-corecmd_exec_bin(traceroute_t)
+corecmd_exec_bin_wrapper(traceroute_t)
 
 dev_getattr_infiniband_dev(traceroute_t)
 

--- a/policy/modules/admin/usermanage.te
+++ b/policy/modules/admin/usermanage.te
@@ -121,7 +121,7 @@ auth_run_chk_passwd(chfn_t, chfn_roles)
 
 # allow checking if a shell is executable
 corecmd_check_exec_shell(chfn_t)
-corecmd_exec_bin(chfn_t)
+corecmd_exec_bin_wrapper(chfn_t)
 
 domain_use_interactive_fds(chfn_t)
 
@@ -190,7 +190,7 @@ files_read_etc_runtime_files(crack_t)
 # for dictionaries
 files_read_usr_files(crack_t)
 
-corecmd_exec_bin(crack_t)
+corecmd_exec_bin_wrapper(crack_t)
 
 logging_send_syslog_msg(crack_t)
 
@@ -254,7 +254,7 @@ files_read_etc_runtime_files(groupadd_t)
 files_read_usr_symlinks(groupadd_t)
 
 # Execute /usr/bin/{passwd, chfn, chsh} and /usr/bin/{useradd, vipw}.
-corecmd_exec_bin(groupadd_t)
+corecmd_exec_bin_wrapper(groupadd_t)
 
 logging_send_audit_msgs(groupadd_t)
 logging_send_syslog_msg(groupadd_t)
@@ -366,7 +366,7 @@ auth_use_pam(passwd_t)
 
 # allow checking if a shell is executable
 corecmd_check_exec_shell(passwd_t)
-corecmd_exec_bin(passwd_t)
+corecmd_exec_bin_wrapper(passwd_t)
 
 corenet_tcp_connect_kerberos_password_port(passwd_t)
 
@@ -488,7 +488,7 @@ auth_etc_filetrans_shadow(sysadm_passwd_t)
 auth_use_nsswitch(sysadm_passwd_t)
 
 # allow vipw to exec the editor
-corecmd_exec_bin(sysadm_passwd_t)
+corecmd_exec_bin_wrapper(sysadm_passwd_t)
 corecmd_exec_shell(sysadm_passwd_t)
 files_read_usr_files(sysadm_passwd_t)
 
@@ -552,7 +552,7 @@ kernel_read_kernel_sysctls(useradd_t)
 
 corecmd_exec_shell(useradd_t)
 # Execute /usr/bin/{passwd,chfn,chsh} and /usr/bin/{useradd,vipw}.
-corecmd_exec_bin(useradd_t)
+corecmd_exec_bin_wrapper(useradd_t)
 
 kernel_getattr_core_if(useradd_t)
 dev_dontaudit_getattr_all(useradd_t)

--- a/policy/modules/apps/seunshare.te
+++ b/policy/modules/apps/seunshare.te
@@ -19,7 +19,7 @@ allow seunshare_domain self:fifo_file rw_file_perms;
 allow seunshare_domain self:unix_stream_socket create_stream_socket_perms;
 
 corecmd_exec_shell(seunshare_domain)
-corecmd_exec_bin(seunshare_domain)
+corecmd_exec_bin_wrapper(seunshare_domain)
 corecmd_getattr_all_executables(seunshare_domain)
 
 dev_read_urand(seunshare_domain)

--- a/policy/modules/contrib/abrt.te
+++ b/policy/modules/contrib/abrt.te
@@ -176,7 +176,7 @@ kernel_read_net_sysctls(abrt_t)
 kernel_rw_usermodehelper_state(abrt_t)
 kernel_read_sysctl(abrt_t)
 
-corecmd_exec_bin(abrt_t)
+corecmd_exec_bin_wrapper(abrt_t)
 corecmd_exec_shell(abrt_t)
 corecmd_read_all_executables(abrt_t)
 
@@ -463,7 +463,7 @@ list_dirs_pattern(abrt_retrace_coredump_t, abrt_retrace_spool_t, abrt_retrace_sp
 read_files_pattern(abrt_retrace_coredump_t, abrt_retrace_spool_t, abrt_retrace_spool_t)
 read_lnk_files_pattern(abrt_retrace_coredump_t, abrt_retrace_spool_t, abrt_retrace_spool_t)
 
-corecmd_exec_bin(abrt_retrace_coredump_t)
+corecmd_exec_bin_wrapper(abrt_retrace_coredump_t)
 corecmd_exec_shell(abrt_retrace_coredump_t)
 
 dev_read_urand(abrt_retrace_coredump_t)
@@ -504,7 +504,7 @@ allow abrt_retrace_worker_t abrt_etc_t:file read_file_perms;
 
 can_exec(abrt_retrace_worker_t, abrt_retrace_worker_exec_t)
 
-corecmd_exec_bin(abrt_retrace_worker_t)
+corecmd_exec_bin_wrapper(abrt_retrace_worker_t)
 corecmd_exec_shell(abrt_retrace_worker_t)
 
 dev_read_urand(abrt_retrace_worker_t)
@@ -554,7 +554,7 @@ kernel_read_security_state(abrt_dump_oops_t)
 auth_read_passwd(abrt_dump_oops_t)
 
 corecmd_getattr_all_executables(abrt_dump_oops_t)
-corecmd_exec_bin(abrt_dump_oops_t)
+corecmd_exec_bin_wrapper(abrt_dump_oops_t)
 
 dev_read_urand(abrt_dump_oops_t)
 dev_read_rand(abrt_dump_oops_t)
@@ -635,7 +635,7 @@ auth_use_nsswitch(abrt_watch_log_t)
 
 domtrans_pattern(abrt_watch_log_t, abrt_dump_oops_exec_t, abrt_dump_oops_t)
 
-corecmd_exec_bin(abrt_watch_log_t)
+corecmd_exec_bin_wrapper(abrt_watch_log_t)
 
 logging_read_all_logs(abrt_watch_log_t)
 logging_send_syslog_msg(abrt_watch_log_t)
@@ -670,7 +670,7 @@ kernel_dgram_send(abrt_upload_watch_t)
 
 abrt_dbus_chat(abrt_upload_watch_t)
 
-corecmd_exec_bin(abrt_upload_watch_t)
+corecmd_exec_bin_wrapper(abrt_upload_watch_t)
 
 dev_read_urand(abrt_upload_watch_t)
 

--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -49,7 +49,7 @@ files_var_lib_filetrans(accountsd_t, accountsd_var_lib_t, dir)
 kernel_read_kernel_sysctls(accountsd_t)
 kernel_read_system_state(accountsd_t)
 
-corecmd_exec_bin(accountsd_t)
+corecmd_exec_bin_wrapper(accountsd_t)
 
 dev_read_sysfs(accountsd_t)
 

--- a/policy/modules/contrib/acct.te
+++ b/policy/modules/contrib/acct.te
@@ -34,7 +34,7 @@ kernel_list_proc(acct_t)
 kernel_read_system_state(acct_t)
 kernel_read_kernel_sysctls(acct_t)
 
-corecmd_exec_bin(acct_t)
+corecmd_exec_bin_wrapper(acct_t)
 corecmd_exec_shell(acct_t)
 
 dev_read_sysfs(acct_t)

--- a/policy/modules/contrib/aisexec.te
+++ b/policy/modules/contrib/aisexec.te
@@ -62,7 +62,7 @@ files_pid_filetrans(aisexec_t, aisexec_var_run_t, { file sock_file })
 
 kernel_read_system_state(aisexec_t)
 
-corecmd_exec_bin(aisexec_t)
+corecmd_exec_bin_wrapper(aisexec_t)
 corecmd_exec_shell(aisexec_t)
 
 corenet_all_recvfrom_unlabeled(aisexec_t)

--- a/policy/modules/contrib/ajaxterm.te
+++ b/policy/modules/contrib/ajaxterm.te
@@ -37,7 +37,7 @@ files_pid_filetrans(ajaxterm_t, ajaxterm_var_run_t, { file dir })
 
 kernel_read_system_state(ajaxterm_t)
 
-corecmd_exec_bin(ajaxterm_t)
+corecmd_exec_bin_wrapper(ajaxterm_t)
 
 corenet_tcp_bind_generic_node(ajaxterm_t)
 corenet_tcp_bind_oa_system_port(ajaxterm_t)

--- a/policy/modules/contrib/alsa.te
+++ b/policy/modules/contrib/alsa.te
@@ -78,7 +78,7 @@ files_pid_filetrans(alsa_t, alsa_var_run_t, { file dir })
 kernel_read_system_state(alsa_t)
 kernel_signal(alsa_t)
 
-corecmd_exec_bin(alsa_t)
+corecmd_exec_bin_wrapper(alsa_t)
 
 dev_getattr_fs(alsa_t)
 dev_read_sound(alsa_t)

--- a/policy/modules/contrib/amanda.te
+++ b/policy/modules/contrib/amanda.te
@@ -113,7 +113,7 @@ kernel_dontaudit_getattr_unlabeled_files(amanda_t)
 kernel_dontaudit_read_proc_symlinks(amanda_t)
 
 corecmd_exec_shell(amanda_t)
-corecmd_exec_bin(amanda_t)
+corecmd_exec_bin_wrapper(amanda_t)
 
 corenet_all_recvfrom_netlabel(amanda_t)
 corenet_tcp_sendrecv_generic_if(amanda_t)
@@ -190,7 +190,7 @@ kernel_read_kernel_sysctls(amanda_recover_t)
 kernel_read_system_state(amanda_recover_t)
 
 corecmd_exec_shell(amanda_recover_t)
-corecmd_exec_bin(amanda_recover_t)
+corecmd_exec_bin_wrapper(amanda_recover_t)
 
 corenet_all_recvfrom_netlabel(amanda_recover_t)
 corenet_tcp_sendrecv_generic_if(amanda_recover_t)

--- a/policy/modules/contrib/amavis.te
+++ b/policy/modules/contrib/amavis.te
@@ -96,7 +96,7 @@ kernel_read_system_state(amavis_t)
 kernel_dontaudit_list_proc(amavis_t)
 kernel_dontaudit_read_proc_symlinks(amavis_t)
 
-corecmd_exec_bin(amavis_t)
+corecmd_exec_bin_wrapper(amavis_t)
 corecmd_exec_shell(amavis_t)
 
 corenet_all_recvfrom_netlabel(amavis_t)

--- a/policy/modules/contrib/antivirus.te
+++ b/policy/modules/contrib/antivirus.te
@@ -110,7 +110,7 @@ kernel_read_system_state(antivirus_t)
 kernel_read_network_state(antivirus_domain)
 kernel_read_all_sysctls(antivirus_domain)
 
-corecmd_exec_bin(antivirus_domain)
+corecmd_exec_bin_wrapper(antivirus_domain)
 corecmd_exec_shell(antivirus_domain)
 
 corenet_all_recvfrom_netlabel(antivirus_t)

--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -650,7 +650,7 @@ auth_use_nsswitch(httpd_t)
 application_exec_all(httpd_t)
 
 # execute perl
-corecmd_exec_bin(httpd_t)
+corecmd_exec_bin_wrapper(httpd_t)
 corecmd_exec_shell(httpd_t)
 
 domain_use_interactive_fds(httpd_t)
@@ -1416,7 +1416,7 @@ fs_search_auto_mountpoints(httpd_suexec_t)
 application_exec_all(httpd_suexec_t)
 
 # for shell scripts
-corecmd_exec_bin(httpd_suexec_t)
+corecmd_exec_bin_wrapper(httpd_suexec_t)
 corecmd_exec_shell(httpd_suexec_t)
 
 files_dontaudit_search_pids(httpd_suexec_t)
@@ -1697,7 +1697,7 @@ kernel_read_kernel_sysctls(httpd_rotatelogs_t)
 kernel_dontaudit_list_proc(httpd_rotatelogs_t)
 kernel_dontaudit_read_proc_symlinks(httpd_rotatelogs_t)
 
-corecmd_exec_bin(httpd_rotatelogs_t)
+corecmd_exec_bin_wrapper(httpd_rotatelogs_t)
 
 logging_search_logs(httpd_rotatelogs_t)
 
@@ -1766,7 +1766,7 @@ allow httpd_passwd_t self:unix_dgram_socket create_socket_perms;
 
 kernel_read_system_state(httpd_passwd_t)
 
-corecmd_exec_bin(httpd_passwd_t)
+corecmd_exec_bin_wrapper(httpd_passwd_t)
 corecmd_exec_shell(httpd_passwd_t)
 
 dev_read_urand(httpd_passwd_t)

--- a/policy/modules/contrib/apcupsd.te
+++ b/policy/modules/contrib/apcupsd.te
@@ -61,7 +61,7 @@ kernel_read_network_state(apcupsd_t)
 
 can_exec(apcupsd_t,apcupsd_exec_t)
 
-corecmd_exec_bin(apcupsd_t)
+corecmd_exec_bin_wrapper(apcupsd_t)
 corecmd_exec_shell(apcupsd_t)
 
 corenet_all_recvfrom_netlabel(apcupsd_t)

--- a/policy/modules/contrib/apt.te
+++ b/policy/modules/contrib/apt.te
@@ -82,7 +82,7 @@ can_exec(apt_t, apt_exec_t)
 kernel_read_system_state(apt_t)
 kernel_read_kernel_sysctls(apt_t)
 
-corecmd_exec_bin(apt_t)
+corecmd_exec_bin_wrapper(apt_t)
 corecmd_exec_shell(apt_t)
 
 corenet_all_recvfrom_netlabel(apt_t)

--- a/policy/modules/contrib/asterisk.te
+++ b/policy/modules/contrib/asterisk.te
@@ -86,7 +86,7 @@ kernel_read_network_state(asterisk_t)
 kernel_read_system_state(asterisk_t)
 kernel_request_load_module(asterisk_t)
 
-corecmd_exec_bin(asterisk_t)
+corecmd_exec_bin_wrapper(asterisk_t)
 corecmd_exec_shell(asterisk_t)
 
 corenet_all_recvfrom_netlabel(asterisk_t)

--- a/policy/modules/contrib/automount.te
+++ b/policy/modules/contrib/automount.te
@@ -68,7 +68,7 @@ kernel_read_network_state(automount_t)
 kernel_list_proc(automount_t)
 kernel_dontaudit_search_xen_state(automount_t)
 
-corecmd_exec_bin(automount_t)
+corecmd_exec_bin_wrapper(automount_t)
 corecmd_exec_shell(automount_t)
 
 corenet_all_recvfrom_netlabel(automount_t)

--- a/policy/modules/contrib/avahi.te
+++ b/policy/modules/contrib/avahi.te
@@ -56,7 +56,7 @@ kernel_read_network_state(avahi_t)
 kernel_read_system_state(avahi_t)
 kernel_request_load_module(avahi_t)
 
-corecmd_exec_bin(avahi_t)
+corecmd_exec_bin_wrapper(avahi_t)
 corecmd_exec_shell(avahi_t)
 
 corenet_all_recvfrom_netlabel(avahi_t)

--- a/policy/modules/contrib/awstats.te
+++ b/policy/modules/contrib/awstats.te
@@ -47,7 +47,7 @@ can_exec(awstats_t, { awstats_exec_t awstats_script_exec_t })
 
 kernel_dontaudit_read_system_state(awstats_t)
 
-corecmd_exec_bin(awstats_t)
+corecmd_exec_bin_wrapper(awstats_t)
 corecmd_exec_shell(awstats_t)
 
 dev_read_urand(awstats_t)

--- a/policy/modules/contrib/backup.te
+++ b/policy/modules/contrib/backup.te
@@ -35,7 +35,7 @@ read_lnk_files_pattern(backup_t, backup_store_t, backup_store_t)
 kernel_read_system_state(backup_t)
 kernel_read_kernel_sysctls(backup_t)
 
-corecmd_exec_bin(backup_t)
+corecmd_exec_bin_wrapper(backup_t)
 corecmd_exec_shell(backup_t)
 
 corenet_all_recvfrom_netlabel(backup_t)

--- a/policy/modules/contrib/bacula.te
+++ b/policy/modules/contrib/bacula.te
@@ -83,7 +83,7 @@ files_pid_filetrans(bacula_t, bacula_var_run_t, file)
 kernel_read_kernel_sysctls(bacula_t)
 kernel_read_system_state(bacula_t)
 
-corecmd_exec_bin(bacula_t)
+corecmd_exec_bin_wrapper(bacula_t)
 corecmd_exec_shell(bacula_t)
 
 corenet_all_recvfrom_unlabeled(bacula_t)

--- a/policy/modules/contrib/bitlbee.te
+++ b/policy/modules/contrib/bitlbee.te
@@ -78,7 +78,7 @@ files_pid_filetrans(bitlbee_t, bitlbee_var_run_t, { dir file sock_file })
 kernel_read_system_state(bitlbee_t)
 kernel_read_kernel_sysctls(bitlbee_t)
 
-corecmd_exec_bin(bitlbee_t)
+corecmd_exec_bin_wrapper(bitlbee_t)
 corecmd_exec_shell(bitlbee_t)
 
 corenet_all_recvfrom_unlabeled(bitlbee_t)

--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -52,7 +52,7 @@ kernel_rw_net_sysctls(blueman_t)
 kernel_read_system_state(blueman_t)
 kernel_request_load_module(blueman_t)
 
-corecmd_exec_bin(blueman_t)
+corecmd_exec_bin_wrapper(blueman_t)
 
 dev_read_sysfs(blueman_t)
 dev_read_rand(blueman_t)

--- a/policy/modules/contrib/bluetooth.te
+++ b/policy/modules/contrib/bluetooth.te
@@ -102,7 +102,7 @@ files_pid_filetrans(bluetooth_t, bluetooth_var_run_t, { file sock_file })
 
 can_exec(bluetooth_t, bluetooth_helper_exec_t)
 
-corecmd_exec_bin(bluetooth_t)
+corecmd_exec_bin_wrapper(bluetooth_t)
 corecmd_exec_shell(bluetooth_t)
 
 kernel_read_kernel_sysctls(bluetooth_t)
@@ -226,7 +226,7 @@ fs_tmpfs_filetrans(bluetooth_helper_t, bluetooth_helper_tmpfs_t, { dir file })
 kernel_read_system_state(bluetooth_helper_t)
 kernel_read_kernel_sysctls(bluetooth_helper_t)
 
-corecmd_exec_bin(bluetooth_helper_t)
+corecmd_exec_bin_wrapper(bluetooth_helper_t)
 corecmd_exec_shell(bluetooth_helper_t)
 
 dev_read_urand(bluetooth_helper_t)

--- a/policy/modules/contrib/boinc.te
+++ b/policy/modules/contrib/boinc.te
@@ -61,7 +61,7 @@ manage_dirs_pattern(boinc_domain, boinc_var_lib_t, boinc_var_lib_t)
 manage_files_pattern(boinc_domain, boinc_var_lib_t, boinc_var_lib_t)
 manage_lnk_files_pattern(boinc_domain, boinc_var_lib_t, boinc_var_lib_t)
 
-corecmd_exec_bin(boinc_domain)
+corecmd_exec_bin_wrapper(boinc_domain)
 corecmd_exec_shell(boinc_domain)
 
 dev_read_rand(boinc_domain)

--- a/policy/modules/contrib/boothd.te
+++ b/policy/modules/contrib/boothd.te
@@ -45,7 +45,7 @@ manage_dirs_pattern(boothd_t, boothd_var_lib_t, boothd_var_lib_t)
 kernel_dgram_send(boothd_t)
 kernel_stream_connect(boothd_t)
 
-corecmd_exec_bin(boothd_t)
+corecmd_exec_bin_wrapper(boothd_t)
 corecmd_exec_shell(boothd_t)
 
 corenet_tcp_bind_boothd_port(boothd_t)

--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -38,7 +38,7 @@ files_pid_filetrans(bootupd_t, bootupd_var_run_t, { file sock_file })
 
 kernel_dgram_send(bootupd_t)
 
-corecmd_exec_bin(bootupd_t)
+corecmd_exec_bin_wrapper(bootupd_t)
 
 dev_read_sysfs(bootupd_t)
 

--- a/policy/modules/contrib/bumblebee.te
+++ b/policy/modules/contrib/bumblebee.te
@@ -38,7 +38,7 @@ kernel_dontaudit_write_proc_files(bumblebee_t)
 kernel_manage_debugfs(bumblebee_t)
 
 corecmd_exec_shell(bumblebee_t)
-corecmd_exec_bin(bumblebee_t)
+corecmd_exec_bin_wrapper(bumblebee_t)
 
 dev_read_sysfs(bumblebee_t)
 

--- a/policy/modules/contrib/calamaris.te
+++ b/policy/modules/contrib/calamaris.te
@@ -39,7 +39,7 @@ manage_lnk_files_pattern(calamaris_t, calamaris_www_t, calamaris_www_t)
 kernel_read_all_sysctls(calamaris_t)
 kernel_read_system_state(calamaris_t)
 
-corecmd_exec_bin(calamaris_t)
+corecmd_exec_bin_wrapper(calamaris_t)
 
 corenet_all_recvfrom_netlabel(calamaris_t)
 corenet_tcp_sendrecv_generic_if(calamaris_t)

--- a/policy/modules/contrib/ccs.te
+++ b/policy/modules/contrib/ccs.te
@@ -73,7 +73,7 @@ files_pid_filetrans(ccs_t, ccs_var_run_t, { file sock_file })
 kernel_read_kernel_sysctls(ccs_t)
 
 corecmd_list_bin(ccs_t)
-corecmd_exec_bin(ccs_t)
+corecmd_exec_bin_wrapper(ccs_t)
 
 corenet_all_recvfrom_netlabel(ccs_t)
 corenet_tcp_sendrecv_generic_if(ccs_t)

--- a/policy/modules/contrib/cdrecord.te
+++ b/policy/modules/contrib/cdrecord.te
@@ -33,7 +33,7 @@ allow cdrecord_t self:capability { ipc_lock sys_nice setuid dac_read_search  sys
 allow cdrecord_t self:process { getcap getsched setrlimit setsched sigkill };
 allow cdrecord_t self:unix_stream_socket { accept listen };
 
-corecmd_exec_bin(cdrecord_t)
+corecmd_exec_bin_wrapper(cdrecord_t)
 
 dev_list_all_dev_nodes(cdrecord_t)
 dev_read_sysfs(cdrecord_t)

--- a/policy/modules/contrib/certmaster.te
+++ b/policy/modules/contrib/certmaster.te
@@ -50,7 +50,7 @@ files_pid_filetrans(certmaster_t ,certmaster_var_run_t, { file sock_file })
 
 kernel_read_system_state(certmaster_t)
 
-corecmd_exec_bin(certmaster_t)
+corecmd_exec_bin_wrapper(certmaster_t)
 
 corenet_all_recvfrom_unlabeled(certmaster_t)
 corenet_all_recvfrom_netlabel(certmaster_t)

--- a/policy/modules/contrib/certmonger.te
+++ b/policy/modules/contrib/certmonger.te
@@ -78,7 +78,7 @@ corenet_tcp_connect_ldap_port(certmonger_t)
 corenet_tcp_connect_pki_ca_port(certmonger_t)
 corenet_tcp_sendrecv_certmaster_port(certmonger_t)
 
-corecmd_exec_bin(certmonger_t)
+corecmd_exec_bin_wrapper(certmonger_t)
 corecmd_exec_shell(certmonger_t)
 
 dev_read_rand(certmonger_t)

--- a/policy/modules/contrib/certwatch.te
+++ b/policy/modules/contrib/certwatch.te
@@ -24,7 +24,7 @@ allow certwatch_t self:tcp_socket create_stream_socket_perms;
 
 kernel_read_system_state(certwatch_t)
 
-corecmd_exec_bin(certwatch_t)
+corecmd_exec_bin_wrapper(certwatch_t)
 
 dev_read_rand(certwatch_t)
 dev_read_urand(certwatch_t)

--- a/policy/modules/contrib/cfengine.te
+++ b/policy/modules/contrib/cfengine.te
@@ -41,7 +41,7 @@ create_files_pattern(cfengine_domain, cfengine_log_t, cfengine_log_t)
 setattr_files_pattern(cfengine_domain, cfengine_log_t, cfengine_log_t)
 logging_log_filetrans(cfengine_domain, cfengine_log_t, dir)
 
-corecmd_exec_bin(cfengine_domain)
+corecmd_exec_bin_wrapper(cfengine_domain)
 corecmd_exec_shell(cfengine_domain)
 
 dev_read_urand(cfengine_domain)

--- a/policy/modules/contrib/chrome.te
+++ b/policy/modules/contrib/chrome.te
@@ -66,7 +66,7 @@ fs_manage_cgroup_files(chrome_sandbox_t)
 fs_read_dos_files(chrome_sandbox_t)
 fs_read_hugetlbfs_files(chrome_sandbox_t)
 
-corecmd_exec_bin(chrome_sandbox_t)
+corecmd_exec_bin_wrapper(chrome_sandbox_t)
 
 corenet_all_recvfrom_netlabel(chrome_sandbox_t)
 corenet_tcp_connect_all_ephemeral_ports(chrome_sandbox_t)

--- a/policy/modules/contrib/chronyd.te
+++ b/policy/modules/contrib/chronyd.te
@@ -134,7 +134,7 @@ dev_rw_realtime_clock(chronyd_t)
 
 auth_use_nsswitch(chronyd_t)
 
-corecmd_exec_bin(chronyd_t)
+corecmd_exec_bin_wrapper(chronyd_t)
 corecmd_exec_shell(chronyd_t)
 
 logging_send_syslog_msg(chronyd_t)
@@ -291,7 +291,7 @@ kernel_read_net_sysctls(chronyc_t)
 
 auth_use_nsswitch(chronyc_t)
 
-corecmd_exec_bin(chronyc_t)
+corecmd_exec_bin_wrapper(chronyc_t)
 
 files_rw_inherited_non_security_files(chronyc_t)
 files_append_non_security_files(chronyc_t)

--- a/policy/modules/contrib/cinder.te
+++ b/policy/modules/contrib/cinder.te
@@ -50,7 +50,7 @@ corenet_tcp_connect_mysqld_port(cinder_domain)
 
 kernel_read_network_state(cinder_domain)
 
-corecmd_exec_bin(cinder_domain)
+corecmd_exec_bin_wrapper(cinder_domain)
 corecmd_exec_shell(cinder_domain)
 corenet_tcp_connect_mysqld_port(cinder_domain)
 

--- a/policy/modules/contrib/cipe.te
+++ b/policy/modules/contrib/cipe.te
@@ -27,7 +27,7 @@ kernel_read_kernel_sysctls(ciped_t)
 kernel_read_system_state(ciped_t)
 
 corecmd_exec_shell(ciped_t)
-corecmd_exec_bin(ciped_t)
+corecmd_exec_bin_wrapper(ciped_t)
 
 corenet_all_recvfrom_netlabel(ciped_t)
 corenet_udp_sendrecv_generic_if(ciped_t)

--- a/policy/modules/contrib/cloudform.te
+++ b/policy/modules/contrib/cloudform.te
@@ -85,7 +85,7 @@ kernel_read_network_state(cloud_init_t)
 
 corenet_tcp_connect_http_port(cloud_init_t)
 
-corecmd_exec_bin(cloud_init_t)
+corecmd_exec_bin_wrapper(cloud_init_t)
 corecmd_exec_shell(cloud_init_t)
 
 domain_read_all_domains_state(cloud_init_t)
@@ -213,7 +213,7 @@ kernel_read_kernel_sysctls(deltacloudd_t)
 kernel_read_system_state(deltacloudd_t)
 kernel_read_network_state(deltacloudd_t)
 
-corecmd_exec_bin(deltacloudd_t)
+corecmd_exec_bin_wrapper(deltacloudd_t)
 
 corenet_tcp_bind_generic_node(deltacloudd_t)
 corenet_tcp_bind_generic_port(deltacloudd_t)

--- a/policy/modules/contrib/cobbler.te
+++ b/policy/modules/contrib/cobbler.te
@@ -93,7 +93,7 @@ logging_log_filetrans(cobblerd_t, cobbler_var_log_t, file)
 kernel_read_system_state(cobblerd_t)
 kernel_read_network_state(cobblerd_t)
 
-corecmd_exec_bin(cobblerd_t)
+corecmd_exec_bin_wrapper(cobblerd_t)
 corecmd_exec_shell(cobblerd_t)
 
 corenet_all_recvfrom_netlabel(cobblerd_t)

--- a/policy/modules/contrib/collectd.te
+++ b/policy/modules/contrib/collectd.te
@@ -77,7 +77,7 @@ kernel_read_network_state_symlinks(collectd_t)
 
 auth_use_nsswitch(collectd_t)
 
-corecmd_exec_bin(collectd_t)
+corecmd_exec_bin_wrapper(collectd_t)
 
 corenet_udp_bind_generic_node(collectd_t)
 corenet_udp_bind_collectd_port(collectd_t)

--- a/policy/modules/contrib/colord.te
+++ b/policy/modules/contrib/colord.te
@@ -82,7 +82,7 @@ corenet_sendrecv_ipp_client_packets(colord_t)
 corenet_tcp_connect_ipp_port(colord_t)
 corenet_tcp_sendrecv_ipp_port(colord_t)
 
-corecmd_exec_bin(colord_t)
+corecmd_exec_bin_wrapper(colord_t)
 corecmd_exec_shell(colord_t)
 
 dev_read_raw_memory(colord_t)

--- a/policy/modules/contrib/condor.te
+++ b/policy/modules/contrib/condor.te
@@ -104,7 +104,7 @@ kernel_rw_kernel_sysctl(condor_domain)
 kernel_search_network_sysctl(condor_domain)
 kernel_read_vm_sysctls(condor_domain)
 
-corecmd_exec_bin(condor_domain)
+corecmd_exec_bin_wrapper(condor_domain)
 corecmd_exec_shell(condor_domain)
 
 corenet_tcp_sendrecv_generic_if(condor_domain)

--- a/policy/modules/contrib/conman.te
+++ b/policy/modules/contrib/conman.te
@@ -76,7 +76,7 @@ corenet_tcp_bind_conman_port(conman_t)
 
 corenet_tcp_connect_all_ephemeral_ports(conman_t)
 
-corecmd_exec_bin(conman_t)
+corecmd_exec_bin_wrapper(conman_t)
 
 dev_read_urand(conman_t)
 

--- a/policy/modules/contrib/consolekit.te
+++ b/policy/modules/contrib/consolekit.te
@@ -48,7 +48,7 @@ corenet_all_recvfrom_netlabel(consolekit_t)
 corenet_tcp_sendrecv_generic_if(consolekit_t)
 corenet_tcp_sendrecv_generic_node(consolekit_t)
 
-corecmd_exec_bin(consolekit_t)
+corecmd_exec_bin_wrapper(consolekit_t)
 corecmd_exec_shell(consolekit_t)
 
 dev_read_urand(consolekit_t)

--- a/policy/modules/contrib/coreos_installer.te
+++ b/policy/modules/contrib/coreos_installer.te
@@ -53,7 +53,7 @@ files_pid_filetrans(coreos_installer_t, coreos_installer_var_run_t, file)
 
 kernel_read_proc_files(coreos_installer_t)
 
-corecmd_exec_bin(coreos_installer_t)
+corecmd_exec_bin_wrapper(coreos_installer_t)
 corecmd_exec_shell(coreos_installer_t)
 
 dev_write_kmsg(coreos_installer_t)
@@ -92,7 +92,7 @@ optional_policy(`
 
 kernel_read_proc_files(coreos_boot_mount_generator_t)
 
-corecmd_exec_bin(coreos_boot_mount_generator_t)
+corecmd_exec_bin_wrapper(coreos_boot_mount_generator_t)
 corecmd_exec_shell(coreos_boot_mount_generator_t)
 dev_write_kmsg(coreos_boot_mount_generator_t)
 
@@ -114,7 +114,7 @@ optional_policy(`
 
 kernel_read_proc_files(coreos_installer_generator_t)
 
-corecmd_exec_bin(coreos_installer_generator_t)
+corecmd_exec_bin_wrapper(coreos_installer_generator_t)
 corecmd_exec_shell(coreos_installer_generator_t)
 dev_write_kmsg(coreos_installer_generator_t)
 
@@ -148,7 +148,7 @@ optional_policy(`
 
 kernel_read_proc_files(coreos_liveiso_autologin_generator_t)
 
-corecmd_exec_bin(coreos_liveiso_autologin_generator_t)
+corecmd_exec_bin_wrapper(coreos_liveiso_autologin_generator_t)
 corecmd_exec_shell(coreos_liveiso_autologin_generator_t)
 dev_write_kmsg(coreos_liveiso_autologin_generator_t)
 

--- a/policy/modules/contrib/corosync.te
+++ b/policy/modules/contrib/corosync.te
@@ -77,7 +77,7 @@ kernel_read_all_sysctls(corosync_t)
 kernel_read_network_state(corosync_t)
 kernel_read_system_state(corosync_t)
 
-corecmd_exec_bin(corosync_t)
+corecmd_exec_bin_wrapper(corosync_t)
 corecmd_exec_shell(corosync_t)
 
 corenet_all_recvfrom_unlabeled(corosync_t)

--- a/policy/modules/contrib/couchdb.te
+++ b/policy/modules/contrib/couchdb.te
@@ -68,7 +68,7 @@ kernel_read_system_state(couchdb_t)
 kernel_read_fs_sysctls(couchdb_t)
 kernel_dgram_send(couchdb_t)
 
-corecmd_exec_bin(couchdb_t)
+corecmd_exec_bin_wrapper(couchdb_t)
 corecmd_exec_shell(couchdb_t)
 
 corenet_all_recvfrom_unlabeled(couchdb_t)

--- a/policy/modules/contrib/courier.te
+++ b/policy/modules/contrib/courier.te
@@ -52,7 +52,7 @@ files_pid_filetrans(courier_domain, courier_var_run_t, dir)
 
 kernel_read_kernel_sysctls(courier_domain)
 
-corecmd_exec_bin(courier_domain)
+corecmd_exec_bin_wrapper(courier_domain)
 
 dev_read_sysfs(courier_domain)
 

--- a/policy/modules/contrib/cpucontrol.te
+++ b/policy/modules/contrib/cpucontrol.te
@@ -77,7 +77,7 @@ dev_rw_sysfs(cpucontrol_t)
 dev_rw_cpu_microcode(cpucontrol_t)
 
 corecmd_exec_shell(cpucontrol_t)
-corecmd_exec_bin(cpucontrol_t)
+corecmd_exec_bin_wrapper(cpucontrol_t)
 
 fs_getattr_xattr_fs(cpucontrol_t)
 

--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -96,7 +96,7 @@ interface(`cron_role',`
 	# Run helper programs as the user domain
 	#corecmd_bin_domtrans(crontab_t, $2)
 	#corecmd_shell_domtrans(crontab_t, $2)
-	corecmd_exec_bin(crontab_t)
+	corecmd_exec_bin_wrapper(crontab_t)
 	corecmd_exec_shell(crontab_t)
 
     tunable_policy(`cron_userdomain_transition',`
@@ -277,7 +277,7 @@ interface(`cron_admin_role',`
 	# Manipulate other users crontab.
 	allow $2_t self:passwd crontab;
 
-	corecmd_exec_bin(admin_crontab_t)
+	corecmd_exec_bin_wrapper(admin_crontab_t)
 	corecmd_exec_shell(admin_crontab_t)
 
     tunable_policy(`cron_userdomain_transition',`

--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -236,7 +236,7 @@ auth_manage_var_auth(crond_t)
 
 corecmd_exec_shell(crond_t)
 corecmd_list_bin(crond_t)
-corecmd_exec_bin(crond_t)
+corecmd_exec_bin_wrapper(crond_t)
 corecmd_read_bin_symlinks(crond_t)
 
 domain_use_interactive_fds(crond_t)
@@ -827,7 +827,7 @@ manage_dirs_pattern(crontab_t, crontab_tmp_t, crontab_tmp_t)
 manage_files_pattern(crontab_t, crontab_tmp_t, crontab_tmp_t)
 files_tmp_filetrans(crontab_t, crontab_tmp_t, { dir file })
 
-corecmd_exec_bin(crontab_domain)
+corecmd_exec_bin_wrapper(crontab_domain)
 corecmd_exec_shell(crontab_domain)
 
 # create files in /var/spool/cron

--- a/policy/modules/contrib/ctdb.te
+++ b/policy/modules/contrib/ctdb.te
@@ -107,7 +107,7 @@ corenet_tcp_connect_gluster_port(ctdbd_t)
 corenet_tcp_connect_nfs_port(ctdbd_t)
 corenet_tcp_connect_portmap_port(ctdbd_t)
 
-corecmd_exec_bin(ctdbd_t)
+corecmd_exec_bin_wrapper(ctdbd_t)
 corecmd_exec_shell(ctdbd_t)
 corecmd_getattr_all_executables(ctdbd_t)
 

--- a/policy/modules/contrib/cups.te
+++ b/policy/modules/contrib/cups.te
@@ -117,7 +117,7 @@ allow cups_domain self:netlink_kobject_uevent_socket create_socket_perms;
 kernel_read_kernel_sysctls(cups_domain)
 kernel_read_network_state(cups_domain)
 
-corecmd_exec_bin(cups_domain)
+corecmd_exec_bin_wrapper(cups_domain)
 corecmd_exec_shell(cups_domain)
 
 dev_read_urand(cups_domain)

--- a/policy/modules/contrib/cvs.te
+++ b/policy/modules/contrib/cvs.te
@@ -77,7 +77,7 @@ corenet_sendrecv_cvs_server_packets(cvs_t)
 corenet_tcp_bind_cvs_port(cvs_t)
 corenet_tcp_sendrecv_cvs_port(cvs_t)
 
-corecmd_exec_bin(cvs_t)
+corecmd_exec_bin_wrapper(cvs_t)
 corecmd_exec_shell(cvs_t)
 
 corenet_all_recvfrom_netlabel(cvs_t)

--- a/policy/modules/contrib/cyrus.te
+++ b/policy/modules/contrib/cyrus.te
@@ -93,7 +93,7 @@ corenet_tcp_bind_sieve_port(cyrus_t)
 corenet_sendrecv_all_client_packets(cyrus_t)
 corenet_tcp_connect_all_ports(cyrus_t)
 
-corecmd_exec_bin(cyrus_t)
+corecmd_exec_bin_wrapper(cyrus_t)
 
 dev_read_rand(cyrus_t)
 dev_read_urand(cyrus_t)

--- a/policy/modules/contrib/daemontools.te
+++ b/policy/modules/contrib/daemontools.te
@@ -77,7 +77,7 @@ kernel_read_system_state(svc_run_t)
 
 dev_read_urand(svc_run_t)
 
-corecmd_exec_bin(svc_run_t)
+corecmd_exec_bin_wrapper(svc_run_t)
 corecmd_exec_shell(svc_run_t)
 
 term_write_console(svc_run_t)
@@ -119,7 +119,7 @@ domtrans_pattern(svc_start_t, svc_run_exec_t, svc_run_t)
 kernel_read_kernel_sysctls(svc_start_t)
 kernel_read_system_state(svc_start_t)
 
-corecmd_exec_bin(svc_start_t)
+corecmd_exec_bin_wrapper(svc_start_t)
 corecmd_exec_shell(svc_start_t)
 
 corenet_tcp_bind_generic_node(svc_start_t)

--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -144,7 +144,7 @@ corecmd_read_bin_pipes(system_dbusd_t)
 corecmd_read_bin_sockets(system_dbusd_t)
 # needed for system-tools-backends
 corecmd_exec_shell(system_dbusd_t)
-corecmd_exec_bin(system_dbusd_t)
+corecmd_exec_bin_wrapper(system_dbusd_t)
 
 domain_use_interactive_fds(system_dbusd_t)
 domain_read_all_domains_state(system_dbusd_t)

--- a/policy/modules/contrib/ddclient.te
+++ b/policy/modules/contrib/ddclient.te
@@ -77,7 +77,7 @@ kernel_read_system_state(ddclient_t)
 kernel_search_network_sysctl(ddclient_t)
 
 corecmd_exec_shell(ddclient_t)
-corecmd_exec_bin(ddclient_t)
+corecmd_exec_bin_wrapper(ddclient_t)
 
 corenet_all_recvfrom_netlabel(ddclient_t)
 corenet_tcp_sendrecv_generic_if(ddclient_t)

--- a/policy/modules/contrib/denyhosts.te
+++ b/policy/modules/contrib/denyhosts.te
@@ -48,7 +48,7 @@ logging_log_filetrans(denyhosts_t, denyhosts_var_log_t, file)
 kernel_read_network_state(denyhosts_t)
 kernel_read_system_state(denyhosts_t)
 
-corecmd_exec_bin(denyhosts_t)
+corecmd_exec_bin_wrapper(denyhosts_t)
 corecmd_exec_shell(denyhosts_t)
 
 corenet_all_recvfrom_netlabel(denyhosts_t)

--- a/policy/modules/contrib/devicekit.te
+++ b/policy/modules/contrib/devicekit.te
@@ -102,7 +102,7 @@ kernel_request_load_module(devicekit_disk_t)
 kernel_get_sysvipc_info(devicekit_disk_t)
 kernel_dontaudit_setsched(devicekit_disk_t)
 
-corecmd_exec_bin(devicekit_disk_t)
+corecmd_exec_bin_wrapper(devicekit_disk_t)
 corecmd_exec_shell(devicekit_disk_t)
 corecmd_getattr_all_executables(devicekit_disk_t)
 
@@ -257,7 +257,7 @@ kernel_search_debugfs(devicekit_power_t)
 kernel_write_proc_files(devicekit_power_t)
 kernel_dontaudit_setsched(devicekit_power_t)
 
-corecmd_exec_bin(devicekit_power_t)
+corecmd_exec_bin_wrapper(devicekit_power_t)
 corecmd_exec_shell(devicekit_power_t)
 
 dev_read_input(devicekit_power_t)

--- a/policy/modules/contrib/dhcp.te
+++ b/policy/modules/contrib/dhcp.te
@@ -88,7 +88,7 @@ corenet_tcp_connect_all_ports(dhcpd_t)
 
 corenet_udp_bind_all_unreserved_ports(dhcpd_t)
 
-corecmd_exec_bin(dhcpd_t)
+corecmd_exec_bin_wrapper(dhcpd_t)
 
 dev_read_sysfs(dhcpd_t)
 dev_read_rand(dhcpd_t)

--- a/policy/modules/contrib/dirsrv-admin.te
+++ b/policy/modules/contrib/dirsrv-admin.te
@@ -44,7 +44,7 @@ files_tmp_filetrans(dirsrvadmin_t, dirsrvadmin_tmp_t, { file dir })
 
 kernel_read_system_state(dirsrvadmin_t)
 
-corecmd_exec_bin(dirsrvadmin_t)
+corecmd_exec_bin_wrapper(dirsrvadmin_t)
 corecmd_read_bin_symlinks(dirsrvadmin_t)
 corecmd_search_bin(dirsrvadmin_t)
 corecmd_shell_entry_type(dirsrvadmin_t)

--- a/policy/modules/contrib/distcc.te
+++ b/policy/modules/contrib/distcc.te
@@ -61,7 +61,7 @@ dev_read_sysfs(distccd_t)
 fs_getattr_all_fs(distccd_t)
 fs_search_auto_mountpoints(distccd_t)
 
-corecmd_exec_bin(distccd_t)
+corecmd_exec_bin_wrapper(distccd_t)
 
 domain_use_interactive_fds(distccd_t)
 

--- a/policy/modules/contrib/dnsmasq.te
+++ b/policy/modules/contrib/dnsmasq.te
@@ -77,7 +77,7 @@ kernel_read_network_state(dnsmasq_t)
 kernel_read_system_state(dnsmasq_t)
 kernel_request_load_module(dnsmasq_t)
 
-corecmd_exec_bin(dnsmasq_t)
+corecmd_exec_bin_wrapper(dnsmasq_t)
 corecmd_exec_shell(dnsmasq_t)
 
 corenet_all_recvfrom_netlabel(dnsmasq_t)

--- a/policy/modules/contrib/dnssec.te
+++ b/policy/modules/contrib/dnssec.te
@@ -45,7 +45,7 @@ kernel_request_load_module(dnssec_trigger_t)
 
 can_exec(dnssec_trigger_t, dnssec_trigger_exec_t)
 
-corecmd_exec_bin(dnssec_trigger_t)
+corecmd_exec_bin_wrapper(dnssec_trigger_t)
 corecmd_exec_shell(dnssec_trigger_t)
 corecmd_read_all_executables(dnssec_trigger_t)
 

--- a/policy/modules/contrib/dovecot.te
+++ b/policy/modules/contrib/dovecot.te
@@ -72,7 +72,7 @@ allow dovecot_domain self:fifo_file rw_fifo_file_perms;
 kernel_read_all_sysctls(dovecot_domain)
 kernel_read_network_state(dovecot_domain)
 
-corecmd_exec_bin(dovecot_domain)
+corecmd_exec_bin_wrapper(dovecot_domain)
 corecmd_exec_shell(dovecot_domain)
 
 dev_read_sysfs(dovecot_domain)
@@ -265,7 +265,7 @@ manage_fifo_files_pattern(dovecot_auth_t, dovecot_var_run_t, dovecot_var_run_t)
 
 dovecot_stream_connect_auth(dovecot_auth_t)
 
-corecmd_exec_bin(dovecot_auth_t)
+corecmd_exec_bin_wrapper(dovecot_auth_t)
 
 logging_send_audit_msgs(dovecot_auth_t)
 

--- a/policy/modules/contrib/drbd.te
+++ b/policy/modules/contrib/drbd.te
@@ -60,7 +60,7 @@ auth_use_nsswitch(drbd_t)
 
 can_exec(drbd_t, drbd_exec_t)
 
-corecmd_exec_bin(drbd_t)
+corecmd_exec_bin_wrapper(drbd_t)
 
 corenet_tcp_connect_http_port(drbd_t)
 

--- a/policy/modules/contrib/evolution.te
+++ b/policy/modules/contrib/evolution.te
@@ -136,7 +136,7 @@ kernel_read_system_state(evolution_t)
 kernel_read_network_state(evolution_t)
 kernel_read_net_sysctls(evolution_t)
 
-corecmd_exec_bin(evolution_t)
+corecmd_exec_bin_wrapper(evolution_t)
 corecmd_exec_shell(evolution_t)
 
 corenet_all_recvfrom_unlabeled(evolution_t)
@@ -348,7 +348,7 @@ stream_connect_pattern(evolution_exchange_t, evolution_alarm_orbit_tmp_t, evolut
 kernel_read_network_state(evolution_exchange_t)
 kernel_read_net_sysctls(evolution_exchange_t)
 
-corecmd_exec_bin(evolution_exchange_t)
+corecmd_exec_bin_wrapper(evolution_exchange_t)
 
 dev_read_urand(evolution_exchange_t)
 

--- a/policy/modules/contrib/exim.te
+++ b/policy/modules/contrib/exim.te
@@ -109,7 +109,7 @@ kernel_read_net_sysctls(exim_t)
 kernel_read_network_state(exim_t)
 kernel_read_system_state(exim_t)
 
-corecmd_exec_bin(exim_t)
+corecmd_exec_bin_wrapper(exim_t)
 
 corenet_all_recvfrom_netlabel(exim_t)
 corenet_tcp_sendrecv_generic_if(exim_t)

--- a/policy/modules/contrib/fdo.te
+++ b/policy/modules/contrib/fdo.te
@@ -88,7 +88,7 @@ kernel_get_sysvipc_info(fdo_t)
 kernel_read_proc_files(fdo_t)
 kernel_stream_connect(fdo_t)
 
-corecmd_exec_bin(fdo_t)
+corecmd_exec_bin_wrapper(fdo_t)
 corecmd_exec_shell(fdo_t)
 
 corenet_tcp_bind_generic_node(fdo_t)

--- a/policy/modules/contrib/fedoratp.te
+++ b/policy/modules/contrib/fedoratp.te
@@ -15,7 +15,7 @@ allow fedoratp_t self:unix_dgram_socket create_socket_perms;
 
 kernel_read_proc_files(fedoratp_t)
 
-corecmd_exec_bin(fedoratp_t)
+corecmd_exec_bin_wrapper(fedoratp_t)
 
 corenet_tcp_connect_http_port(fedoratp_t)
 

--- a/policy/modules/contrib/fetchmail.te
+++ b/policy/modules/contrib/fetchmail.te
@@ -64,7 +64,7 @@ kernel_getattr_proc_files(fetchmail_t)
 kernel_read_proc_symlinks(fetchmail_t)
 kernel_dontaudit_read_system_state(fetchmail_t)
 
-corecmd_exec_bin(fetchmail_t)
+corecmd_exec_bin_wrapper(fetchmail_t)
 corecmd_exec_shell(fetchmail_t)
 
 corenet_all_recvfrom_netlabel(fetchmail_t)

--- a/policy/modules/contrib/finger.te
+++ b/policy/modules/contrib/finger.te
@@ -54,7 +54,7 @@ corenet_sendrecv_fingerd_server_packets(fingerd_t)
 corenet_tcp_bind_fingerd_port(fingerd_t)
 corenet_tcp_sendrecv_fingerd_port(fingerd_t)
 
-corecmd_exec_bin(fingerd_t)
+corecmd_exec_bin_wrapper(fingerd_t)
 corecmd_exec_shell(fingerd_t)
 
 dev_read_sysfs(fingerd_t)

--- a/policy/modules/contrib/firewalld.te
+++ b/policy/modules/contrib/firewalld.te
@@ -78,7 +78,7 @@ kernel_request_load_module(firewalld_t)
 
 files_list_kernel_modules(firewalld_t)
 
-corecmd_exec_bin(firewalld_t)
+corecmd_exec_bin_wrapper(firewalld_t)
 corecmd_exec_shell(firewalld_t)
 
 dev_read_urand(firewalld_t)

--- a/policy/modules/contrib/firewallgui.te
+++ b/policy/modules/contrib/firewallgui.te
@@ -30,7 +30,7 @@ kernel_rw_net_sysctls(firewallgui_t)
 kernel_rw_kernel_sysctl(firewallgui_t)
 kernel_rw_vm_sysctls(firewallgui_t)
 
-corecmd_exec_bin(firewallgui_t)
+corecmd_exec_bin_wrapper(firewallgui_t)
 corecmd_exec_shell(firewallgui_t)
 
 dev_read_sysfs(firewallgui_t)

--- a/policy/modules/contrib/fprintd.te
+++ b/policy/modules/contrib/fprintd.te
@@ -37,7 +37,7 @@ files_tmp_filetrans(fprintd_t, fprintd_tmp_t, { file dir })
 
 kernel_read_system_state(fprintd_t)
 
-corecmd_exec_bin(fprintd_t)
+corecmd_exec_bin_wrapper(fprintd_t)
 
 dev_list_usbfs(fprintd_t)
 dev_rw_sysfs(fprintd_t)

--- a/policy/modules/contrib/ftp.te
+++ b/policy/modules/contrib/ftp.te
@@ -182,7 +182,7 @@ kernel_read_net_sysctls(ftpd_t)
 dev_read_sysfs(ftpd_t)
 dev_read_urand(ftpd_t)
 
-corecmd_exec_bin(ftpd_t)
+corecmd_exec_bin_wrapper(ftpd_t)
 
 corenet_all_recvfrom_netlabel(ftpd_t)
 corenet_tcp_sendrecv_generic_if(ftpd_t)

--- a/policy/modules/contrib/games.te
+++ b/policy/modules/contrib/games.te
@@ -116,7 +116,7 @@ can_exec(games_t, games_exec_t)
 
 kernel_read_system_state(games_t)
 
-corecmd_exec_bin(games_t)
+corecmd_exec_bin_wrapper(games_t)
 
 corenet_all_recvfrom_netlabel(games_t)
 corenet_tcp_sendrecv_generic_if(games_t)

--- a/policy/modules/contrib/geoclue.te
+++ b/policy/modules/contrib/geoclue.te
@@ -45,7 +45,7 @@ corenet_tcp_connect_http_port(geoclue_t)
 corenet_tcp_connect_http_cache_port(geoclue_t)
 corenet_tcp_connect_nmea_port(geoclue_t)
 
-corecmd_exec_bin(geoclue_t)
+corecmd_exec_bin_wrapper(geoclue_t)
 
 dev_read_urand(geoclue_t)
 

--- a/policy/modules/contrib/git.te
+++ b/policy/modules/contrib/git.te
@@ -285,7 +285,7 @@ allow git_daemon self:fifo_file rw_fifo_file_perms;
 
 #kernel_read_system_state(git_daemon)
 
-corecmd_exec_bin(git_daemon)
+corecmd_exec_bin_wrapper(git_daemon)
 
 fs_search_auto_mountpoints(git_daemon)
 

--- a/policy/modules/contrib/gitosis.te
+++ b/policy/modules/contrib/gitosis.te
@@ -47,7 +47,7 @@ corenet_sendrecv_ssh_server_packets(gitosis_t)
 corenet_tcp_bind_ssh_port(gitosis_t)
 corenet_tcp_sendrecv_ssh_port(gitosis_t)
 
-corecmd_exec_bin(gitosis_t)
+corecmd_exec_bin_wrapper(gitosis_t)
 corecmd_exec_shell(gitosis_t)
 
 dev_read_urand(gitosis_t)

--- a/policy/modules/contrib/glance.te
+++ b/policy/modules/contrib/glance.te
@@ -93,7 +93,7 @@ corenet_tcp_bind_generic_node(glance_domain)
 corenet_tcp_connect_mysqld_port(glance_domain)
 corenet_tcp_connect_http_port(glance_domain)
 
-corecmd_exec_bin(glance_domain)
+corecmd_exec_bin_wrapper(glance_domain)
 corecmd_exec_shell(glance_domain)
 
 dev_read_urand(glance_domain)

--- a/policy/modules/contrib/glusterd.te
+++ b/policy/modules/contrib/glusterd.te
@@ -130,7 +130,7 @@ kernel_read_network_state(glusterd_t)
 kernel_read_net_sysctls(glusterd_t)
 kernel_request_load_module(glusterd_t)
 
-corecmd_exec_bin(glusterd_t)
+corecmd_exec_bin_wrapper(glusterd_t)
 corecmd_exec_shell(glusterd_t)
 
 corenet_all_recvfrom_unlabeled(glusterd_t)

--- a/policy/modules/contrib/gnome.te
+++ b/policy/modules/contrib/gnome.te
@@ -385,7 +385,7 @@ kernel_stream_connect(gnome_initial_setup_t)
 
 auth_read_passwd_file(gnome_initial_setup_t)
 
-corecmd_exec_bin(gnome_initial_setup_t)
+corecmd_exec_bin_wrapper(gnome_initial_setup_t)
 
 corenet_tcp_connect_http_port(gnome_initial_setup_t)
 

--- a/policy/modules/contrib/gnomeclock.te
+++ b/policy/modules/contrib/gnomeclock.te
@@ -30,7 +30,7 @@ files_tmp_filetrans(gnomeclock_t, gnomeclock_tmp_t, { file dir })
 
 kernel_read_system_state(gnomeclock_t)
 
-corecmd_exec_bin(gnomeclock_t)
+corecmd_exec_bin_wrapper(gnomeclock_t)
 corecmd_exec_shell(gnomeclock_t)
 corecmd_dontaudit_access_check_bin(gnomeclock_t)
 

--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -122,7 +122,7 @@ kernel_read_system_state(gpg_t)
 kernel_getattr_core_if(gpg_t)
 
 corecmd_exec_shell(gpg_t)
-corecmd_exec_bin(gpg_t)
+corecmd_exec_bin_wrapper(gpg_t)
 
 corenet_all_recvfrom_netlabel(gpg_t)
 corenet_tcp_sendrecv_generic_if(gpg_t)
@@ -320,7 +320,7 @@ kernel_read_core_if(gpg_agent_t)
 auth_use_nsswitch(gpg_agent_t)
 
 corecmd_read_bin_symlinks(gpg_agent_t)
-corecmd_exec_bin(gpg_agent_t)
+corecmd_exec_bin_wrapper(gpg_agent_t)
 corecmd_exec_shell(gpg_agent_t)
 
 dev_read_rand(gpg_agent_t)
@@ -437,7 +437,7 @@ manage_lnk_files_pattern(gpg_pinentry_t, gpg_secret_t, gpg_secret_t)
 kernel_read_system_state(gpg_pinentry_t)
 
 corecmd_exec_shell(gpg_pinentry_t)
-corecmd_exec_bin(gpg_pinentry_t)
+corecmd_exec_bin_wrapper(gpg_pinentry_t)
 
 corenet_all_recvfrom_netlabel(gpg_pinentry_t)
 corenet_sendrecv_pulseaudio_client_packets(gpg_pinentry_t)

--- a/policy/modules/contrib/hadoop.te
+++ b/policy/modules/contrib/hadoop.te
@@ -124,7 +124,7 @@ getattr_dirs_pattern(hadoop_t, hadoop_var_run_t, hadoop_var_run_t)
 kernel_read_network_state(hadoop_t)
 kernel_read_system_state(hadoop_t)
 
-corecmd_exec_bin(hadoop_t)
+corecmd_exec_bin_wrapper(hadoop_t)
 corecmd_exec_shell(hadoop_t)
 
 corenet_all_recvfrom_unlabeled(hadoop_t)
@@ -199,7 +199,7 @@ kernel_read_network_state(hadoop_domain)
 kernel_read_sysctl(hadoop_domain)
 kernel_read_system_state(hadoop_domain)
 
-corecmd_exec_bin(hadoop_domain)
+corecmd_exec_bin_wrapper(hadoop_domain)
 corecmd_exec_shell(hadoop_domain)
 
 corenet_all_recvfrom_unlabeled(hadoop_domain)
@@ -259,7 +259,7 @@ kernel_read_kernel_sysctls(hadoop_initrc_domain)
 kernel_read_sysctl(hadoop_initrc_domain)
 kernel_read_system_state(hadoop_initrc_domain)
 
-corecmd_exec_bin(hadoop_initrc_domain)
+corecmd_exec_bin_wrapper(hadoop_initrc_domain)
 corecmd_exec_shell(hadoop_initrc_domain)
 
 files_search_locks(hadoop_initrc_domain)
@@ -429,7 +429,7 @@ filetrans_pattern(zookeeper_t, hadoop_hsperfdata_t, zookeeper_tmp_t, file)
 kernel_read_network_state(zookeeper_t)
 kernel_read_system_state(zookeeper_t)
 
-corecmd_exec_bin(zookeeper_t)
+corecmd_exec_bin_wrapper(zookeeper_t)
 corecmd_exec_shell(zookeeper_t)
 
 corenet_all_recvfrom_unlabeled(zookeeper_t)
@@ -501,7 +501,7 @@ can_exec(zookeeper_server_t, zookeeper_server_exec_t)
 kernel_read_network_state(zookeeper_server_t)
 kernel_read_system_state(zookeeper_server_t)
 
-corecmd_exec_bin(zookeeper_server_t)
+corecmd_exec_bin_wrapper(zookeeper_server_t)
 corecmd_exec_shell(zookeeper_server_t)
 
 corenet_all_recvfrom_unlabeled(zookeeper_server_t)

--- a/policy/modules/contrib/hsqldb.te
+++ b/policy/modules/contrib/hsqldb.te
@@ -42,7 +42,7 @@ files_var_lib_filetrans(hsqldb_t, hsqldb_var_lib_t, { dir })
 kernel_read_system_state(hsqldb_t)
 kernel_read_network_state(hsqldb_t)
 
-corecmd_exec_bin(hsqldb_t)
+corecmd_exec_bin_wrapper(hsqldb_t)
 
 corenet_tcp_bind_generic_node(hsqldb_t)
 corenet_tcp_bind_tor_port(hsqldb_t)

--- a/policy/modules/contrib/hypervkvp.te
+++ b/policy/modules/contrib/hypervkvp.te
@@ -42,7 +42,7 @@ allow hyperv_domain self:fifo_file rw_fifo_file_perms;
 allow hyperv_domain self:unix_stream_socket create_stream_socket_perms;
 
 corecmd_exec_shell(hyperv_domain)
-corecmd_exec_bin(hyperv_domain)
+corecmd_exec_bin_wrapper(hyperv_domain)
 
 dev_read_sysfs(hyperv_domain)
 

--- a/policy/modules/contrib/ibacm.te
+++ b/policy/modules/contrib/ibacm.te
@@ -60,7 +60,7 @@ kernel_read_network_state(ibacm_t)
 
 auth_use_nsswitch(ibacm_t)
 
-corecmd_exec_bin(ibacm_t)
+corecmd_exec_bin_wrapper(ibacm_t)
 corecmd_exec_shell(ibacm_t)
 
 corenet_ib_access_unlabeled_pkeys(ibacm_t)

--- a/policy/modules/contrib/ifplugd.te
+++ b/policy/modules/contrib/ifplugd.te
@@ -43,7 +43,7 @@ kernel_read_network_state(ifplugd_t)
 kernel_read_system_state(ifplugd_t)
 kernel_rw_net_sysctls(ifplugd_t)
 
-corecmd_exec_bin(ifplugd_t)
+corecmd_exec_bin_wrapper(ifplugd_t)
 corecmd_exec_shell(ifplugd_t)
 
 dev_read_sysfs(ifplugd_t)

--- a/policy/modules/contrib/inn.te
+++ b/policy/modules/contrib/inn.te
@@ -82,7 +82,7 @@ corenet_tcp_bind_innd_port(innd_t)
 corenet_sendrecv_all_client_packets(innd_t)
 corenet_tcp_connect_all_ports(innd_t)
 
-corecmd_exec_bin(innd_t)
+corecmd_exec_bin_wrapper(innd_t)
 corecmd_exec_shell(innd_t)
 
 dev_read_sysfs(innd_t)

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -126,7 +126,7 @@ optional_policy(`
 #kernel_request_load_module(insights_client_t)
 #kernel_view_key(insights_client_t)
 
-corecmd_exec_bin(insights_client_t)
+corecmd_exec_bin_wrapper(insights_client_t)
 #corecmd_exec_all_executables(insights_client_t)
 corenet_tcp_bind_generic_node(insights_client_t)
 #corenet_tcp_connect_all_ports(insights_client_t)

--- a/policy/modules/contrib/insights_core.te
+++ b/policy/modules/contrib/insights_core.te
@@ -87,7 +87,7 @@ kernel_read_software_raid_state(insights_core_t)
 kernel_read_sysctl(insights_core_t)
 
 corecmd_bin_entry_type(insights_core_t)
-corecmd_exec_bin(insights_core_t)
+corecmd_exec_bin_wrapper(insights_core_t)
 corecmd_exec_all_executables(insights_core_t)
 
 corenet_tcp_bind_generic_node(insights_core_t)

--- a/policy/modules/contrib/iotop.te
+++ b/policy/modules/contrib/iotop.te
@@ -34,7 +34,7 @@ dev_read_urand(iotop_t)
 domain_getsched_all_domains(iotop_t)
 domain_read_all_domains_state(iotop_t)
 
-corecmd_exec_bin(iotop_t)
+corecmd_exec_bin_wrapper(iotop_t)
 
 init_stream_connectto(iotop_t)
 

--- a/policy/modules/contrib/ipmievd.te
+++ b/policy/modules/contrib/ipmievd.te
@@ -42,7 +42,7 @@ kernel_load_module(ipmievd_t)
 
 auth_use_nsswitch(ipmievd_t)
 
-corecmd_exec_bin(ipmievd_t)
+corecmd_exec_bin_wrapper(ipmievd_t)
 
 dev_manage_ipmi_dev(ipmievd_t)
 dev_filetrans_ipmi(ipmievd_t)

--- a/policy/modules/contrib/irc.te
+++ b/policy/modules/contrib/irc.te
@@ -87,7 +87,7 @@ files_tmp_filetrans(irc_t, irc_tmp_t, { file dir lnk_file sock_file fifo_file })
 kernel_read_system_state(irc_t)
 
 corecmd_exec_shell(irc_t)
-corecmd_exec_bin(irc_t)
+corecmd_exec_bin_wrapper(irc_t)
 
 corenet_all_recvfrom_netlabel(irc_t)
 corenet_tcp_sendrecv_generic_if(irc_t)

--- a/policy/modules/contrib/ircd.te
+++ b/policy/modules/contrib/ircd.te
@@ -50,7 +50,7 @@ files_pid_filetrans(ircd_t, ircd_var_run_t, file)
 kernel_read_system_state(ircd_t)
 kernel_read_kernel_sysctls(ircd_t)
 
-corecmd_exec_bin(ircd_t)
+corecmd_exec_bin_wrapper(ircd_t)
 
 corenet_all_recvfrom_netlabel(ircd_t)
 corenet_tcp_sendrecv_generic_if(ircd_t)

--- a/policy/modules/contrib/iscsi.te
+++ b/policy/modules/contrib/iscsi.te
@@ -96,7 +96,7 @@ corenet_sendrecv_winshadow_client_packets(iscsid_t)
 corenet_tcp_connect_winshadow_port(iscsid_t)
 corenet_tcp_sendrecv_winshadow_port(iscsid_t)
 
-corecmd_exec_bin(iscsid_t)
+corecmd_exec_bin_wrapper(iscsid_t)
 corecmd_exec_shell(iscsid_t)
 
 dev_read_urand(iscsid_t)

--- a/policy/modules/contrib/jabber.te
+++ b/policy/modules/contrib/jabber.te
@@ -105,7 +105,7 @@ manage_files_pattern(pyicqt_t, pyicqt_var_spool_t, pyicqt_var_spool_t);
 corenet_tcp_bind_jabber_router_port(pyicqt_t)
 corenet_tcp_connect_jabber_router_port(pyicqt_t)
 
-corecmd_exec_bin(pyicqt_t)
+corecmd_exec_bin_wrapper(pyicqt_t)
 
 dev_read_urand(pyicqt_t)
 

--- a/policy/modules/contrib/jetty.te
+++ b/policy/modules/contrib/jetty.te
@@ -65,7 +65,7 @@ fs_read_cgroup_files(jetty_t)
 kernel_read_system_state(jetty_t)
 kernel_read_network_state(jetty_t)
 
-corecmd_exec_bin(jetty_t)
+corecmd_exec_bin_wrapper(jetty_t)
 corecmd_exec_shell(jetty_t)
 
 corenet_tcp_bind_http_cache_port(jetty_t)

--- a/policy/modules/contrib/jockey.te
+++ b/policy/modules/contrib/jockey.te
@@ -42,7 +42,7 @@ fs_tmpfs_filetrans(jockey_t, jockey_tmpfs_t, { dir file })
 
 kernel_read_system_state(jockey_t)
 
-corecmd_exec_bin(jockey_t)
+corecmd_exec_bin_wrapper(jockey_t)
 corecmd_exec_shell(jockey_t)
 
 dev_read_rand(jockey_t)

--- a/policy/modules/contrib/journalctl.te
+++ b/policy/modules/contrib/journalctl.te
@@ -28,7 +28,7 @@ kernel_read_fs_sysctls(journalctl_t)
 kernel_read_system_state(journalctl_t)
 kernel_stream_connect(journalctl_t)
 
-corecmd_exec_bin(journalctl_t)
+corecmd_exec_bin_wrapper(journalctl_t)
 
 domain_use_interactive_fds(journalctl_t)
 

--- a/policy/modules/contrib/kdump.te
+++ b/policy/modules/contrib/kdump.te
@@ -134,7 +134,7 @@ kernel_stream_connect(kdumpctl_t)
 
 mls_file_read_all_levels(kdumpctl_t)
 
-corecmd_exec_bin(kdumpctl_t)
+corecmd_exec_bin_wrapper(kdumpctl_t)
 corecmd_exec_shell(kdumpctl_t)
 
 dev_read_sysfs(kdumpctl_t)

--- a/policy/modules/contrib/kdumpgui.te
+++ b/policy/modules/contrib/kdumpgui.te
@@ -39,7 +39,7 @@ kernel_read_system_state(kdumpgui_t)
 kernel_read_network_state(kdumpgui_t)
 kernel_getattr_core_if(kdumpgui_t)
 
-corecmd_exec_bin(kdumpgui_t)
+corecmd_exec_bin_wrapper(kdumpgui_t)
 corecmd_exec_shell(kdumpgui_t)
 
 dev_dontaudit_getattr_all_chr_files(kdumpgui_t)

--- a/policy/modules/contrib/keepalived.te
+++ b/policy/modules/contrib/keepalived.te
@@ -71,7 +71,7 @@ kernel_rw_net_sysctls(keepalived_t)
 
 auth_use_nsswitch(keepalived_t)
 
-corecmd_exec_bin(keepalived_t)
+corecmd_exec_bin_wrapper(keepalived_t)
 corecmd_exec_shell(keepalived_t)
 
 corenet_raw_bind_generic_node(keepalived_t)

--- a/policy/modules/contrib/kerberos.te
+++ b/policy/modules/contrib/kerberos.te
@@ -123,7 +123,7 @@ kernel_read_network_state(kadmind_t)
 kernel_read_proc_symlinks(kadmind_t)
 kernel_read_system_state(kadmind_t)
 
-corecmd_exec_bin(kadmind_t)
+corecmd_exec_bin_wrapper(kadmind_t)
 corecmd_exec_shell(kadmind_t)
 
 corenet_all_recvfrom_netlabel(kadmind_t)
@@ -263,7 +263,7 @@ kernel_read_proc_symlinks(krb5kdc_t)
 kernel_read_network_state(krb5kdc_t)
 kernel_search_network_sysctl(krb5kdc_t)
 
-corecmd_exec_bin(krb5kdc_t)
+corecmd_exec_bin_wrapper(krb5kdc_t)
 
 corenet_all_recvfrom_netlabel(krb5kdc_t)
 corenet_tcp_sendrecv_generic_if(krb5kdc_t)
@@ -373,7 +373,7 @@ kernel_read_net_sysctls(kpropd_t)
 
 can_exec(kpropd_t,kpropd_exec_t)
 
-corecmd_exec_bin(kpropd_t)
+corecmd_exec_bin_wrapper(kpropd_t)
 
 corenet_tcp_sendrecv_generic_if(kpropd_t)
 corenet_tcp_sendrecv_generic_node(kpropd_t)

--- a/policy/modules/contrib/keystone.te
+++ b/policy/modules/contrib/keystone.te
@@ -60,7 +60,7 @@ can_exec(keystone_t, keystone_tmp_t)
 
 kernel_read_system_state(keystone_t)
 
-corecmd_exec_bin(keystone_t)
+corecmd_exec_bin_wrapper(keystone_t)
 corecmd_exec_shell(keystone_t)
 
 corenet_all_recvfrom_unlabeled(keystone_t)

--- a/policy/modules/contrib/keyutils.te
+++ b/policy/modules/contrib/keyutils.te
@@ -20,7 +20,7 @@ role system_r types keyutils_dns_resolver_t;
 allow keyutils_request_t self:unix_dgram_socket create_socket_perms;
 allow keyutils_request_t keyutils_request_exec_t:file execute_no_trans;
 
-corecmd_exec_bin(keyutils_request_t)
+corecmd_exec_bin_wrapper(keyutils_request_t)
 
 domain_manage_all_domains_keyrings(keyutils_request_t)
 

--- a/policy/modules/contrib/kismet.te
+++ b/policy/modules/contrib/kismet.te
@@ -79,7 +79,7 @@ kernel_search_debugfs(kismet_t)
 kernel_read_system_state(kismet_t)
 kernel_read_network_state(kismet_t)
 
-corecmd_exec_bin(kismet_t)
+corecmd_exec_bin_wrapper(kismet_t)
 
 corenet_all_recvfrom_netlabel(kismet_t)
 corenet_tcp_sendrecv_generic_if(kismet_t)

--- a/policy/modules/contrib/kmscon.te
+++ b/policy/modules/contrib/kmscon.te
@@ -52,7 +52,7 @@ auth_read_passwd(kmscon_t)
 # because it is a shell script https://github.com/Aetf/kmscon/pull/7/files
 corecmd_exec_shell(kmscon_t)
 # for dbus-send in the shell script
-corecmd_exec_bin(kmscon_t)
+corecmd_exec_bin_wrapper(kmscon_t)
 
 dev_rw_dri(kmscon_t)
 dev_read_sysfs(kmscon_t)

--- a/policy/modules/contrib/kpatch.te
+++ b/policy/modules/contrib/kpatch.te
@@ -25,7 +25,7 @@ allow kpatch_t kpatch_var_lib_t:system module_load;
 
 auth_use_nsswitch(kpatch_t)
 
-corecmd_exec_bin(kpatch_t)
+corecmd_exec_bin_wrapper(kpatch_t)
 corecmd_mmap_bin_files(kpatch_t)
 
 dev_list_sysfs(kpatch_t)

--- a/policy/modules/contrib/ksmtuned.te
+++ b/policy/modules/contrib/ksmtuned.te
@@ -62,7 +62,7 @@ files_pid_filetrans(ksmtuned_t, ksmtuned_var_run_t, file)
 
 kernel_read_system_state(ksmtuned_t)
 
-corecmd_exec_bin(ksmtuned_t)
+corecmd_exec_bin_wrapper(ksmtuned_t)
 corecmd_exec_shell(ksmtuned_t)
 
 dev_manage_sysfs(ksmtuned_t)

--- a/policy/modules/contrib/l2tp.te
+++ b/policy/modules/contrib/l2tp.te
@@ -75,7 +75,7 @@ kernel_read_network_state(l2tpd_t)
 kernel_read_system_state(l2tpd_t)
 kernel_request_load_module(l2tpd_t)
 
-corecmd_exec_bin(l2tpd_t)
+corecmd_exec_bin_wrapper(l2tpd_t)
 
 dev_read_urand(l2tpd_t)
 dev_read_sysfs(l2tpd_t)

--- a/policy/modules/contrib/lightsquid.te
+++ b/policy/modules/contrib/lightsquid.te
@@ -26,7 +26,7 @@ manage_files_pattern(lightsquid_t, lightsquid_report_content_t, lightsquid_repor
 manage_lnk_files_pattern(lightsquid_t, lightsquid_report_content_t, lightsquid_report_content_t)
 files_var_filetrans(lightsquid_t, lightsquid_report_content_t, dir)
 
-corecmd_exec_bin(lightsquid_t)
+corecmd_exec_bin_wrapper(lightsquid_t)
 corecmd_exec_shell(lightsquid_t)
 
 dev_read_urand(lightsquid_t)

--- a/policy/modules/contrib/likewise.te
+++ b/policy/modules/contrib/likewise.te
@@ -115,7 +115,7 @@ stream_connect_pattern(lsassd_t, likewise_var_lib_t, netlogond_var_socket_t, net
 
 kernel_list_all_proc(lsassd_t)
 
-corecmd_exec_bin(lsassd_t)
+corecmd_exec_bin_wrapper(lsassd_t)
 corecmd_exec_shell(lsassd_t)
 
 corenet_all_recvfrom_netlabel(lsassd_t)

--- a/policy/modules/contrib/lircd.te
+++ b/policy/modules/contrib/lircd.te
@@ -42,7 +42,7 @@ kernel_request_load_module(lircd_t)
 kernel_read_system_state(lircd_t)
 
 corecmd_exec_shell(lircd_t)
-corecmd_exec_bin(lircd_t)
+corecmd_exec_bin_wrapper(lircd_t)
 
 corenet_all_recvfrom_unlabeled(lircd_t)
 corenet_all_recvfrom_netlabel(lircd_t)

--- a/policy/modules/contrib/lldpad.te
+++ b/policy/modules/contrib/lldpad.te
@@ -55,7 +55,7 @@ kernel_request_load_module(lldpad_t)
 
 auth_read_passwd(lldpad_t)
 
-corecmd_exec_bin(lldpad_t)
+corecmd_exec_bin_wrapper(lldpad_t)
 
 corenet_tcp_connect_agentx_port(lldpad_t)
 

--- a/policy/modules/contrib/loadkeys.te
+++ b/policy/modules/contrib/loadkeys.te
@@ -22,7 +22,7 @@ allow loadkeys_t self:fifo_file rw_fifo_file_perms;
 
 kernel_read_system_state(loadkeys_t)
 
-corecmd_exec_bin(loadkeys_t)
+corecmd_exec_bin_wrapper(loadkeys_t)
 corecmd_exec_shell(loadkeys_t)
 
 files_read_etc_runtime_files(loadkeys_t)

--- a/policy/modules/contrib/logrotate.te
+++ b/policy/modules/contrib/logrotate.te
@@ -123,7 +123,7 @@ selinux_get_fs_mount(logrotate_t)
 selinux_get_enforce_mode(logrotate_t)
 
 # Run helper programs.
-corecmd_exec_bin(logrotate_t)
+corecmd_exec_bin_wrapper(logrotate_t)
 corecmd_exec_shell(logrotate_t)
 corecmd_getattr_all_executables(logrotate_t)
 

--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -68,7 +68,7 @@ corenet_all_recvfrom_netlabel(logwatch_t)
 corenet_tcp_sendrecv_generic_if(logwatch_t)
 corenet_tcp_sendrecv_generic_node(logwatch_t)
 
-corecmd_exec_bin(logwatch_t)
+corecmd_exec_bin_wrapper(logwatch_t)
 corecmd_exec_shell(logwatch_t)
 
 dev_read_urand(logwatch_t)

--- a/policy/modules/contrib/lpd.te
+++ b/policy/modules/contrib/lpd.te
@@ -92,7 +92,7 @@ corenet_sendrecv_all_client_packets(checkpc_t)
 corenet_tcp_connect_all_ports(checkpc_t)
 
 corecmd_exec_shell(checkpc_t)
-corecmd_exec_bin(checkpc_t)
+corecmd_exec_bin_wrapper(checkpc_t)
 
 dev_append_printer(checkpc_t)
 
@@ -164,7 +164,7 @@ corenet_sendrecv_printer_server_packets(lpd_t)
 corenet_tcp_bind_printer_port(lpd_t)
 corenet_tcp_sendrecv_printer_port(lpd_t)
 
-corecmd_exec_bin(lpd_t)
+corecmd_exec_bin_wrapper(lpd_t)
 corecmd_exec_shell(lpd_t)
 
 dev_read_sysfs(lpd_t)

--- a/policy/modules/contrib/lsm.te
+++ b/policy/modules/contrib/lsm.te
@@ -46,7 +46,7 @@ files_pid_filetrans(lsmd_t, lsmd_var_run_t, { dir file sock_file })
 
 auth_use_nsswitch(lsmd_t)
 
-corecmd_exec_bin(lsmd_t)
+corecmd_exec_bin_wrapper(lsmd_t)
 corecmd_getattr_all_executables(lsmd_t)
 
 logging_send_syslog_msg(lsmd_t)
@@ -92,7 +92,7 @@ auth_read_passwd(lsmd_plugin_t)
 dev_read_urand(lsmd_plugin_t)
 dev_read_sysfs(lsmd_plugin_t)
 
-corecmd_exec_bin(lsmd_plugin_t)
+corecmd_exec_bin_wrapper(lsmd_plugin_t)
 
 corenet_tcp_connect_http_port(lsmd_plugin_t)
 corenet_tcp_connect_http_cache_port(lsmd_plugin_t)

--- a/policy/modules/contrib/mailscanner.te
+++ b/policy/modules/contrib/mailscanner.te
@@ -51,7 +51,7 @@ can_exec(mscan_t, mscan_exec_t)
 
 kernel_read_system_state(mscan_t)
 
-corecmd_exec_bin(mscan_t)
+corecmd_exec_bin_wrapper(mscan_t)
 corecmd_exec_shell(mscan_t)
 
 corenet_all_recvfrom_netlabel(mscan_t)

--- a/policy/modules/contrib/mandb.te
+++ b/policy/modules/contrib/mandb.te
@@ -50,7 +50,7 @@ kernel_read_system_state(mandb_t)
 
 auth_read_passwd(mandb_t)
 
-corecmd_exec_bin(mandb_t)
+corecmd_exec_bin_wrapper(mandb_t)
 corecmd_exec_shell(mandb_t)
 
 dev_search_sysfs(mandb_t)

--- a/policy/modules/contrib/mcelog.te
+++ b/policy/modules/contrib/mcelog.te
@@ -78,7 +78,7 @@ files_pid_filetrans(mcelog_t, mcelog_var_run_t, { dir file sock_file })
 kernel_read_system_state(mcelog_t)
 
 corecmd_exec_shell(mcelog_t)
-corecmd_exec_bin(mcelog_t)
+corecmd_exec_bin_wrapper(mcelog_t)
 
 dev_read_raw_memory(mcelog_t)
 dev_read_kmsg(mcelog_t)
@@ -99,7 +99,6 @@ tunable_policy(`mcelog_client',`
 
 tunable_policy(`mcelog_exec_scripts',`
 	allow mcelog_t self:fifo_file rw_fifo_file_perms;
-	corecmd_exec_bin(mcelog_t)
 	corecmd_exec_shell(mcelog_t)
 ')
 

--- a/policy/modules/contrib/milter.te
+++ b/policy/modules/contrib/milter.te
@@ -117,7 +117,7 @@ files_pid_filetrans(greylist_milter_t, greylist_milter_data_t, file)
 kernel_read_kernel_sysctls(greylist_milter_t)
 kernel_read_network_state(greylist_milter_t)
 
-corecmd_exec_bin(greylist_milter_t)
+corecmd_exec_bin_wrapper(greylist_milter_t)
 corecmd_exec_shell(greylist_milter_t)
 
 corenet_tcp_bind_movaz_ssc_port(greylist_milter_t)

--- a/policy/modules/contrib/minidlna.te
+++ b/policy/modules/contrib/minidlna.te
@@ -57,7 +57,7 @@ kernel_read_fs_sysctls(minidlna_t)
 kernel_read_system_state(minidlna_t)
 kernel_read_network_state(minidlna_t)
 
-corecmd_exec_bin(minidlna_t)
+corecmd_exec_bin_wrapper(minidlna_t)
 corecmd_exec_shell(minidlna_t)
 
 corenet_all_recvfrom_netlabel(minidlna_t)

--- a/policy/modules/contrib/mock.te
+++ b/policy/modules/contrib/mock.te
@@ -100,7 +100,7 @@ fs_mount_tmpfs(mock_t)
 fs_unmount_tmpfs(mock_t)
 fs_unmount_xattr_fs(mock_t)
 
-corecmd_exec_bin(mock_t)
+corecmd_exec_bin_wrapper(mock_t)
 corecmd_exec_shell(mock_t)
 corecmd_dontaudit_exec_all_executables(mock_t)
 
@@ -252,7 +252,7 @@ kernel_read_kernel_sysctls(mock_build_t)
 kernel_request_load_module(mock_build_t)
 kernel_dontaudit_setattr_proc_dirs(mock_build_t)
 
-corecmd_exec_bin(mock_build_t)
+corecmd_exec_bin_wrapper(mock_build_t)
 corecmd_exec_shell(mock_build_t)
 corecmd_dontaudit_exec_all_executables(mock_build_t)
 

--- a/policy/modules/contrib/modemmanager.te
+++ b/policy/modules/contrib/modemmanager.te
@@ -34,7 +34,7 @@ kernel_request_load_module(modemmanager_t)
 
 auth_read_passwd(modemmanager_t)
 
-corecmd_exec_bin(modemmanager_t)
+corecmd_exec_bin_wrapper(modemmanager_t)
 
 dev_create_sysfs_files(modemmanager_t)
 dev_rw_sysfs(modemmanager_t)

--- a/policy/modules/contrib/mongodb.te
+++ b/policy/modules/contrib/mongodb.te
@@ -76,7 +76,7 @@ kernel_read_fs_sysctls(mongod_t)
 kernel_read_net_sysctls(mongod_t)
 kernel_read_vm_sysctls(mongod_t)
 
-corecmd_exec_bin(mongod_t)
+corecmd_exec_bin_wrapper(mongod_t)
 corecmd_exec_shell(mongod_t)
 
 corenet_all_recvfrom_unlabeled(mongod_t)

--- a/policy/modules/contrib/mozilla.te
+++ b/policy/modules/contrib/mozilla.te
@@ -151,7 +151,7 @@ kernel_read_net_sysctls(mozilla_t)
 corecmd_list_bin(mozilla_t)
 # for bash - old mozilla binary
 corecmd_exec_shell(mozilla_t)
-corecmd_exec_bin(mozilla_t)
+corecmd_exec_bin_wrapper(mozilla_t)
 
 # Browse the web, connect to printer
 corenet_all_recvfrom_netlabel(mozilla_t)
@@ -403,7 +403,7 @@ files_dontaudit_read_root_files(mozilla_plugin_t)
 kernel_dontaudit_list_all_proc(mozilla_plugin_t)
 kernel_dontaudit_list_all_sysctls(mozilla_plugin_t)
 
-corecmd_exec_bin(mozilla_plugin_t)
+corecmd_exec_bin_wrapper(mozilla_plugin_t)
 corecmd_exec_shell(mozilla_plugin_t)
 corecmd_dontaudit_access_all_executables(mozilla_plugin_t)
 corecmd_getattr_all_executables(mozilla_plugin_t)
@@ -670,7 +670,7 @@ userdom_user_tmp_filetrans(mozilla_plugin_config_t, mozilla_plugin_tmp_t, { dir 
 mozilla_filetrans_home_content(mozilla_plugin_config_t)
 dontaudit mozilla_plugin_t mozilla_plugin_tmp_t:file relabelfrom;
 
-corecmd_exec_bin(mozilla_plugin_config_t)
+corecmd_exec_bin_wrapper(mozilla_plugin_config_t)
 corecmd_exec_shell(mozilla_plugin_config_t)
 
 kernel_read_system_state(mozilla_plugin_config_t)

--- a/policy/modules/contrib/mpd.te
+++ b/policy/modules/contrib/mpd.te
@@ -125,7 +125,7 @@ kernel_read_system_state(mpd_t)
 kernel_read_kernel_sysctls(mpd_t)
 kernel_io_uring_use(mpd_t)
 
-corecmd_exec_bin(mpd_t)
+corecmd_exec_bin_wrapper(mpd_t)
 
 corenet_all_recvfrom_netlabel(mpd_t)
 corenet_tcp_sendrecv_generic_if(mpd_t)

--- a/policy/modules/contrib/mplayer.te
+++ b/policy/modules/contrib/mplayer.te
@@ -152,7 +152,7 @@ kernel_dontaudit_read_unlabeled_files(mplayer_t)
 kernel_read_system_state(mplayer_t)
 kernel_read_kernel_sysctls(mplayer_t)
 
-corecmd_exec_bin(mplayer_t)
+corecmd_exec_bin_wrapper(mplayer_t)
 corecmd_exec_shell(mplayer_t)
 
 corenet_all_recvfrom_unlabeled(mplayer_t)

--- a/policy/modules/contrib/mrtg.te
+++ b/policy/modules/contrib/mrtg.te
@@ -68,7 +68,7 @@ kernel_read_system_state(mrtg_t)
 kernel_read_network_state(mrtg_t)
 kernel_read_kernel_sysctls(mrtg_t)
 
-corecmd_exec_bin(mrtg_t)
+corecmd_exec_bin_wrapper(mrtg_t)
 corecmd_exec_shell(mrtg_t)
 
 corenet_all_recvfrom_netlabel(mrtg_t)

--- a/policy/modules/contrib/mta.te
+++ b/policy/modules/contrib/mta.te
@@ -88,7 +88,7 @@ corenet_sendrecv_all_client_packets(user_mail_domain)
 corenet_tcp_connect_all_ports(user_mail_domain)
 corenet_tcp_sendrecv_all_ports(user_mail_domain)
 
-corecmd_exec_bin(user_mail_domain)
+corecmd_exec_bin_wrapper(user_mail_domain)
 
 dev_read_urand(user_mail_domain)
 

--- a/policy/modules/contrib/munin.te
+++ b/policy/modules/contrib/munin.te
@@ -71,7 +71,7 @@ manage_files_pattern(munin_plugin_domain, munin_plugin_state_t, munin_plugin_sta
 corenet_tcp_sendrecv_generic_if(munin_plugin_domain)
 corenet_tcp_sendrecv_generic_node(munin_plugin_domain)
 
-corecmd_exec_bin(munin_plugin_domain)
+corecmd_exec_bin_wrapper(munin_plugin_domain)
 corecmd_exec_shell(munin_plugin_domain)
 
 files_search_var_lib(munin_plugin_domain)
@@ -132,7 +132,7 @@ kernel_read_system_state(munin_t)
 kernel_read_network_state(munin_t)
 kernel_read_all_sysctls(munin_t)
 
-corecmd_exec_bin(munin_t)
+corecmd_exec_bin_wrapper(munin_t)
 corecmd_exec_shell(munin_t)
 
 corenet_all_recvfrom_netlabel(munin_t)

--- a/policy/modules/contrib/nagios.te
+++ b/policy/modules/contrib/nagios.te
@@ -103,7 +103,7 @@ allow nagios_plugin_domain nagios_t:process signal_perms;
 dontaudit nagios_plugin_domain nrpe_t:tcp_socket { read write };
 dontaudit nagios_plugin_domain nagios_log_t:file { read write };
 
-corecmd_exec_bin(nagios_plugin_domain)
+corecmd_exec_bin_wrapper(nagios_plugin_domain)
 
 dev_read_urand(nagios_plugin_domain)
 dev_read_rand(nagios_plugin_domain)
@@ -167,7 +167,7 @@ kernel_read_system_state(nagios_t)
 kernel_read_kernel_sysctls(nagios_t)
 kernel_read_software_raid_state(nagios_t)
 
-corecmd_exec_bin(nagios_t)
+corecmd_exec_bin_wrapper(nagios_t)
 corecmd_exec_shell(nagios_t)
 
 corenet_all_recvfrom_netlabel(nagios_t)
@@ -340,7 +340,7 @@ kernel_read_software_raid_state(nrpe_t)
 
 can_exec(nagios_t, nagios_exec_t)
 
-corecmd_exec_bin(nrpe_t)
+corecmd_exec_bin_wrapper(nrpe_t)
 corecmd_exec_shell(nrpe_t)
 
 corenet_all_recvfrom_unlabeled(nrpe_t)
@@ -499,7 +499,7 @@ allow nagios_checkdisk_plugin_t self:capability { sys_admin sys_rawio };
 
 kernel_read_software_raid_state(nagios_checkdisk_plugin_t)
 
-corecmd_exec_bin(nagios_checkdisk_plugin_t)
+corecmd_exec_bin_wrapper(nagios_checkdisk_plugin_t)
 
 files_getattr_all_dirs(nagios_checkdisk_plugin_t)
 files_getattr_all_mountpoints(nagios_checkdisk_plugin_t)
@@ -522,7 +522,7 @@ allow nagios_services_plugin_t self:tcp_socket create_stream_socket_perms;
 allow nagios_services_plugin_t self:udp_socket create_socket_perms;
 allow nagios_services_plugin_t self:rawip_socket create_socket_perms;
 
-corecmd_exec_bin(nagios_services_plugin_t)
+corecmd_exec_bin_wrapper(nagios_services_plugin_t)
 
 corenet_all_recvfrom_unlabeled(nagios_services_plugin_t)
 corenet_all_recvfrom_netlabel(nagios_services_plugin_t)
@@ -582,7 +582,7 @@ files_tmp_filetrans(nagios_system_plugin_t, nagios_system_plugin_tmp_t, { dir fi
 kernel_read_system_state(nagios_system_plugin_t)
 kernel_read_kernel_sysctls(nagios_system_plugin_t)
 
-corecmd_exec_bin(nagios_system_plugin_t)
+corecmd_exec_bin_wrapper(nagios_system_plugin_t)
 corecmd_exec_shell(nagios_system_plugin_t)
 corecmd_getattr_all_executables(nagios_system_plugin_t)
 
@@ -611,7 +611,7 @@ manage_files_pattern(nagios_eventhandler_plugin_t, nagios_eventhandler_plugin_tm
 manage_dirs_pattern(nagios_eventhandler_plugin_t, nagios_eventhandler_plugin_tmp_t, nagios_eventhandler_plugin_tmp_t)
 files_tmp_filetrans(nagios_eventhandler_plugin_t, nagios_eventhandler_plugin_tmp_t, { dir file })
 
-corecmd_exec_bin(nagios_eventhandler_plugin_t)
+corecmd_exec_bin_wrapper(nagios_eventhandler_plugin_t)
 corecmd_exec_shell(nagios_eventhandler_plugin_t)
 
 init_domtrans_script(nagios_eventhandler_plugin_t)
@@ -635,7 +635,7 @@ manage_dirs_pattern(nagios_openshift_plugin_t, nagios_openshift_plugin_tmp_t, na
 manage_files_pattern(nagios_openshift_plugin_t, nagios_openshift_plugin_tmp_t, nagios_openshift_plugin_tmp_t)
 files_tmp_filetrans(nagios_openshift_plugin_t, nagios_openshift_plugin_tmp_t, { file dir })
 
-corecmd_exec_bin(nagios_openshift_plugin_t)
+corecmd_exec_bin_wrapper(nagios_openshift_plugin_t)
 corecmd_exec_shell(nagios_openshift_plugin_t)
 
 domain_read_all_domains_state(nagios_openshift_plugin_t)

--- a/policy/modules/contrib/ncftool.te
+++ b/policy/modules/contrib/ncftool.te
@@ -34,7 +34,7 @@ kernel_read_system_state(ncftool_t)
 kernel_request_load_module(ncftool_t)
 kernel_rw_net_sysctls(ncftool_t)
 
-corecmd_exec_bin(ncftool_t)
+corecmd_exec_bin_wrapper(ncftool_t)
 corecmd_exec_shell(ncftool_t)
 
 domain_read_all_domains_state(ncftool_t)

--- a/policy/modules/contrib/nessus.te
+++ b/policy/modules/contrib/nessus.te
@@ -56,7 +56,7 @@ files_pid_filetrans(nessusd_t, nessusd_var_run_t, file)
 kernel_read_system_state(nessusd_t)
 kernel_read_kernel_sysctls(nessusd_t)
 
-corecmd_exec_bin(nessusd_t)
+corecmd_exec_bin_wrapper(nessusd_t)
 
 corenet_all_recvfrom_netlabel(nessusd_t)
 corenet_tcp_sendrecv_generic_if(nessusd_t)

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -213,7 +213,7 @@ mls_file_read_all_levels(NetworkManager_t)
 selinux_dontaudit_search_fs(NetworkManager_t)
 
 corecmd_exec_shell(NetworkManager_t)
-corecmd_exec_bin(NetworkManager_t)
+corecmd_exec_bin_wrapper(NetworkManager_t)
 
 domain_use_interactive_fds(NetworkManager_t)
 domain_read_all_domains_state(NetworkManager_t)
@@ -599,8 +599,8 @@ kernel_request_load_module(NetworkManager_dispatcher_ddclient_t)
 
 auth_read_passwd(networkmanager_dispatcher_plugin)
 
-corecmd_exec_bin(NetworkManager_dispatcher_t)
-corecmd_exec_bin(networkmanager_dispatcher_plugin)
+corecmd_exec_bin_wrapper(NetworkManager_dispatcher_t)
+corecmd_exec_bin_wrapper(networkmanager_dispatcher_plugin)
 corecmd_exec_shell(NetworkManager_dispatcher_t)
 corecmd_exec_shell(NetworkManager_dispatcher_chronyc_t)
 corecmd_exec_shell(NetworkManager_dispatcher_cloud_t)

--- a/policy/modules/contrib/nis.te
+++ b/policy/modules/contrib/nis.te
@@ -204,7 +204,7 @@ auth_manage_passwd(yppasswdd_t)
 auth_relabel_shadow(yppasswdd_t)
 auth_etc_filetrans_shadow(yppasswdd_t)
 
-corecmd_exec_bin(yppasswdd_t)
+corecmd_exec_bin_wrapper(yppasswdd_t)
 corecmd_exec_shell(yppasswdd_t)
 
 domain_use_interactive_fds(yppasswdd_t)
@@ -293,7 +293,7 @@ dev_read_sysfs(ypserv_t)
 fs_getattr_all_fs(ypserv_t)
 fs_search_auto_mountpoints(ypserv_t)
 
-corecmd_exec_bin(ypserv_t)
+corecmd_exec_bin_wrapper(ypserv_t)
 
 domain_use_interactive_fds(ypserv_t)
 

--- a/policy/modules/contrib/nova.te
+++ b/policy/modules/contrib/nova.te
@@ -92,7 +92,7 @@ logging_send_syslog_msg(nova_t)
 
 miscfiles_read_generic_certs(nova_t)
 
-corecmd_exec_bin(nova_domain)
+corecmd_exec_bin_wrapper(nova_domain)
 corecmd_exec_shell(nova_domain)
 
 corenet_tcp_bind_generic_node(nova_domain)

--- a/policy/modules/contrib/nsd.te
+++ b/policy/modules/contrib/nsd.te
@@ -70,7 +70,7 @@ can_exec(nsd_t, nsd_exec_t)
 kernel_read_system_state(nsd_t)
 kernel_read_kernel_sysctls(nsd_t)
 
-corecmd_exec_bin(nsd_t)
+corecmd_exec_bin_wrapper(nsd_t)
 
 corenet_all_recvfrom_netlabel(nsd_t)
 corenet_tcp_sendrecv_generic_if(nsd_t)
@@ -144,7 +144,7 @@ can_exec(nsd_crond_t, nsd_exec_t)
 
 kernel_read_system_state(nsd_crond_t)
 
-corecmd_exec_bin(nsd_crond_t)
+corecmd_exec_bin_wrapper(nsd_crond_t)
 corecmd_exec_shell(nsd_crond_t)
 
 corenet_all_recvfrom_netlabel(nsd_crond_t)

--- a/policy/modules/contrib/nslcd.te
+++ b/policy/modules/contrib/nslcd.te
@@ -47,7 +47,7 @@ corenet_sendrecv_ldap_client_packets(nslcd_t)
 dev_read_sysfs(nslcd_t)
 dev_read_urand(nslcd_t)
 
-corecmd_exec_bin(nslcd_t)
+corecmd_exec_bin_wrapper(nslcd_t)
 
 files_read_usr_symlinks(nslcd_t)
 files_list_tmp(nslcd_t)

--- a/policy/modules/contrib/ntp.te
+++ b/policy/modules/contrib/ntp.te
@@ -102,7 +102,7 @@ corenet_sendrecv_ntp_client_packets(ntpd_t)
 corenet_tcp_bind_ntske_port(ntpd_t)
 corenet_tcp_connect_ntske_port(ntpd_t)
 
-corecmd_exec_bin(ntpd_t)
+corecmd_exec_bin_wrapper(ntpd_t)
 corecmd_exec_shell(ntpd_t)
 
 dev_read_sysfs(ntpd_t)

--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -83,7 +83,7 @@ read_files_pattern(nut_upsmon_t, nut_conf_t, nut_conf_t)
 kernel_read_kernel_sysctls(nut_upsmon_t)
 kernel_read_system_state(nut_upsmon_t)
 
-corecmd_exec_bin(nut_upsmon_t)
+corecmd_exec_bin_wrapper(nut_upsmon_t)
 corecmd_exec_shell(nut_upsmon_t)
 
 corenet_tcp_connect_ups_port(nut_upsmon_t)
@@ -139,7 +139,7 @@ read_files_pattern(nut_upsdrvctl_t, nut_conf_t, nut_conf_t)
 kernel_read_kernel_sysctls(nut_upsdrvctl_t)
 
 # /sbin/upsdrvctl executes other drivers
-corecmd_exec_bin(nut_upsdrvctl_t)
+corecmd_exec_bin_wrapper(nut_upsdrvctl_t)
 
 dev_read_sysfs(nut_upsdrvctl_t)
 dev_read_usbfs(nut_upsdrvctl_t)

--- a/policy/modules/contrib/nvme_stas.te
+++ b/policy/modules/contrib/nvme_stas.te
@@ -51,7 +51,7 @@ files_pid_filetrans(nvme_stas_t, nvme_stas_var_run_t, file, "last-known-config.p
 kernel_dgram_send(nvme_stas_t)
 kernel_request_load_module(nvme_stas_t)
 
-corecmd_exec_bin(nvme_stas_t)
+corecmd_exec_bin_wrapper(nvme_stas_t)
 
 dev_read_sysfs(nvme_stas_t)
 domain_use_interactive_fds(nvme_stas_t)

--- a/policy/modules/contrib/nx.te
+++ b/policy/modules/contrib/nx.te
@@ -60,7 +60,7 @@ kernel_read_system_state(nx_server_t)
 kernel_read_kernel_sysctls(nx_server_t)
 
 corecmd_exec_shell(nx_server_t)
-corecmd_exec_bin(nx_server_t)
+corecmd_exec_bin_wrapper(nx_server_t)
 
 corenet_all_recvfrom_netlabel(nx_server_t)
 corenet_tcp_sendrecv_generic_if(nx_server_t)

--- a/policy/modules/contrib/oddjob.te
+++ b/policy/modules/contrib/oddjob.te
@@ -47,7 +47,7 @@ files_pid_filetrans(oddjob_t, oddjob_var_run_t, { file sock_file })
 
 kernel_read_system_state(oddjob_t)
 
-corecmd_exec_bin(oddjob_t)
+corecmd_exec_bin_wrapper(oddjob_t)
 corecmd_exec_shell(oddjob_t)
 
 mcs_process_set_categories(oddjob_t)

--- a/policy/modules/contrib/openca.te
+++ b/policy/modules/contrib/openca.te
@@ -51,7 +51,7 @@ allow openca_ca_t openca_usr_share_t:dir list_dir_perms;
 allow openca_ca_t openca_usr_share_t:file read_file_perms;
 allow openca_ca_t openca_usr_share_t:lnk_file read_lnk_file_perms;
 
-corecmd_exec_bin(openca_ca_t)
+corecmd_exec_bin_wrapper(openca_ca_t)
 
 dev_read_rand(openca_ca_t)
 

--- a/policy/modules/contrib/opendnssec.te
+++ b/policy/modules/contrib/opendnssec.te
@@ -59,7 +59,7 @@ kernel_read_system_state(opendnssec_t)
 
 auth_use_nsswitch(opendnssec_t)
 
-corecmd_exec_bin(opendnssec_t)
+corecmd_exec_bin_wrapper(opendnssec_t)
 
 corenet_tcp_bind_opendnssec_port(opendnssec_t)
 corenet_udp_bind_opendnssec_port(opendnssec_t)

--- a/policy/modules/contrib/openshift.te
+++ b/policy/modules/contrib/openshift.te
@@ -474,7 +474,7 @@ optional_policy(`
 	ssh_use_ptys(openshift_cgroup_read_t)
 ')
 
-corecmd_exec_bin(openshift_cgroup_read_t)
+corecmd_exec_bin_wrapper(openshift_cgroup_read_t)
 corecmd_exec_shell(openshift_cgroup_read_t)
 
 dev_read_urand(openshift_cgroup_read_t)
@@ -512,7 +512,7 @@ allow openshift_net_read_t openshift_file_type:file rw_inherited_file_perms;
 kernel_read_network_state(openshift_net_read_t)
 kernel_read_system_state(openshift_net_read_t)
 
-corecmd_exec_bin(openshift_net_read_t)
+corecmd_exec_bin_wrapper(openshift_net_read_t)
 corecmd_exec_shell(openshift_net_read_t)
 
 dev_read_urand(openshift_net_read_t)
@@ -569,7 +569,7 @@ kernel_read_system_state(openshift_cron_t)
 
 files_dontaudit_search_all_mountpoints(openshift_cron_t)
 
-corecmd_exec_bin(openshift_cron_t)
+corecmd_exec_bin_wrapper(openshift_cron_t)
 corecmd_exec_shell(openshift_cron_t)
 
 dev_read_raw_memory(openshift_cron_t)

--- a/policy/modules/contrib/opensm.te
+++ b/policy/modules/contrib/opensm.te
@@ -40,7 +40,7 @@ auth_use_nsswitch(opensm_t)
 corenet_ib_access_unlabeled_pkeys(opensm_t)
 corenet_ib_manage_subnet_unlabeled_endports(opensm_t)
 
-corecmd_exec_bin(opensm_t)
+corecmd_exec_bin_wrapper(opensm_t)
 
 dev_read_sysfs(opensm_t)
 dev_rw_infiniband_dev(opensm_t)

--- a/policy/modules/contrib/openvpn.te
+++ b/policy/modules/contrib/openvpn.te
@@ -113,7 +113,7 @@ kernel_read_network_state(openvpn_t)
 kernel_read_system_state(openvpn_t)
 kernel_request_load_module(openvpn_t)
 
-corecmd_exec_bin(openvpn_t)
+corecmd_exec_bin_wrapper(openvpn_t)
 corecmd_exec_shell(openvpn_t)
 
 corenet_all_recvfrom_netlabel(openvpn_t)

--- a/policy/modules/contrib/openvswitch.te
+++ b/policy/modules/contrib/openvswitch.te
@@ -95,7 +95,7 @@ corenet_tcp_connect_openvswitch_port(openvswitch_t)
 corenet_tcp_bind_generic_node(openvswitch_t)
 corenet_tcp_bind_openvswitch_port(openvswitch_t)
 
-corecmd_exec_bin(openvswitch_t)
+corecmd_exec_bin_wrapper(openvswitch_t)
 corecmd_exec_shell(openvswitch_t)
 
 dev_ioctl_vduse(openvswitch_t)

--- a/policy/modules/contrib/oracleasm.te
+++ b/policy/modules/contrib/oracleasm.te
@@ -44,7 +44,7 @@ dev_rw_sysfs(oracleasm_t)
 domain_use_interactive_fds(oracleasm_t)
 
 corecmd_exec_shell(oracleasm_t)
-corecmd_exec_bin(oracleasm_t)
+corecmd_exec_bin_wrapper(oracleasm_t)
 
 fs_getattr_xattr_fs(oracleasm_t)
 fs_list_oracleasmfs(oracleasm_t)

--- a/policy/modules/contrib/osad.te
+++ b/policy/modules/contrib/osad.te
@@ -33,7 +33,7 @@ files_pid_filetrans(osad_t, osad_var_run_t, file)
 
 kernel_read_system_state(osad_t)
 
-corecmd_exec_bin(osad_t)
+corecmd_exec_bin_wrapper(osad_t)
 
 corenet_tcp_connect_http_port(osad_t)
 corenet_tcp_connect_jabber_client_port(osad_t)

--- a/policy/modules/contrib/pacemaker.te
+++ b/policy/modules/contrib/pacemaker.te
@@ -69,7 +69,7 @@ kernel_read_network_state(pacemaker_t)
 kernel_read_software_raid_state(pacemaker_t)
 kernel_read_system_state(pacemaker_t)
 
-corecmd_exec_bin(pacemaker_t)
+corecmd_exec_bin_wrapper(pacemaker_t)
 corecmd_exec_shell(pacemaker_t)
 
 domain_use_interactive_fds(pacemaker_t)

--- a/policy/modules/contrib/passenger.te
+++ b/policy/modules/contrib/passenger.te
@@ -69,7 +69,7 @@ corenet_tcp_connect_http_port(passenger_t)
 corenet_tcp_connect_postgresql_port(passenger_t)
 corenet_tcp_connect_mysqld_port(passenger_t)
 
-corecmd_exec_bin(passenger_t)
+corecmd_exec_bin_wrapper(passenger_t)
 corecmd_exec_shell(passenger_t)
 
 dev_read_urand(passenger_t)

--- a/policy/modules/contrib/pegasus.te
+++ b/policy/modules/contrib/pegasus.te
@@ -68,7 +68,7 @@ allow pegasus_openlmi_domain self:udp_socket create_socket_perms;
 manage_files_pattern(pegasus_openlmi_domain, pegasus_data_t, pegasus_data_t)
 manage_dirs_pattern(pegasus_openlmi_domain, pegasus_data_t, pegasus_data_t)
 
-corecmd_exec_bin(pegasus_openlmi_domain)
+corecmd_exec_bin_wrapper(pegasus_openlmi_domain)
 corecmd_exec_shell(pegasus_openlmi_domain)
 
 dev_read_sysfs(pegasus_openlmi_domain)
@@ -413,7 +413,7 @@ corenet_sendrecv_pegasus_http_server_packets(pegasus_t)
 corenet_sendrecv_pegasus_https_client_packets(pegasus_t)
 corenet_sendrecv_pegasus_https_server_packets(pegasus_t)
 
-corecmd_exec_bin(pegasus_t)
+corecmd_exec_bin_wrapper(pegasus_t)
 corecmd_exec_shell(pegasus_t)
 
 dev_rw_sysfs(pegasus_t)

--- a/policy/modules/contrib/piranha.te
+++ b/policy/modules/contrib/piranha.te
@@ -180,7 +180,7 @@ kernel_rw_rpc_sysctls(piranha_pulse_t)
 kernel_search_debugfs(piranha_pulse_t)
 kernel_search_network_state(piranha_pulse_t)
 
-corecmd_exec_bin(piranha_pulse_t)
+corecmd_exec_bin_wrapper(piranha_pulse_t)
 corecmd_exec_shell(piranha_pulse_t)
 optional_policy(`
 	consoletype_exec(piranha_pulse_t)
@@ -286,7 +286,7 @@ corenet_udp_sendrecv_all_ports(piranha_domain)
 corenet_tcp_bind_generic_node(piranha_domain)
 corenet_udp_bind_generic_node(piranha_domain)
 
-corecmd_exec_bin(piranha_domain)
+corecmd_exec_bin_wrapper(piranha_domain)
 corecmd_exec_shell(piranha_domain)
 
 sysnet_read_config(piranha_domain)

--- a/policy/modules/contrib/pki.te
+++ b/policy/modules/contrib/pki.te
@@ -251,7 +251,7 @@ libs_exec_lib_files(pki_apache_domain)
 
 fs_search_cgroup_dirs(pki_apache_domain)
 
-corecmd_exec_bin(pki_apache_domain)
+corecmd_exec_bin_wrapper(pki_apache_domain)
 corecmd_exec_shell(pki_apache_domain)
 
 dev_read_urand(pki_apache_domain)

--- a/policy/modules/contrib/plymouthd.te
+++ b/policy/modules/contrib/plymouthd.te
@@ -62,7 +62,7 @@ kernel_read_system_state(plymouthd_t)
 kernel_request_load_module(plymouthd_t)
 kernel_change_ring_buffer_level(plymouthd_t)
 
-corecmd_exec_bin(plymouthd_t)
+corecmd_exec_bin_wrapper(plymouthd_t)
 
 dev_rw_dri(plymouthd_t)
 dev_read_sysfs(plymouthd_t)

--- a/policy/modules/contrib/podsleuth.te
+++ b/policy/modules/contrib/podsleuth.te
@@ -53,7 +53,7 @@ fs_tmpfs_filetrans(podsleuth_t, podsleuth_tmpfs_t, { dir file lnk_file })
 kernel_read_system_state(podsleuth_t)
 kernel_request_load_module(podsleuth_t)
 
-corecmd_exec_bin(podsleuth_t)
+corecmd_exec_bin_wrapper(podsleuth_t)
 
 corenet_all_recvfrom_unlabeled(podsleuth_t)
 corenet_all_recvfrom_netlabel(podsleuth_t)

--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -64,7 +64,7 @@ allow policykit_t policykit_auth_t:process signal;
 allow policykit_t policykit_auth_t:process2 nnp_transition;
 
 can_exec(policykit_t, policykit_exec_t)
-corecmd_exec_bin(policykit_t)
+corecmd_exec_bin_wrapper(policykit_t)
 
 dev_read_sysfs(policykit_t)
 
@@ -179,7 +179,7 @@ policykit_dbus_chat(policykit_auth_t)
 kernel_read_system_state(policykit_auth_t)
 
 can_exec(policykit_auth_t, policykit_auth_exec_t)
-corecmd_exec_bin(policykit_auth_t)
+corecmd_exec_bin_wrapper(policykit_auth_t)
 
 rw_files_pattern(policykit_auth_t, policykit_reload_t, policykit_reload_t)
 

--- a/policy/modules/contrib/portage.te
+++ b/policy/modules/contrib/portage.te
@@ -101,7 +101,7 @@ kernel_read_system_state(gcc_config_t)
 kernel_read_kernel_sysctls(gcc_config_t)
 
 corecmd_exec_shell(gcc_config_t)
-corecmd_exec_bin(gcc_config_t)
+corecmd_exec_bin_wrapper(gcc_config_t)
 corecmd_manage_bin_files(gcc_config_t)
 
 domain_use_interactive_fds(gcc_config_t)
@@ -264,7 +264,7 @@ files_tmp_filetrans(portage_fetch_t, portage_fetch_tmp_t, { file dir })
 kernel_read_system_state(portage_fetch_t)
 kernel_read_kernel_sysctls(portage_fetch_t)
 
-corecmd_exec_bin(portage_fetch_t)
+corecmd_exec_bin_wrapper(portage_fetch_t)
 corecmd_exec_shell(portage_fetch_t)
 
 corenet_all_recvfrom_unlabeled(portage_fetch_t)

--- a/policy/modules/contrib/portslave.te
+++ b/policy/modules/contrib/portslave.te
@@ -45,7 +45,7 @@ files_lock_filetrans(portslave_t, portslave_lock_t, file)
 kernel_read_system_state(portslave_t)
 kernel_read_kernel_sysctls(portslave_t)
 
-corecmd_exec_bin(portslave_t)
+corecmd_exec_bin_wrapper(portslave_t)
 corecmd_exec_shell(portslave_t)
 
 corenet_all_recvfrom_netlabel(portslave_t)

--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -192,7 +192,7 @@ corenet_tcp_bind_spamd_port(postfix_master_t)
 selinux_dontaudit_search_fs(postfix_master_t)
 
 corecmd_exec_shell(postfix_master_t)
-corecmd_exec_bin(postfix_master_t)
+corecmd_exec_bin_wrapper(postfix_master_t)
 
 domain_use_interactive_fds(postfix_master_t)
 
@@ -292,7 +292,7 @@ allow postfix_cleanup_t postfix_spool_maildrop_t:lnk_file read_lnk_file_perms;
 
 allow postfix_cleanup_t postfix_spool_bounce_t:dir list_dir_perms;
 
-corecmd_exec_bin(postfix_cleanup_t)
+corecmd_exec_bin_wrapper(postfix_cleanup_t)
 
 # allow postfix to connect to sqlgrey
 corenet_tcp_connect_rtsclient_port(postfix_cleanup_t)
@@ -326,7 +326,7 @@ domtrans_pattern(postfix_local_t, postfix_postdrop_exec_t, postfix_postdrop_t)
 allow postfix_local_t postfix_spool_t:file rw_file_perms;
 
 corecmd_exec_shell(postfix_local_t)
-corecmd_exec_bin(postfix_local_t)
+corecmd_exec_bin_wrapper(postfix_local_t)
 
 logging_dontaudit_search_logs(postfix_local_t)
 
@@ -499,7 +499,7 @@ rw_files_pattern(postfix_pipe_t, postfix_spool_t, postfix_spool_t)
 
 domtrans_pattern(postfix_pipe_t, postfix_postdrop_exec_t, postfix_postdrop_t)
 
-corecmd_exec_bin(postfix_pipe_t)
+corecmd_exec_bin_wrapper(postfix_pipe_t)
 
 optional_policy(`
     cyrus_stream_connect(postfix_pipe_t)
@@ -640,7 +640,7 @@ manage_dirs_pattern(postfix_qmgr_t, postfix_spool_bounce_t, postfix_spool_bounce
 manage_files_pattern(postfix_qmgr_t, postfix_spool_bounce_t, postfix_spool_bounce_t)
 manage_lnk_files_pattern(postfix_qmgr_t, postfix_spool_bounce_t, postfix_spool_bounce_t)
 
-corecmd_exec_bin(postfix_qmgr_t)
+corecmd_exec_bin_wrapper(postfix_qmgr_t)
 
 ########################################
 #
@@ -724,7 +724,7 @@ manage_files_pattern(postfix_smtpd_t, postfix_spool_t, postfix_spool_t)
 manage_lnk_files_pattern(postfix_smtpd_t, postfix_spool_t, postfix_spool_t)
 allow postfix_smtpd_t postfix_prng_t:file rw_file_perms;
 
-corecmd_exec_bin(postfix_smtpd_t)
+corecmd_exec_bin_wrapper(postfix_smtpd_t)
 
 # for OpenSSL certificates
 
@@ -782,7 +782,7 @@ manage_files_pattern(postfix_virtual_t, postfix_spool_t, postfix_spool_t)
 stream_connect_pattern(postfix_virtual_t, { postfix_private_t postfix_public_t }, { postfix_private_t postfix_public_t }, postfix_master_t)
 
 corecmd_exec_shell(postfix_virtual_t)
-corecmd_exec_bin(postfix_virtual_t)
+corecmd_exec_bin_wrapper(postfix_virtual_t)
 
 mta_delete_spool(postfix_virtual_t)
 mta_manage_spool(postfix_virtual_t)

--- a/policy/modules/contrib/postgrey.te
+++ b/policy/modules/contrib/postgrey.te
@@ -59,7 +59,7 @@ kernel_read_network_state(postgrey_t)
 
 auth_use_nsswitch(postgrey_t)
 
-corecmd_exec_bin(postgrey_t)
+corecmd_exec_bin_wrapper(postgrey_t)
 
 corenet_all_recvfrom_netlabel(postgrey_t)
 corenet_tcp_sendrecv_generic_if(postgrey_t)

--- a/policy/modules/contrib/ppp.te
+++ b/policy/modules/contrib/ppp.te
@@ -166,7 +166,7 @@ term_create_pty(pppd_t, pppd_devpts_t)
 term_use_generic_ptys(pppd_t)
 
 # allow running ip-up and ip-down scripts and running chat.
-corecmd_exec_bin(pppd_t)
+corecmd_exec_bin_wrapper(pppd_t)
 corecmd_exec_shell(pppd_t)
 
 domain_use_interactive_fds(pppd_t)

--- a/policy/modules/contrib/prelink.te
+++ b/policy/modules/contrib/prelink.te
@@ -162,7 +162,7 @@ optional_policy(`
 
 	kernel_read_system_state(prelink_cron_system_t)
 
-	corecmd_exec_bin(prelink_cron_system_t)
+	corecmd_exec_bin_wrapper(prelink_cron_system_t)
 	corecmd_exec_shell(prelink_cron_system_t)
 
 	dev_list_sysfs(prelink_cron_system_t)

--- a/policy/modules/contrib/prelude.te
+++ b/policy/modules/contrib/prelude.te
@@ -218,7 +218,7 @@ files_pid_filetrans(prelude_lml_t, prelude_lml_var_run_t, file)
 kernel_read_system_state(prelude_lml_t)
 kernel_read_sysctl(prelude_lml_t)
 
-corecmd_exec_bin(prelude_lml_t)
+corecmd_exec_bin_wrapper(prelude_lml_t)
 
 corenet_all_recvfrom_unlabeled(prelude_lml_t)
 corenet_all_recvfrom_netlabel(prelude_lml_t)

--- a/policy/modules/contrib/procmail.te
+++ b/policy/modules/contrib/procmail.te
@@ -68,7 +68,7 @@ fs_search_auto_mountpoints(procmail_t)
 
 auth_use_nsswitch(procmail_t)
 
-corecmd_exec_bin(procmail_t)
+corecmd_exec_bin_wrapper(procmail_t)
 corecmd_exec_shell(procmail_t)
 
 files_read_etc_runtime_files(procmail_t)

--- a/policy/modules/contrib/prosody.te
+++ b/policy/modules/contrib/prosody.te
@@ -65,7 +65,7 @@ can_exec(prosody_t, prosody_exec_t)
 kernel_read_net_sysctls(prosody_t)
 kernel_read_system_state(prosody_t)
 
-corecmd_exec_bin(prosody_t)
+corecmd_exec_bin_wrapper(prosody_t)
 corecmd_exec_shell(prosody_t)
 
 corenet_udp_bind_generic_node(prosody_t)

--- a/policy/modules/contrib/psad.te
+++ b/policy/modules/contrib/psad.te
@@ -64,7 +64,7 @@ kernel_read_system_state(psad_t)
 kernel_read_network_state(psad_t)
 kernel_read_net_sysctls(psad_t)
 
-corecmd_exec_bin(psad_t)
+corecmd_exec_bin_wrapper(psad_t)
 corecmd_exec_shell(psad_t)
 
 corenet_all_recvfrom_netlabel(psad_t)

--- a/policy/modules/contrib/pulseaudio.te
+++ b/policy/modules/contrib/pulseaudio.te
@@ -70,7 +70,7 @@ can_exec(pulseaudio_t, pulseaudio_exec_t)
 kernel_read_system_state(pulseaudio_t)
 kernel_read_kernel_sysctls(pulseaudio_t)
 
-corecmd_exec_bin(pulseaudio_t)
+corecmd_exec_bin_wrapper(pulseaudio_t)
 
 corenet_all_recvfrom_netlabel(pulseaudio_t)
 corenet_tcp_bind_pulseaudio_port(pulseaudio_t)

--- a/policy/modules/contrib/puppet.te
+++ b/policy/modules/contrib/puppet.te
@@ -100,7 +100,7 @@ kernel_read_kernel_sysctls(puppetagent_t)
 
 corecmd_read_all_executables(puppetagent_t)
 corecmd_dontaudit_access_all_executables(puppetagent_t)
-corecmd_exec_bin(puppetagent_t)
+corecmd_exec_bin_wrapper(puppetagent_t)
 corecmd_exec_shell(puppetagent_t)
 
 corenet_all_recvfrom_netlabel(puppetagent_t)
@@ -247,7 +247,7 @@ kernel_read_system_state(puppetca_t)
 # Maybe dontaudit this like we did with other puppet domains?
 kernel_read_kernel_sysctls(puppetca_t)
 
-corecmd_exec_bin(puppetca_t)
+corecmd_exec_bin_wrapper(puppetca_t)
 corecmd_exec_shell(puppetca_t)
 
 dev_read_urand(puppetca_t)
@@ -318,7 +318,7 @@ kernel_read_system_state(puppetmaster_t)
 kernel_read_crypto_sysctls(puppetmaster_t)
 kernel_read_kernel_sysctls(puppetmaster_t)
 
-corecmd_exec_bin(puppetmaster_t)
+corecmd_exec_bin_wrapper(puppetmaster_t)
 corecmd_exec_shell(puppetmaster_t)
 
 corenet_all_recvfrom_netlabel(puppetmaster_t)

--- a/policy/modules/contrib/pyzor.te
+++ b/policy/modules/contrib/pyzor.te
@@ -142,7 +142,7 @@ kernel_read_system_state(pyzord_t)
 
 dev_read_urand(pyzord_t)
 
-corecmd_exec_bin(pyzord_t)
+corecmd_exec_bin_wrapper(pyzord_t)
 
 corenet_all_recvfrom_netlabel(pyzord_t)
 corenet_udp_sendrecv_generic_if(pyzord_t)

--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -44,7 +44,7 @@ kernel_search_debugfs(qatlib_t)
 kernel_stream_connect(qatlib_t)
 
 corecmd_exec_shell(qatlib_t)
-corecmd_exec_bin(qatlib_t)
+corecmd_exec_bin_wrapper(qatlib_t)
 
 dev_create_sysfs_files(qatlib_t)
 dev_getattr_generic_chr_files(qatlib_t)

--- a/policy/modules/contrib/qmail.te
+++ b/policy/modules/contrib/qmail.te
@@ -108,7 +108,7 @@ allow qmail_local_t qmail_spool_t:file read_file_perms;
 
 kernel_read_system_state(qmail_local_t)
 
-corecmd_exec_bin(qmail_local_t)
+corecmd_exec_bin_wrapper(qmail_local_t)
 corecmd_exec_shell(qmail_local_t)
 
 files_read_etc_runtime_files(qmail_local_t)
@@ -168,7 +168,7 @@ manage_dirs_pattern(qmail_queue_t, qmail_spool_t, qmail_spool_t)
 manage_files_pattern(qmail_queue_t, qmail_spool_t, qmail_spool_t)
 rw_fifo_files_pattern(qmail_queue_t, qmail_spool_t, qmail_spool_t)
 
-corecmd_exec_bin(qmail_queue_t)
+corecmd_exec_bin_wrapper(qmail_queue_t)
 
 logging_send_syslog_msg(qmail_queue_t)
 

--- a/policy/modules/contrib/quantum.te
+++ b/policy/modules/contrib/quantum.te
@@ -80,7 +80,7 @@ kernel_read_network_state(neutron_t)
 kernel_request_load_module(neutron_t)
 
 corecmd_exec_shell(neutron_t)
-corecmd_exec_bin(neutron_t)
+corecmd_exec_bin_wrapper(neutron_t)
 
 corenet_all_recvfrom_unlabeled(neutron_t)
 corenet_all_recvfrom_netlabel(neutron_t)

--- a/policy/modules/contrib/rabbitmq.te
+++ b/policy/modules/contrib/rabbitmq.te
@@ -87,7 +87,7 @@ kernel_read_system_state(rabbitmq_t)
 kernel_read_fs_sysctls(rabbitmq_t)
 kernel_read_net_sysctls(rabbitmq_t)
 
-corecmd_exec_bin(rabbitmq_t)
+corecmd_exec_bin_wrapper(rabbitmq_t)
 corecmd_exec_shell(rabbitmq_t)
 
 corenet_tcp_bind_generic_node(rabbitmq_t)

--- a/policy/modules/contrib/radius.te
+++ b/policy/modules/contrib/radius.te
@@ -137,7 +137,7 @@ corenet_sendrecv_generic_server_packets(radiusd_t)
 corenet_udp_bind_generic_port(radiusd_t)
 corenet_dontaudit_udp_bind_all_ports(radiusd_t)
 
-corecmd_exec_bin(radiusd_t)
+corecmd_exec_bin_wrapper(radiusd_t)
 corecmd_exec_shell(radiusd_t)
 
 dev_read_sysfs(radiusd_t)

--- a/policy/modules/contrib/raid.te
+++ b/policy/modules/contrib/raid.te
@@ -83,7 +83,7 @@ kernel_signal(mdadm_t)
 kernel_signull(mdadm_t)
 kernel_stream_connect(mdadm_t)
 
-corecmd_exec_bin(mdadm_t)
+corecmd_exec_bin_wrapper(mdadm_t)
 corecmd_exec_shell(mdadm_t)
 
 dev_rw_sysfs(mdadm_t)

--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -35,7 +35,7 @@ dev_rw_sysfs(rasdaemon_t)
 dev_read_urand(rasdaemon_t)
 dev_rw_cpu_microcode(rasdaemon_t)
 
-corecmd_exec_bin(rasdaemon_t)
+corecmd_exec_bin_wrapper(rasdaemon_t)
 
 fs_list_pstore(rasdaemon_t)
 fs_rw_tracefs_files(rasdaemon_t)

--- a/policy/modules/contrib/razor.if
+++ b/policy/modules/contrib/razor.if
@@ -70,7 +70,7 @@ template(`razor_common_domain_template',`
 	kernel_getattr_message_if($1_t)
 	kernel_read_kernel_sysctls($1_t)
 
-	corecmd_exec_bin($1_t)
+	corecmd_exec_bin_wrapper($1_t)
 
 	corenet_all_recvfrom_unlabeled($1_t)
 	corenet_all_recvfrom_netlabel($1_t)

--- a/policy/modules/contrib/realmd.te
+++ b/policy/modules/contrib/realmd.te
@@ -44,7 +44,7 @@ files_var_lib_filetrans(realmd_t, realmd_var_lib_t, dir)
 kernel_read_system_state(realmd_t)
 kernel_read_network_state(realmd_t)
 
-corecmd_exec_bin(realmd_t)
+corecmd_exec_bin_wrapper(realmd_t)
 corecmd_exec_shell(realmd_t)
 
 corenet_tcp_connect_http_port(realmd_t)

--- a/policy/modules/contrib/redfish-finder.te
+++ b/policy/modules/contrib/redfish-finder.te
@@ -16,7 +16,7 @@ init_daemon_domain(redfish_finder_t, redfish_finder_exec_t)
 
 permissive redfish_finder_t;
 
-corecmd_exec_bin(redfish_finder_t)
+corecmd_exec_bin_wrapper(redfish_finder_t)
 dev_read_sysfs(redfish_finder_t)
 
 optional_policy(`

--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -107,6 +107,12 @@ tunable_policy(`redis_enable_notify',`
 	fs_getattr_xattr_fs(redis_t)
 ')
 
+tunable_policy(`redis_enable_notify && corecmd_bin_sys_resource',`
+	allow redis_t self:capability sys_resource;
+	',`
+	dontaudit redis_t self:capability sys_resource;
+')
+
 optional_policy(`
 	tunable_policy(`redis_enable_notify',`
 		auth_read_passwd_file(redis_t)

--- a/policy/modules/contrib/rgmanager.te
+++ b/policy/modules/contrib/rgmanager.te
@@ -81,7 +81,7 @@ kernel_rw_rpc_sysctls(rgmanager_t)
 kernel_search_debugfs(rgmanager_t)
 kernel_search_network_state(rgmanager_t)
 
-corecmd_exec_bin(rgmanager_t)
+corecmd_exec_bin_wrapper(rgmanager_t)
 corecmd_exec_shell(rgmanager_t)
 
 # need to write to /dev/misc/dlm-control

--- a/policy/modules/contrib/rhcd.te
+++ b/policy/modules/contrib/rhcd.te
@@ -275,7 +275,7 @@ kernel_read_security_state(rhc_worker_playbook_t)
 kernel_read_software_raid_state(rhc_worker_playbook_t)
 kernel_read_system_state(rhc_worker_playbook_t)
 
-corecmd_exec_bin(rhc_worker_playbook_t)
+corecmd_exec_bin_wrapper(rhc_worker_playbook_t)
 corecmd_exec_shell(rhc_worker_playbook_t)
 
 corenet_tcp_bind_generic_node(rhc_worker_playbook_t)
@@ -448,7 +448,7 @@ allow rhc_playbook_verifier_t rhc_playbook_verifier_var_lib_t:dir watch;
 
 stream_connect_pattern(rhc_playbook_verifier_t, rhc_playbook_verifier_var_lib_t, rhc_playbook_verifier_var_lib_t, rhc_playbook_verifier_t)
 
-corecmd_exec_bin(rhc_playbook_verifier_t)
+corecmd_exec_bin_wrapper(rhc_playbook_verifier_t)
 
 optional_policy(`
 	auth_read_passwd(rhc_playbook_verifier_t)

--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -174,7 +174,7 @@ kernel_rw_rpc_sysctls(cluster_t)
 kernel_search_debugfs(cluster_t)
 kernel_search_network_state(cluster_t)
 
-corecmd_exec_bin(cluster_t)
+corecmd_exec_bin_wrapper(cluster_t)
 corecmd_exec_shell(cluster_t)
 
 corenet_all_recvfrom_unlabeled(cluster_t)
@@ -387,7 +387,7 @@ stream_connect_pattern(dlm_controld_t, groupd_var_run_t, groupd_var_run_t, group
 
 kernel_rw_net_sysctls(dlm_controld_t)
 
-corecmd_exec_bin(dlm_controld_t)
+corecmd_exec_bin_wrapper(dlm_controld_t)
 
 dev_read_rand(dlm_controld_t)
 dev_rw_dlm_control(dlm_controld_t)
@@ -439,7 +439,7 @@ stream_connect_pattern(fenced_t, groupd_var_run_t, groupd_var_run_t, groupd_t)
 kernel_read_network_state(fenced_t)
 kernel_read_fs_sysctls(fenced_t)
 
-corecmd_exec_bin(fenced_t)
+corecmd_exec_bin_wrapper(fenced_t)
 corecmd_exec_shell(fenced_t)
 
 corenet_all_recvfrom_unlabeled(fenced_t)
@@ -702,7 +702,7 @@ files_var_lib_filetrans(qdiskd_t, qdiskd_var_lib_t, { file dir sock_file })
 kernel_read_software_raid_state(qdiskd_t)
 kernel_getattr_core_if(qdiskd_t)
 
-corecmd_exec_bin(qdiskd_t)
+corecmd_exec_bin_wrapper(qdiskd_t)
 corecmd_exec_shell(qdiskd_t)
 
 dev_read_sysfs(qdiskd_t)

--- a/policy/modules/contrib/rhgb.te
+++ b/policy/modules/contrib/rhgb.te
@@ -40,7 +40,7 @@ fs_tmpfs_filetrans(rhgb_t, rhgb_tmpfs_t, { dir file lnk_file sock_file fifo_file
 kernel_read_kernel_sysctls(rhgb_t)
 kernel_read_system_state(rhgb_t)
 
-corecmd_exec_bin(rhgb_t)
+corecmd_exec_bin_wrapper(rhgb_t)
 corecmd_exec_shell(rhgb_t)
 
 corenet_all_recvfrom_netlabel(rhgb_t)

--- a/policy/modules/contrib/rhnsd.te
+++ b/policy/modules/contrib/rhnsd.te
@@ -41,7 +41,7 @@ manage_lnk_files_pattern(rhnsd_t, rhnsd_conf_t, rhnsd_conf_t)
 
 auth_use_nsswitch(rhnsd_t)
 
-corecmd_exec_bin(rhnsd_t)
+corecmd_exec_bin_wrapper(rhnsd_t)
 
 logging_send_syslog_msg(rhnsd_t)
 

--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -92,7 +92,7 @@ corenet_tcp_connect_squid_port(rhsmcertd_t)
 corenet_tcp_connect_netport_port(rhsmcertd_t)
 corenet_tcp_connect_websm_port(rhsmcertd_t)
 
-corecmd_exec_bin(rhsmcertd_t)
+corecmd_exec_bin_wrapper(rhsmcertd_t)
 corecmd_exec_shell(rhsmcertd_t)
 
 dev_dontaudit_write_raw_memory(rhsmcertd_t)

--- a/policy/modules/contrib/ricci.te
+++ b/policy/modules/contrib/ricci.te
@@ -113,7 +113,7 @@ files_pid_filetrans(ricci_t, ricci_var_run_t, { file sock_file })
 kernel_read_kernel_sysctls(ricci_t)
 kernel_read_system_state(ricci_t)
 
-corecmd_exec_bin(ricci_t)
+corecmd_exec_bin_wrapper(ricci_t)
 
 corenet_all_recvfrom_netlabel(ricci_t)
 corenet_tcp_sendrecv_generic_if(ricci_t)
@@ -203,7 +203,7 @@ allow ricci_modcluster_t self:fifo_file rw_fifo_file_perms;
 kernel_read_kernel_sysctls(ricci_modcluster_t)
 kernel_read_system_state(ricci_modcluster_t)
 
-corecmd_exec_bin(ricci_modcluster_t)
+corecmd_exec_bin_wrapper(ricci_modcluster_t)
 corecmd_exec_shell(ricci_modcluster_t)
 
 corenet_all_recvfrom_unlabeled(ricci_modcluster_t)
@@ -301,7 +301,7 @@ kernel_read_kernel_sysctls(ricci_modclusterd_t)
 kernel_read_system_state(ricci_modclusterd_t)
 kernel_request_load_module(ricci_modclusterd_t)
 
-corecmd_exec_bin(ricci_modclusterd_t)
+corecmd_exec_bin_wrapper(ricci_modclusterd_t)
 
 corenet_all_recvfrom_unlabeled(ricci_modclusterd_t)
 corenet_all_recvfrom_netlabel(ricci_modclusterd_t)
@@ -356,7 +356,7 @@ allow ricci_modlog_t self:process setsched;
 kernel_read_kernel_sysctls(ricci_modlog_t)
 kernel_read_system_state(ricci_modlog_t)
 
-corecmd_exec_bin(ricci_modlog_t)
+corecmd_exec_bin_wrapper(ricci_modlog_t)
 
 domain_read_all_domains_state(ricci_modlog_t)
 
@@ -382,7 +382,7 @@ allow ricci_modrpm_t self:fifo_file read_fifo_file_perms;
 
 kernel_read_kernel_sysctls(ricci_modrpm_t)
 
-corecmd_exec_bin(ricci_modrpm_t)
+corecmd_exec_bin_wrapper(ricci_modrpm_t)
 
 files_search_usr(ricci_modrpm_t)
 
@@ -408,7 +408,7 @@ allow ricci_modservice_t self:fifo_file rw_fifo_file_perms;
 kernel_read_kernel_sysctls(ricci_modservice_t)
 kernel_read_system_state(ricci_modservice_t)
 
-corecmd_exec_bin(ricci_modservice_t)
+corecmd_exec_bin_wrapper(ricci_modservice_t)
 corecmd_exec_shell(ricci_modservice_t)
 
 files_read_etc_runtime_files(ricci_modservice_t)
@@ -450,7 +450,7 @@ kernel_read_system_state(ricci_modstorage_t)
 create_files_pattern(ricci_modstorage_t, ricci_modstorage_lock_t, ricci_modstorage_lock_t)
 files_lock_filetrans(ricci_modstorage_t, ricci_modstorage_lock_t, file)
 
-corecmd_exec_bin(ricci_modstorage_t)
+corecmd_exec_bin_wrapper(ricci_modstorage_t)
 corecmd_exec_shell(ricci_modstorage_t)
 
 dev_read_sysfs(ricci_modstorage_t)

--- a/policy/modules/contrib/roundup.te
+++ b/policy/modules/contrib/roundup.te
@@ -40,7 +40,7 @@ kernel_list_proc(roundup_t)
 kernel_read_proc_symlinks(roundup_t)
 kernel_read_system_state(roundup_t)
 
-corecmd_exec_bin(roundup_t)
+corecmd_exec_bin_wrapper(roundup_t)
 
 corenet_all_recvfrom_netlabel(roundup_t)
 corenet_tcp_sendrecv_generic_if(roundup_t)

--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -166,7 +166,7 @@ kernel_rw_fs_sysctls(rpcd_t)
 kernel_dontaudit_getattr_core_if(rpcd_t)
 kernel_signal(rpcd_t)
 
-corecmd_exec_bin(rpcd_t)
+corecmd_exec_bin_wrapper(rpcd_t)
 
 files_manage_mounttab(rpcd_t)
 files_getattr_all_dirs(rpcd_t)
@@ -370,7 +370,7 @@ kernel_request_load_module(gssd_t)
 kernel_read_net_sysctls(gssd_t)
 kernel_signal(gssd_t)
 
-corecmd_exec_bin(gssd_t)
+corecmd_exec_bin_wrapper(gssd_t)
 
 domain_manage_all_domains_keyrings(gssd_t)
 

--- a/policy/modules/contrib/rpm.te
+++ b/policy/modules/contrib/rpm.te
@@ -273,7 +273,7 @@ manage_files_pattern(rpmdb_t, rpmdb_tmp_t, rpmdb_tmp_t)
 files_tmp_filetrans(rpmdb_t, rpmdb_tmp_t, { file dir })
 allow rpmdb_t rpmdb_tmp_t:file map;
 
-corecmd_exec_bin(rpmdb_t)
+corecmd_exec_bin_wrapper(rpmdb_t)
 corecmd_exec_shell(rpmdb_t)
 
 files_rw_inherited_non_security_files(rpmdb_t)

--- a/policy/modules/contrib/rtas.te
+++ b/policy/modules/contrib/rtas.te
@@ -67,7 +67,7 @@ domain_read_all_domains_state(rtas_errd_t)
 
 auth_use_nsswitch(rtas_errd_t)
 
-corecmd_exec_bin(rtas_errd_t)
+corecmd_exec_bin_wrapper(rtas_errd_t)
 
 dev_read_rand(rtas_errd_t)
 dev_read_urand(rtas_errd_t)

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -453,7 +453,7 @@ kernel_read_software_raid_state(smbd_t)
 kernel_read_system_state(smbd_t)
 
 corecmd_exec_shell(smbd_t)
-corecmd_exec_bin(smbd_t)
+corecmd_exec_bin_wrapper(smbd_t)
 
 corenet_all_recvfrom_netlabel(smbd_t)
 corenet_tcp_sendrecv_generic_if(smbd_t)
@@ -1128,7 +1128,7 @@ kernel_read_system_state(winbind_t)
 kernel_signull(winbind_t)
 kernel_request_load_module(winbind_t)
 
-corecmd_exec_bin(winbind_t)
+corecmd_exec_bin_wrapper(winbind_t)
 
 corenet_all_recvfrom_netlabel(winbind_t)
 corenet_tcp_sendrecv_generic_if(winbind_t)
@@ -1234,7 +1234,7 @@ dev_read_urand(winbind_helper_t)
 
 term_list_ptys(winbind_helper_t)
 
-corecmd_exec_bin(winbind_helper_t)
+corecmd_exec_bin_wrapper(winbind_helper_t)
 
 domain_use_interactive_fds(winbind_helper_t)
 
@@ -1302,7 +1302,7 @@ manage_files_pattern(samba_dcerpcd_t, smbd_tmp_t, smbd_tmp_t)
 
 kernel_read_network_state(samba_dcerpcd_t)
 
-corecmd_exec_bin(samba_dcerpcd_t)
+corecmd_exec_bin_wrapper(samba_dcerpcd_t)
 
 corenet_tcp_connect_ipp_port(samba_dcerpcd_t)
 corenet_tcp_connect_ldap_port(samba_dcerpcd_t)

--- a/policy/modules/contrib/sambagui.te
+++ b/policy/modules/contrib/sambagui.te
@@ -23,7 +23,7 @@ allow sambagui_t self:fifo_file rw_fifo_file_perms;
 
 kernel_read_system_state(sambagui_t)
 
-corecmd_exec_bin(sambagui_t)
+corecmd_exec_bin_wrapper(sambagui_t)
 corecmd_exec_shell(sambagui_t)
 
 dev_dontaudit_read_urand(sambagui_t)

--- a/policy/modules/contrib/sandboxX.te
+++ b/policy/modules/contrib/sandboxX.te
@@ -71,7 +71,7 @@ kernel_dontaudit_request_load_module(sandbox_xserver_t)
 kernel_read_device_sysctls(sandbox_xserver_t)
 kernel_read_system_state(sandbox_xserver_t)
 
-corecmd_exec_bin(sandbox_xserver_t)
+corecmd_exec_bin_wrapper(sandbox_xserver_t)
 corecmd_exec_shell(sandbox_xserver_t)
 
 corenet_all_recvfrom_netlabel(sandbox_xserver_t)

--- a/policy/modules/contrib/sasl.te
+++ b/policy/modules/contrib/sasl.te
@@ -51,7 +51,7 @@ kernel_read_system_state(saslauthd_t)
 kernel_rw_afs_state(saslauthd_t)
 
 #577519
-corecmd_exec_bin(saslauthd_t)
+corecmd_exec_bin_wrapper(saslauthd_t)
 
 corenet_all_recvfrom_netlabel(saslauthd_t)
 corenet_tcp_sendrecv_generic_if(saslauthd_t)

--- a/policy/modules/contrib/sblim.te
+++ b/policy/modules/contrib/sblim.te
@@ -79,7 +79,7 @@ domtrans_pattern(sblim_gatherd_t, sblim_reposd_exec_t, sblim_reposd_t)
 kernel_read_fs_sysctls(sblim_gatherd_t)
 kernel_read_kernel_sysctls(sblim_gatherd_t)
 
-corecmd_exec_bin(sblim_gatherd_t)
+corecmd_exec_bin_wrapper(sblim_gatherd_t)
 corecmd_exec_shell(sblim_gatherd_t)
 
 corenet_sendrecv_repository_client_packets(sblim_gatherd_t)
@@ -177,7 +177,7 @@ corenet_tcp_connect_pegasus_https_port(sblim_sfcbd_t)
 corenet_tcp_connect_http_port(sblim_sfcbd_t)
 
 corecmd_exec_shell(sblim_sfcbd_t)
-corecmd_exec_bin(sblim_sfcbd_t)
+corecmd_exec_bin_wrapper(sblim_sfcbd_t)
 
 dev_read_rand(sblim_sfcbd_t)
 dev_read_urand(sblim_sfcbd_t)

--- a/policy/modules/contrib/sectoolm.te
+++ b/policy/modules/contrib/sectoolm.te
@@ -44,7 +44,7 @@ kernel_read_net_sysctls(sectoolm_t)
 kernel_read_network_state(sectoolm_t)
 kernel_read_kernel_sysctls(sectoolm_t)
 
-corecmd_exec_bin(sectoolm_t)
+corecmd_exec_bin_wrapper(sectoolm_t)
 corecmd_exec_shell(sectoolm_t)
 
 dev_read_sysfs(sectoolm_t)

--- a/policy/modules/contrib/sendmail.te
+++ b/policy/modules/contrib/sendmail.te
@@ -95,7 +95,7 @@ term_dontaudit_use_generic_ptys(sendmail_t)
 
 # for piping mail to a command
 corecmd_exec_shell(sendmail_t)
-corecmd_exec_bin(sendmail_t)
+corecmd_exec_bin_wrapper(sendmail_t)
 
 domain_use_interactive_fds(sendmail_t)
 

--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -102,7 +102,7 @@ kernel_read_irq_sysctls(setroubleshootd_t)
 kernel_read_rpc_sysctls(setroubleshootd_t)
 kernel_read_unlabeled_state(setroubleshootd_t)
 
-corecmd_exec_bin(setroubleshootd_t)
+corecmd_exec_bin_wrapper(setroubleshootd_t)
 corecmd_exec_shell(setroubleshootd_t)
 corecmd_read_all_executables(setroubleshootd_t)
 
@@ -220,7 +220,7 @@ setroubleshoot_stream_connect(setroubleshoot_fixit_t)
 kernel_read_system_state(setroubleshoot_fixit_t)
 kernel_read_network_state(setroubleshoot_fixit_t)
 
-corecmd_exec_bin(setroubleshoot_fixit_t)
+corecmd_exec_bin_wrapper(setroubleshoot_fixit_t)
 corecmd_exec_shell(setroubleshoot_fixit_t)
 corecmd_getattr_all_executables(setroubleshoot_fixit_t)
 

--- a/policy/modules/contrib/sge.te
+++ b/policy/modules/contrib/sge.te
@@ -170,7 +170,7 @@ files_tmp_filetrans(sge_domain, sge_tmp_t, { file dir })
 
 kernel_read_network_state(sge_domain)
 
-corecmd_exec_bin(sge_domain)
+corecmd_exec_bin_wrapper(sge_domain)
 corecmd_exec_shell(sge_domain)
 
 domain_read_all_domains_state(sge_domain)

--- a/policy/modules/contrib/shorewall.te
+++ b/policy/modules/contrib/shorewall.te
@@ -67,7 +67,7 @@ kernel_read_network_state(shorewall_t)
 kernel_read_system_state(shorewall_t)
 kernel_rw_net_sysctls(shorewall_t)
 
-corecmd_exec_bin(shorewall_t)
+corecmd_exec_bin_wrapper(shorewall_t)
 corecmd_exec_shell(shorewall_t)
 
 dev_read_sysfs(shorewall_t)

--- a/policy/modules/contrib/slocate.te
+++ b/policy/modules/contrib/slocate.te
@@ -41,7 +41,7 @@ kernel_dontaudit_search_network_state(locate_t)
 kernel_dontaudit_search_sysctl(locate_t)
 kernel_stream_connect(locate_t)
 
-corecmd_exec_bin(locate_t)
+corecmd_exec_bin_wrapper(locate_t)
 corecmd_exec_shell(locate_t)
 
 dev_getattr_all_blk_files(locate_t)

--- a/policy/modules/contrib/smokeping.te
+++ b/policy/modules/contrib/smokeping.te
@@ -37,7 +37,7 @@ manage_files_pattern(smokeping_t, smokeping_var_lib_t, smokeping_var_lib_t)
 files_var_lib_filetrans(smokeping_t, smokeping_var_lib_t, { file dir })
 allow smokeping_t smokeping_var_lib_t:file map;
 
-corecmd_exec_bin(smokeping_t)
+corecmd_exec_bin_wrapper(smokeping_t)
 
 dev_read_urand(smokeping_t)
 

--- a/policy/modules/contrib/smoltclient.te
+++ b/policy/modules/contrib/smoltclient.te
@@ -30,7 +30,7 @@ kernel_read_system_state(smoltclient_t)
 kernel_read_network_state(smoltclient_t)
 kernel_read_kernel_sysctls(smoltclient_t)
 
-corecmd_exec_bin(smoltclient_t)
+corecmd_exec_bin_wrapper(smoltclient_t)
 corecmd_exec_shell(smoltclient_t)
 
 corenet_all_recvfrom_unlabeled(smoltclient_t)

--- a/policy/modules/contrib/snapper.te
+++ b/policy/modules/contrib/snapper.te
@@ -49,7 +49,7 @@ kernel_stream_connect(snapperd_t)
 domain_read_all_domains_state(snapperd_t)
 
 corecmd_exec_shell(snapperd_t)
-corecmd_exec_bin(snapperd_t)
+corecmd_exec_bin_wrapper(snapperd_t)
 
 files_write_all_dirs(snapperd_t)
 files_setattr_all_mountpoints(snapperd_t)

--- a/policy/modules/contrib/snmp.te
+++ b/policy/modules/contrib/snmp.te
@@ -62,7 +62,7 @@ kernel_read_proc_symlinks(snmpd_t)
 kernel_read_all_proc(snmpd_t)
 kernel_read_system_state(snmpd_t)
 
-corecmd_exec_bin(snmpd_t)
+corecmd_exec_bin_wrapper(snmpd_t)
 corecmd_exec_shell(snmpd_t)
 
 corenet_all_recvfrom_netlabel(snmpd_t)

--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -311,7 +311,7 @@ kernel_read_kernel_sysctls(spamc_t)
 kernel_read_network_state(spamc_t)
 kernel_read_system_state(spamc_t)
 
-corecmd_exec_bin(spamc_t)
+corecmd_exec_bin_wrapper(spamc_t)
 
 corenet_all_recvfrom_netlabel(spamc_t)
 corenet_tcp_sendrecv_generic_if(spamc_t)
@@ -500,7 +500,7 @@ fs_search_auto_mountpoints(spamd_t)
 
 auth_dontaudit_read_shadow(spamd_t)
 
-corecmd_exec_bin(spamd_t)
+corecmd_exec_bin_wrapper(spamd_t)
 
 domain_use_interactive_fds(spamd_t)
 
@@ -640,7 +640,7 @@ can_exec(spamd_update_t, spamd_update_exec_t)
 # for updating rules
 corenet_tcp_connect_http_port(spamd_update_t)
 
-corecmd_exec_bin(spamd_update_t)
+corecmd_exec_bin_wrapper(spamd_update_t)
 corecmd_exec_shell(spamd_update_t)
 
 dev_read_sysfs(spamd_update_t)

--- a/policy/modules/contrib/squid.te
+++ b/policy/modules/contrib/squid.te
@@ -166,7 +166,7 @@ corenet_sendrecv_pgpkeyserver_client_packets(squid_t)
 corenet_tcp_connect_pgpkeyserver_port(squid_t)
 corenet_tcp_sendrecv_pgpkeyserver_port(squid_t)
 
-corecmd_exec_bin(squid_t)
+corecmd_exec_bin_wrapper(squid_t)
 corecmd_exec_shell(squid_t)
 
 dev_read_sysfs(squid_t)
@@ -276,7 +276,7 @@ read_files_pattern(squid_cron_t, squid_conf_t, squid_conf_t)
 
 read_files_pattern(squid_cron_t, squid_log_t, squid_log_t)
 
-corecmd_exec_bin(squid_cron_t)
+corecmd_exec_bin_wrapper(squid_cron_t)
 
 dev_read_urand(squid_cron_t)
 

--- a/policy/modules/contrib/sssd.te
+++ b/policy/modules/contrib/sssd.te
@@ -116,7 +116,7 @@ corenet_tcp_connect_smbd_port(sssd_t)
 corenet_tcp_connect_http_port(sssd_t)
 corenet_tcp_connect_http_cache_port(sssd_t)
 
-corecmd_exec_bin(sssd_t)
+corecmd_exec_bin_wrapper(sssd_t)
 
 dev_read_urand(sssd_t)
 dev_read_sysfs(sssd_t)

--- a/policy/modules/contrib/stapserver.te
+++ b/policy/modules/contrib/stapserver.te
@@ -70,7 +70,7 @@ kernel_read_vm_sysctls(stapserver_t)
 kernel_read_fs_sysctls(stapserver_t)
 files_list_kernel_modules(stapserver_t)
 
-corecmd_exec_bin(stapserver_t)
+corecmd_exec_bin_wrapper(stapserver_t)
 corecmd_exec_shell(stapserver_t)
 
 domain_read_all_domains_state(stapserver_t)

--- a/policy/modules/contrib/stunnel.te
+++ b/policy/modules/contrib/stunnel.te
@@ -52,7 +52,7 @@ kernel_read_kernel_sysctls(stunnel_t)
 kernel_read_system_state(stunnel_t)
 kernel_read_network_state(stunnel_t)
 
-corecmd_exec_bin(stunnel_t)
+corecmd_exec_bin_wrapper(stunnel_t)
 
 corenet_all_recvfrom_netlabel(stunnel_t)
 corenet_tcp_sendrecv_generic_if(stunnel_t)

--- a/policy/modules/contrib/svnserve.te
+++ b/policy/modules/contrib/svnserve.te
@@ -57,7 +57,7 @@ kernel_read_system_state(svnserve_t)
 
 auth_use_nsswitch(svnserve_t)
 
-corecmd_exec_bin(svnserve_t)
+corecmd_exec_bin_wrapper(svnserve_t)
 corecmd_exec_shell(svnserve_t)
 
 corenet_all_recvfrom_unlabeled(svnserve_t)

--- a/policy/modules/contrib/swift.te
+++ b/policy/modules/contrib/swift.te
@@ -95,7 +95,7 @@ corenet_tcp_connect_memcache_port(swift_t)
 corenet_tcp_connect_all_ephemeral_ports(swift_t)
 
 corecmd_exec_shell(swift_t)
-corecmd_exec_bin(swift_t)
+corecmd_exec_bin_wrapper(swift_t)
 
 dev_read_urand(swift_t)
 

--- a/policy/modules/contrib/sxid.te
+++ b/policy/modules/contrib/sxid.te
@@ -37,7 +37,7 @@ files_tmp_filetrans(sxid_t, sxid_tmp_t, { file dir })
 kernel_read_system_state(sxid_t)
 kernel_read_kernel_sysctls(sxid_t)
 
-corecmd_exec_bin(sxid_t)
+corecmd_exec_bin_wrapper(sxid_t)
 corecmd_exec_shell(sxid_t)
 
 corenet_all_recvfrom_netlabel(sxid_t)

--- a/policy/modules/contrib/sysstat.te
+++ b/policy/modules/contrib/sysstat.te
@@ -38,7 +38,7 @@ kernel_read_rpc_sysctls(sysstat_t)
 kernel_read_psi(sysstat_t)
 
 corecmd_exec_shell(sysstat_t)
-corecmd_exec_bin(sysstat_t)
+corecmd_exec_bin_wrapper(sysstat_t)
 
 dev_read_sysfs(sysstat_t)
 dev_read_urand(sysstat_t)

--- a/policy/modules/contrib/tangd.te
+++ b/policy/modules/contrib/tangd.te
@@ -44,7 +44,7 @@ corenet_tcp_bind_generic_node(tangd_t)
 corenet_tcp_bind_http_port(tangd_t)
 corenet_tcp_bind_tangd_port(tangd_t)
 
-corecmd_exec_bin(tangd_t)
+corecmd_exec_bin_wrapper(tangd_t)
 
 miscfiles_read_certs(tangd_t)
 

--- a/policy/modules/contrib/targetd.te
+++ b/policy/modules/contrib/targetd.te
@@ -83,7 +83,7 @@ storage_raw_rw_fixed_disk(targetd_t)
 auth_use_nsswitch(targetd_t)
 
 corecmd_exec_shell(targetd_t)
-corecmd_exec_bin(targetd_t)
+corecmd_exec_bin_wrapper(targetd_t)
 
 corenet_tcp_bind_generic_node(targetd_t)
 corenet_tcp_bind_lsm_plugin_port(targetd_t)
@@ -163,7 +163,7 @@ manage_dirs_pattern(targetclid_t, targetd_etc_rw_t, targetd_etc_rw_t)
 kernel_load_module(targetclid_t)
 kernel_read_all_proc(targetclid_t)
 
-corecmd_exec_bin(targetclid_t)
+corecmd_exec_bin_wrapper(targetclid_t)
 
 dev_read_sysfs(targetclid_t)
 

--- a/policy/modules/contrib/tcpd.te
+++ b/policy/modules/contrib/tcpd.te
@@ -44,7 +44,7 @@ corenet_tcp_bind_vnc_port(tcpd_t)
 
 fs_getattr_xattr_fs(tcpd_t)
 
-corecmd_exec_bin(tcpd_t)
+corecmd_exec_bin_wrapper(tcpd_t)
 
 files_dontaudit_search_var(tcpd_t)
 

--- a/policy/modules/contrib/telepathy.te
+++ b/policy/modules/contrib/telepathy.te
@@ -403,7 +403,7 @@ optional_policy(`
 	gnome_cache_filetrans(telepathy_domain, telepathy_cache_home_t, dir, "telepathy")
 ')
 
-corecmd_exec_bin(telepathy_domain)
+corecmd_exec_bin_wrapper(telepathy_domain)
 corecmd_exec_shell(telepathy_domain)
 
 dev_read_urand(telepathy_domain)

--- a/policy/modules/contrib/thin.te
+++ b/policy/modules/contrib/thin.te
@@ -40,7 +40,7 @@ allow thin_domain self:tcp_socket create_stream_socket_perms;
 # # initrc_t@thin_test_exec_t->thin_test_t@thin_exec_t->thin_test_t
 can_exec(thin_domain, thin_exec_t)
 
-corecmd_exec_bin(thin_domain)
+corecmd_exec_bin_wrapper(thin_domain)
 corecmd_exec_shell(thin_domain)
 
 corenet_tcp_bind_generic_node(thin_domain)

--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -77,7 +77,7 @@ kernel_read_system_state(thumb_t)
 kernel_dgram_send(thumb_t)
 kernel_dontaudit_list_all_sysctls(thumb_t)
 
-corecmd_exec_bin(thumb_t)
+corecmd_exec_bin_wrapper(thumb_t)
 corecmd_exec_shell(thumb_t)
 
 corenet_tcp_connect_xserver_port(thumb_t)

--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -59,7 +59,7 @@ auth_read_passwd(tlp_t)
 
 can_exec(tlp_t, tlp_exec_t)
 
-corecmd_exec_bin(tlp_t)
+corecmd_exec_bin_wrapper(tlp_t)
 
 dev_list_sysfs(tlp_t)
 dev_manage_sysfs(tlp_t)

--- a/policy/modules/contrib/tmpreaper.te
+++ b/policy/modules/contrib/tmpreaper.te
@@ -55,7 +55,7 @@ dev_getattr_all_chr_files(tmpreaper_t)
 dev_getattr_all_blk_files(tmpreaper_t)
 dev_getattr_mtrr_dev(tmpreaper_t)
 
-corecmd_exec_bin(tmpreaper_t)
+corecmd_exec_bin_wrapper(tmpreaper_t)
 corecmd_exec_shell(tmpreaper_t)
 
 domain_read_all_domains_state(tmpreaper_t)

--- a/policy/modules/contrib/tomcat.te
+++ b/policy/modules/contrib/tomcat.te
@@ -89,7 +89,7 @@ can_exec(tomcat_domain, tomcat_exec_t)
 kernel_read_network_state(tomcat_domain)
 kernel_read_net_sysctls(tomcat_domain)
 
-corecmd_exec_bin(tomcat_domain)
+corecmd_exec_bin_wrapper(tomcat_domain)
 corecmd_exec_shell(tomcat_domain)
 
 corenet_tcp_bind_generic_node(tomcat_domain)

--- a/policy/modules/contrib/tor.te
+++ b/policy/modules/contrib/tor.te
@@ -92,7 +92,7 @@ kernel_read_kernel_sysctls(tor_t)
 kernel_read_net_sysctls(tor_t)
 kernel_read_system_state(tor_t)
 
-corecmd_exec_bin(tor_t)
+corecmd_exec_bin_wrapper(tor_t)
 
 corenet_all_recvfrom_unlabeled(tor_t)
 corenet_all_recvfrom_netlabel(tor_t)

--- a/policy/modules/contrib/tripwire.te
+++ b/policy/modules/contrib/tripwire.te
@@ -74,7 +74,7 @@ kernel_getattr_core_if(tripwire_t)
 kernel_getattr_message_if(tripwire_t)
 kernel_read_kernel_sysctls(tripwire_t)
 
-corecmd_exec_bin(tripwire_t)
+corecmd_exec_bin_wrapper(tripwire_t)
 corecmd_exec_shell(tripwire_t)
 
 domain_use_interactive_fds(tripwire_t)

--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -86,7 +86,7 @@ kernel_rw_usermodehelper_state(tuned_t)
 kernel_setsched(tuned_t)
 kernel_manage_perf_event(tuned_t)
 
-corecmd_exec_bin(tuned_t)
+corecmd_exec_bin_wrapper(tuned_t)
 corecmd_exec_shell(tuned_t)
 
 dev_getattr_all_blk_files(tuned_t)
@@ -188,7 +188,7 @@ filetrans_pattern(tuned_ppd_t, tuned_etc_t, tuned_rw_etc_t, file, "ppd_base_prof
 
 manage_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
 
-corecmd_exec_bin(tuned_ppd_t)
+corecmd_exec_bin_wrapper(tuned_ppd_t)
 dev_read_sysfs(tuned_ppd_t)
 dev_watch_sysfs_dirs(tuned_ppd_t)
 dev_watch_reads_sysfs_dirs(tuned_ppd_t)

--- a/policy/modules/contrib/uml.te
+++ b/policy/modules/contrib/uml.te
@@ -88,7 +88,7 @@ can_exec(uml_t, { uml_exec_t uml_tmp_t uml_tmpfs_t })
 kernel_read_system_state(uml_t)
 kernel_write_proc_files(uml_t)
 
-corecmd_exec_bin(uml_t)
+corecmd_exec_bin_wrapper(uml_t)
 
 corenet_all_recvfrom_netlabel(uml_t)
 corenet_tcp_sendrecv_generic_if(uml_t)

--- a/policy/modules/contrib/updfstab.te
+++ b/policy/modules/contrib/updfstab.te
@@ -25,7 +25,7 @@ kernel_dontaudit_write_kernel_sysctl(updfstab_t)
 kernel_read_system_state(updfstab_t)
 kernel_change_ring_buffer_level(updfstab_t)
 
-corecmd_exec_bin(updfstab_t)
+corecmd_exec_bin_wrapper(updfstab_t)
 
 dev_read_sysfs(updfstab_t)
 dev_manage_generic_symlinks(updfstab_t)

--- a/policy/modules/contrib/userhelper.te
+++ b/policy/modules/contrib/userhelper.te
@@ -39,7 +39,7 @@ allow consolehelper_domain self:unix_stream_socket create_stream_socket_perms;
 
 kernel_read_kernel_sysctls(consolehelper_domain)
 
-corecmd_exec_bin(consolehelper_domain)
+corecmd_exec_bin_wrapper(consolehelper_domain)
 
 dev_getattr_all_chr_files(consolehelper_domain)
 dev_dontaudit_list_all_dev_nodes(consolehelper_domain)

--- a/policy/modules/contrib/usernetctl.te
+++ b/policy/modules/contrib/usernetctl.te
@@ -31,7 +31,7 @@ kernel_read_system_state(usernetctl_t)
 kernel_read_kernel_sysctls(usernetctl_t)
 
 corecmd_list_bin(usernetctl_t)
-corecmd_exec_bin(usernetctl_t)
+corecmd_exec_bin_wrapper(usernetctl_t)
 corecmd_exec_shell(usernetctl_t)
 
 domain_dontaudit_read_all_domains_state(usernetctl_t)

--- a/policy/modules/contrib/uucp.te
+++ b/policy/modules/contrib/uucp.te
@@ -98,7 +98,7 @@ corenet_tcp_sendrecv_ssh_port(uucpd_t)
 corenet_tcp_bind_uucpd_port(uucpd_t)
 corenet_tcp_connect_uucpd_port(uucpd_t)
 
-corecmd_exec_bin(uucpd_t)
+corecmd_exec_bin_wrapper(uucpd_t)
 corecmd_exec_shell(uucpd_t)
 
 dev_read_urand(uucpd_t)
@@ -150,7 +150,7 @@ manage_dirs_pattern(uux_t, uucpd_spool_t, uucpd_spool_t)
 manage_files_pattern(uux_t, uucpd_spool_t, uucpd_spool_t)
 manage_lnk_files_pattern(uux_t, uucpd_spool_t, uucpd_spool_t)
 
-corecmd_exec_bin(uux_t)
+corecmd_exec_bin_wrapper(uux_t)
 
 files_search_spool(uux_t)
 

--- a/policy/modules/contrib/varnishd.te
+++ b/policy/modules/contrib/varnishd.te
@@ -77,7 +77,7 @@ can_exec(varnishd_t, varnishd_var_lib_t)
 
 kernel_read_system_state(varnishd_t)
 
-corecmd_exec_bin(varnishd_t)
+corecmd_exec_bin_wrapper(varnishd_t)
 corecmd_exec_shell(varnishd_t)
 
 corenet_all_recvfrom_unlabeled(varnishd_t)

--- a/policy/modules/contrib/vhostmd.te
+++ b/policy/modules/contrib/vhostmd.te
@@ -41,7 +41,7 @@ kernel_read_system_state(vhostmd_t)
 kernel_read_network_state(vhostmd_t)
 kernel_write_xen_state(vhostmd_t)
 
-corecmd_exec_bin(vhostmd_t)
+corecmd_exec_bin_wrapper(vhostmd_t)
 corecmd_exec_shell(vhostmd_t)
 
 corenet_all_recvfrom_unlabeled(vhostmd_t)

--- a/policy/modules/contrib/virt.if.orig
+++ b/policy/modules/contrib/virt.if.orig
@@ -1,0 +1,1972 @@
+## <summary>Libvirt virtualization API</summary>
+
+########################################
+## <summary>
+##	virtd_lxc_t stub interface.  No access allowed.
+## </summary>
+## <param name="domain" unused="true">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_stub_lxc',`
+	gen_require(`
+		type virtd_lxc_t;
+	')
+')
+
+########################################
+## <summary>
+##	svirt_sandbox_domain attribute stub interface.  No access allowed.
+## </summary>
+## <param name="domain" unused="true">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_stub_svirt_sandbox_domain',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+	')
+')
+
+########################################
+## <summary>
+##	container_file_t stub interface.  No access allowed.
+## </summary>
+## <param name="domain" unused="true">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_stub_container_image',`
+	gen_require(`
+		type container_file_t;
+	')
+')
+
+interface(`virt_stub_svirt_sandbox_file',`
+	gen_require(`
+		type container_file_t;
+		type container_ro_file_t;
+	')
+')
+
+########################################
+## <summary>
+##	Creates types and rules for a basic
+##	qemu process domain.
+## </summary>
+## <param name="prefix">
+##	<summary>
+##	Prefix for the domain.
+##	</summary>
+## </param>
+#
+template(`virt_domain_template',`
+	gen_require(`
+		attribute virt_image_type, virt_domain;
+		attribute virt_tmpfs_type;
+		attribute virt_ptynode;
+		type qemu_exec_t;
+		type virtlogd_t;
+	')
+
+	type $1_t, virt_domain;
+	application_domain($1_t, qemu_exec_t)
+	domain_user_exemption_target($1_t)
+	mls_rangetrans_target($1_t)
+	mcs_constrained($1_t)
+	role system_r types $1_t;
+
+	type $1_devpts_t, virt_ptynode;
+	term_pty($1_devpts_t)
+
+	kernel_read_system_state($1_t)
+
+	auth_read_passwd($1_t)
+
+	logging_send_syslog_msg($1_t)
+
+	allow $1_t $1_devpts_t:chr_file { rw_chr_file_perms setattr_chr_file_perms };
+	term_create_pty($1_t, $1_devpts_t)
+
+	# Allow domain to write to pipes connected to virtlogd
+	allow $1_t virtlogd_t:fd use;
+	allow $1_t virtlogd_t:fifo_file rw_inherited_fifo_file_perms;
+')
+
+########################################
+## <summary>
+##	Make the specified type usable as a virt image
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type to be used as a virtual image
+##	</summary>
+## </param>
+#
+interface(`virt_image',`
+	gen_require(`
+		attribute virt_image_type;
+	')
+
+	typeattribute $1 virt_image_type;
+	files_type($1)
+
+	# virt images can be assigned to blk devices
+	dev_node($1)
+')
+
+#######################################
+## <summary>
+##  Getattr on virt executable.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed to transition.
+##  </summary>
+## </param>
+#
+interface(`virt_getattr_exec',`
+    gen_require(`
+        type virtd_exec_t;
+    ')
+
+	allow $1 virtd_exec_t:file getattr;
+')
+
+########################################
+## <summary>
+##	Execute a domain transition to run virt.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`virt_domtrans',`
+	gen_require(`
+		type virtd_t, virtd_exec_t;
+	')
+
+	domtrans_pattern($1, virtd_exec_t, virtd_t)
+')
+
+########################################
+## <summary>
+##	Execute virtd in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_exec',`
+	gen_require(`
+		type virtd_exec_t;
+	')
+
+	can_exec($1, virtd_exec_t)
+')
+
+########################################
+## <summary>
+##  Transition to virt_bridgehelper.
+## </summary>
+## <param name="domain">
+## <summary>
+##  Domain allowed to transition.
+## </summary>
+## </param>
+interface(`virt_domtrans_bridgehelper',`
+	gen_require(`
+		type virt_bridgehelper_t, virt_bridgehelper_exec_t;
+	')
+
+	domtrans_pattern($1, virt_bridgehelper_exec_t, virt_bridgehelper_t)
+')
+
+########################################
+## <summary>
+##      Allow caller domain to run bpftool.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`virt_prog_run_bpf',`
+        gen_require(`
+                type virtd_t;
+        ')
+
+    allow $1 virtd_t:bpf { map_create map_read map_write prog_load prog_run };
+')
+
+
+#######################################
+## <summary>
+##	Connect to virt over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_stream_connect',`
+	gen_require(`
+		type virtd_t, virt_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, virt_var_run_t, virt_var_run_t, virtd_t)
+')
+
+#######################################
+## <summary>
+##	Connect to svirt process over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_stream_connect_svirt',`
+	gen_require(`
+		type svirt_t;
+        type svirt_image_t;
+	')
+
+	stream_connect_pattern($1, svirt_image_t, svirt_image_t, svirt_t)
+')
+
+########################################
+## <summary>
+##	Read and write to apmd unix
+##	stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_rw_stream_sockets_svirt',`
+	gen_require(`
+		type svirt_t;
+	')
+
+	allow $1 svirt_t:unix_stream_socket { setopt getopt read write };
+')
+
+########################################
+## <summary>
+##	Allow domain to attach to virt TUN devices
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_attach_tun_iface',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	allow $1 virtd_t:tun_socket relabelfrom;
+	allow $1 self:tun_socket relabelto;
+')
+
+########################################
+## <summary>
+##	Allow domain to attach to virt sandbox TUN devices
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_attach_sandbox_tun_iface',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+	')
+
+	allow $1 svirt_sandbox_domain:tun_socket relabelfrom;
+	allow $1 self:tun_socket relabelto;
+')
+
+########################################
+## <summary>
+##	Read virt config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_config',`
+	gen_require(`
+		type virt_etc_t, virt_etc_rw_t;
+	')
+
+	files_search_etc($1)
+	read_files_pattern($1, virt_etc_t, virt_etc_t)
+	read_files_pattern($1, virt_etc_rw_t, virt_etc_rw_t)
+	read_lnk_files_pattern($1, virt_etc_rw_t, virt_etc_rw_t)
+')
+
+########################################
+## <summary>
+##	manage virt config files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_config',`
+	gen_require(`
+		type virt_etc_t, virt_etc_rw_t;
+	')
+
+	files_search_etc($1)
+	manage_files_pattern($1, virt_etc_t, virt_etc_t)
+	manage_files_pattern($1, virt_etc_rw_t, virt_etc_rw_t)
+	manage_lnk_files_pattern($1, virt_etc_rw_t, virt_etc_rw_t)
+')
+
+########################################
+## <summary>
+##	Allow domain to manage virt image files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_getattr_content',`
+	gen_require(`
+		type virt_content_t;
+	')
+
+    allow $1 virt_content_t:file getattr_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow domain to manage virt image files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_content',`
+	gen_require(`
+		type virt_content_t;
+	')
+
+	virt_search_lib($1)
+	allow $1 virt_content_t:dir list_dir_perms;
+	allow $1 virt_content_t:blk_file map;
+	allow $1 virt_content_t:file map;
+	list_dirs_pattern($1, virt_content_t, virt_content_t)
+	read_files_pattern($1, virt_content_t, virt_content_t)
+	read_lnk_files_pattern($1, virt_content_t, virt_content_t)
+	read_blk_files_pattern($1, virt_content_t, virt_content_t)
+    read_chr_files_pattern($1, virt_content_t, virt_content_t)
+
+	tunable_policy(`virt_use_nfs',`
+		fs_list_nfs($1)
+		fs_read_nfs_files($1)
+		fs_read_nfs_symlinks($1)
+	')
+
+	tunable_policy(`virt_use_samba',`
+		fs_list_cifs($1)
+		fs_read_cifs_files($1)
+		fs_read_cifs_symlinks($1)
+	')
+')
+
+########################################
+## <summary>
+##	Allow domain to write virt image files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_write_content',`
+	gen_require(`
+		type virt_content_t;
+	')
+
+	allow $1 virt_content_t:file write_file_perms;
+')
+
+########################################
+## <summary>
+##	Read virt PID symlinks files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_pid_symlinks',`
+	gen_require(`
+		type virt_var_run_t;
+	')
+
+	files_search_pids($1)
+	read_lnk_files_pattern($1, virt_var_run_t, virt_var_run_t)
+')
+
+########################################
+## <summary>
+##	Read virt PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_pid_files',`
+	gen_require(`
+		type virt_var_run_t;
+	')
+
+	files_search_pids($1)
+	read_files_pattern($1, virt_var_run_t, virt_var_run_t)
+    read_lnk_files_pattern($1, virt_var_run_t, virt_var_run_t)
+')
+
+########################################
+## <summary>
+##	Manage virt pid directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_pid_dirs',`
+	gen_require(`
+		type virt_var_run_t;
+		type virt_lxc_var_run_t;
+	')
+
+	files_search_pids($1)
+	manage_dirs_pattern($1, virt_var_run_t, virt_var_run_t)
+	manage_dirs_pattern($1, virt_lxc_var_run_t, virt_lxc_var_run_t)
+	virt_filetrans_named_content($1)
+')
+
+########################################
+## <summary>
+##	Manage virt pid files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_pid_files',`
+	gen_require(`
+		type virt_var_run_t;
+		type virt_lxc_var_run_t;
+	')
+
+	files_search_pids($1)
+	manage_files_pattern($1, virt_var_run_t, virt_var_run_t)
+	manage_files_pattern($1, virt_lxc_var_run_t, virt_lxc_var_run_t)
+')
+
+########################################
+## <summary>
+##	Create objects in the pid directory
+##	with a private type with a type transition.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="file">
+##	<summary>
+##	Type to which the created node will be transitioned.
+##	</summary>
+## </param>
+## <param name="class">
+##	<summary>
+##	Object class(es) (single or set including {}) for which this
+##	the transition will occur.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`virt_pid_filetrans',`
+	gen_require(`
+		type virt_var_run_t;
+	')
+
+	filetrans_pattern($1, virt_var_run_t, $2, $3, $4)
+')
+
+########################################
+## <summary>
+##	Search virt lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_search_lib',`
+	gen_require(`
+		type virt_var_lib_t;
+	')
+
+	allow $1 virt_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Read virt lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_lib_files',`
+	gen_require(`
+		type virt_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, virt_var_lib_t, virt_var_lib_t)
+	list_dirs_pattern($1, virt_var_lib_t, virt_var_lib_t)
+	read_lnk_files_pattern($1, virt_var_lib_t, virt_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Dontaudit inherited read virt lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`virt_dontaudit_read_lib_files',`
+	gen_require(`
+		type virt_var_lib_t;
+	')
+
+	dontaudit $1 virt_var_lib_t:file read_inherited_file_perms;
+')
+
+########################################
+## <summary>
+##	Create, read, write, and delete
+##	virt lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_lib_files',`
+	gen_require(`
+		type virt_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, virt_var_lib_t, virt_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to read virt's log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`virt_read_log',`
+	gen_require(`
+		type virt_log_t;
+	')
+
+	logging_search_logs($1)
+	read_files_pattern($1, virt_log_t, virt_log_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to append
+##	virt log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_append_log',`
+	gen_require(`
+		type virt_log_t;
+	')
+
+	logging_search_logs($1)
+	append_files_pattern($1, virt_log_t, virt_log_t)
+')
+
+########################################
+## <summary>
+##	Allow domain to manage virt log files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_log',`
+	gen_require(`
+		type virt_log_t;
+	')
+
+	manage_dirs_pattern($1, virt_log_t, virt_log_t)
+	manage_files_pattern($1, virt_log_t, virt_log_t)
+	manage_lnk_files_pattern($1, virt_log_t, virt_log_t)
+')
+
+########################################
+## <summary>
+##	Allow domain to getattr virt image direcories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_getattr_images',`
+	gen_require(`
+		attribute virt_image_type;
+	')
+
+	virt_search_lib($1)
+	allow $1 virt_image_type:file getattr_file_perms;
+')
+
+########################################
+## <summary>
+##	Allow domain to search virt image direcories
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_search_images',`
+	gen_require(`
+		attribute virt_image_type;
+	')
+
+	virt_search_lib($1)
+	allow $1 virt_image_type:dir search_dir_perms;
+')
+
+########################################
+## <summary>
+##	Allow domain to read virt image files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_images',`
+	gen_require(`
+		type virt_var_lib_t;
+		attribute virt_image_type;
+	')
+
+	virt_search_lib($1)
+	allow $1 virt_image_type:dir list_dir_perms;
+	list_dirs_pattern($1, virt_image_type, virt_image_type)
+	read_files_pattern($1, virt_image_type, virt_image_type)
+	read_lnk_files_pattern($1, virt_image_type, virt_image_type)
+	read_blk_files_pattern($1, virt_image_type, virt_image_type)
+	read_chr_files_pattern($1, virt_image_type, virt_image_type)
+
+	tunable_policy(`virt_use_nfs',`
+		fs_list_nfs($1)
+		fs_read_nfs_files($1)
+		fs_read_nfs_symlinks($1)
+	')
+
+	tunable_policy(`virt_use_samba',`
+		fs_list_cifs($1)
+		fs_read_cifs_files($1)
+		fs_read_cifs_symlinks($1)
+	')
+')
+
+########################################
+## <summary>
+##	Allow domain to read virt blk image files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_blk_images',`
+	gen_require(`
+		attribute virt_image_type;
+	')
+
+	read_blk_files_pattern($1, virt_image_type, virt_image_type)
+')
+
+########################################
+## <summary>
+##	Allow domain to read/write virt image chr files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_rw_chr_files',`
+	gen_require(`
+		attribute virt_image_type;
+	')
+
+	rw_chr_files_pattern($1, virt_image_type, virt_image_type)
+')
+
+########################################
+## <summary>
+##	Create, read, write, and delete
+##	svirt cache files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_cache',`
+	gen_require(`
+		type virt_cache_t;
+	')
+
+	files_search_var($1)
+	manage_dirs_pattern($1, virt_cache_t, virt_cache_t)
+	manage_files_pattern($1, virt_cache_t, virt_cache_t)
+	manage_lnk_files_pattern($1, virt_cache_t, virt_cache_t)
+')
+
+########################################
+## <summary>
+##	Allow domain to manage virt image files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_images',`
+	gen_require(`
+		type virt_var_lib_t;
+		attribute virt_image_type;
+	')
+
+	virt_search_lib($1)
+	allow $1 virt_image_type:dir list_dir_perms;
+	manage_dirs_pattern($1, virt_image_type, virt_image_type)
+	manage_files_pattern($1, virt_image_type, virt_image_type)
+	read_lnk_files_pattern($1, virt_image_type, virt_image_type)
+	rw_blk_files_pattern($1, virt_image_type, virt_image_type)
+	rw_chr_files_pattern($1, virt_image_type, virt_image_type)
+')
+
+#######################################
+## <summary>
+##  Allow domain to manage virt image files
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`virt_manage_default_image_type',`
+    gen_require(`
+        type virt_var_lib_t;
+        type virt_image_t;
+    ')
+
+    virt_search_lib($1)
+    manage_dirs_pattern($1, virt_image_t, virt_image_t)
+    manage_files_pattern($1, virt_image_t, virt_image_t)
+    read_lnk_files_pattern($1, virt_image_t, virt_image_t)
+')
+
+########################################
+## <summary>
+##	Execute virt server in the virt domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`virt_systemctl',`
+	gen_require(`
+		type virtd_unit_file_t;
+		type virtd_t;
+	')
+
+	systemd_exec_systemctl($1)
+	init_reload_services($1)
+	allow $1 virtd_unit_file_t:file read_file_perms;
+	allow $1 virtd_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, virtd_t)
+')
+
+########################################
+## <summary>
+##	Ptrace the svirt domain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`virt_ptrace',`
+	gen_require(`
+		attribute virt_domain;
+	')
+
+	allow $1 virt_domain:process ptrace;
+')
+
+#######################################
+## <summary>
+##	Execute Sandbox Files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_exec_sandbox_files',`
+	gen_require(`
+		attribute svirt_file_type;
+	')
+
+	can_exec($1, svirt_file_type)
+')
+
+########################################
+## <summary>
+##	Allow any svirt_file_type to be an entrypoint of this domain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`virt_sandbox_entrypoint',`
+	gen_require(`
+		attribute svirt_file_type;
+	')
+	allow $1 svirt_file_type:file entrypoint;
+')
+
+#######################################
+## <summary>
+##	List Sandbox Dirs
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_list_sandbox_dirs',`
+	gen_require(`
+		type svirt_sandbox_file_t;
+	')
+
+	list_dirs_pattern($1, svirt_sandbox_file_t, svirt_sandbox_file_t)
+')
+
+#######################################
+## <summary>
+##	Read Sandbox Files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_read_sandbox_files',`
+	gen_require(`
+		attribute svirt_file_type;
+	')
+
+	list_dirs_pattern($1, svirt_file_type, svirt_file_type)
+	read_files_pattern($1, svirt_file_type, svirt_file_type)
+	read_lnk_files_pattern($1, svirt_file_type, svirt_file_type)
+')
+
+#######################################
+## <summary>
+##	Manage Sandbox Files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_sandbox_files',`
+	gen_require(`
+		attribute svirt_file_type;
+	')
+
+	manage_dirs_pattern($1, svirt_file_type, svirt_file_type)
+	manage_files_pattern($1, svirt_file_type, svirt_file_type)
+	manage_fifo_files_pattern($1, svirt_file_type, svirt_file_type)
+	manage_chr_files_pattern($1, svirt_file_type, svirt_file_type)
+	manage_lnk_files_pattern($1, svirt_file_type, svirt_file_type)
+	allow $1 svirt_file_type:dir_file_class_set { relabelfrom relabelto };
+')
+
+#######################################
+## <summary>
+##	Getattr Sandbox File systems
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_getattr_sandbox_filesystem',`
+	gen_require(`
+		attribute svirt_file_type;
+	')
+
+	allow $1 svirt_file_type:filesystem getattr;
+')
+
+#######################################
+## <summary>
+##	Relabel Sandbox File systems
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_relabel_sandbox_filesystem',`
+	gen_require(`
+		attribute svirt_file_type;
+	')
+
+	allow $1 svirt_file_type:filesystem { relabelfrom relabelto };
+')
+
+#######################################
+## <summary>
+##	Mounton Sandbox Files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_mounton_sandbox_file',`
+	gen_require(`
+		attribute svirt_file_type;
+	')
+
+	allow $1 svirt_file_type:dir_file_class_set mounton;
+')
+
+#######################################
+## <summary>
+##	Connect to virt over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_stream_connect_sandbox',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+		attribute svirt_file_type;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, svirt_file_type, svirt_file_type, svirt_sandbox_domain)
+	ps_process_pattern(svirt_sandbox_domain, $1)
+')
+
+########################################
+## <summary>
+##	Execute qemu in the svirt domain, and
+##	allow the specified role the svirt domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed the sandbox domain.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`virt_transition_svirt',`
+	gen_require(`
+		attribute virt_domain;
+		type virt_bridgehelper_t;
+		type svirt_image_t;
+		type svirt_socket_t;
+	')
+
+	allow $1 virt_domain:process transition;
+	role $2 types virt_domain;
+	role $2 types virt_bridgehelper_t;
+	role $2 types svirt_socket_t;
+
+	allow $1 virt_domain:process { sigkill sigstop signull signal };
+	allow $1 svirt_image_t:file { relabelfrom relabelto };
+	allow $1 svirt_image_t:fifo_file { read_fifo_file_perms relabelto };
+	allow $1 svirt_image_t:sock_file { create_sock_file_perms relabelto };
+	allow $1 svirt_socket_t:unix_stream_socket create_stream_socket_perms;
+
+	optional_policy(`
+		ptchown_run(virt_domain, $2)
+	')
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to write virt daemon unnamed pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`virt_dontaudit_write_pipes',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	dontaudit $1 virtd_t:fd use;
+	dontaudit $1 virtd_t:fifo_file write_fifo_file_perms;
+')
+
+########################################
+## <summary>
+##	Send a sigkill to virtual machines
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_kill_svirt',`
+	gen_require(`
+		attribute virt_domain;
+	')
+
+	allow $1 virt_domain:process sigkill;
+')
+
+########################################
+## <summary>
+##	Send a sigkill to virtd daemon.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_kill',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	allow $1 virtd_t:process sigkill;
+')
+
+########################################
+## <summary>
+##	Send a signal to virtd daemon.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_signal',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	allow $1 virtd_t:process signal;
+')
+
+########################################
+## <summary>
+##	Send null signal to virtd daemon.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_signull',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	allow $1 virtd_t:process signull;
+')
+
+########################################
+## <summary>
+##	Send a signal to virtual machines
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_signal_svirt',`
+	gen_require(`
+		attribute virt_domain;
+	')
+
+	allow $1 virt_domain:process signal;
+')
+
+########################################
+## <summary>
+##	Send a signal to sandbox domains
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_signal_sandbox',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+	')
+
+	allow $1 svirt_sandbox_domain:process signal;
+')
+
+########################################
+## <summary>
+##	Manage virt home files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_manage_home_files',`
+	gen_require(`
+		type virt_home_t;
+	')
+
+	userdom_search_user_home_dirs($1)
+	manage_files_pattern($1, virt_home_t, virt_home_t)
+')
+
+########################################
+## <summary>
+##	allow domain to read
+##	virt tmpfs files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`virt_read_tmpfs_files',`
+	gen_require(`
+		attribute virt_tmpfs_type;
+	')
+
+	allow $1 virt_tmpfs_type:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	allow domain to manage
+##	virt tmpfs files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`virt_manage_tmpfs_files',`
+	gen_require(`
+		attribute virt_tmpfs_type;
+	')
+
+	allow $1 virt_tmpfs_type:file manage_file_perms;
+')
+
+########################################
+## <summary>
+##	Create .virt directory in the user home directory
+##	with an correct label.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_filetrans_home_content',`
+	gen_require(`
+		type virt_home_t;
+		type svirt_home_t;
+	')
+
+	userdom_user_home_dir_filetrans($1, virt_home_t, dir, ".libvirt")
+	userdom_user_home_dir_filetrans($1, virt_home_t, dir, ".virtinst")
+	filetrans_pattern($1, virt_home_t, svirt_home_t, dir, "qemu")
+
+	optional_policy(`
+		gnome_config_filetrans($1, virt_home_t, dir, "libvirt")
+		gnome_cache_filetrans($1, virt_home_t, dir, "libvirt")
+		gnome_cache_filetrans($1, virt_home_t, dir, "libvirt-sandbox")
+		gnome_cache_filetrans($1, virt_home_t, dir, "gnome-boxes")
+		gnome_data_filetrans($1, svirt_home_t, dir, "images")
+		gnome_data_filetrans($1, svirt_home_t, dir, "boot")
+	')
+')
+
+########################################
+## <summary>
+##	Dontaudit attempts to Read virt_image_type devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_dontaudit_read_chr_dev',`
+	gen_require(`
+		attribute virt_image_type;
+	')
+
+	dontaudit $1 virt_image_type:chr_file read_chr_file_perms;
+')
+
+########################################
+## <summary>
+##	Creates types and rules for a basic
+##	virt_lxc process domain.
+## </summary>
+## <param name="prefix">
+##	<summary>
+##	Prefix for the domain.
+##	</summary>
+## </param>
+#
+template(`virt_sandbox_domain_template',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+	')
+
+	type $1_t, svirt_sandbox_domain;
+	domain_type($1_t)
+	domain_user_exemption_target($1_t)
+	mls_rangetrans_target($1_t)
+	mcs_constrained($1_t)
+	role system_r types $1_t;
+
+	logging_send_syslog_msg($1_t)
+
+	kernel_read_system_state($1_t)
+	kernel_read_all_proc($1_t)
+
+ #   optional_policy(`
+ #       container_runtime_typebounds($1_t)
+ #   ')
+')
+
+########################################
+## <summary>
+##	Make the specified type usable as a lxc domain
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type to be used as a lxc domain
+##	</summary>
+## </param>
+#
+template(`virt_sandbox_domain',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+	')
+
+	typeattribute  $1 svirt_sandbox_domain;
+')
+
+########################################
+## <summary>
+##	Make the specified type usable as a lxc network domain
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type to be used as a lxc network domain
+##	</summary>
+## </param>
+#
+template(`virt_sandbox_net_domain',`
+	gen_require(`
+		attribute sandbox_net_domain;
+	')
+
+	virt_sandbox_domain($1)
+	typeattribute  $1 sandbox_net_domain;
+')
+
+########################################
+## <summary>
+##	Execute a qemu_exec_t in the callers domain
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`virt_exec_qemu',`
+	gen_require(`
+		type qemu_exec_t;
+	')
+
+	can_exec($1, qemu_exec_t)
+')
+
+########################################
+## <summary>
+##	Transition to virt named content
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_filetrans_named_content',`
+	gen_require(`
+		type virt_lxc_var_run_t;
+		type virt_var_run_t;
+	')
+
+	files_pid_filetrans($1, virt_lxc_var_run_t, dir, "libvirt-sandbox")
+	files_pid_filetrans($1, virt_var_run_t, dir, "libvirt")
+	files_pid_filetrans($1, virt_var_run_t, dir, "libguestfs")
+')
+
+########################################
+## <summary>
+##	Execute qemu in the svirt domain, and
+##	allow the specified role the svirt domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed the sandbox domain.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`virt_transition_svirt_sandbox',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+	')
+
+	allow $1 svirt_sandbox_domain:process { transition signal_perms };
+	role $2 types svirt_sandbox_domain;
+	allow $1 svirt_sandbox_domain:unix_dgram_socket sendto;
+
+	allow svirt_sandbox_domain $1:fd use;
+
+	allow svirt_sandbox_domain $1:process sigchld;
+	ps_process_pattern($1, svirt_sandbox_domain)
+')
+
+########################################
+## <summary>
+##	Read the process state of virt sandbox containers
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_sandbox_read_state',`
+	gen_require(`
+		attribute svirt_sandbox_domain;
+	')
+
+	ps_process_pattern($1, svirt_sandbox_domain)
+')
+
+########################################
+## <summary>
+##	Read and write to svirt_image devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_rw_svirt_dev',`
+	gen_require(`
+		type svirt_image_t;
+	')
+
+	allow $1 svirt_image_t:chr_file rw_file_perms;
+')
+
+########################################
+## <summary>
+##	Read and write to svirt_image files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_rw_svirt_image',`
+	gen_require(`
+		type svirt_image_t;
+	')
+
+	allow $1 svirt_image_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
+##	Read and write to svirt_image devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_rlimitinh',`
+	gen_require(`
+		type virtd_t;
+	')
+
+    allow $1 virtd_t:process { rlimitinh };
+')
+
+########################################
+## <summary>
+##	Read and write to svirt_image devices.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_noatsecure',`
+	gen_require(`
+		type virtd_t;
+	')
+
+    allow $1 virtd_t:process { noatsecure rlimitinh };
+')
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an virt environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`virt_admin',`
+	gen_require(`
+		attribute virt_domain;
+		attribute virt_system_domain;
+		attribute svirt_file_type;
+		attribute virt_file_type;
+		type virtd_initrc_exec_t;
+	')
+
+	allow $1 virt_system_domain:process signal_perms;
+	allow $1 virt_domain:process signal_perms;
+	ps_process_pattern($1, virt_system_domain)
+	ps_process_pattern($1, virt_domain)
+	tunable_policy(`deny_ptrace',`',`
+		allow $1 virt_system_domain:process ptrace;
+		allow $1 virt_domain:process ptrace;
+	')
+
+	init_labeled_script_domtrans($1, virtd_initrc_exec_t)
+	domain_system_change_exemption($1)
+	role_transition $2 virtd_initrc_exec_t system_r;
+	allow $2 system_r;
+
+	allow $1 virt_domain:process signal_perms;
+
+	admin_pattern($1, virt_file_type)
+	admin_pattern($1, svirt_file_type)
+
+	virt_systemctl($1)
+	allow $1 virtd_unit_file_t:service all_service_perms;
+
+	virt_stream_connect_sandbox($1)
+	virt_stream_connect_svirt($1)
+	virt_stream_connect($1)
+')
+#######################################
+## <summary>
+##  Getattr on virt executable.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed to transition.
+##  </summary>
+## </param>
+#
+interface(`virt_default_capabilities',`
+	gen_require(`
+		attribute sandbox_caps_domain;
+	')
+
+	typeattribute $1 sandbox_caps_domain;
+')
+
+
+########################################
+## <summary>
+##      Send and receive messages from
+##      virt over dbus.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`virt_dbus_chat',`
+        gen_require(`
+                type virtd_t;
+                class dbus send_msg;
+        ')
+
+        allow $1 virtd_t:dbus send_msg;
+        allow virtd_t $1:dbus send_msg;
+        ps_process_pattern(virtd_t, $1)
+')
+
+########################################
+## <summary>
+##	Execute a file in a sandbox directory
+##	in the specified domain.
+## </summary>
+## <desc>
+##	<p>
+##	Execute a file in a sandbox directory
+##	in the specified domain.  This allows
+##	the specified domain to execute any file
+##	on these filesystems in the specified
+##	domain.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+## <param name="target_domain">
+##	<summary>
+##	The type of the new process.
+##	</summary>
+## </param>
+#
+interface(`virt_sandbox_domtrans',`
+	gen_require(`
+		type container_file_t;
+	')
+
+	domtrans_pattern($1,container_file_t, $2)
+')
+
+########################################
+## <summary>
+##	Dontaudit read the process state (/proc/pid) of libvirt
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_dontaudit_read_state',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	dontaudit $1 virtd_t:dir search_dir_perms;
+	dontaudit $1 virtd_t:file read_file_perms;
+	dontaudit $1 virtd_t:lnk_file read_lnk_file_perms;
+')
+
+#######################################
+## <summary>
+##	Send to libvirt with a unix dgram socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_dgram_send',`
+	gen_require(`
+		type virtd_t, virt_var_run_t;
+	')
+
+	files_search_pids($1)
+	dgram_send_pattern($1, virt_var_run_t, virt_var_run_t, virtd_t)
+')
+
+########################################
+## <summary>
+##	Write svirt tmp files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_svirt_write_tmp',`
+        gen_require(`
+                type svirt_tmp_t;
+        ')
+
+	write_files_pattern($1, svirt_tmp_t, svirt_tmp_t)
+')
+
+########################################
+## <summary>
+##  Manage svirt tmp files,dirs and sockfiles.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##   </summary>
+## </param>
+#
+interface(`virt_svirt_manage_tmp',`
+        gen_require(`
+                type svirt_tmp_t;
+        ')
+
+	manage_files_pattern($1, svirt_tmp_t, svirt_tmp_t)
+	manage_dirs_pattern($1, svirt_tmp_t, svirt_tmp_t)
+	manage_sock_files_pattern($1, svirt_tmp_t, svirt_tmp_t)
+')
+
+########################################
+## <summary>
+##     Read qemu PID files.
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`virt_read_qemu_pid_files',`
+       gen_require(`
+               type qemu_var_run_t;
+       ')
+
+       files_search_pids($1)
+       list_dirs_pattern($1, qemu_var_run_t, qemu_var_run_t)
+       read_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
+')
+
+########################################
+## <summary>
+##     Write qemu PID files.
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`virt_write_qemu_pid_files',`
+       gen_require(`
+               type qemu_var_run_t;
+       ')
+
+       files_search_pids($1)
+       write_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
+')
+
+########################################
+## <summary>
+##     Create qemu PID files.
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`virt_create_qemu_pid_files',`
+       gen_require(`
+               type qemu_var_run_t;
+       ')
+
+       files_search_pids($1)
+       create_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
+')
+
+########################################
+## <summary>
+##     Manage qemu PID socket files.
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`virt_manage_qemu_pid_sock_files',`
+       gen_require(`
+               type qemu_var_run_t;
+       ')
+
+       files_search_pids($1)
+       manage_sock_files_pattern($1, qemu_var_run_t, qemu_var_run_t)
+')
+
+########################################
+## <summary>
+<<<<<<< HEAD
+=======
+##	Allow the specified domain to ioctl
+##	virtqemud over a unix domain stream socket.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`virt_virtqemud_ioctl_stream_sockets',`
+	gen_require(`
+		type virtqemud_t;
+	')
+
+	allow $1 virtqemud_t:unix_stream_socket ioctl;
+')
+
+########################################
+## <summary>
+##	Allow the specified domain read and write
+##	to virtqemud unix stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_rw_stream_sockets_virtqemud',`
+	gen_require(`
+		type virtqemud_t;
+	')
+
+	allow $1 virtqemud_t:unix_stream_socket { read write };
+')
+
+########################################
+## <summary>
+##	Read the virtqemud process state
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_virtqemud_read_state',`
+	gen_require(`
+		type virtqemud_t;
+	')
+
+	ps_process_pattern($1, virtqemud_t)
+')
+
+########################################
+## <summary>
+##	Read the virtd process state.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_virtd_read_state',`
+	gen_require(`
+		type virtd_t;
+	')
+
+	kernel_search_proc($1)
+	ps_process_pattern($1, virtd_t)
+')
+
+########################################
+## <summary>
+>>>>>>> b61470d79e (Allow systemd-machined read virtd process state)
+##	Read the svirt process state.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_svirt_read_state',`
+	gen_require(`
+		type svirt_t;
+	')
+
+	kernel_search_proc($1)
+	ps_process_pattern($1, svirt_t)
+')
+
+########################################
+## <summary>
+##	Execute virsh in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`virt_exec_virsh',`
+	gen_require(`
+		type virsh_exec_t;
+	')
+
+	can_exec($1, virsh_exec_t)
+')

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -705,7 +705,7 @@ kernel_dontaudit_setsched(virtd_t)
 kernel_write_proc_files(virtd_t)
 kernel_io_uring_use(virtd_t)
 
-corecmd_exec_bin(virtd_t)
+corecmd_exec_bin_wrapper(virtd_t)
 corecmd_exec_shell(virtd_t)
 
 corenet_all_recvfrom_netlabel(virtd_t)
@@ -1139,7 +1139,7 @@ append_files_pattern(virt_domain, virt_log_t, virt_log_t)
 
 append_files_pattern(virt_domain, virt_var_lib_t, virt_var_lib_t)
 
-corecmd_exec_bin(virt_domain)
+corecmd_exec_bin_wrapper(virt_domain)
 corecmd_exec_shell(virt_domain)
 
 corenet_tcp_sendrecv_generic_if(virt_domain)
@@ -1422,7 +1422,7 @@ kernel_read_sysctl(virsh_t)
 kernel_read_xen_state(virsh_t)
 kernel_write_xen_state(virsh_t)
 
-corecmd_exec_bin(virsh_t)
+corecmd_exec_bin_wrapper(virsh_t)
 corecmd_exec_shell(virsh_t)
 
 corenet_tcp_sendrecv_generic_if(virsh_t)
@@ -1580,7 +1580,7 @@ kernel_read_network_state(virtd_lxc_t)
 kernel_read_system_state(virtd_lxc_t)
 kernel_request_load_module(virtd_lxc_t)
 
-corecmd_exec_bin(virtd_lxc_t)
+corecmd_exec_bin_wrapper(virtd_lxc_t)
 corecmd_exec_shell(virtd_lxc_t)
 
 dev_relabel_all_dev_nodes(virtd_lxc_t)
@@ -1950,7 +1950,7 @@ filetrans_pattern(virtinterfaced_t, virt_var_run_t, virtinterfaced_var_run_t, { 
 
 kernel_read_network_state(virtinterfaced_t)
 
-corecmd_exec_bin(virtinterfaced_t)
+corecmd_exec_bin_wrapper(virtinterfaced_t)
 
 fs_getattr_all_fs(virtinterfaced_t)
 
@@ -2043,7 +2043,7 @@ filetrans_pattern(virtnodedevd_t, virt_var_run_t, virtnodedevd_var_run_t, { file
 
 kernel_request_load_module(virtnodedevd_t)
 
-corecmd_exec_bin(virtnodedevd_t)
+corecmd_exec_bin_wrapper(virtnodedevd_t)
 corecmd_exec_shell(virtnodedevd_t)
 
 dev_read_vfio_dev(virtnodedevd_t)
@@ -2096,7 +2096,7 @@ kernel_read_all_proc(virtnwfilterd_t)
 kernel_read_net_sysctls(virtnwfilterd_t)
 kernel_request_load_module(virtnwfilterd_t)
 
-corecmd_exec_bin(virtnwfilterd_t)
+corecmd_exec_bin_wrapper(virtnwfilterd_t)
 
 optional_policy(`
 	dnsmasq_domtrans(virtnwfilterd_t)
@@ -2258,7 +2258,7 @@ kernel_read_network_state_symlinks(virtqemud_t)
 kernel_read_vm_sysctls(virtqemud_t)
 kernel_request_load_module(virtqemud_t)
 
-corecmd_exec_bin(virtqemud_t)
+corecmd_exec_bin_wrapper(virtqemud_t)
 corecmd_exec_shell(virtqemud_t)
 
 corenet_rw_tun_tap_dev(virtqemud_t)
@@ -2482,7 +2482,7 @@ kernel_get_sysvipc_info(virtstoraged_t)
 kernel_io_uring_use(virtstoraged_t)
 kernel_read_vm_sysctls(virtstoraged_t)
 
-corecmd_exec_bin(virtstoraged_t)
+corecmd_exec_bin_wrapper(virtstoraged_t)
 
 dev_write_sysfs(virtstoraged_t)
 

--- a/policy/modules/contrib/virt_supplementary.te
+++ b/policy/modules/contrib/virt_supplementary.te
@@ -188,7 +188,7 @@ kernel_rw_kernel_sysctl(virt_qemu_ga_t)
 kernel_read_vm_sysctls(virt_qemu_ga_t)
 
 corecmd_exec_shell(virt_qemu_ga_t)
-corecmd_exec_bin(virt_qemu_ga_t)
+corecmd_exec_bin_wrapper(virt_qemu_ga_t)
 
 dev_getattr_apm_bios_dev(virt_qemu_ga_t)
 dev_rw_sysfs(virt_qemu_ga_t)

--- a/policy/modules/contrib/vmtools.te
+++ b/policy/modules/contrib/vmtools.te
@@ -47,7 +47,7 @@ files_tmp_filetrans(vmtools_t, vmtools_tmp_t, { file dir })
 kernel_read_system_state(vmtools_t)
 kernel_read_network_state(vmtools_t)
 
-corecmd_exec_bin(vmtools_t)
+corecmd_exec_bin_wrapper(vmtools_t)
 corecmd_exec_shell(vmtools_t)
 
 dev_read_urand(vmtools_t)
@@ -96,7 +96,7 @@ optional_policy(`
 domtrans_pattern(vmtools_helper_t, vmtools_exec_t, vmtools_t)
 can_exec(vmtools_helper_t, vmtools_helper_exec_t)
 
-corecmd_exec_bin(vmtools_helper_t)
+corecmd_exec_bin_wrapper(vmtools_helper_t)
 
 userdom_stream_connect(vmtools_helper_t)
 userdom_use_inherited_user_ttys(vmtools_helper_t)

--- a/policy/modules/contrib/vmware.te
+++ b/policy/modules/contrib/vmware.te
@@ -110,7 +110,7 @@ corenet_tcp_sendrecv_all_ports(vmware_host_t)
 corenet_sendrecv_all_client_packets(vmware_host_t)
 corenet_tcp_connect_all_ports(vmware_host_t)
 
-corecmd_exec_bin(vmware_host_t)
+corecmd_exec_bin_wrapper(vmware_host_t)
 corecmd_exec_shell(vmware_host_t)
 
 dev_getattr_all_blk_files(vmware_host_t)
@@ -235,7 +235,7 @@ kernel_read_system_state(vmware_t)
 kernel_read_network_state(vmware_t)
 kernel_read_kernel_sysctls(vmware_t)
 
-corecmd_exec_bin(vmware_t)
+corecmd_exec_bin_wrapper(vmware_t)
 corecmd_exec_shell(vmware_t)
 
 dev_read_raw_memory(vmware_t)

--- a/policy/modules/contrib/watchdog.te
+++ b/policy/modules/contrib/watchdog.te
@@ -52,7 +52,7 @@ kernel_read_kernel_sysctls(watchdog_t)
 kernel_unmount_proc(watchdog_t)
 
 corecmd_exec_shell(watchdog_t)
-corecmd_exec_bin(watchdog_t)
+corecmd_exec_bin_wrapper(watchdog_t)
 
 corenet_all_recvfrom_unlabeled(watchdog_t)
 corenet_all_recvfrom_netlabel(watchdog_t)

--- a/policy/modules/contrib/wdmd.te
+++ b/policy/modules/contrib/wdmd.te
@@ -39,7 +39,7 @@ fs_tmpfs_filetrans(wdmd_t, wdmd_tmpfs_t, { dir file })
 
 kernel_read_system_state(wdmd_t)
 
-corecmd_exec_bin(wdmd_t)
+corecmd_exec_bin_wrapper(wdmd_t)
 corecmd_exec_shell(wdmd_t)
 
 dev_read_sysfs(wdmd_t)

--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -32,7 +32,7 @@ kernel_rw_net_sysctls(wireguard_t)
 kernel_search_debugfs(wireguard_t)
 kernel_read_proc_files(wireguard_t)
 
-corecmd_exec_bin(wireguard_t)
+corecmd_exec_bin_wrapper(wireguard_t)
 
 dev_read_sysfs(wireguard_t)
 dev_write_kmsg(wireguard_t)

--- a/policy/modules/contrib/wireshark.te
+++ b/policy/modules/contrib/wireshark.te
@@ -71,7 +71,7 @@ kernel_read_system_state(wireshark_t)
 kernel_read_sysctl(wireshark_t)
 kernel_request_load_module(wireshark_t)
 
-corecmd_exec_bin(wireshark_t)
+corecmd_exec_bin_wrapper(wireshark_t)
 
 corenet_all_recvfrom_unlabeled(wireshark_t)
 corenet_all_recvfrom_netlabel(wireshark_t)

--- a/policy/modules/contrib/xen.te
+++ b/policy/modules/contrib/xen.te
@@ -280,7 +280,7 @@ kernel_rw_net_sysctls(xend_t)
 kernel_read_network_state(xend_t)
 kernel_request_load_module(xend_t)
 
-corecmd_exec_bin(xend_t)
+corecmd_exec_bin_wrapper(xend_t)
 corecmd_exec_shell(xend_t)
 
 corenet_all_recvfrom_netlabel(xend_t)
@@ -474,7 +474,7 @@ can_exec(xenstored_t, xenstored_exec_t)
 kernel_write_xen_state(xenstored_t)
 kernel_read_xen_state(xenstored_t)
 
-corecmd_exec_bin(xenstored_t)
+corecmd_exec_bin_wrapper(xenstored_t)
 
 dev_filetrans_xen(xenstored_t)
 dev_rw_xen(xenstored_t)

--- a/policy/modules/contrib/zabbix.te
+++ b/policy/modules/contrib/zabbix.te
@@ -88,7 +88,7 @@ corenet_tcp_sendrecv_generic_node(zabbix_domain)
 corenet_tcp_bind_generic_node(zabbix_domain)
 
 corecmd_exec_shell(zabbix_domain)
-corecmd_exec_bin(zabbix_domain)
+corecmd_exec_bin_wrapper(zabbix_domain)
 
 dev_read_sysfs(zabbix_domain)
 dev_read_urand(zabbix_domain)

--- a/policy/modules/contrib/zoneminder.te
+++ b/policy/modules/contrib/zoneminder.te
@@ -91,7 +91,7 @@ kernel_read_system_state(zoneminder_t)
 
 domain_read_all_domains_state(zoneminder_t)
 
-corecmd_exec_bin(zoneminder_t)
+corecmd_exec_bin_wrapper(zoneminder_t)
 corecmd_exec_shell(zoneminder_t)
 
 corenet_tcp_bind_http_cache_port(zoneminder_t)

--- a/policy/modules/kernel/corecommands.if
+++ b/policy/modules/kernel/corecommands.if
@@ -412,6 +412,58 @@ interface(`corecmd_exec_bin',`
 
 ########################################
 ## <summary>
+##	Execute generic programs in bin directories
+##	in the caller domain and allow sys_resource capability conditionally.
+## </summary>
+## <desc>
+##	<p>
+##	This is a wrapper to corecmd_exec_bin() and corecmd_exec_bin_sys_resource().
+##	</p>
+##	<p>
+##	Related interfaces:
+##	</p>
+##	<ul>
+##		<li>corecmd_exec_bin()</li>
+##		<li>corecmd_exec_bin_sys_resource()</li>
+##	</ul>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corecmd_exec_bin_wrapper',`
+	corecmd_exec_bin($1)
+	corecmd_exec_bin_sys_resource($1)
+')
+
+########################################
+## <summary>
+##	Allow sys_resource capability conditionally
+## </summary>
+## <desc>
+##	<p>
+##	Allow the specified domain the sys_resource capability conditionally
+##	when the corecmd_bin_sys_resource tunable is on.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corecmd_exec_bin_sys_resource',`
+	tunable_policy(`corecmd_bin_sys_resource',`
+		allow $1 self:capability sys_resource;
+	',`
+		dontaudit $1 self:capability sys_resource;
+	')
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete bin files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -10075,7 +10075,6 @@ interface(`files_polyinstantiate_all',`
 		# namespace.init
 		files_search_tmp($1)
 		files_search_home($1)
-		#corecmd_exec_bin($1)
 		seutil_domtrans_setfiles($1)
 	')
 ')

--- a/policy/modules/services/postgresql.te
+++ b/policy/modules/services/postgresql.te
@@ -348,7 +348,7 @@ selinux_compute_relabel_context(postgresql_t)
 
 term_use_controlling_term(postgresql_t)
 
-corecmd_exec_bin(postgresql_t)
+corecmd_exec_bin_wrapper(postgresql_t)
 corecmd_exec_shell(postgresql_t)
 
 domain_dontaudit_list_all_domains_state(postgresql_t)

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -129,7 +129,7 @@ template(`ssh_basic_client_template',`
 
 	# run helper programs - needed eg for x11-ssh-askpass
 	corecmd_exec_shell($1_ssh_t)
-	corecmd_exec_bin($1_ssh_t)
+	corecmd_exec_bin_wrapper($1_ssh_t)
 
 	domain_use_interactive_fds($1_ssh_t)
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -329,7 +329,7 @@ fs_search_auto_mountpoints(ssh_t)
 
 # run helper programs - needed eg for x11-ssh-askpass
 corecmd_exec_shell(ssh_t)
-corecmd_exec_bin(ssh_t)
+corecmd_exec_bin_wrapper(ssh_t)
 
 domain_use_interactive_fds(ssh_t)
 
@@ -677,7 +677,7 @@ kernel_read_system_state(sshd_keygen_t)
 kernel_dontaudit_request_load_module(sshd_keygen_t)
 kernel_stream_connect(sshd_keygen_t)
 
-corecmd_exec_bin(sshd_keygen_t)
+corecmd_exec_bin_wrapper(sshd_keygen_t)
 
 auth_use_nsswitch(sshd_keygen_t)
 
@@ -721,7 +721,7 @@ kernel_read_system_state(ssh_keygen_t)
 kernel_read_kernel_sysctls(ssh_keygen_t)
 
 corecmd_exec_shell(ssh_keygen_t)
-corecmd_exec_bin(ssh_keygen_t)
+corecmd_exec_bin_wrapper(ssh_keygen_t)
 
 fs_search_auto_mountpoints(ssh_keygen_t)
 

--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -573,7 +573,7 @@ kernel_read_key(xdm_t)
 kernel_view_key(xdm_t)
 
 corecmd_exec_shell(xdm_t)
-corecmd_exec_bin(xdm_t)
+corecmd_exec_bin_wrapper(xdm_t)
 corecmd_dontaudit_access_all_executables(xdm_t)
 
 corenet_all_recvfrom_netlabel(xdm_t)
@@ -1292,7 +1292,7 @@ kernel_write_proc_files(xserver_t)
 kernel_request_load_module(xserver_t)
 
 # Run helper programs in xserver_t.
-corecmd_exec_bin(xserver_t)
+corecmd_exec_bin_wrapper(xserver_t)
 corecmd_exec_shell(xserver_t)
 
 corenet_all_recvfrom_netlabel(xserver_t)

--- a/policy/modules/system/application.if
+++ b/policy/modules/system/application.if
@@ -95,7 +95,7 @@ interface(`application_exec',`
 #
 interface(`application_exec_all',`
 	corecmd_dontaudit_exec_all_executables($1)
-	corecmd_exec_bin($1)
+	corecmd_exec_bin_wrapper($1)
 	corecmd_exec_shell($1)
 
 	application_exec($1)

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -703,7 +703,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	corecmd_exec_bin(login_pgm)
+	corecmd_exec_bin_wrapper(login_pgm)
 	storage_getattr_fixed_disk_dev(login_pgm)
 	mount_domtrans(login_pgm)
 	mount_domtrans_ecryptmount(login_pgm)

--- a/policy/modules/system/clock.te
+++ b/policy/modules/system/clock.te
@@ -31,7 +31,7 @@ allow hwclock_t adjtime_t:file { rw_file_perms setattr };
 kernel_read_kernel_sysctls(hwclock_t)
 kernel_read_system_state(hwclock_t)
 
-corecmd_exec_bin(hwclock_t)
+corecmd_exec_bin_wrapper(hwclock_t)
 corecmd_exec_shell(hwclock_t)
 
 dev_read_sysfs(hwclock_t)

--- a/policy/modules/system/fstools.te
+++ b/policy/modules/system/fstools.te
@@ -85,7 +85,7 @@ kernel_getattr_core_if(fsadm_t)
 kernel_rw_unlabeled_dirs(fsadm_t)
 kernel_rw_unlabeled_blk_files(fsadm_t)
 
-corecmd_exec_bin(fsadm_t)
+corecmd_exec_bin_wrapper(fsadm_t)
 #RedHat bug #201164
 corecmd_exec_shell(fsadm_t)
 # cjp: these are probably not needed:

--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -71,7 +71,7 @@ kernel_read_system_state(getty_t)
 kernel_read_network_state(getty_t)
 
 # these two needed for receiving faxes
-corecmd_exec_bin(getty_t)
+corecmd_exec_bin_wrapper(getty_t)
 corecmd_exec_shell(getty_t)
 
 dev_read_sysfs(getty_t)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1117,7 +1117,7 @@ interface(`init_telinit',`
 		type init_t;
 	')
 
-	corecmd_exec_bin($1)
+	corecmd_exec_bin_wrapper($1)
 
 	dev_list_all_dev_nodes($1)
 	allow $1 initctl_t:fifo_file rw_fifo_file_perms;

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -268,7 +268,7 @@ kernel_mounton_crypto_sysctl_files(init_t)
 kernel_dontaudit_request_load_module(init_t)
 
 corecmd_exec_chroot(init_t)
-corecmd_exec_bin(init_t)
+corecmd_exec_bin_wrapper(init_t)
 
 corenet_all_recvfrom_netlabel(init_t)
 corenet_tcp_bind_all_ports(init_t)

--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -154,7 +154,7 @@ kernel_getattr_core_if(ipsec_t)
 kernel_getattr_message_if(ipsec_t)
 
 corecmd_exec_shell(ipsec_t)
-corecmd_exec_bin(ipsec_t)
+corecmd_exec_bin_wrapper(ipsec_t)
 
 # Pluto needs network access
 corenet_tcp_sendrecv_generic_if(ipsec_t)
@@ -356,7 +356,7 @@ files_getattr_kernel_modules(ipsec_mgmt_t)
 # the default updown script wants to run route
 # the ipsec wrapper wants to run /usr/bin/logger (should we put
 # it in its own domain?)
-corecmd_exec_bin(ipsec_mgmt_t)
+corecmd_exec_bin_wrapper(ipsec_mgmt_t)
 corecmd_exec_shell(ipsec_mgmt_t)
 
 corenet_tcp_connect_rndc_port(ipsec_mgmt_t)
@@ -495,7 +495,7 @@ kernel_read_network_state(racoon_t)
 kernel_request_load_module(racoon_t)
 
 corecmd_exec_shell(racoon_t)
-corecmd_exec_bin(racoon_t)
+corecmd_exec_bin_wrapper(racoon_t)
 
 corenet_tcp_sendrecv_generic_if(racoon_t)
 corenet_udp_sendrecv_generic_if(racoon_t)

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -81,7 +81,7 @@ kernel_search_network_sysctl(iptables_t)
 
 
 # needed by ipvsadm
-corecmd_exec_bin(iptables_t)
+corecmd_exec_bin_wrapper(iptables_t)
 corecmd_exec_shell(iptables_t)
 
 corenet_relabelto_all_packets(iptables_t)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -253,7 +253,7 @@ corenet_sendrecv_audit_server_packets(auditd_t)
 
 # Needs to be able to run dispatcher.  see /etc/audit/auditd.conf
 # Probably want a transition, and a new auditd_helper app
-corecmd_exec_bin(auditd_t)
+corecmd_exec_bin_wrapper(auditd_t)
 corecmd_exec_shell(auditd_t)
 
 domain_read_all_domains_state(auditd_t)
@@ -337,7 +337,7 @@ files_pid_filetrans(audisp_t, audisp_var_run_t, sock_file)
 
 kernel_read_system_state(audisp_t)
 
-corecmd_exec_bin(audisp_t)
+corecmd_exec_bin_wrapper(audisp_t)
 corecmd_exec_shell(audisp_t)
 
 domain_use_interactive_fds(audisp_t)
@@ -389,7 +389,7 @@ files_spool_filetrans(audisp_remote_t, audit_spool_t, { dir file })
 
 kernel_read_system_state(audisp_remote_t)
 
-corecmd_exec_bin(audisp_remote_t)
+corecmd_exec_bin_wrapper(audisp_remote_t)
 
 corenet_all_recvfrom_netlabel(audisp_remote_t)
 corenet_tcp_sendrecv_generic_if(audisp_remote_t)
@@ -577,7 +577,7 @@ ifdef(`hide_broken_symptoms',`
 	kernel_rw_unix_dgram_sockets(syslogd_t)
 ')
 
-corecmd_exec_bin(syslogd_t)
+corecmd_exec_bin_wrapper(syslogd_t)
 corecmd_exec_shell(syslogd_t)
 
 corenet_all_recvfrom_netlabel(syslogd_t)

--- a/policy/modules/system/lvm.te
+++ b/policy/modules/system/lvm.te
@@ -246,7 +246,7 @@ kernel_use_fds(lvm_t)
 kernel_request_load_module(lvm_t)
 kernel_search_debugfs(lvm_t)
 
-corecmd_exec_bin(lvm_t)
+corecmd_exec_bin_wrapper(lvm_t)
 corecmd_exec_shell(lvm_t)
 
 dev_create_generic_chr_files(lvm_t)

--- a/policy/modules/system/modutils.te
+++ b/policy/modules/system/modutils.te
@@ -90,7 +90,7 @@ kernel_read_kernel_sysctls(kmod_t)
 kernel_rw_kernel_sysctl(kmod_t)
 kernel_setsched(kmod_t)
 
-corecmd_exec_bin(kmod_t)
+corecmd_exec_bin_wrapper(kmod_t)
 corecmd_exec_shell(kmod_t)
 
 dev_rw_sysfs(kmod_t)

--- a/policy/modules/system/mount.te
+++ b/policy/modules/system/mount.te
@@ -96,7 +96,7 @@ kernel_dontaudit_write_proc_dirs(mount_t)
 kernel_request_load_module(mount_t)
 
 # required for mount.smbfs
-corecmd_exec_bin(mount_t)
+corecmd_exec_bin_wrapper(mount_t)
 
 dev_getattr_generic_blk_files(mount_t)
 dev_getattr_all_blk_files(mount_t)

--- a/policy/modules/system/netlabel.te
+++ b/policy/modules/system/netlabel.te
@@ -29,7 +29,7 @@ can_exec(netlabel_mgmt_t, netlabel_mgmt_exec_t)
 kernel_read_network_state(netlabel_mgmt_t)
 kernel_read_system_state(netlabel_mgmt_t)
 
-corecmd_exec_bin(netlabel_mgmt_t)
+corecmd_exec_bin_wrapper(netlabel_mgmt_t)
 corecmd_exec_shell(netlabel_mgmt_t)
 
 files_read_etc_files(netlabel_mgmt_t)

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -437,7 +437,7 @@ dontaudit run_init_t self:capability {  dac_read_search };
 
 kernel_dontaudit_getattr_core_if(run_init_t)
 
-corecmd_exec_bin(run_init_t)
+corecmd_exec_bin_wrapper(run_init_t)
 corecmd_exec_shell(run_init_t)
 
 dev_dontaudit_getattr_all(run_init_t)
@@ -774,7 +774,7 @@ files_tmp_filetrans(policy_manager_domain, semanage_tmp_t, { file dir })
 
 kernel_read_kernel_sysctls(policy_manager_domain)
 
-corecmd_exec_bin(policy_manager_domain)
+corecmd_exec_bin_wrapper(policy_manager_domain)
 corecmd_exec_shell(policy_manager_domain)
 
 domain_use_interactive_fds(policy_manager_domain)

--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -123,7 +123,7 @@ kernel_request_load_module(dhcpc_t)
 kernel_use_fds(dhcpc_t)
 kernel_rw_net_sysctls(dhcpc_t)
 
-corecmd_exec_bin(dhcpc_t)
+corecmd_exec_bin_wrapper(dhcpc_t)
 corecmd_exec_shell(dhcpc_t)
 
 corenet_all_recvfrom_netlabel(dhcpc_t)
@@ -329,7 +329,7 @@ manage_dirs_pattern(dhcpc_hook_t, dhcpc_var_run_t, dhcpc_var_run_t)
 manage_files_pattern(dhcpc_hook_t, dhcpc_var_run_t, dhcpc_var_run_t)
 files_pid_filetrans(dhcpc_hook_t, dhcpc_var_run_t, { file dir sock_file })
 
-corecmd_exec_bin(dhcpc_hook_t)
+corecmd_exec_bin_wrapper(dhcpc_hook_t)
 corecmd_exec_shell(dhcpc_hook_t)
 files_rw_etc_files(dhcpc_hook_t)
 
@@ -408,7 +408,7 @@ kernel_unmount_proc(ifconfig_t)
 
 corenet_rw_tun_tap_dev(ifconfig_t)
 
-corecmd_exec_bin(ifconfig_t)
+corecmd_exec_bin_wrapper(ifconfig_t)
 corecmd_exec_shell(ifconfig_t)
 
 dev_read_sysfs(ifconfig_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1223,7 +1223,7 @@ read_files_pattern(systemd_timedated_t, systemd_networkd_var_run_t, systemd_netw
 
 kernel_rw_psi(systemd_timedated_t)
 
-corecmd_exec_bin(systemd_timedated_t)
+corecmd_exec_bin_wrapper(systemd_timedated_t)
 corecmd_exec_shell(systemd_timedated_t)
 corecmd_dontaudit_access_check_bin(systemd_timedated_t)
 
@@ -1433,7 +1433,7 @@ kernel_read_proc_files(systemd_generator)
 kernel_read_sysctl(systemd_generator)
 kernel_read_net_sysctls(systemd_generator)
 
-corecmd_exec_bin(systemd_generator)
+corecmd_exec_bin_wrapper(systemd_generator)
 dev_read_sysfs(systemd_generator)
 dev_write_kmsg(systemd_generator)
 files_read_non_security_files(systemd_generator)
@@ -1786,7 +1786,7 @@ kernel_load_unsigned_module(systemd_modules_load_t)
 kernel_ib_access_unlabeled_pkeys(systemd_modules_load_t)
 kernel_request_load_module(systemd_modules_load_t)
 
-corecmd_exec_bin(systemd_modules_load_t)
+corecmd_exec_bin_wrapper(systemd_modules_load_t)
 corecmd_exec_shell(systemd_modules_load_t)
 
 dev_read_sysfs(systemd_modules_load_t)
@@ -1894,7 +1894,7 @@ kernel_read_system_state(systemd_importd_t)
 
 auth_read_passwd(systemd_importd_t)
 
-corecmd_exec_bin(systemd_importd_t)
+corecmd_exec_bin_wrapper(systemd_importd_t)
 
 corenet_tcp_connect_http_port(systemd_importd_t)
 
@@ -1968,7 +1968,7 @@ manage_files_pattern(systemd_sleep_t, systemd_sleep_var_lib_t, systemd_sleep_var
 
 kernel_dgram_send(systemd_sleep_t)
 
-corecmd_exec_bin(systemd_sleep_t)
+corecmd_exec_bin_wrapper(systemd_sleep_t)
 corecmd_exec_shell(systemd_sleep_t)
 
 dev_create_sysfs_files(systemd_sleep_t)


### PR DESCRIPTION
Allow the sys_resource capability to each domain which is allowed to execute generic programs in system bin directories without domain transition when the coreutils_single tunable is on.

coreutils-single is a collection of GNU core utilities, but packaged as a single multicall binary. Each program now executes prctl() with PR_SET_MM which requires the CAP_SYS_RESOURCE capability.

prctl(PR_SET_NAME, "mkdir")             = 0
prctl(PR_SET_MM, PR_SET_MM_ARG_START, 0x7fff20a92dc7, 0, 0) = 0

capabilities(7)
      CAP_SYS_RESOURCE
             •  employ the prctl(2) PR_SET_MM operation;

PR_SET_MM(2const)
DESCRIPTION
       Modify certain kernel memory map descriptor fields of the calling
process. Usually these fields are set by the kernel and dynamic loader (see ld.so(8) for more information) and a regular application should not use this feature. However, there are cases, such as self-modifying programs, where a program might find it useful to change its own memory map. The calling process must have the CAP_SYS_RESOURCE capability.

Resolves: RHEL-141858