### PR TITLE
Allow xdm_exec_t be an entrypoint of login_userdomain

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -940,6 +940,24 @@ interface(`xserver_connect_xdm_bus',`
 
 ########################################
 ## <summary>
+##	Allow xdm_exec_t be an entrypoint of the specified domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xserver_entrypoint_xdm',`
+	gen_require(`
+		type xdm_exec_t;
+	')
+
+	allow $1 xdm_exec_t:file entrypoint;
+')
+
+########################################
+## <summary>
 ##	Read xserver configuration files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -515,6 +515,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	xserver_entrypoint_xdm(login_userdomain)
 	xserver_stream_accept_xdm(login_userdomain)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/19/2026 13:13:21.396:319) : proctitle=/usr/libexec/plasmalogin-helper --socket /tmp/plasmalogin-auth-e34cd045-6bfc-4d6a-8ac6-230957afb001 --id 2 --start /usr/bin/star type=PATH msg=audit(03/19/2026 13:13:21.396:319) : item=0 name=/usr/libexec/plasmalogin-helper-start-x11user inode=34906038 dev=00:25 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:xdm_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/19/2026 13:13:21.396:319) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x55d73ca70750 a1=0x55d73ca2a110 a2=0x55d73ca1efe0 a3=0x8 items=1 ppid=4651 pid=4654 auid=liveuser uid=liveuser gid=liveuser euid=liveuser suid=liveuser fsuid=liveuser egid=liveuser sgid=liveuser fsgid=liveuser tty=tty2 ses=7 comm=plasmalogin-hel exe=/usr/libexec/plasmalogin-helper subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(03/19/2026 13:13:21.396:319) : avc:  denied  { entrypoint } for  pid=4654 comm=plasmalogin-hel path=/usr/libexec/plasmalogin-helper-start-x11user dev="overlay" ino=34906038 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xdm_exec_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2442269