### PR TITLE
Allow virtqemud_t to call into udev

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2333,6 +2333,8 @@ sysnet_manage_config(virtqemud_t)
 term_use_generic_ptys(virtqemud_t)
 term_use_ptmx(virtqemud_t)
 
+udev_domtrans(virtqemud_t)
+
 tunable_policy(`virtqemud_use_execmem',`
 	allow virtqemud_t self:process { execmem execstack };
 ')


### PR DESCRIPTION
With https://lists.libvirt.org/archives/list/devel@lists.libvirt.org/thread/BGNNY2CVQXYJ7XA4EMJNAV2MAQ6WSE27/ virtqemud_t calls into udev to wait for devices to settle to prevent issues like https://bugzilla.suse.com/show_bug.cgi?id=1251789 (tap devices not having the proper type in time)

Apparently this can already happen now with the right config:
https://gitlab.com/libvirt/libvirt/-/work_items/866#note_3240343787

Solves
avc:  denied  { read } for  pid=3951 comm="udevadm" name="root" dev="proc" ino=1295 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=lnk_file permissive=1 avc:  denied  { write } for  pid=3951 comm="udevadm" name="io.systemd.Udev" dev="tmpfs" ino=855 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=sock_file permissive=1 avc:  denied  { connectto } for  pid=3951 comm="udevadm" path="/run/udev/io.systemd.Udev" scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:udev_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1 avc:  denied  { search } for  pid=765 comm="systemd-machine" name="3956" dev="proc" ino=36742 scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:system_r:svirt_t:s0:c270,c908 tclass=dir permissive=0 avc:  denied  { execute } for  pid=1005 comm="rpc-virtqemud" name="udevadm" dev="vda2" ino=578140 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:udev_exec_t:s0 tclass=file permissive=1 avc:  denied  { execute_no_trans } for  pid=4029 comm="rpc-virtqemud" path="/usr/bin/udevadm" dev="vda2" ino=578140 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:udev_exec_t:s0 tclass=file permissive=1 avc:  denied  { watch } for  pid=4029 comm="udevadm" path="/run/udev" dev="tmpfs" ino=51 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:udev_var_run_t:s0 tclass=dir permissive=1