### PR TITLE
Allow nfsidmap connect to xdm over a unix stream socket

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -481,3 +481,7 @@ optional_policy(`
 optional_policy(`
 	virt_search_lib(nfsidmap_t)
 ')
+
+optional_policy(`
+	xserver_stream_connect_xdm(nfsidmap_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1761727798.207:231): avc:  denied  { write } for  pid=12660 comm="nfsidmap" name="org.gnome.DisplayManager" dev="tmpfs" ino=5864 scontext=system_u:system_r:nfsidmap_t:s0 tcontext=system_u:object_r:xdm_var_run_t:s0 tclass=sock_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2407011