### PR TITLE
Allow xdm dbus chat with rhsmcertd

### DIFF
--- a/policy/modules/services/xserver.te
+++ b/policy/modules/services/xserver.te
@@ -1027,6 +1027,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhsmcertd_dbus_chat(xdm_t)
+')
+
+optional_policy(`
 	# Talk to the console mouse server.
 	gpm_stream_connect(xdm_t)
 	gpm_setattr_gpmctl(xdm_t)


### PR DESCRIPTION
Adds D-Bus communication permissions between xdm_t and rhsmcertd_t.

Resolves: https://redhat.atlassian.net/browse/RHEL-157008

Fixes avc:
type=USER_AVC msg=audit(03/18/2026 12:40:53.280:678) : pid=622 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:rhsmcertd_t:s0 tclass=dbus permissive=0 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'
