### PR TITLE
Allow systemd-tmpfiles the sys_resource capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -816,7 +816,7 @@ optional_policy(`
 # Local policy
 #
 
-allow systemd_tmpfiles_t self:capability { chown dac_read_search dac_override fsetid fowner mknod sys_admin };
+allow systemd_tmpfiles_t self:capability { chown dac_read_search dac_override fsetid fowner mknod sys_admin sys_resource };
 allow systemd_tmpfiles_t self:process { setrlimit setfscreate };
 
 allow systemd_tmpfiles_t self:unix_dgram_socket create_socket_perms;


### PR DESCRIPTION
systemd-tmpfiles bumps RLIMIT_NOFILE to HIGH_RLIMIT_NOFILE to ensure deep directory trees can be descent into [1]. This requires the sys_resource capability on systems wich default rlimit set low.
[1] https://github.com/systemd/systemd/commit/e5358401b5df8d395e99815b7a69b8424887472c

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/09/2026 07:38:18.790:962) : proctitle=systemd-tmpfiles --clean type=SYSCALL msg=audit(01/09/2026 07:38:18.790:962) : arch=x86_64 syscall=prlimit64 success=no exit=EPERM(Operation not permitted) a0=0x0 a1=0x7 a2=0x7ffdbbb96d50 a3=0x0 items=0 ppid=1 pid=43418 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=systemd-tmpfile exe=/usr/bin/systemd-tmpfiles subj=system_u:system_r:systemd_tmpfiles_t:s0 key=(null) type=AVC msg=audit(01/09/2026 07:38:18.790:962) : avc:  denied  { sys_resource } for  pid=43418 comm=systemd-tmpfile capability=sys_resource  scontext=system_u:system_r:systemd_tmpfiles_t:s0 tcontext=system_u:system_r:systemd_tmpfiles_t:s0 tclass=capability permissive=0

Resolves: RHEL-163080