### PR TITLE
Allow Polkit to get attributes of user terminals

### DIFF
--- a/policy/modules/contrib/policykit.te
+++ b/policy/modules/contrib/policykit.te
@@ -105,6 +105,7 @@ systemd_machined_watch_pid_dirs(policykit_t)
 systemd_read_logind_sessions_files(policykit_t)
 
 userdom_getattr_all_users(policykit_t)
+userdom_getattr_user_terminals(policykit_t)
 userdom_read_all_users_state(policykit_t)
 userdom_dontaudit_search_admin_dir(policykit_t)
 


### PR DESCRIPTION
Polkit 127 supports a new authentication caching mechanism that allows processes to skip authentication if another process meeting certain conditions was recently authenticated in the same terminal. For reference, see: https://github.com/polkit-org/polkit/pull/533

For this to work, Polkit needs to be allowed to get attributes of user terminals. This is granted by the following rule:
`userdom_getattr_user_terminals(policykit_t)`

I tested this on a freshly created and updated VM running Fedora 44 Workstation, and the addition of this rule does allow Polkit authentication caching to work. (You can test this by running `run0 true` or `pkexec true` twice in a row in the same terminal.)