### PR TITLE
Allow logwatch to getattr nsfs files

### DIFF
--- a/policy/modules/contrib/logwatch.te
+++ b/policy/modules/contrib/logwatch.te
@@ -87,6 +87,7 @@ files_read_system_conf_files(logwatch_t)
 fs_getattr_all_dirs(logwatch_t)
 fs_getattr_all_fs(logwatch_t)
 fs_getattr_all_dirs(logwatch_t)
+fs_getattr_nsfs_files(logwatch_t)
 fs_dontaudit_list_auto_mountpoints(logwatch_t)
 
 storage_dontaudit_getattr_fixed_disk_dev(logwatch_t)


### PR DESCRIPTION
Fixes AVC denial:
type=AVC msg=audit(03/26/2026 03:25:20.575:370) : avc:  denied  { getattr } for  pid=9113 comm=df path=/run/netns/my-ns dev="nsfs" ino=4026532443 scontext=system_u:system_r:logwatch_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=0

Resolves: [RHEL-160896](https://redhat.atlassian.net/browse/RHEL-160896)