### PR TITLE
Allow auditctl_t read audit log_file

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -167,6 +167,8 @@ read_files_pattern(auditctl_t, auditd_etc_t, auditd_etc_t)
 allow auditctl_t auditd_etc_t:dir list_dir_perms;
 allow auditctl_t auditd_etc_t:file map;
 
+read_files_pattern(auditctl_t, auditd_log_t, auditd_log_t)
+
 # Needed for adding watches
 files_getattr_all_dirs(auditctl_t)
 files_getattr_all_files(auditctl_t)


### PR DESCRIPTION
During initialization phase, auparse_init() parses auditd configuration file and for the log_file entry runs log_file_parser() to check if the directory exist and the log file can be opened with O_RDONLY.

The auditctl_t domain can be entered e.g. from sysadm_t when auditctl was executed from cli.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/26/2026 18:49:09.621:439) : proctitle=auditctl -l type=PATH msg=audit(03/26/2026 18:49:09.621:439) : item=0 name=/var/log/audit/audit.log inode=220452 dev=00:21 mode=file,600 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:auditd_log_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/26/2026 18:49:09.621:439) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x7ffcd3c0a01b a2=O_RDONLY a3=0x0 items=1 ppid=3417 pid=4268 auid=zpytela uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts3 ses=3 comm=auditctl exe=/usr/bin/auditctl subj=staff_u:sysadm_r:auditctl_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(03/26/2026 18:49:09.621:439) : avc:  denied  { open } for  pid=4268 comm=auditctl path=/var/log/audit/audit.log dev="vda3" ino=220452 scontext=staff_u:sysadm_r:auditctl_t:s0-s0:c0.c1023 tcontext=system_u:object_r:auditd_log_t:s0 tclass=file permissive=1 type=AVC msg=audit(03/26/2026 18:49:09.621:439) : avc:  denied  { read } for  pid=4268 comm=auditctl name=audit.log dev="vda3" ino=220452 scontext=staff_u:sysadm_r:auditctl_t:s0-s0:c0.c1023 tcontext=system_u:object_r:auditd_log_t:s0 tclass=file permissive=1