### PR TITLE
WIP: systemd_run policy

### DIFF
--- a/policy/modules/admin/systemd_run.fc
+++ b/policy/modules/admin/systemd_run.fc
@@ -1,7 +1,8 @@
 
-/usr/bin/systemd-run(edit)?	--	gen_context(system_u:object_r:systemd-run_exec_t,s0)
+/usr/bin/systemd-run(edit)?	--	gen_context(system_u:object_r:systemd_run_exec_t,s0)
+/usr/bin/run0(edit)?		--	gen_context(system_u:object_r:systemd_run_exec_t,s0)
 
-/var/db/systemd-run(/.*)?		gen_context(system_u:object_r:systemd-run_db_t,s0)
+/var/db/systemd-run(/.*)?		gen_context(system_u:object_r:systemd_run_db_t,s0)
 
-/var/log/systemd-run-io(/.*)?		gen_context(system_u:object_r:systemd-run_log_t,s0)
-/var/log/systemd-run\.log	--	gen_context(system_u:object_r:systemd-run_log_t,s0)
+/var/log/systemd-run-io(/.*)?		gen_context(system_u:object_r:systemd_run_log_t,s0)
+/var/log/systemd-run\.log	--	gen_context(system_u:object_r:systemd_run_log_t,s0)

--- a/policy/modules/admin/systemd_run.fc
+++ b/policy/modules/admin/systemd_run.fc
@@ -1,0 +1,7 @@
+
+/usr/bin/systemd-run(edit)?	--	gen_context(system_u:object_r:systemd-run_exec_t,s0)
+
+/var/db/systemd-run(/.*)?		gen_context(system_u:object_r:systemd-run_db_t,s0)
+
+/var/log/systemd-run-io(/.*)?		gen_context(system_u:object_r:systemd-run_log_t,s0)
+/var/log/systemd-run\.log	--	gen_context(system_u:object_r:systemd-run_log_t,s0)

--- a/policy/modules/admin/systemd_run.if
+++ b/policy/modules/admin/systemd_run.if
@@ -223,3 +223,79 @@ interface(`systemd_run_filetrans_named_content_log',`
 	logging_log_filetrans($1, systemd_run_log_t, file, "systemd-run.log")
 	logging_log_filetrans($1, systemd_run_log_t, dir, "systemd-run-io")
 ')
+
+########################################
+## <summary>
+##	Allow init to transition into systemd_run domain for run0.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Target systemd_run domain.
+##	</summary>
+## </param>
+#
+interface(`systemd_run_init_transition',`
+	gen_require(`
+		type init_t;
+		class passwd { passwd rootok };
+	')
+
+	domain_auto_transition_pattern(init_t, systemd_run_exec_t, $1)
+	allow init_t $1:key { create write };
+	allow init_t $1:process dyntransition;
+	allow init_t self:process setexec;
+')
+
+########################################
+## <summary>
+##	Allow the given type in system_r for systemd_run sessions.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to be assigned to system_r.
+##	</summary>
+## </param>
+#
+interface(`systemd_run_system_role',`
+	gen_require(`
+		role system_r;
+	')
+
+	role system_r types $1;
+')
+
+########################################
+## <summary>
+##	Allow the given type in unconfined_r for systemd_run sessions.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to be assigned to unconfined_r.
+##	</summary>
+## </param>
+#
+interface(`systemd_run_unconfined_role',`
+	gen_require(`
+		role unconfined_r;
+	')
+
+	role unconfined_r types $1;
+')
+
+########################################
+## <summary>
+##	Read systemd ask-password FIFO files in /run.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_run_read_passwd_run_fifo',`
+	gen_require(`
+		type systemd_passwd_var_run_t;
+	')
+
+	allow $1 systemd_passwd_var_run_t:fifo_file read_fifo_file_perms;
+')

--- a/policy/modules/admin/systemd_run.if
+++ b/policy/modules/admin/systemd_run.if
@@ -57,7 +57,7 @@ template(`systemd_run_role_template',`
 	# Declarations
 	#
 
-	type $1_systemd_run_t, systemd_rundomain; 
+	type $1_systemd_run_t, systemd_rundomain;
 	userdom_user_application_domain($1_systemd_run_t, systemd_run_exec_t)
 	domain_interactive_fd($1_systemd_run_t)
 	domain_role_change_exemption($1_systemd_run_t)
@@ -71,8 +71,8 @@ template(`systemd_run_role_template',`
 	files_tmp_filetrans($1_systemd_run_t, $1_systemd_run_tmp_t, file)
 
 	allow $1_systemd_run_t $3:process getpgid;
-	allow $1_systemd_run_t $3:dir search_dir_perms;;
-	allow $1_systemd_run_t $3:file read_file_perms;;
+	allow $1_systemd_run_t $3:dir search_dir_perms;
+	allow $1_systemd_run_t $3:file read_file_perms;
 	allow $1_systemd_run_t $3:key search;
 
 	allow $1_systemd_run_t $1_t:unix_stream_socket { getattr connectto ioctl read write };
@@ -99,18 +99,10 @@ template(`systemd_run_role_template',`
 	auth_use_nsswitch($1_systemd_run_t)
 
 	logging_send_syslog_msg($1_systemd_run_t)
-    logging_read_syslog_pid($1_systemd_run_t)
+	logging_read_syslog_pid($1_systemd_run_t)
 
-    term_use_generic_ptys($1_systemd_run_t)
-    term_setattr_generic_ptys($1_systemd_run_t)
-
-	optional_policy(`
-		mta_role($2, $1_systemd_run_t)
-	')
-
-    optional_policy(`
-	    rpm_run($1_systemd_run_t, $2)
-    ')
+	term_use_generic_ptys($1_systemd_run_t)
+	term_setattr_generic_ptys($1_systemd_run_t)
 
 	optional_policy(`
 		dmidecode_domtrans($1_systemd_run_t)
@@ -121,13 +113,21 @@ template(`systemd_run_role_template',`
 	')
 
 	optional_policy(`
-	    	kerberos_manage_host_rcache($1_systemd_run_t)
+		kerberos_manage_host_rcache($1_systemd_run_t)
 		kerberos_read_config($1_systemd_run_t)
+	')
+
+	optional_policy(`
+		mta_role($2, $1_systemd_run_t)
 	')
 
 	optional_policy(`
 		netutils_domtrans($1_systemd_run_t)
 		netutils_run_traceroute($1_systemd_run_t, $2)
+	')
+
+	optional_policy(`
+		rpm_run($1_systemd_run_t, $2)
 	')
 
 	optional_policy(`
@@ -149,24 +149,6 @@ template(`systemd_run_role_template',`
 	')
 ')
 
-########################################
-## <summary>
-##	Send a SIGCHLD signal to the systemd_run domain.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`systemd_run_sigchld',`
-	gen_require(`
-		attribute systemd_rundomain;
-	')
-
-	allow $1 systemd_rundomain:process sigchld;
-')
-
 #######################################
 ## <summary>
 ##  Allow execute systemd-run in called domain.
@@ -179,30 +161,11 @@ interface(`systemd_run_sigchld',`
 ## </param>
 #
 interface(`systemd_run_exec',`
-    gen_require(`
-        type systemd_run_exec_t;
-    ')
+	gen_require(`
+		type systemd_run_exec_t;
+	')
 
 	can_exec($1, systemd_run_exec_t)
-')
-
-######################################
-## <summary>
-##  Allow to manage systemd-run database in called domain.
-## </summary>
-## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
-## </param>
-#
-interface(`systemd_run_manage_db',`
-    gen_require(`
-        type systemd_run_db_t;
-    ')
-    
-    manage_dirs_pattern($1, systemd_run_db_t, systemd_run_db_t)
-    manage_files_pattern($1, systemd_run_db_t, systemd_run_db_t)
 ')
 
 ########################################
@@ -246,6 +209,61 @@ interface(`systemd_run_init_transition',`
 	allow init_t self:process setexec;
 ')
 
+######################################
+## <summary>
+##  Allow to manage systemd-run database in called domain.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`systemd_run_manage_db',`
+	gen_require(`
+		type systemd_run_db_t;
+	')
+
+	manage_dirs_pattern($1, systemd_run_db_t, systemd_run_db_t)
+	manage_files_pattern($1, systemd_run_db_t, systemd_run_db_t)
+')
+
+########################################
+## <summary>
+##	Read systemd ask-password FIFO files in /run.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_run_read_passwd_run_fifo',`
+	gen_require(`
+		type systemd_passwd_var_run_t;
+	')
+
+	allow $1 systemd_passwd_var_run_t:fifo_file read_fifo_file_perms;
+')
+
+########################################
+## <summary>
+##	Send a SIGCHLD signal to the systemd_run domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_run_sigchld',`
+	gen_require(`
+		attribute systemd_rundomain;
+	')
+
+	allow $1 systemd_rundomain:process sigchld;
+')
+
 ########################################
 ## <summary>
 ##	Allow the given type in system_r for systemd_run sessions.
@@ -280,22 +298,4 @@ interface(`systemd_run_unconfined_role',`
 	')
 
 	role unconfined_r types $1;
-')
-
-########################################
-## <summary>
-##	Read systemd ask-password FIFO files in /run.
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`systemd_run_read_passwd_run_fifo',`
-	gen_require(`
-		type systemd_passwd_var_run_t;
-	')
-
-	allow $1 systemd_passwd_var_run_t:fifo_file read_fifo_file_perms;
 ')

--- a/policy/modules/admin/systemd_run.if
+++ b/policy/modules/admin/systemd_run.if
@@ -1,8 +1,24 @@
-## <summary>Execute a command with a substitute user</summary>
+## <summary>Execute a command with a substitute user (systemd-run, run0)</summary>
+## <desc>
+##	<p>
+##	run0 is a symlink to systemd-run. Session policy uses type systemd_run_t
+##	(see systemd_run.te) for the PAM stack (e.g. systemd-run0). With
+##	pam_selinux.so, ordered contexts should prefer systemd_run_t over the
+##	interactive user domain (e.g. unconfined_t) so RPM clients (dnf) are covered
+##	by rpm_domtrans(systemd_run_t) in this module instead of requiring broad
+##	entrypoint access on user domains.
+##	</p>
+##	<p>
+##	To build only this module with selinux-policy-devel, use a directory that
+##	contains systemd_run.te, systemd_run.if, and systemd_run.fc only. Do not add
+##	copies of other modules' .if files there; they duplicate
+##	/usr/share/selinux/devel/include and cause M4 duplicate definition warnings.
+##	</p>
+## </desc>
 
 #######################################
 ## <summary>
-##	The role template for the systemd-run module.
+##	The role template for the systemd_run module.
 ## </summary>
 ## <desc>
 ##	<p>
@@ -28,12 +44,12 @@
 ##	</summary>
 ## </param>
 #
-template(`systemd-run_role_template',`
+template(`systemd_run_role_template',`
 
 	gen_require(`
-		type systemd-run_exec_t;
-		type systemd-run_db_t;
-		attribute systemd-rundomain;
+		type systemd_run_exec_t;
+		type systemd_run_db_t;
+		attribute systemd_rundomain;
 	')
 
 	##############################
@@ -41,101 +57,101 @@ template(`systemd-run_role_template',`
 	# Declarations
 	#
 
-	type $1_systemd-run_t, systemd-rundomain; 
-	userdom_user_application_domain($1_systemd-run_t, systemd-run_exec_t)
-	domain_interactive_fd($1_systemd-run_t)
-	domain_role_change_exemption($1_systemd-run_t)
-	role $2 types $1_systemd-run_t;
-	userdom_home_manager($1_systemd-run_t)
+	type $1_systemd_run_t, systemd_rundomain; 
+	userdom_user_application_domain($1_systemd_run_t, systemd_run_exec_t)
+	domain_interactive_fd($1_systemd_run_t)
+	domain_role_change_exemption($1_systemd_run_t)
+	role $2 types $1_systemd_run_t;
+	userdom_home_manager($1_systemd_run_t)
 
-	type $1_systemd-run_tmp_t;
-	files_tmp_file($1_systemd-run_tmp_t)
+	type $1_systemd_run_tmp_t;
+	files_tmp_file($1_systemd_run_tmp_t)
 
-	allow $1_systemd-run_t $1_systemd-run_tmp_t:file manage_file_perms;
-	files_tmp_filetrans($1_systemd-run_t, $1_systemd-run_tmp_t, file)
+	allow $1_systemd_run_t $1_systemd_run_tmp_t:file manage_file_perms;
+	files_tmp_filetrans($1_systemd_run_t, $1_systemd_run_tmp_t, file)
 
-	allow $1_systemd-run_t $3:process getpgid;
-	allow $1_systemd-run_t $3:dir search_dir_perms;;
-	allow $1_systemd-run_t $3:file read_file_perms;;
-	allow $1_systemd-run_t $3:key search;
+	allow $1_systemd_run_t $3:process getpgid;
+	allow $1_systemd_run_t $3:dir search_dir_perms;;
+	allow $1_systemd_run_t $3:file read_file_perms;;
+	allow $1_systemd_run_t $3:key search;
 
-	allow $1_systemd-run_t $1_t:unix_stream_socket { getattr connectto ioctl read write };
+	allow $1_systemd_run_t $1_t:unix_stream_socket { getattr connectto ioctl read write };
 
 	# Enter this derived domain from the user domain
-	domtrans_pattern($3, systemd-run_exec_t, $1_systemd-run_t)
+	domtrans_pattern($3, systemd_run_exec_t, $1_systemd_run_t)
 
 	# By default, revert to the calling domain when a shell is executed.
-	corecmd_shell_domtrans($1_systemd-run_t, $3)
-	corecmd_bin_domtrans($1_systemd-run_t, $3)
-	userdom_domtrans_user_home($1_systemd-run_t, $3)
-	userdom_domtrans_user_tmp($1_systemd-run_t, $3)
-	domain_entry_file($3, systemd-run_exec_t)
-	domain_auto_transition_pattern($1_systemd-run_t, systemd-run_exec_t, $3)
+	corecmd_shell_domtrans($1_systemd_run_t, $3)
+	corecmd_bin_domtrans($1_systemd_run_t, $3)
+	userdom_domtrans_user_home($1_systemd_run_t, $3)
+	userdom_domtrans_user_tmp($1_systemd_run_t, $3)
+	domain_entry_file($3, systemd_run_exec_t)
+	domain_auto_transition_pattern($1_systemd_run_t, systemd_run_exec_t, $3)
 
-	allow $3 $1_systemd-run_t:fd use;
-	allow $3 $1_systemd-run_t:fifo_file rw_fifo_file_perms;
-	allow $3 $1_systemd-run_t:process signal_perms;
+	allow $3 $1_systemd_run_t:fd use;
+	allow $3 $1_systemd_run_t:fifo_file rw_fifo_file_perms;
+	allow $3 $1_systemd_run_t:process signal_perms;
 
-	kernel_read_system_state($1_systemd-run_t)
-	seutil_libselinux_linked($1_systemd-run_t)
+	kernel_read_system_state($1_systemd_run_t)
+	seutil_libselinux_linked($1_systemd_run_t)
 
-	auth_run_chk_passwd($1_systemd-run_t, $2)
-	auth_use_nsswitch($1_systemd-run_t)
+	auth_run_chk_passwd($1_systemd_run_t, $2)
+	auth_use_nsswitch($1_systemd_run_t)
 
-	logging_send_syslog_msg($1_systemd-run_t)
-    logging_read_syslog_pid($1_systemd-run_t)
+	logging_send_syslog_msg($1_systemd_run_t)
+    logging_read_syslog_pid($1_systemd_run_t)
 
-    term_use_generic_ptys($1_systemd-run_t)
-    term_setattr_generic_ptys($1_systemd-run_t)
+    term_use_generic_ptys($1_systemd_run_t)
+    term_setattr_generic_ptys($1_systemd_run_t)
 
 	optional_policy(`
-		mta_role($2, $1_systemd-run_t)
+		mta_role($2, $1_systemd_run_t)
 	')
 
     optional_policy(`
-	    rpm_run($1_systemd-run_t, $2)
+	    rpm_run($1_systemd_run_t, $2)
     ')
 
 	optional_policy(`
-		dmidecode_domtrans($1_systemd-run_t)
+		dmidecode_domtrans($1_systemd_run_t)
 	')
 
 	optional_policy(`
-		iotop_domtrans($1_systemd-run_t)
+		iotop_domtrans($1_systemd_run_t)
 	')
 
 	optional_policy(`
-	    	kerberos_manage_host_rcache($1_systemd-run_t)
-		kerberos_read_config($1_systemd-run_t)
+	    	kerberos_manage_host_rcache($1_systemd_run_t)
+		kerberos_read_config($1_systemd_run_t)
 	')
 
 	optional_policy(`
-		netutils_domtrans($1_systemd-run_t)
-		netutils_run_traceroute($1_systemd-run_t, $2)
+		netutils_domtrans($1_systemd_run_t)
+		netutils_run_traceroute($1_systemd_run_t, $2)
 	')
 
 	optional_policy(`
-		ssh_agent_stream_connect($1_systemd-run_t)
+		ssh_agent_stream_connect($1_systemd_run_t)
 	')
 
 	optional_policy(`
-		systemd_domtrans_systemctl($1_systemd-run_t, $3)
-		systemd_logind_stream_connect($1_systemd-run_t)
+		systemd_domtrans_systemctl($1_systemd_run_t, $3)
+		systemd_logind_stream_connect($1_systemd_run_t)
 		systemd_systemctl_entrypoint($3)
 	')
 
 	optional_policy(`
-		userdom_write_user_tmp_sockets($1_systemd-run_t)
+		userdom_write_user_tmp_sockets($1_systemd_run_t)
 	')
 
 	optional_policy(`
-		usermanage_domtrans_passwd($1_systemd-run_t)
+		usermanage_domtrans_passwd($1_systemd_run_t)
 	')
 ')
 
 ########################################
 ## <summary>
-##	Send a SIGCHLD signal to the systemd-run domain.
+##	Send a SIGCHLD signal to the systemd_run domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -143,12 +159,12 @@ template(`systemd-run_role_template',`
 ##	</summary>
 ## </param>
 #
-interface(`systemd-run_sigchld',`
+interface(`systemd_run_sigchld',`
 	gen_require(`
-		attribute systemd-rundomain;
+		attribute systemd_rundomain;
 	')
 
-	allow $1 systemd-rundomain:process sigchld;
+	allow $1 systemd_rundomain:process sigchld;
 ')
 
 #######################################
@@ -162,12 +178,12 @@ interface(`systemd-run_sigchld',`
 ##  </summary>
 ## </param>
 #
-interface(`systemd-run_exec',`
+interface(`systemd_run_exec',`
     gen_require(`
-        type systemd-run_exec_t;
+        type systemd_run_exec_t;
     ')
 
-	can_exec($1, systemd-run_exec_t)
+	can_exec($1, systemd_run_exec_t)
 ')
 
 ######################################
@@ -180,13 +196,13 @@ interface(`systemd-run_exec',`
 ##  </summary>
 ## </param>
 #
-interface(`systemd-run_manage_db',`
+interface(`systemd_run_manage_db',`
     gen_require(`
-        type systemd-run_db_t;
+        type systemd_run_db_t;
     ')
     
-    manage_dirs_pattern($1, systemd-run_db_t, systemd-run_db_t)
-    manage_files_pattern($1, systemd-run_db_t, systemd-run_db_t)
+    manage_dirs_pattern($1, systemd_run_db_t, systemd_run_db_t)
+    manage_files_pattern($1, systemd_run_db_t, systemd_run_db_t)
 ')
 
 ########################################
@@ -199,11 +215,11 @@ interface(`systemd-run_manage_db',`
 ## </summary>
 ## </param>
 #
-interface(`systemd-run_filetrans_named_content_log',`
+interface(`systemd_run_filetrans_named_content_log',`
 	gen_require(`
-		type systemd-run_log_t;
+		type systemd_run_log_t;
 	')
 
-	logging_log_filetrans($1, systemd-run_log_t, file, "systemd-run.log")
-	logging_log_filetrans($1, systemd-run_log_t, dir, "systemd-run-io")
+	logging_log_filetrans($1, systemd_run_log_t, file, "systemd-run.log")
+	logging_log_filetrans($1, systemd_run_log_t, dir, "systemd-run-io")
 ')

--- a/policy/modules/admin/systemd_run.if
+++ b/policy/modules/admin/systemd_run.if
@@ -1,0 +1,209 @@
+## <summary>Execute a command with a substitute user</summary>
+
+#######################################
+## <summary>
+##	The role template for the systemd-run module.
+## </summary>
+## <desc>
+##	<p>
+##	This template creates a derived domain which is allowed
+##	to change the linux user id, to run commands as a different
+##	user.
+##	</p>
+## </desc>
+## <param name="role_prefix">
+##	<summary>
+##	The prefix of the user role (e.g., user
+##	is the prefix for user_r).
+##	</summary>
+## </param>
+## <param name="user_role">
+##	<summary>
+##	The user role.
+##	</summary>
+## </param>
+## <param name="user_domain">
+##	<summary>
+##	The user domain associated with the role.
+##	</summary>
+## </param>
+#
+template(`systemd-run_role_template',`
+
+	gen_require(`
+		type systemd-run_exec_t;
+		type systemd-run_db_t;
+		attribute systemd-rundomain;
+	')
+
+	##############################
+	#
+	# Declarations
+	#
+
+	type $1_systemd-run_t, systemd-rundomain; 
+	userdom_user_application_domain($1_systemd-run_t, systemd-run_exec_t)
+	domain_interactive_fd($1_systemd-run_t)
+	domain_role_change_exemption($1_systemd-run_t)
+	role $2 types $1_systemd-run_t;
+	userdom_home_manager($1_systemd-run_t)
+
+	type $1_systemd-run_tmp_t;
+	files_tmp_file($1_systemd-run_tmp_t)
+
+	allow $1_systemd-run_t $1_systemd-run_tmp_t:file manage_file_perms;
+	files_tmp_filetrans($1_systemd-run_t, $1_systemd-run_tmp_t, file)
+
+	allow $1_systemd-run_t $3:process getpgid;
+	allow $1_systemd-run_t $3:dir search_dir_perms;;
+	allow $1_systemd-run_t $3:file read_file_perms;;
+	allow $1_systemd-run_t $3:key search;
+
+	allow $1_systemd-run_t $1_t:unix_stream_socket { getattr connectto ioctl read write };
+
+	# Enter this derived domain from the user domain
+	domtrans_pattern($3, systemd-run_exec_t, $1_systemd-run_t)
+
+	# By default, revert to the calling domain when a shell is executed.
+	corecmd_shell_domtrans($1_systemd-run_t, $3)
+	corecmd_bin_domtrans($1_systemd-run_t, $3)
+	userdom_domtrans_user_home($1_systemd-run_t, $3)
+	userdom_domtrans_user_tmp($1_systemd-run_t, $3)
+	domain_entry_file($3, systemd-run_exec_t)
+	domain_auto_transition_pattern($1_systemd-run_t, systemd-run_exec_t, $3)
+
+	allow $3 $1_systemd-run_t:fd use;
+	allow $3 $1_systemd-run_t:fifo_file rw_fifo_file_perms;
+	allow $3 $1_systemd-run_t:process signal_perms;
+
+	kernel_read_system_state($1_systemd-run_t)
+	seutil_libselinux_linked($1_systemd-run_t)
+
+	auth_run_chk_passwd($1_systemd-run_t, $2)
+	auth_use_nsswitch($1_systemd-run_t)
+
+	logging_send_syslog_msg($1_systemd-run_t)
+    logging_read_syslog_pid($1_systemd-run_t)
+
+    term_use_generic_ptys($1_systemd-run_t)
+    term_setattr_generic_ptys($1_systemd-run_t)
+
+	optional_policy(`
+		mta_role($2, $1_systemd-run_t)
+	')
+
+    optional_policy(`
+	    rpm_run($1_systemd-run_t, $2)
+    ')
+
+	optional_policy(`
+		dmidecode_domtrans($1_systemd-run_t)
+	')
+
+	optional_policy(`
+		iotop_domtrans($1_systemd-run_t)
+	')
+
+	optional_policy(`
+	    	kerberos_manage_host_rcache($1_systemd-run_t)
+		kerberos_read_config($1_systemd-run_t)
+	')
+
+	optional_policy(`
+		netutils_domtrans($1_systemd-run_t)
+		netutils_run_traceroute($1_systemd-run_t, $2)
+	')
+
+	optional_policy(`
+		ssh_agent_stream_connect($1_systemd-run_t)
+	')
+
+	optional_policy(`
+		systemd_domtrans_systemctl($1_systemd-run_t, $3)
+		systemd_logind_stream_connect($1_systemd-run_t)
+		systemd_systemctl_entrypoint($3)
+	')
+
+	optional_policy(`
+		userdom_write_user_tmp_sockets($1_systemd-run_t)
+	')
+
+	optional_policy(`
+		usermanage_domtrans_passwd($1_systemd-run_t)
+	')
+')
+
+########################################
+## <summary>
+##	Send a SIGCHLD signal to the systemd-run domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd-run_sigchld',`
+	gen_require(`
+		attribute systemd-rundomain;
+	')
+
+	allow $1 systemd-rundomain:process sigchld;
+')
+
+#######################################
+## <summary>
+##  Allow execute systemd-run in called domain.
+##  This interfaces is added for nova-stack policy.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`systemd-run_exec',`
+    gen_require(`
+        type systemd-run_exec_t;
+    ')
+
+	can_exec($1, systemd-run_exec_t)
+')
+
+######################################
+## <summary>
+##  Allow to manage systemd-run database in called domain.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`systemd-run_manage_db',`
+    gen_require(`
+        type systemd-run_db_t;
+    ')
+    
+    manage_dirs_pattern($1, systemd-run_db_t, systemd-run_db_t)
+    manage_files_pattern($1, systemd-run_db_t, systemd-run_db_t)
+')
+
+########################################
+## <summary>
+## 	Transition to systemd-run log named content
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`systemd-run_filetrans_named_content_log',`
+	gen_require(`
+		type systemd-run_log_t;
+	')
+
+	logging_log_filetrans($1, systemd-run_log_t, file, "systemd-run.log")
+	logging_log_filetrans($1, systemd-run_log_t, dir, "systemd-run-io")
+')

--- a/policy/modules/admin/systemd_run.te
+++ b/policy/modules/admin/systemd_run.te
@@ -1,4 +1,4 @@
-policy_module(systemd_run, 1.10.9)
+policy_module(systemd_run, 1.10.11)
 
 
 ########################################
@@ -230,6 +230,30 @@ optional_policy(`
 	systemd_exec_systemctl(systemd_run_t)
 	systemd_systemctl_entrypoint(systemd_run_t)
 	systemd_write_inherited_logind_sessions_pipes(systemd_rundomain)
+')
+
+# See support/run0-pam-test.md § "Simple vs complex use cases" for passwd/polkit/init assessment.
+# Prefer domtrans to dedicated types over exec-only bits where optional modules link.
+optional_policy(`
+	auth_domtrans_chkpwd(systemd_run_t)
+')
+optional_policy(`
+	systemd_passwd_agent_domtrans(systemd_run_t)
+	systemd_signal_passwd_agent(systemd_run_t)
+	gen_require(`
+		type systemd_passwd_agent_t;
+		type user_tmp_t;
+	')
+	# ask-password may live under the callers XDG runtime dir (/run/user/<uid>/systemd/…)
+	allow systemd_passwd_agent_t user_tmp_t:dir { getattr open read search watch watch_reads };
+')
+optional_policy(`
+	policykit_domtrans_auth(systemd_run_t)
+	policykit_dbus_chat(systemd_run_t)
+')
+optional_policy(`
+	init_status(systemd_run_t)
+	init_start(systemd_run_t)
 ')
 
 ########################################

--- a/policy/modules/admin/systemd_run.te
+++ b/policy/modules/admin/systemd_run.te
@@ -1,9 +1,5 @@
-policy_module(systemd_run, 1.10.8)
+policy_module(systemd_run, 1.10.9)
 
-# systemd-run and run0 (symlink): PAM session domain is systemd_run_t; the invoked
-# command (e.g. dnf, sleep, shell) often runs in the same domain or transitions via
-# rpm_domtrans. Rules below were tightened from run0/dnf regressions and related AVCs
-# (init_t starting run0, PAM/auth, RPM, logind/session pipes, /run and pid paths).
 
 ########################################
 #
@@ -116,7 +112,8 @@ domain_use_interactive_fds(systemd_rundomain)
 files_dontaudit_search_home(systemd_rundomain)
 files_list_tmp(systemd_rundomain)
 files_list_var(systemd_rundomain)
-# run0 dnf: systemd_run_t may run dnf without transition to rpm_t
+# /run pid files and similar (session/package metadata). run0 stays systemd_run_t; /usr/bin/dnf
+# still transitions to rpm_t when executed (rpm_domtrans), as seen under run0/dnf check-update.
 files_manage_all_pids(systemd_rundomain)
 files_manage_generic_tmp_dirs(systemd_rundomain)
 files_manage_generic_tmp_files(systemd_rundomain)

--- a/policy/modules/admin/systemd_run.te
+++ b/policy/modules/admin/systemd_run.te
@@ -1,191 +1,232 @@
-policy_module(systemd-run, 1.10.0)
+policy_module(systemd_run, 1.10.7)
 
 gen_require(`
 	class passwd { passwd rootok };
-	type unconfined_t;
+	type init_t;
+	type rpm_exec_t;
+	type systemd_passwd_var_run_t;
 ')
 
 ########################################
 #
 # Declarations
-attribute systemd-rundomain;
-
-# Define the actual domain type
-type systemd-run_t, systemd-rundomain;
-domain_type(systemd-run_t)
-
-type systemd-run_exec_t;
-application_executable_file(systemd-run_exec_t)
-
-type systemd-run_db_t;
-files_type(systemd-run_db_t)
-mls_trusted_object(systemd-run_db_t)
-
-type systemd-run_log_t;
-logging_log_file(systemd-run_log_t)
-
-manage_dirs_pattern(systemd-rundomain, systemd-run_db_t, systemd-run_db_t)
-manage_files_pattern(systemd-rundomain, systemd-run_db_t, systemd-run_db_t)
-
-manage_dirs_pattern(systemd-rundomain, systemd-run_log_t, systemd-run_log_t)
-manage_files_pattern(systemd-rundomain, systemd-run_log_t, systemd-run_log_t)
-logging_log_filetrans(systemd-rundomain, systemd-run_log_t, dir, "systemd-run-io")
-logging_log_filetrans(systemd-rundomain, systemd-run_log_t, file, "systemd-run.log")
-
-
-# Macro handles the transition from unconfined to systemd-run_t
-domain_auto_transition_pattern(unconfined_t, systemd-run_exec_t, systemd-run_t)
-
-# Use the specific TYPE for domain transitions
-corecmd_shell_domtrans(systemd-run_t, systemd-run_t)
-userdom_spec_domtrans_all_users(systemd-run_t)
-
-##############################
 #
-# Local Policy
-#
+attribute systemd_rundomain;
 
-allow systemd-run_t systemd-run_exec_t:file entrypoint;
+type systemd_run_t, systemd_rundomain;
+domain_type(systemd_run_t)
+domain_obj_id_change_exemption(systemd_run_t)
+# run0: init_t -> unconfined_u:system_r:systemd_run_t needs process_user_target (policy/constraints).
+domain_user_exemption_target(systemd_run_t)
 
-# (This happens when systemd-run executes a shell)
-allow systemd-run_t systemd-run_exec_t:file { getattr read map execute open };
+type systemd_run_exec_t;
+application_executable_file(systemd_run_exec_t)
 
-gen_require(`
-    type unconfined_t;
-    type rpm_t;
-    type rpm_exec_t;
-    type init_var_run_t;
-    role unconfined_r;
-')
+type systemd_run_db_t;
+files_type(systemd_run_db_t)
+mls_trusted_object(systemd_run_db_t)
+
+type systemd_run_log_t;
+logging_log_file(systemd_run_log_t)
+
+manage_dirs_pattern(systemd_rundomain, systemd_run_db_t, systemd_run_db_t)
+manage_files_pattern(systemd_rundomain, systemd_run_db_t, systemd_run_db_t)
+
+manage_dirs_pattern(systemd_rundomain, systemd_run_log_t, systemd_run_log_t)
+manage_files_pattern(systemd_rundomain, systemd_run_log_t, systemd_run_log_t)
+logging_log_filetrans(systemd_rundomain, systemd_run_log_t, dir, "systemd-run-io")
+logging_log_filetrans(systemd_rundomain, systemd_run_log_t, file, "systemd-run.log")
 
 ########################################
-# Fix the entrypoint for systemd-run itself
-allow systemd-run_t systemd-run_exec_t:file entrypoint;
+#
+# Exec transitions into systemd_run_t
+#
+unconfined_domtrans_to(systemd_run_t, systemd_run_exec_t)
+# run0: init_t execs run0 (systemd_run_exec_t)
+domain_auto_transition_pattern(init_t, systemd_run_exec_t, systemd_run_t)
 
-# Fix the /run/systemd search
-allow systemd-run_t init_var_run_t:dir search;
+########################################
+#
+# Roles (default_contexts / pam_selinux session for systemd_run_t)
+#
+gen_require(`
+	role unconfined_r;
+	role system_r;
+')
+role unconfined_r types systemd_run_t;
+role system_r types systemd_run_t;
 
-# 3. Explicitly allow systemd-run_t to run RPM
-allow systemd-run_t rpm_exec_t:file { getattr open read execute map };
-type_transition systemd-run_t rpm_exec_t:process rpm_t;
-allow systemd-run_t rpm_t:process transition;
 
-# Transition to standard shells
-corecmd_shell_domtrans(systemd-run_t, systemd-run_t)
+########################################
+#
+# run0: PAM session systemd_run_t; init_t execs user command (dnf, sleep, …)
+#
+# domain_auto_transition_pattern(init_t, …) supplies allow init_t systemd_run_t:process transition.
+allow init_t systemd_run_t:key { create write };
+allow init_t systemd_run_t:process dyntransition;
+allow init_t self:process setexec;
+init_signal(systemd_run_t)
 
-type_transition unconfined_t rpm_exec_t:process rpm_t;
-allow unconfined_t rpm_t:process transition;
+# systemd-run binary (shell path and run0)
+allow systemd_run_t systemd_run_exec_t:file { getattr read map execute open entrypoint };
 
-# Use capabilities.
-allow systemd-rundomain self:capability { chown fowner setuid setgid dac_read_search dac_override sys_nice sys_resource };
-dontaudit systemd-rundomain self:capability net_admin;
-allow systemd-rundomain self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
-allow systemd-rundomain self:process { setexec setrlimit };
-allow systemd-rundomain self:fd use;
-allow systemd-rundomain self:fifo_file rw_fifo_file_perms;
-allow systemd-rundomain self:shm create_shm_perms;
-allow systemd-rundomain self:sem create_sem_perms;
-allow systemd-rundomain self:msgq create_msgq_perms;
-allow systemd-rundomain self:msg { send receive };
-allow systemd-rundomain self:unix_dgram_socket create_socket_perms;
-allow systemd-rundomain self:unix_stream_socket create_stream_socket_perms;
-allow systemd-rundomain self:unix_dgram_socket sendto;
-allow systemd-rundomain self:unix_stream_socket connectto;
-allow systemd-rundomain self:key manage_key_perms;
-allow systemd-rundomain self:netlink_kobject_uevent_socket create_socket_perms;
-allow systemd-rundomain self:netlink_selinux_socket create_socket_perms;
-allow systemd-rundomain self:passwd { passwd rootok };
+files_search_pids(systemd_run_t)
 
-kernel_getattr_core_if(systemd-rundomain)
-kernel_link_key(systemd-rundomain)
-kernel_read_kernel_sysctls(systemd-rundomain)
+# RPM transition when run0 executes dnf/rpm binaries.
+allow systemd_run_t rpm_exec_t:file entrypoint;
+optional_policy(`
+	rpm_domtrans(systemd_run_t)
+')
 
-corecmd_read_bin_symlinks(systemd-rundomain)
-corecmd_exec_all_executables(systemd-rundomain)
+# Generic commands in same domain (corecmd_exec_all_executables lacks entrypoint)
+allow systemd_rundomain bin_t:file entrypoint;
 
-dev_getattr_fs(systemd-rundomain)
-dev_read_urand(systemd-rundomain)
-dev_rw_generic_usb_dev(systemd-rundomain)
-dev_read_sysfs(systemd-rundomain)
-dev_dontaudit_getattr_all(systemd-rundomain)
+corecmd_shell_domtrans(systemd_run_t, systemd_run_t)
+corecmd_shell_entry_type(systemd_run_t)
+userdom_spec_domtrans_all_users(systemd_run_t)
 
-domain_use_interactive_fds(systemd-rundomain)
-domain_sigchld_interactive_fds(systemd-rundomain)
-domain_getattr_all_entry_files(systemd-rundomain)
+########################################
+#
+# Capabilities and self
+#
+allow systemd_rundomain self:capability { chown fowner setuid setgid dac_read_search dac_override sys_nice sys_resource };
+dontaudit systemd_rundomain self:capability net_admin;
+allow systemd_rundomain self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
+allow systemd_rundomain self:process { setexec setfscreate setrlimit };
+allow systemd_rundomain self:fd use;
+allow systemd_rundomain self:fifo_file rw_fifo_file_perms;
+allow systemd_rundomain self:shm create_shm_perms;
+allow systemd_rundomain self:sem create_sem_perms;
+allow systemd_rundomain self:msgq create_msgq_perms;
+allow systemd_rundomain self:msg { send receive };
+allow systemd_rundomain self:unix_dgram_socket create_socket_perms;
+allow systemd_rundomain self:unix_stream_socket create_stream_socket_perms;
+allow systemd_rundomain self:unix_dgram_socket sendto;
+allow systemd_rundomain self:unix_stream_socket connectto;
+allow systemd_rundomain self:key manage_key_perms;
+allow systemd_rundomain self:netlink_kobject_uevent_socket create_socket_perms;
+allow systemd_rundomain self:netlink_selinux_socket create_socket_perms;
+allow systemd_rundomain self:passwd { passwd rootok };
 
-files_read_etc_files(systemd-rundomain)
-files_list_var(systemd-rundomain)
-files_read_var_files(systemd-rundomain)
-files_read_usr_files(systemd-rundomain)
-# for some PAM modules and for cwd
-files_dontaudit_search_home(systemd-rundomain)
-files_list_tmp(systemd-rundomain)
+kernel_getattr_core_if(systemd_rundomain)
+kernel_read_system_state(systemd_run_t)
+kernel_link_key(systemd_rundomain)
+kernel_read_kernel_sysctls(systemd_rundomain)
+kernel_read_fs_sysctls(systemd_rundomain)
 
-fs_search_auto_mountpoints(systemd-rundomain)
-fs_getattr_all_fs(systemd-rundomain)
+corecmd_read_bin_symlinks(systemd_rundomain)
+corecmd_exec_all_executables(systemd_rundomain)
 
-selinux_validate_context(systemd-rundomain)
-selinux_compute_relabel_context(systemd-rundomain)
-selinux_compute_access_vector(systemd-rundomain)
+dev_getattr_fs(systemd_rundomain)
+dev_read_urand(systemd_rundomain)
+dev_rw_generic_usb_dev(systemd_rundomain)
+dev_read_sysfs(systemd_rundomain)
+dev_dontaudit_getattr_all(systemd_rundomain)
 
-term_getattr_pty_fs(systemd-rundomain)
-term_relabel_all_ttys(systemd-rundomain)
-term_relabel_all_ptys(systemd-rundomain)
-term_use_ptmx(systemd-rundomain)
+domain_use_interactive_fds(systemd_rundomain)
+domain_sigchld_interactive_fds(systemd_rundomain)
+domain_getattr_all_entry_files(systemd_rundomain)
+domain_read_all_domains_state(systemd_rundomain)
+domain_getattr_all_domains(systemd_rundomain)
 
-#auth_run_chk_passwd(systemd-rundomain)
-# systemd-run stores a token in the pam_pid directory
-auth_manage_pam_pid(systemd-rundomain)
-auth_manage_faillog(systemd-rundomain)
-auth_read_var_auth(systemd-rundomain)
-auth_rw_lastlog(systemd-rundomain)
+files_read_etc_files(systemd_rundomain)
+files_list_var(systemd_rundomain)
+files_read_var_files(systemd_rundomain)
+files_read_usr_files(systemd_rundomain)
+files_dontaudit_search_home(systemd_rundomain)
+files_list_tmp(systemd_rundomain)
+# run0 dnf: systemd_run_t may run dnf without transition to rpm_t
+files_rw_generic_pids(systemd_rundomain)
+files_rw_pid_dirs(systemd_rundomain)
+files_manage_all_pids(systemd_rundomain)
+files_manage_generic_tmp_dirs(systemd_rundomain)
+files_manage_generic_tmp_files(systemd_rundomain)
+userdom_list_admin_dir(systemd_rundomain)
+userdom_read_admin_home_files(systemd_rundomain)
+logging_append_all_logs(systemd_rundomain)
+logging_read_all_logs(systemd_rundomain)
+sysnet_read_config(systemd_rundomain)
+allow systemd_rundomain self:netlink_route_socket create_netlink_socket_perms;
+allow systemd_rundomain self:netlink_route_socket nlmsg_read;
+allow systemd_rundomain self:udp_socket create_socket_perms;
+allow systemd_rundomain self:udp_socket connect;
+optional_policy(`
+	rpm_manage_db(systemd_rundomain)
+	rpm_read_cache(systemd_rundomain)
+')
+optional_policy(`
+	miscfiles_read_generic_certs(systemd_rundomain)
+')
+allow systemd_rundomain systemd_passwd_var_run_t:fifo_file read_fifo_file_perms;
+systemd_passwd_watch_pid_dirs(systemd_rundomain)
+userdom_watch_tmp_dirs(systemd_rundomain)
 
-application_signal(systemd-rundomain)
+fs_search_auto_mountpoints(systemd_rundomain)
+fs_getattr_all_fs(systemd_rundomain)
+fs_getattr_nsfs_files(systemd_rundomain)
 
-init_rw_utmp(systemd-rundomain)
+selinux_validate_context(systemd_rundomain)
+selinux_compute_relabel_context(systemd_rundomain)
+selinux_compute_access_vector(systemd_rundomain)
 
-logging_send_audit_msgs(systemd-rundomain)
-logging_set_audit_parameters(systemd-rundomain)
+term_getattr_pty_fs(systemd_rundomain)
+term_relabel_all_ttys(systemd_rundomain)
+term_relabel_all_ptys(systemd_rundomain)
+term_use_ptmx(systemd_rundomain)
 
-seutil_read_default_contexts(systemd-rundomain)
+#auth_run_chk_passwd(systemd_rundomain)
+auth_manage_pam_pid(systemd_rundomain)
+auth_manage_faillog(systemd_rundomain)
+auth_read_passwd(systemd_rundomain)
+auth_read_var_auth(systemd_rundomain)
+auth_rw_lastlog(systemd_rundomain)
 
-userdom_spec_domtrans_all_users(systemd-rundomain)
-userdom_manage_user_home_content_files(systemd-rundomain)
-userdom_manage_user_home_content_symlinks(systemd-rundomain)
-userdom_manage_user_tmp_files(systemd-rundomain)
-userdom_manage_user_tmp_symlinks(systemd-rundomain)
-userdom_use_user_terminals(systemd-rundomain)
-userdom_create_user_pty(systemd-rundomain)
-userdom_setattr_user_ptys(systemd-rundomain)
-userdom_setattr_user_ttys(systemd-rundomain)
-userdom_signal_all_users(systemd-rundomain)
-userdom_exec_user_home_content_files(systemd-rundomain)
-# for some PAM modules and for cwd
-userdom_search_user_home_content(systemd-rundomain)
-userdom_search_admin_dir(systemd-rundomain)
-userdom_manage_all_users_keys(systemd-rundomain)
+application_signal(systemd_rundomain)
+
+init_rw_utmp(systemd_rundomain)
+
+logging_send_audit_msgs(systemd_rundomain)
+logging_set_audit_parameters(systemd_rundomain)
+
+seutil_read_default_contexts(systemd_rundomain)
+
+userdom_manage_user_home_content_files(systemd_rundomain)
+userdom_manage_user_home_content_symlinks(systemd_rundomain)
+userdom_manage_user_tmp_files(systemd_rundomain)
+userdom_manage_user_tmp_symlinks(systemd_rundomain)
+userdom_use_user_terminals(systemd_rundomain)
+userdom_create_user_pty(systemd_rundomain)
+userdom_setattr_user_ptys(systemd_rundomain)
+userdom_setattr_user_ttys(systemd_rundomain)
+userdom_signal_all_users(systemd_rundomain)
+userdom_exec_user_home_content_files(systemd_rundomain)
+userdom_search_user_home_content(systemd_rundomain)
+userdom_search_admin_dir(systemd_rundomain)
+userdom_manage_all_users_keys(systemd_rundomain)
 
 tunable_policy(`authlogin_yubikey',`
-    auth_manage_home_content(systemd-rundomain)
+	auth_manage_home_content(systemd_rundomain)
 ')
 
 optional_policy(`
-	dbus_system_bus_client(systemd-rundomain)
-
-	optional_policy(`
-		systemd_dbus_chat_logind(systemd-rundomain)
-		init_getpgid(systemd-rundomain)
-	')
+	dbus_system_bus_client(systemd_rundomain)
 ')
 
 optional_policy(`
-	ssh_signull(systemd-rundomain)
+	systemd_exec_systemctl(systemd_run_t)
+	systemd_systemctl_entrypoint(systemd_run_t)
+	systemd_dbus_chat_logind(systemd_rundomain)
+	init_getpgid(systemd_rundomain)
 ')
 
 optional_policy(`
-    systemd_write_inherited_logind_sessions_pipes(systemd-rundomain)
+	ssh_signull(systemd_rundomain)
 ')
 
 optional_policy(`
-	fprintd_dbus_chat(systemd-rundomain)
+	systemd_write_inherited_logind_sessions_pipes(systemd_rundomain)
+')
+
+optional_policy(`
+	fprintd_dbus_chat(systemd_rundomain)
 ')

--- a/policy/modules/admin/systemd_run.te
+++ b/policy/modules/admin/systemd_run.te
@@ -1,4 +1,9 @@
-policy_module(systemd_run, 1.10.7)
+policy_module(systemd_run, 1.10.8)
+
+# systemd-run and run0 (symlink): PAM session domain is systemd_run_t; the invoked
+# command (e.g. dnf, sleep, shell) often runs in the same domain or transitions via
+# rpm_domtrans. Rules below were tightened from run0/dnf regressions and related AVCs
+# (init_t starting run0, PAM/auth, RPM, logind/session pipes, /run and pid paths).
 
 ########################################
 #
@@ -7,13 +12,11 @@ policy_module(systemd_run, 1.10.7)
 attribute systemd_rundomain;
 
 type systemd_run_t, systemd_rundomain;
-domain_type(systemd_run_t)
+type systemd_run_exec_t;
+application_domain(systemd_run_t, systemd_run_exec_t)
 domain_obj_id_change_exemption(systemd_run_t)
 # run0: init_t -> unconfined_u:system_r:systemd_run_t needs process_user_target (policy/constraints).
 domain_user_exemption_target(systemd_run_t)
-
-type systemd_run_exec_t;
-application_executable_file(systemd_run_exec_t)
 
 type systemd_run_db_t;
 files_type(systemd_run_db_t)
@@ -30,48 +33,18 @@ manage_files_pattern(systemd_rundomain, systemd_run_log_t, systemd_run_log_t)
 logging_log_filetrans(systemd_rundomain, systemd_run_log_t, dir, "systemd-run-io")
 logging_log_filetrans(systemd_rundomain, systemd_run_log_t, file, "systemd-run.log")
 
-########################################
-#
-# Exec transitions into systemd_run_t
-#
-unconfined_domtrans_to(systemd_run_t, systemd_run_exec_t)
-# run0: init_t execs run0 (systemd_run_exec_t)
-systemd_run_init_transition(systemd_run_t)
+# Paths: /var/db/systemd-run, /var/log/systemd-run* (see systemd_run.fc).
 
 ########################################
 #
-# Roles (default_contexts / pam_selinux session for systemd_run_t)
+# systemd_run domain
 #
-systemd_run_unconfined_role(systemd_run_t)
-systemd_run_system_role(systemd_run_t)
-
 
 ########################################
 #
-# run0: PAM session systemd_run_t; init_t execs user command (dnf, sleep, ...).
-init_signal(systemd_run_t)
-
-# systemd-run binary (shell path and run0)
-allow systemd_run_t systemd_run_exec_t:file { getattr read map execute open entrypoint };
-
-files_search_pids(systemd_run_t)
-
-# RPM transition when run0 executes dnf/rpm binaries.
-optional_policy(`
-	rpm_entry_type(systemd_run_t)
-	rpm_domtrans(systemd_run_t)
-')
-
-# Generic commands in same domain (corecmd_exec_all_executables lacks entrypoint)
-allow systemd_rundomain bin_t:file entrypoint;
-
-corecmd_shell_domtrans(systemd_run_t, systemd_run_t)
-corecmd_shell_entry_type(systemd_run_t)
-userdom_spec_domtrans_all_users(systemd_run_t)
-
-########################################
-#
-# Capabilities and self
+# Self
+# (setuid/setgid and DAC for id switching; passwd class for PAM/stack; keys for
+# session keyring; route/udp often hit by nss or short-lived clients under the command)
 #
 allow systemd_rundomain self:capability { chown fowner setuid setgid dac_read_search dac_override sys_nice sys_resource };
 dontaudit systemd_rundomain self:capability net_admin;
@@ -89,131 +62,182 @@ allow systemd_rundomain self:unix_dgram_socket sendto;
 allow systemd_rundomain self:unix_stream_socket connectto;
 allow systemd_rundomain self:key manage_key_perms;
 allow systemd_rundomain self:netlink_kobject_uevent_socket create_socket_perms;
-allow systemd_rundomain self:netlink_selinux_socket create_socket_perms;
-allow systemd_rundomain self:passwd { passwd rootok };
-
-kernel_getattr_core_if(systemd_rundomain)
-kernel_read_system_state(systemd_run_t)
-kernel_link_key(systemd_rundomain)
-kernel_read_kernel_sysctls(systemd_rundomain)
-kernel_read_fs_sysctls(systemd_rundomain)
-
-corecmd_read_bin_symlinks(systemd_rundomain)
-corecmd_exec_all_executables(systemd_rundomain)
-
-dev_getattr_fs(systemd_rundomain)
-dev_read_urand(systemd_rundomain)
-dev_rw_generic_usb_dev(systemd_rundomain)
-dev_read_sysfs(systemd_rundomain)
-dev_dontaudit_getattr_all(systemd_rundomain)
-
-domain_use_interactive_fds(systemd_rundomain)
-domain_sigchld_interactive_fds(systemd_rundomain)
-domain_getattr_all_entry_files(systemd_rundomain)
-domain_read_all_domains_state(systemd_rundomain)
-domain_getattr_all_domains(systemd_rundomain)
-
-files_read_etc_files(systemd_rundomain)
-files_list_var(systemd_rundomain)
-files_read_var_files(systemd_rundomain)
-files_read_usr_files(systemd_rundomain)
-files_dontaudit_search_home(systemd_rundomain)
-files_list_tmp(systemd_rundomain)
-# run0 dnf: systemd_run_t may run dnf without transition to rpm_t
-files_rw_generic_pids(systemd_rundomain)
-files_rw_pid_dirs(systemd_rundomain)
-files_manage_all_pids(systemd_rundomain)
-files_manage_generic_tmp_dirs(systemd_rundomain)
-files_manage_generic_tmp_files(systemd_rundomain)
-userdom_list_admin_dir(systemd_rundomain)
-userdom_read_admin_home_files(systemd_rundomain)
-logging_append_all_logs(systemd_rundomain)
-logging_read_all_logs(systemd_rundomain)
-sysnet_read_config(systemd_rundomain)
 allow systemd_rundomain self:netlink_route_socket create_netlink_socket_perms;
 allow systemd_rundomain self:netlink_route_socket nlmsg_read;
+allow systemd_rundomain self:netlink_selinux_socket create_socket_perms;
+allow systemd_rundomain self:passwd { passwd rootok };
 allow systemd_rundomain self:udp_socket create_socket_perms;
 allow systemd_rundomain self:udp_socket connect;
-optional_policy(`
-	rpm_manage_db(systemd_rundomain)
-	rpm_read_cache(systemd_rundomain)
-')
-optional_policy(`
-	miscfiles_read_generic_certs(systemd_rundomain)
-')
-systemd_run_read_passwd_run_fifo(systemd_rundomain)
-systemd_passwd_watch_pid_dirs(systemd_rundomain)
-userdom_watch_tmp_dirs(systemd_rundomain)
 
-fs_search_auto_mountpoints(systemd_rundomain)
-fs_getattr_all_fs(systemd_rundomain)
-fs_getattr_nsfs_files(systemd_rundomain)
+########################################
+#
+# Local rules (objects in this module)
+# Interactive shell and transitions to target user domains after PAM (run0 --user, etc.).
+#
+corecmd_shell_domtrans(systemd_run_t, systemd_run_t)
+corecmd_shell_entry_type(systemd_run_t)
+userdom_spec_domtrans_all_users(systemd_run_t)
 
-selinux_validate_context(systemd_rundomain)
-selinux_compute_relabel_context(systemd_rundomain)
-selinux_compute_access_vector(systemd_rundomain)
+files_search_pids(systemd_run_t)
 
-term_getattr_pty_fs(systemd_rundomain)
-term_relabel_all_ttys(systemd_rundomain)
-term_relabel_all_ptys(systemd_rundomain)
-term_use_ptmx(systemd_rundomain)
+########################################
+#
+# Calls to other modules (alphabetical)
+#
+# Auth stack for session login (faillock, lastlog, nss, pam paths).
+application_signal(systemd_rundomain)
 
 #auth_run_chk_passwd(systemd_rundomain)
-auth_manage_pam_pid(systemd_rundomain)
 auth_manage_faillog(systemd_rundomain)
+auth_manage_pam_pid(systemd_rundomain)
 auth_read_passwd(systemd_rundomain)
 auth_read_var_auth(systemd_rundomain)
 auth_rw_lastlog(systemd_rundomain)
 
-application_signal(systemd_rundomain)
+# corecmd_exec_all_executables lacks entrypoint on generic bin programs
+corecmd_bin_entry_type(systemd_rundomain)
+corecmd_exec_all_executables(systemd_rundomain)
+corecmd_read_bin_symlinks(systemd_rundomain)
 
+# Devices and sysfs commonly touched by libc/tooling in arbitrary commands.
+dev_dontaudit_getattr_all(systemd_rundomain)
+dev_getattr_fs(systemd_rundomain)
+dev_read_sysfs(systemd_rundomain)
+dev_read_urand(systemd_rundomain)
+dev_rw_generic_usb_dev(systemd_rundomain)
+
+domain_getattr_all_domains(systemd_rundomain)
+domain_getattr_all_entry_files(systemd_rundomain)
+domain_read_all_domains_state(systemd_rundomain)
+domain_sigchld_interactive_fds(systemd_rundomain)
+domain_use_interactive_fds(systemd_rundomain)
+
+# Broad file access: package managers use /var/run and tmp; list/read system config.
+files_dontaudit_search_home(systemd_rundomain)
+files_list_tmp(systemd_rundomain)
+files_list_var(systemd_rundomain)
+# run0 dnf: systemd_run_t may run dnf without transition to rpm_t
+files_manage_all_pids(systemd_rundomain)
+files_manage_generic_tmp_dirs(systemd_rundomain)
+files_manage_generic_tmp_files(systemd_rundomain)
+files_read_etc_files(systemd_rundomain)
+files_read_usr_files(systemd_rundomain)
+files_read_var_files(systemd_rundomain)
+files_rw_generic_pids(systemd_rundomain)
+files_rw_pid_dirs(systemd_rundomain)
+
+fs_getattr_all_fs(systemd_rundomain)
+fs_getattr_nsfs_files(systemd_rundomain)
+fs_search_auto_mountpoints(systemd_rundomain)
+
+# Session accounting (login/wtmp) when PAM treats this as a session domain.
 init_rw_utmp(systemd_rundomain)
+# PID 1 may signal the run0/systemd-run child (e.g. unit lifecycle).
+init_signal(systemd_run_t)
 
+kernel_getattr_core_if(systemd_rundomain)
+kernel_link_key(systemd_rundomain)
+kernel_read_fs_sysctls(systemd_rundomain)
+kernel_read_kernel_sysctls(systemd_rundomain)
+kernel_read_system_state(systemd_run_t)
+
+logging_append_all_logs(systemd_rundomain)
+logging_read_all_logs(systemd_rundomain)
 logging_send_audit_msgs(systemd_rundomain)
 logging_set_audit_parameters(systemd_rundomain)
 
+# libselinux / default_contexts for pam_selinux and context computation.
 seutil_read_default_contexts(systemd_rundomain)
 
+selinux_compute_access_vector(systemd_rundomain)
+selinux_compute_relabel_context(systemd_rundomain)
+selinux_validate_context(systemd_rundomain)
+
+sysnet_read_config(systemd_rundomain)
+
+# systemd ask-password agent under /run/systemd (e.g. polkit/password prompts).
+systemd_passwd_watch_pid_dirs(systemd_rundomain)
+
+# run0: init_t executes /usr/bin/run0 and PAM session uses systemd_run_t; roles for
+# default_contexts / pam_selinux ordered role (unconfined_u + system_r).
+systemd_run_init_transition(systemd_run_t)
+# Read side of systemd ask-password FIFO (run0 password prompts).
+systemd_run_read_passwd_run_fifo(systemd_rundomain)
+systemd_run_system_role(systemd_run_t)
+systemd_run_unconfined_role(systemd_run_t)
+
+term_getattr_pty_fs(systemd_rundomain)
+term_relabel_all_ptys(systemd_rundomain)
+term_relabel_all_ttys(systemd_rundomain)
+term_use_ptmx(systemd_rundomain)
+
+# TTY/PTY and user home/tmp for the target user after authentication.
+userdom_create_user_pty(systemd_rundomain)
+userdom_exec_user_home_content_files(systemd_rundomain)
+userdom_list_admin_dir(systemd_rundomain)
+userdom_manage_all_users_keys(systemd_rundomain)
 userdom_manage_user_home_content_files(systemd_rundomain)
 userdom_manage_user_home_content_symlinks(systemd_rundomain)
 userdom_manage_user_tmp_files(systemd_rundomain)
 userdom_manage_user_tmp_symlinks(systemd_rundomain)
-userdom_use_user_terminals(systemd_rundomain)
-userdom_create_user_pty(systemd_rundomain)
+userdom_read_admin_home_files(systemd_rundomain)
+userdom_search_admin_dir(systemd_rundomain)
+userdom_search_user_home_content(systemd_rundomain)
 userdom_setattr_user_ptys(systemd_rundomain)
 userdom_setattr_user_ttys(systemd_rundomain)
 userdom_signal_all_users(systemd_rundomain)
-userdom_exec_user_home_content_files(systemd_rundomain)
-userdom_search_user_home_content(systemd_rundomain)
-userdom_search_admin_dir(systemd_rundomain)
-userdom_manage_all_users_keys(systemd_rundomain)
+userdom_use_user_terminals(systemd_rundomain)
+userdom_watch_tmp_dirs(systemd_rundomain)
 
+# YubiKey PAM modules touching user home (optional tunable).
 tunable_policy(`authlogin_yubikey',`
 	auth_manage_home_content(systemd_rundomain)
 ')
 
+# Desktop/session integration when the stack talks to system D-Bus (e.g. polkit).
 optional_policy(`
 	dbus_system_bus_client(systemd_rundomain)
 ')
 
+# Fingerprint auth (optional contrib module).
 optional_policy(`
-	systemd_exec_systemctl(systemd_run_t)
-	systemd_systemctl_entrypoint(systemd_run_t)
-	systemd_dbus_chat_logind(systemd_rundomain)
+	fprintd_dbus_chat(systemd_rundomain)
 ')
 
+# Session/cgroup helpers querying parent process group (e.g. systemd tooling).
 optional_policy(`
 	init_getpgid(systemd_rundomain)
 ')
 
+# TLS trust store for HTTPS clients run under run0.
+optional_policy(`
+	miscfiles_read_generic_certs(systemd_rundomain)
+')
+
+# dnf/yum/rpm: domtrans when binary allows it; same-domain still needs rpmdb/cache.
+optional_policy(`
+	rpm_domtrans(systemd_run_t)
+	rpm_entry_type(systemd_run_t)
+	rpm_manage_db(systemd_rundomain)
+	rpm_read_cache(systemd_rundomain)
+')
+
+# ssh-agent on inherited session (optional).
 optional_policy(`
 	ssh_signull(systemd_rundomain)
 ')
 
+# systemctl, logind D-Bus and session pipes (machinectl, run0, user@ session).
 optional_policy(`
+	systemd_dbus_chat_logind(systemd_rundomain)
+	systemd_exec_systemctl(systemd_run_t)
+	systemd_systemctl_entrypoint(systemd_run_t)
 	systemd_write_inherited_logind_sessions_pipes(systemd_rundomain)
 ')
 
-optional_policy(`
-	fprintd_dbus_chat(systemd_rundomain)
-')
+########################################
+#
+# Unconfined access rules
+# Direct systemd-run/run0 from an unconfined login shell (non-PID1 path).
+#
+unconfined_domtrans_to(systemd_run_t, systemd_run_exec_t)

--- a/policy/modules/admin/systemd_run.te
+++ b/policy/modules/admin/systemd_run.te
@@ -1,12 +1,5 @@
 policy_module(systemd_run, 1.10.7)
 
-gen_require(`
-	class passwd { passwd rootok };
-	type init_t;
-	type rpm_exec_t;
-	type systemd_passwd_var_run_t;
-')
-
 ########################################
 #
 # Declarations
@@ -43,28 +36,19 @@ logging_log_filetrans(systemd_rundomain, systemd_run_log_t, file, "systemd-run.l
 #
 unconfined_domtrans_to(systemd_run_t, systemd_run_exec_t)
 # run0: init_t execs run0 (systemd_run_exec_t)
-domain_auto_transition_pattern(init_t, systemd_run_exec_t, systemd_run_t)
+systemd_run_init_transition(systemd_run_t)
 
 ########################################
 #
 # Roles (default_contexts / pam_selinux session for systemd_run_t)
 #
-gen_require(`
-	role unconfined_r;
-	role system_r;
-')
-role unconfined_r types systemd_run_t;
-role system_r types systemd_run_t;
+systemd_run_unconfined_role(systemd_run_t)
+systemd_run_system_role(systemd_run_t)
 
 
 ########################################
 #
-# run0: PAM session systemd_run_t; init_t execs user command (dnf, sleep, …)
-#
-# domain_auto_transition_pattern(init_t, …) supplies allow init_t systemd_run_t:process transition.
-allow init_t systemd_run_t:key { create write };
-allow init_t systemd_run_t:process dyntransition;
-allow init_t self:process setexec;
+# run0: PAM session systemd_run_t; init_t execs user command (dnf, sleep, ...).
 init_signal(systemd_run_t)
 
 # systemd-run binary (shell path and run0)
@@ -73,8 +57,8 @@ allow systemd_run_t systemd_run_exec_t:file { getattr read map execute open entr
 files_search_pids(systemd_run_t)
 
 # RPM transition when run0 executes dnf/rpm binaries.
-allow systemd_run_t rpm_exec_t:file entrypoint;
 optional_policy(`
+	rpm_entry_type(systemd_run_t)
 	rpm_domtrans(systemd_run_t)
 ')
 
@@ -157,7 +141,7 @@ optional_policy(`
 optional_policy(`
 	miscfiles_read_generic_certs(systemd_rundomain)
 ')
-allow systemd_rundomain systemd_passwd_var_run_t:fifo_file read_fifo_file_perms;
+systemd_run_read_passwd_run_fifo(systemd_rundomain)
 systemd_passwd_watch_pid_dirs(systemd_rundomain)
 userdom_watch_tmp_dirs(systemd_rundomain)
 
@@ -216,6 +200,9 @@ optional_policy(`
 	systemd_exec_systemctl(systemd_run_t)
 	systemd_systemctl_entrypoint(systemd_run_t)
 	systemd_dbus_chat_logind(systemd_rundomain)
+')
+
+optional_policy(`
 	init_getpgid(systemd_rundomain)
 ')
 

--- a/policy/modules/admin/systemd_run.te
+++ b/policy/modules/admin/systemd_run.te
@@ -1,0 +1,191 @@
+policy_module(systemd-run, 1.10.0)
+
+gen_require(`
+	class passwd { passwd rootok };
+	type unconfined_t;
+')
+
+########################################
+#
+# Declarations
+attribute systemd-rundomain;
+
+# Define the actual domain type
+type systemd-run_t, systemd-rundomain;
+domain_type(systemd-run_t)
+
+type systemd-run_exec_t;
+application_executable_file(systemd-run_exec_t)
+
+type systemd-run_db_t;
+files_type(systemd-run_db_t)
+mls_trusted_object(systemd-run_db_t)
+
+type systemd-run_log_t;
+logging_log_file(systemd-run_log_t)
+
+manage_dirs_pattern(systemd-rundomain, systemd-run_db_t, systemd-run_db_t)
+manage_files_pattern(systemd-rundomain, systemd-run_db_t, systemd-run_db_t)
+
+manage_dirs_pattern(systemd-rundomain, systemd-run_log_t, systemd-run_log_t)
+manage_files_pattern(systemd-rundomain, systemd-run_log_t, systemd-run_log_t)
+logging_log_filetrans(systemd-rundomain, systemd-run_log_t, dir, "systemd-run-io")
+logging_log_filetrans(systemd-rundomain, systemd-run_log_t, file, "systemd-run.log")
+
+
+# Macro handles the transition from unconfined to systemd-run_t
+domain_auto_transition_pattern(unconfined_t, systemd-run_exec_t, systemd-run_t)
+
+# Use the specific TYPE for domain transitions
+corecmd_shell_domtrans(systemd-run_t, systemd-run_t)
+userdom_spec_domtrans_all_users(systemd-run_t)
+
+##############################
+#
+# Local Policy
+#
+
+allow systemd-run_t systemd-run_exec_t:file entrypoint;
+
+# (This happens when systemd-run executes a shell)
+allow systemd-run_t systemd-run_exec_t:file { getattr read map execute open };
+
+gen_require(`
+    type unconfined_t;
+    type rpm_t;
+    type rpm_exec_t;
+    type init_var_run_t;
+    role unconfined_r;
+')
+
+########################################
+# Fix the entrypoint for systemd-run itself
+allow systemd-run_t systemd-run_exec_t:file entrypoint;
+
+# Fix the /run/systemd search
+allow systemd-run_t init_var_run_t:dir search;
+
+# 3. Explicitly allow systemd-run_t to run RPM
+allow systemd-run_t rpm_exec_t:file { getattr open read execute map };
+type_transition systemd-run_t rpm_exec_t:process rpm_t;
+allow systemd-run_t rpm_t:process transition;
+
+# Transition to standard shells
+corecmd_shell_domtrans(systemd-run_t, systemd-run_t)
+
+type_transition unconfined_t rpm_exec_t:process rpm_t;
+allow unconfined_t rpm_t:process transition;
+
+# Use capabilities.
+allow systemd-rundomain self:capability { chown fowner setuid setgid dac_read_search dac_override sys_nice sys_resource };
+dontaudit systemd-rundomain self:capability net_admin;
+allow systemd-rundomain self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
+allow systemd-rundomain self:process { setexec setrlimit };
+allow systemd-rundomain self:fd use;
+allow systemd-rundomain self:fifo_file rw_fifo_file_perms;
+allow systemd-rundomain self:shm create_shm_perms;
+allow systemd-rundomain self:sem create_sem_perms;
+allow systemd-rundomain self:msgq create_msgq_perms;
+allow systemd-rundomain self:msg { send receive };
+allow systemd-rundomain self:unix_dgram_socket create_socket_perms;
+allow systemd-rundomain self:unix_stream_socket create_stream_socket_perms;
+allow systemd-rundomain self:unix_dgram_socket sendto;
+allow systemd-rundomain self:unix_stream_socket connectto;
+allow systemd-rundomain self:key manage_key_perms;
+allow systemd-rundomain self:netlink_kobject_uevent_socket create_socket_perms;
+allow systemd-rundomain self:netlink_selinux_socket create_socket_perms;
+allow systemd-rundomain self:passwd { passwd rootok };
+
+kernel_getattr_core_if(systemd-rundomain)
+kernel_link_key(systemd-rundomain)
+kernel_read_kernel_sysctls(systemd-rundomain)
+
+corecmd_read_bin_symlinks(systemd-rundomain)
+corecmd_exec_all_executables(systemd-rundomain)
+
+dev_getattr_fs(systemd-rundomain)
+dev_read_urand(systemd-rundomain)
+dev_rw_generic_usb_dev(systemd-rundomain)
+dev_read_sysfs(systemd-rundomain)
+dev_dontaudit_getattr_all(systemd-rundomain)
+
+domain_use_interactive_fds(systemd-rundomain)
+domain_sigchld_interactive_fds(systemd-rundomain)
+domain_getattr_all_entry_files(systemd-rundomain)
+
+files_read_etc_files(systemd-rundomain)
+files_list_var(systemd-rundomain)
+files_read_var_files(systemd-rundomain)
+files_read_usr_files(systemd-rundomain)
+# for some PAM modules and for cwd
+files_dontaudit_search_home(systemd-rundomain)
+files_list_tmp(systemd-rundomain)
+
+fs_search_auto_mountpoints(systemd-rundomain)
+fs_getattr_all_fs(systemd-rundomain)
+
+selinux_validate_context(systemd-rundomain)
+selinux_compute_relabel_context(systemd-rundomain)
+selinux_compute_access_vector(systemd-rundomain)
+
+term_getattr_pty_fs(systemd-rundomain)
+term_relabel_all_ttys(systemd-rundomain)
+term_relabel_all_ptys(systemd-rundomain)
+term_use_ptmx(systemd-rundomain)
+
+#auth_run_chk_passwd(systemd-rundomain)
+# systemd-run stores a token in the pam_pid directory
+auth_manage_pam_pid(systemd-rundomain)
+auth_manage_faillog(systemd-rundomain)
+auth_read_var_auth(systemd-rundomain)
+auth_rw_lastlog(systemd-rundomain)
+
+application_signal(systemd-rundomain)
+
+init_rw_utmp(systemd-rundomain)
+
+logging_send_audit_msgs(systemd-rundomain)
+logging_set_audit_parameters(systemd-rundomain)
+
+seutil_read_default_contexts(systemd-rundomain)
+
+userdom_spec_domtrans_all_users(systemd-rundomain)
+userdom_manage_user_home_content_files(systemd-rundomain)
+userdom_manage_user_home_content_symlinks(systemd-rundomain)
+userdom_manage_user_tmp_files(systemd-rundomain)
+userdom_manage_user_tmp_symlinks(systemd-rundomain)
+userdom_use_user_terminals(systemd-rundomain)
+userdom_create_user_pty(systemd-rundomain)
+userdom_setattr_user_ptys(systemd-rundomain)
+userdom_setattr_user_ttys(systemd-rundomain)
+userdom_signal_all_users(systemd-rundomain)
+userdom_exec_user_home_content_files(systemd-rundomain)
+# for some PAM modules and for cwd
+userdom_search_user_home_content(systemd-rundomain)
+userdom_search_admin_dir(systemd-rundomain)
+userdom_manage_all_users_keys(systemd-rundomain)
+
+tunable_policy(`authlogin_yubikey',`
+    auth_manage_home_content(systemd-rundomain)
+')
+
+optional_policy(`
+	dbus_system_bus_client(systemd-rundomain)
+
+	optional_policy(`
+		systemd_dbus_chat_logind(systemd-rundomain)
+		init_getpgid(systemd-rundomain)
+	')
+')
+
+optional_policy(`
+	ssh_signull(systemd-rundomain)
+')
+
+optional_policy(`
+    systemd_write_inherited_logind_sessions_pipes(systemd-rundomain)
+')
+
+optional_policy(`
+	fprintd_dbus_chat(systemd-rundomain)
+')


### PR DESCRIPTION
Introduce the module to systemd_run and extend policy so run0 sessions can run common commands (dnf, shell, systemctl, password prompts) under systemd_run_t without relying on broad unconfined_t entrypoint rules.

