### PR TITLE
Allow sysadm user connect to lvm over a unix stream socket

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -399,6 +399,7 @@ optional_policy(`
 
 optional_policy(`
 	lvm_run(sysadm_t, sysadm_r)
+	lvm_stream_connect(sysadm_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Reproduced e.g. by the "multipath -r" command.
The /usr/bin/multipath is not specifically confined.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/06/2026 03:14:15.110:393) : proctitle=multipath -r type=PATH msg=audit(03/06/2026 03:14:15.110:393) : item=0 name=/run/multipathd.socket inode=1864 dev=00:1b mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:lvm_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(03/06/2026 03:14:15.110:393) : saddr={ saddr_fam=local path=/run/multipathd.socket } type=SYSCALL msg=audit(03/06/2026 03:14:15.110:393) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x3 a1=0x7ffed0e12950 a2=0x19 a3=0x0 items=1 ppid=6300 pid=6336 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts1 ses=4 comm=multipath exe=/usr/sbin/multipath subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(03/06/2026 03:14:15.110:393) : avc:  denied  { connectto } for  pid=6336 comm=multipath path=/run/multipathd.socket scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:lvm_t:s0 tclass=unix_stream_socket permissive=0

Resolves: RHEL-150996