### PR TITLE
Allow systemd-coredump signull containers

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1377,6 +1377,10 @@ fs_read_nsfs_files(systemd_coredump_t)
 fs_mounton_tmpfs(systemd_coredump_t)
 
 optional_policy(`
+	container_signull(systemd_coredump_t)
+')
+
+optional_policy(`
 	logging_send_syslog_msg(systemd_coredump_t)
 ')
 


### PR DESCRIPTION
When coredump forwarding (CoredumpReceive) is enabled, systemd-coredump checks if the container leader is alive and listens on the coredump socket.

The commit addresses the following AVC denial:
type=AVC msg=audit(1764684762.061:465): avc:  denied  { signull } for  pid=8570 comm="systemd-coredum" scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:container_t:s0:c96,c446 tclass=process permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2418343