### PR TITLE
Fix file context specification for /usr/share/accountsservice

### DIFF
--- a/policy/modules/contrib/accountsd.fc
+++ b/policy/modules/contrib/accountsd.fc
@@ -4,6 +4,6 @@
 
 /usr/lib/accountsservice/accounts-daemon	--	gen_context(system_u:object_r:accountsd_exec_t,s0)
 
-/usr/share/accountsservice(/.*)? --	gen_context(system_u:object_r:accountsd_share_t,s0)
+/usr/share/accountsservice(/.*)? 	gen_context(system_u:object_r:accountsd_share_t,s0)
 
 /var/lib/AccountsService(/.*)?	gen_context(system_u:object_r:accountsd_var_lib_t,s0)

--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -37,6 +37,7 @@ allow accountsd_t self:process signal;
 allow accountsd_t self:fifo_file rw_fifo_file_perms;
 allow accountsd_t self:passwd { rootok passwd chfn chsh };
 
+read_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 watch_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 
 manage_dirs_pattern(accountsd_t, accountsd_var_lib_t, accountsd_var_lib_t)

--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -108,6 +108,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_homed_dbus_chat(accountsd_t)
+')
+
+optional_policy(`
 	xserver_read_xdm_tmp_files(accountsd_t)
 	xserver_read_state_xdm(accountsd_t)
 	xserver_dbus_chat_xdm(accountsd_t)


### PR DESCRIPTION
The 9950cce8cc07 ("Label /usr/share/accountsservice with accountsd_share_t") commit contained "--" in the file context specification which limits its validity to plain files only. This commit labels all fyle types with accountsd_share_t.