### PR TITLE
Allow systemd-tmpfiles to adjust resource limits

### DIFF
--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -164,6 +164,7 @@ seutil_read_config(setroubleshootd_t)
 seutil_read_default_contexts(setroubleshootd_t)
 seutil_read_file_contexts(setroubleshootd_t)
 
+userdom_dontaudit_read_admin_home_files(setroubleshootd_t)
 userdom_dontaudit_read_user_home_content_files(setroubleshootd_t)
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -663,7 +663,7 @@ optional_policy(`
 # Local policy
 #
 
-allow systemd_tmpfiles_t self:capability { chown dac_read_search dac_override fsetid fowner mknod sys_admin };
+allow systemd_tmpfiles_t self:capability { chown dac_read_search dac_override fsetid fowner mknod sys_admin sys_resource };
 allow systemd_tmpfiles_t self:process { setrlimit setfscreate };
 
 allow systemd_tmpfiles_t self:unix_dgram_socket create_socket_perms;


### PR DESCRIPTION
systemd-tmpfiles attempts to raise the NOFILE rlimit when it detects the current limit is too low. This requires the sys_resource capability to modify resource limits via prlimit64 syscall.

Fixes:
type=AVC msg=audit(01/08/2026 07:31:45.489:389) : avc:  denied  { sys_resource } for  pid=57559 comm=systemd-tmpfile capability=sys_resource  scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:system_r:systemd_tmpfiles_t:s0 tclass=capability permissive=0

Resolves: [RHEL-163080](https://redhat.atlassian.net/browse/RHEL-163080)