### PR TITLE
Allow dhcpc_hook_t unix_dgram_socket and module_request

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -321,6 +321,9 @@ permissive dhcpc_hook_t;
 domtrans_pattern(dhcpc_t, dhcpc_hook_exec_t, dhcpc_hook_t)
 
 allow dhcpc_hook_t self:netlink_route_socket create_netlink_socket_perms;
+allow dhcpc_hook_t self:unix_dgram_socket { create ioctl };
+
+kernel_request_load_module(dhcpc_hook_t)
 
 manage_dirs_pattern(dhcpc_hook_t, dhcpc_var_run_t, dhcpc_var_run_t)
 manage_files_pattern(dhcpc_hook_t, dhcpc_var_run_t, dhcpc_var_run_t)


### PR DESCRIPTION
resolvconf (DHCP client hook) needs to:
- Create and use unix datagram sockets for system service communication
- Request kernel module loads for network device configuration

Resolves: https://redhat.atlassian.net/browse/RHEL-147155

Co-authored by: Claude 