### PR TITLE
Support sandboxing features for sysadm_t

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -9,6 +9,7 @@ role sysadm_r;
 
 userdom_admin_user_template(sysadm)
 allow sysadm_t self:socket { accept listen };
+allow sysadm_t self:netlink_route_socket nlmsg_write;
 allow sysadm_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 allow sysadm_t self:netlink_selinux_socket create_socket_perms;
 allow sysadm_t self:netlink_generic_socket create_socket_perms;
@@ -40,6 +41,7 @@ corecmd_exec_shell(sysadm_t)
 
 dev_filetrans_all_named_dev(sysadm_t)
 dev_read_tpm(sysadm_t)
+dev_rw_dma_dev(sysadm_t)
 dev_rw_ipmi_dev(sysadm_t)
 dev_rw_autofs(sysadm_t)
 dev_rw_lvm_control(sysadm_t)
@@ -63,6 +65,8 @@ fs_mount_fusefs(sysadm_t)
 fs_rw_tracefs_files(sysadm_t)
 fs_mount_tracefs(sysadm_t)
 fs_read_nsfs_files(sysadm_t)
+fs_remount_xattr_fs(sysadm_t)
+fs_unmount_xattr_fs(sysadm_t)
 
 storage_filetrans_all_named_dev(sysadm_t)
 storage_read_scsi_generic(sysadm_t)
@@ -101,6 +105,7 @@ init_undefined(sysadm_t)
 init_ioctl_stream_sockets(sysadm_t)
 init_prog_run_bpf(sysadm_t)
 init_run_script(sysadm_t, sysadm_r)
+init_rw_stream_sockets(sysadm_t)
 
 logging_filetrans_named_content(sysadm_t)
 logging_map_audit_config(sysadm_t)
@@ -550,6 +555,7 @@ optional_policy(`
 
 optional_policy(`
     rtkit_daemon_dbus_chat(sysadm_t)
+    rtkit_scheduled(sysadm_t)
 ')
 
 optional_policy(`
@@ -726,6 +732,7 @@ optional_policy(`
 
 optional_policy(`
 	xserver_role(sysadm_r, sysadm_t)
+	xserver_rw_xdm_stream_sockets(sysadm_t)
 ')
 
 optional_policy(`

--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -1699,6 +1699,24 @@ interface(`xserver_dontaudit_rw_stream_sockets',`
 
 ########################################
 ## <summary>
+##	Read and write xdm unix stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xserver_rw_xdm_stream_sockets',`
+	gen_require(`
+		type xdm_t;
+	')
+
+	allow $1 xdm_t:unix_stream_socket { read write };
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to read and write xdm
 ##	unix domain stream sockets.
 ## </summary>


### PR DESCRIPTION
In graphical environments, applications use various tools like bubblewrap for sandboxing which requires additional SELinux permissions, mostly for setting up mount namespacing.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2412225