### PR TITLE
Add systemd system nfs-server generator the dac_read_search capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1545,6 +1545,7 @@ corecmd_exec_shell(systemd_kdump_dep_generator_t)
 
 ### nfs generator
 permissive systemd_nfs_generator_t;
+allow systemd_nfs_generator_t self:capability dac_read_search;
 allow systemd_nfs_generator_t self:udp_socket create_socket_perms;
 allow systemd_nfs_generator_t self:netlink_route_socket { create_netlink_socket_perms };
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(...): avc:  denied  { dac_read_search } for  pid=... comm="nfs-server-gene" capability=2  scontext=system_u:system_r:systemd_nfs_generator_t:s0 tcontext=system_u:system_r:systemd_nfs_generator_t:s0 tclass=capability permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2417873