### PR TITLE
Allow svirt_tcg_t to connect to passt sockets

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -574,6 +574,14 @@ optional_policy(`
 	nbdkit_stream_connect(svirt_tcg_t)
 ')
 
+optional_policy(`
+	passt_stream_connect(svirt_tcg_t)
+
+	optional_policy(`
+		userdom_write_user_tmp_sockets(svirt_tcg_t)
+	')
+')
+
 ########################################
 #
 # virtd local policy


### PR DESCRIPTION
The commit addresses the following AVC denial:

```
type=AVC msg=audit(1775752061.555:2582): avc: denied { write }
  for pid=190780 comm="io-task-worker"
  name="8-rocky9-arm64-test-net0.socket" dev="tmpfs" ino=5453
  scontext=unconfined_u:unconfined_r:svirt_tcg_t:s0:c391,c437
  tcontext=unconfined_u:object_r:user_tmp_t:s0
  tclass=sock_file permissive=0
```

When libvirt runs QEMU under TCG (e.g. aarch64 guest on x86_64 host), QEMU runs in the `svirt_tcg_t` domain. The `svirt_t` domain has rules allowing connection to passt sockets for usermode networking, but `svirt_tcg_t` does not. This causes `EACCES` when QEMU's io-task-worker thread tries to connect to the passt unix socket, completely breaking guest networking for TCG VMs using passt.

**Testing:** Built and installed the patched `selinux-policy-targeted` RPM on Fedora 42. Verified that an aarch64 TCG guest with passt networking connects successfully — `info network` in the QEMU monitor shows the stream netdev connected (previously stuck in `connecting`), no AVC denials are generated, and the guest obtains a DHCP lease.