### PR TITLE
Allow accountsd list accountsd_share_t dirs

### DIFF
--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -38,6 +38,7 @@ allow accountsd_t self:fifo_file rw_fifo_file_perms;
 allow accountsd_t self:passwd { rootok passwd chfn chsh };
 
 read_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
+list_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 watch_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 
 manage_dirs_pattern(accountsd_t, accountsd_var_lib_t, accountsd_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(9.4.2026 21:43:15.354:83) : proctitle=/usr/libexec/accounts-daemon type=PATH msg=audit(9.4.2026 21:43:15.354:83) : item=0 name=/usr/share/accountsservice/interfaces inode=52915 dev=00:24 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:accountsd_share_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(9.4.2026 21:43:15.354:83) : arch=x86_64 syscall=openat success=yes exit=7 a0=AT_FDCWD a1=0x55829647f320 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=1 pid=1769 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=accounts-daemon exe=/usr/libexec/accounts-daemon subj=system_u:system_r:accountsd_t:s0 key=(null) type=AVC msg=audit(9.4.2026 21:43:15.354:83) : avc:  denied  { read } for  pid=1769 comm=accounts-daemon path=/usr/share/accountsservice/interfaces dev="dm-0" ino=52915 scontext=system_u:system_r:accountsd_t:s0 tcontext=system_u:object_r:accountsd_share_t:s0 tclass=dir permissive=1