### PR TITLE
Allow systemd-resolved write to systemd-networkd socket

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1664,6 +1664,8 @@ manage_lnk_files_pattern(systemd_resolved_t, systemd_resolved_var_run_t, systemd
 manage_sock_files_pattern(systemd_resolved_t, systemd_resolved_var_run_t, systemd_resolved_var_run_t)
 init_pid_filetrans(systemd_resolved_t, systemd_resolved_var_run_t, dir)
 
+allow systemd_resolved_t systemd_machined_var_run_t:sock_file write;
+
 list_dirs_pattern(systemd_resolved_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 read_files_pattern(systemd_resolved_t, systemd_networkd_var_run_t, systemd_networkd_var_run_t)
 allow systemd_resolved_t systemd_networkd_var_run_t:sock_file write;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PATH msg=audit(1774881716.146:84): item=0 name=/run/systemd/resolve.hook/io.systemd.Machine inode=4104 dev=00:1d mode=0140666 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:systemd_machined_var_run_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 type=AVC msg=audit(1774881716.146:84): avc:  denied  { write } for  pid=1149 comm="systemd-resolve" name="io.systemd.Machine" dev="tmpfs" ino=4104 scontext=system_u:system_r:systemd_resolved_t:s0 tcontext=system_u:object_r:systemd_machined_var_run_t:s0 tclass=sock_file permissive=1 type=SYSCALL msg=audit(1774881716.146:84): arch=x86_64 syscall=connect success=yes exit=0 a0=1a a1=7fff151251c0 a2=2f a3=0 items=1 ppid=1 pid=1149 auid=4294967295 uid=193 gid=193 euid=193 suid=193 fsuid=193 egid=193 sgid=193 fsgid=193 tty=(none) ses=4294967295 comm=systemd-resolve exe=/usr/lib/systemd/systemd-resolved subj=system_u:system_r:systemd_resolved_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2453109