### PR TITLE
Allow virtnetworkd get attributes of filesystems with extended attrib…

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1993,6 +1993,8 @@ corenet_rw_tun_tap_dev(virtnetworkd_t)
 
 dev_rw_sysfs(virtnetworkd_t)
 
+fs_getattr_xattr_fs(virtnetworkd_t)
+
 sysnet_domtrans_ifconfig(virtnetworkd_t)
 sysnet_read_config(virtnetworkd_t)
 


### PR DESCRIPTION
…utes

The commit addresses the following AVC denial:
type=AVC msg=audit(1771664631.137:486): avc:  denied  { getattr } for  pid=11193 comm="rpc-virtnetwork" name="/" dev="nvme0n1p3" ino=256 scontext=system_u:system_r:virtnetworkd_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2441614