### PR TITLE
Allow svirt_tcg_t entrypoint for dbusd and virtlogd manage qemu runtime files

### DIFF
--- a/policy/modules/contrib/dbus.if
+++ b/policy/modules/contrib/dbus.if
@@ -36,6 +36,23 @@ interface(`dbus_exec_dbusd',`
 
 ########################################
 ## <summary>
+##	Entrypoint access for dbus.
+## </summary>
+## <param name="domain" unused="true">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`dbus_entrypoint',`                                                                                 
+        gen_require(`
+                type dbusd_exec_t;
+        ')                                                                                                      
+        allow $1 dbusd_exec_t:file entrypoint;                                                                  
+  ')
+
+########################################
+## <summary>
 ##	Role access for dbus
 ## </summary>
 ## <param name="role_prefix">

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -429,6 +429,9 @@ allow svirt_tcg_t self:capability sys_rawio;
 allow svirt_tcg_t self:process { execmem execstack };
 allow svirt_tcg_t self:netlink_route_socket r_netlink_socket_perms;
 
+#allow svirt_tcg_t dbusd_exec_t:file { entrypoint };
+dbus_entrypoint(svirt_tcg_t)
+
 kernel_read_vm_sysctls(svirt_tcg_t)
 
 corenet_udp_sendrecv_generic_if(svirt_tcg_t)
@@ -553,6 +556,7 @@ filetrans_pattern(virtd_t, virt_var_run_t, virt_common_var_run_t, dir, "common")
 allow virtlogd_t virt_common_var_run_t:file append_file_perms;
 manage_files_pattern(virtlogd_t, virt_common_var_run_t, virt_common_var_run_t)
 
+manage_files_pattern(virtlogd_t, qemu_var_run_t, qemu_var_run_t)
 manage_dirs_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t)
 manage_files_pattern(virtd_t, virt_lxc_var_run_t, virt_lxc_var_run_t)
 filetrans_pattern(virtd_t, virt_var_run_t, virt_lxc_var_run_t, dir, "lxc")


### PR DESCRIPTION

The commit addresses RHEL-90744 plus further avc's that were found with the newer rhel 9.8