### PR TITLE
Dontaudit apcupsd dac_override (bsc#1261232)

### DIFF
--- a/policy/modules/contrib/apcupsd.te
+++ b/policy/modules/contrib/apcupsd.te
@@ -35,6 +35,8 @@ systemd_unit_file(apcupsd_unit_file_t)
 # Local policy
 #
 
+dontaudit apcupsd_t self:capability dac_override;
+
 allow apcupsd_t self:capability { dac_read_search  setgid sys_tty_config };
 allow apcupsd_t self:process signal;
 allow apcupsd_t self:fifo_file rw_file_perms;


### PR DESCRIPTION
Hiding the following extended AVC:
```
---
type=PROCTITLE msg=audit(..): proctitle="wall"
type=PATH msg=audit(..): item=0 name="/dev/tty2" inode=21 dev=00:06 mode=020600 ouid=1000 ogid=5 
  rdev=04:02 obj=unconfined_u:object_r:user_tty_device_t:s0 nametype=NORMAL 
  cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(..): cwd="/"
type=SYSCALL msg=audit(..): arch=c000003e syscall=257 success=no exit=-13 a0=ffffffffffffff9c 
  a1=561cc232f080 a2=801 a3=0 items=1 ppid=202303 pid=202313 auid=4294967295 
  uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=5 sgid=5 fsgid=5 tty=(none) ses=4294967295 
  comm="wall" exe="/usr/bin/wall" subj=system_u:system_r:apcupsd_t:s0 key=(null) 
type=AVC msg=audit(..): avc:  denied  { dac_override } for  pid=202313 comm="wall" capability=1  
  scontext=system_u:system_r:apcupsd_t:s0 tcontext=system_u:system_r:apcupsd_t:s0 tclass=capability 
  permissive=0
---
```

and the following tty device
```
$ ls -lZ /dev/tt* | grep user_tty_device_t
crw-------. 1 user tty     unconfined_u:object_r:user_tty_device_t:s0 4,  2 Apr 11 13:23 /dev/tty2
```
Udev changed the access mode bits for tty devices from 0620 to 0600 with systemd v258 [0]. This is to improve security by making it harder to mess with other users terminals [1]. There is also work underway to remove setgid/setuid binaries like 'wall'. Meaning there will be another mechanism to send messages for system events, likely via dbus.

[0] https://github.com/systemd/systemd/commit/a4d18914751e687c9e44f22fe4e5f95b843a45c8
[1] https://github.com/systemd/systemd/issues/35599#issuecomment-2633559542