### PR TITLE
Allow snmpd create and use netlink tcpdiag socket

### DIFF
--- a/policy/modules/contrib/snmp.te
+++ b/policy/modules/contrib/snmp.te
@@ -34,6 +34,8 @@ allow snmpd_t self:process { signal_perms getsched setsched };
 allow snmpd_t self:fifo_file rw_fifo_file_perms;
 allow snmpd_t self:unix_dgram_socket create_socket_perms;
 allow snmpd_t self:unix_stream_socket { create_stream_socket_perms connectto };
+allow snmpd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
+
 allow snmpd_t self:tcp_socket create_stream_socket_perms;
 allow snmpd_t self:udp_socket connected_stream_socket_perms;
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(03/24/26 23:25:50.277:757) : avc:  denied  { create } for  pid=800 comm=snmpd scontext=system_u:system_r:snmpd_t:s0 tcontext=system_u:system_r:snmpd_t:s0 tclass=netlink_tcpdiag_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2451293