### PR TITLE
Label /usr/lib/systemd/systemd-ssh-proxy with systemd_ssh_proxy_exec_t

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -67,6 +67,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/systemd-rfkill     --  gen_context(system_u:object_r:systemd_rfkill_exec_t,s0)
 /usr/lib/systemd/systemd-socket-proxyd	--	gen_context(system_u:object_r:systemd_socket_proxyd_exec_t,s0)
 /usr/lib/systemd/systemd-ssh-issue	--	gen_context(system_u:object_r:systemd_ssh_issue_exec_t,s0)
+/usr/lib/systemd/systemd-ssh-proxy	--	gen_context(system_u:object_r:systemd_ssh_proxy_exec_t,s0)
 /usr/lib/systemd/systemd-sysctl		--	gen_context(system_u:object_r:systemd_sysctl_exec_t,s0)
 /usr/lib/systemd/systemd-timedated	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
 /usr/lib/systemd/systemd-timesyncd	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
@@ -132,6 +133,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/resolv.*   --   gen_context(system_u:object_r:lib_t,s0)
 
 /run/issue.d(/.*)?	gen_context(system_u:object_r:systemd_ssh_issue_var_run_t,s0)
+
+/run/ssh-unix-local(/.*)?	gen_context(system_u:object_r:systemd_ssh_unix_local_run_t,s0)
 
 /run/systemd/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
 /run/systemd/.+\.conf\.d	-d	gen_context(system_u:object_r:systemd_conf_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -183,6 +183,11 @@ corenet_port(systemd_socket_proxyd_port_t)
 type systemd_socket_proxyd_unit_file_t;
 systemd_unit_file(systemd_socket_proxyd_unit_file_t)
 
+type systemd_ssh_proxy_exec_t;
+corecmd_executable_file(systemd_ssh_proxy_exec_t)
+type systemd_ssh_unix_local_run_t;
+files_pid_file(systemd_ssh_unix_local_run_t)
+
 systemd_domain_template(systemd_ssh_issue)
 
 systemd_domain_template(systemd_timedated)


### PR DESCRIPTION
Make systemd_ssh_proxy_exec_t a part of the exec_type attribute.