### PR TITLE
Label /usr/share/accountsservice with accountsd_share_t

### DIFF
--- a/policy/modules/contrib/accountsd.fc
+++ b/policy/modules/contrib/accountsd.fc
@@ -4,4 +4,6 @@
 
 /usr/lib/accountsservice/accounts-daemon	--	gen_context(system_u:object_r:accountsd_exec_t,s0)
 
+/usr/share/accountsservice(/.*)? --	gen_context(system_u:object_r:accountsd_share_t,s0)
+
 /var/lib/AccountsService(/.*)?	gen_context(system_u:object_r:accountsd_var_lib_t,s0)

--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -18,6 +18,9 @@ type accountsd_exec_t;
 init_daemon_domain(accountsd_t, accountsd_exec_t)
 role system_r types accountsd_t;
 
+type accountsd_share_t;
+files_type(accountsd_share_t)
+
 type accountsd_var_lib_t;
 files_type(accountsd_var_lib_t)
 
@@ -33,6 +36,8 @@ allow accountsd_t self:capability { chown dac_read_search dac_override setuid se
 allow accountsd_t self:process signal;
 allow accountsd_t self:fifo_file rw_fifo_file_perms;
 allow accountsd_t self:passwd { rootok passwd chfn chsh };
+
+watch_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 
 manage_dirs_pattern(accountsd_t, accountsd_var_lib_t, accountsd_var_lib_t)
 manage_files_pattern(accountsd_t, accountsd_var_lib_t, accountsd_var_lib_t)


### PR DESCRIPTION
Additionally, allow accountsd_t watch dirs with this type.

The commit addresses the following AVC denial:
type=AVC msg=audit(1774422164.639:72): avc:  denied  { watch } for  pid=967 comm="accounts-daemon" path="/usr/share/accountsservice/interfaces" dev="vdb3" ino=58124 scontext=system_u:system_r:accountsd_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2451397