### PR TITLE
Allow samba-bgqd sendto over a unix dgram socket

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -321,7 +321,7 @@ permissive samba_bgqd_t;
 allow samba_bgqd_t self:netlink_route_socket r_netlink_socket_perms;
 allow samba_bgqd_t self:tcp_socket create_stream_socket_perms;
 allow samba_bgqd_t self:udp_socket create_socket_perms;
-allow samba_bgqd_t self:unix_dgram_socket create_socket_perms;
+allow samba_bgqd_t self:unix_dgram_socket { create_socket_perms sendto };
 
 read_files_pattern(samba_bgqd_t, samba_etc_t, samba_etc_t)
 allow samba_bgqd_t samba_log_t:dir create_dir_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/23/2026 17:25:20.548:8733) : proctitle=/usr/libexec/samba/samba-bgqd --foreground --no-process-group type=PATH msg=audit(03/23/2026 17:25:20.548:8733) : item=0 name=/var/lib/samba/private/msg.sock/436360 inode=357604 dev=00:22 mode=socket,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:samba_var_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(03/23/2026 17:25:20.548:8733) : saddr={ saddr_fam=local path=/var/lib/samba/private/msg.sock/436360 } type=SYSCALL msg=audit(03/23/2026 17:25:20.548:8733) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x14 a1=0x7ffe9d160400 a2=0x6e a3=0x0 items=1 ppid=1 pid=436358 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=samba-bgqd exe=/usr/libexec/samba/samba-bgqd subj=system_u:system_r:samba_bgqd_t:s0 key=(null) type=AVC msg=audit(03/23/2026 17:25:20.548:8733) : avc:  denied  { sendto } for  pid=436358 comm=samba-bgqd path=/var/lib/samba/private/msg.sock/436360 scontext=system_u:system_r:samba_bgqd_t:s0 tcontext=system_u:system_r:samba_bgqd_t:s0 tclass=unix_dgram_socket permissive=1