### PR TITLE
Dontaudit setroubleshootd read root's home files like .rpmmacros

### DIFF
--- a/policy/modules/contrib/setroubleshoot.te
+++ b/policy/modules/contrib/setroubleshoot.te
@@ -164,6 +164,7 @@ seutil_read_config(setroubleshootd_t)
 seutil_read_default_contexts(setroubleshootd_t)
 seutil_read_file_contexts(setroubleshootd_t)
 
+userdom_dontaudit_read_admin_home_files(setroubleshootd_t)
 userdom_dontaudit_read_user_home_content_files(setroubleshootd_t)
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/28/2026 17:17:24.551:7812) : proctitle=rpm -qf /var/lib/selinux/targeted/active/modules/100/usermanage type=PATH msg=audit(03/28/2026 17:17:24.551:7812) : item=0 name=/root/.rpmmacros inode=105965 dev=00:22 mode=file,644 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:admin_home_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/28/2026 17:17:24.551:7812) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x5561ee873bd0 a2=O_RDONLY a3=0x0 items=1 ppid=285369 pid=285373 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpm exe=/usr/bin/rpm subj=system_u:system_r:setroubleshootd_t:s0 key=(null) type=AVC msg=audit(03/28/2026 17:17:24.551:7812) : avc:  denied  { read } for  pid=285373 comm=rpm name=.rpmmacros dev="nvme0n1p3" ino=105965 scontext=system_u:system_r:setroubleshootd_t:s0 tcontext=unconfined_u:object_r:admin_home_t:s0 tclass=file permissive=0

Resolves: https://redhat.atlassian.net/browse/RHEL-147470