### PR TITLE
Allow unconfined_t mounton on itself (bsc#1261035)

### DIFF
--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -62,6 +62,7 @@ typealias unconfined_t alias unconfined_crontab_t;
 # Local policy
 #
 
+allow unconfined_t self:{dir file} mounton;
 dontaudit unconfined_t self:dir write;
 dontaudit unconfined_t self:file setattr;
 


### PR DESCRIPTION
When using sandboxing applications like firejail this can be used to hide specific file system entries. If this happens in /proc this is necessary

Solves
avc:  denied  { mounton }
comm="firejail" path="/proc/1/comm" dev="proc"
scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=file