### PR TITLE
Pkcsslotd map tmpfs

### DIFF
--- a/policy/modules/contrib/pkcs.te
+++ b/policy/modules/contrib/pkcs.te
@@ -80,6 +80,7 @@ files_tmp_filetrans(pkcs_slotd_t, pkcs_slotd_tmp_t, dir)
 
 manage_dirs_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
 manage_files_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
+allow pkcs_slotd_t pkcs_slotd_tmpfs_t:file map;
 fs_tmpfs_filetrans(pkcs_slotd_t, pkcs_slotd_tmpfs_t, { file dir })
 
 can_exec(pkcs_slotd_t, pkcs_slotd_exec_t)

--- a/policy/modules/contrib/pkcs.te
+++ b/policy/modules/contrib/pkcs.te
@@ -85,7 +85,11 @@ fs_tmpfs_filetrans(pkcs_slotd_t, pkcs_slotd_tmpfs_t, { file dir })
 
 can_exec(pkcs_slotd_t, pkcs_slotd_exec_t)
 
+kernel_read_proc_files(pkcs_slotd_t)
+
 auth_use_nsswitch(pkcs_slotd_t)
+
+dev_read_sysfs(pkcs_slotd_t)
 
 files_search_locks(pkcs_slotd_t)
 


### PR DESCRIPTION
The fix is also relevant for c9s.

Resolves: https://redhat.atlassian.net/browse/RHEL-155929