### PR TITLE
Allow sshd-session send a generic signal to sshd-auth

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -98,6 +98,8 @@ allow sshd_session_t sshd_t:tcp_socket { getattr getopt read setopt write };
 allow sshd_session_t sshd_t:unix_stream_socket { read write };
 allow sshd_session_t sshd_t:vsock_socket { getattr };
 
+allow sshd_session_t sshd_auth_t:process signal;
+
 allow sshd_session_t ssh_home_t:dir relabelto;
 allow sshd_session_t ssh_home_t:file relabelto;
 manage_dirs_pattern(sshd_session_t, ssh_home_t, ssh_home_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1773241893.531:407): avc:  denied  { signal } for  pid=106890 comm="sshd-session" scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_auth_t:s0-s0:c0.c1023 tclass=process permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2446563