### PR TITLE
Allow fedoratp_exec_t be an entrypoint of unconfined_t

### DIFF
--- a/policy/modules/contrib/fedoratp.if
+++ b/policy/modules/contrib/fedoratp.if
@@ -18,3 +18,21 @@ interface(`fedoratp_domtrans',`
 	corecmd_search_bin($1)
 	domtrans_pattern($1, fedoratp_exec_t, fedoratp_t)
 ')
+
+########################################
+## <summary>
+##	Allow fedoratp_exec_t be an entrypoint of the specified domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fedoratp_entrypoint',`
+	gen_require(`
+		type fedoratp_exec_t;
+	')
+
+	allow $1 fedoratp_exec_t:file entrypoint;
+')

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -150,6 +150,10 @@ optional_policy(`
 	')
 
 	optional_policy(`
+		fedoratp_entrypoint(unconfined_t)
+	')
+
+	optional_policy(`
 		gpg_filetrans_admin_home_content(unconfined_t)
 	')
 


### PR DESCRIPTION
Required for gnome-initial-setup be able to enable third party repos in F44 which changed using pkexec for authorization to run0.

The commit addresses the following AVC denial:
Mar 11 15:22:45 fedora audit[9196]: AVC avc:  denied  { entrypoint } for  pid=9196 comm="(fedora-third-)" path="/usr/bin/fedora-third-party" dev="vda3" ino=9494 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=system_u:object_r:fedoratp_exec_t:s0 tclass=file permissive=0

accompanied with journal entry
Mar 11 15:22:45 fedora (fedora-third-party)[9196]: run-p8841-i8842.service: Failed to execute /usr/bin/fedora-third-party: Permission denied

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2446745