### PR TITLE
Allow virt_qemu_ga_run_unconfined control guest-exec (bsc#1237450)

### DIFF
--- a/policy/modules/contrib/virt_supplementary.fc
+++ b/policy/modules/contrib/virt_supplementary.fc
@@ -67,6 +67,7 @@ HOME_DIR/\.local/share/gnome-boxes/images(/.*)? gen_context(system_u:object_r:sv
 # support for QEMU-GA
 /etc/qemu-ga/fsfreeze-hook\.d(/.*)?		gen_context(system_u:object_r:virt_qemu_ga_unconfined_exec_t,s0)
 /usr/bin/qemu-ga			--	gen_context(system_u:object_r:virt_qemu_ga_exec_t,s0)
+/usr/libexec/qemu-ga-selinux-helper     --      gen_context(system_u:object_r:virt_qemu_ga_selinux_helper_exec_t,s0)
 /usr/libexec/qemu-ga(/.*)?			gen_context(system_u:object_r:virt_qemu_ga_exec_t,s0)
 /usr/libexec/qemu-ga/fsfreeze-hook\.d(/.*)?	gen_context(system_u:object_r:virt_qemu_ga_unconfined_exec_t,s0)
 /run/qemu-ga/fsfreeze-hook\.d(/.*)?		gen_context(system_u:object_r:virt_qemu_ga_unconfined_exec_t,s0)

--- a/policy/modules/contrib/virt_supplementary.te
+++ b/policy/modules/contrib/virt_supplementary.te
@@ -73,6 +73,14 @@ files_tmp_file(virt_qemu_ga_tmp_t)
 type virt_qemu_ga_data_t;
 files_type(virt_qemu_ga_data_t)
 
+type virt_qemu_ga_selinux_helper_t;
+domain_type(virt_qemu_ga_selinux_helper_t)
+
+type virt_qemu_ga_selinux_helper_exec_t;
+application_executable_file(virt_qemu_ga_selinux_helper_exec_t)
+domain_entry_file(virt_qemu_ga_selinux_helper_t, virt_qemu_ga_selinux_helper_exec_t)
+role system_r types virt_qemu_ga_selinux_helper_t;
+
 type virt_qemu_ga_unconfined_exec_t;
 application_executable_file(virt_qemu_ga_unconfined_exec_t)
 
@@ -243,10 +251,12 @@ tunable_policy(`virt_qemu_ga_read_nonsecurity_files',`
 ')
 
 tunable_policy(`virt_qemu_ga_run_unconfined',`
+    domtrans_pattern(virt_qemu_ga_t, virt_qemu_ga_selinux_helper_exec_t, virt_qemu_ga_selinux_helper_t)
     domtrans_pattern(virt_qemu_ga_t, virt_qemu_ga_unconfined_exec_t, virt_qemu_ga_unconfined_t)
 ',`
     can_exec(virt_qemu_ga_t, virt_qemu_ga_unconfined_exec_t)
 ')
+
 
 optional_policy(`
 	ssh_filetrans_home_content(virt_qemu_ga_t)
@@ -320,4 +330,14 @@ optional_policy(`
     optional_policy(`
         unconfined_domain(virt_qemu_ga_unconfined_t)
     ')
+')
+
+#######################################
+#
+# qemu-ga selinux-helper (unconfined) local policy
+#
+
+allow virt_qemu_ga_selinux_helper_t self:process { fork signal };
+optional_policy(`
+    unconfined_domain(virt_qemu_ga_selinux_helper_t)
 ')


### PR DESCRIPTION
The qemu-ga guest-exec command allows a host to execute arbitrary commands on the guest.

Before this commit, when the guest-exec command was used with qemu-guest-agent, SELinux allowed the the host to execute processes that were generally allowed by the virt_qemu_ga_t domain and denied accessing processes that were not allowed.

However, this bad in security and usability as not all commands are denied and not all commands are allowed and there is no way to configure which ones are allowed, except by giving the main virt_qemu_ga_t domain more permissions in general.

This breaks use cases such as ansible with the qemu-guest-agent plugin.

Quick reproducer for the problem that this commit tries to solve: Using virsh on the host:
- list VM names and grab your guest where you want to execute commands on
- for example execute this with cloud-init installed on the guest:
```
$ qemu-agent-command <your-vm-name> '{"execute": "guest-exec", "arguments": { "path": "/usr/bin/cloud-init", "arg": [ "/" ], "capture-output": true }}'
error: guest agent command failed: unable to execute QEMU agent command 'guest-exec': Failed to execute child process “/usr/bin/cloud-init” (Permission denied)

$ qemu-agent-command <your-vm-name> '{"execute": "guest-exec", "arguments": { "path": "/usr/bin/ls", "arg": [ "/" ], "capture-output": true }}'
{"return":{"pid":109083}}
```

With this commit and a change in libvirt, this can be controlled with the virt_qemu_ga_run_unconfined boolean.

virt_qemu_ga_run_unconfined off -> both ls and cloud-init will fail with guest-exec virt_qemu_ga_run_unconfined on -> both ls and cloud-init will be executed with guest-exec

Requires a change with a selinux-helper in libvirt to be functional!