### PR TITLE
Allow systemd_homework_t to delete systemd_homed_record_t dirs

### DIFF
--- a/policy/modules/system/systemd-homed.te
+++ b/policy/modules/system/systemd-homed.te
@@ -190,6 +190,7 @@ files_delete_home_dir(systemd_homework_t)
 files_search_home(systemd_homework_t)
 files_home_filetrans(systemd_homework_t, systemd_homed_crypto_luks_t, file)
 delete_files_pattern(systemd_homework_t, systemd_homed_record_t, systemd_homed_record_t)
+delete_dirs_pattern(systemd_homework_t, systemd_homed_record_t, systemd_homed_record_t)
 
 # unlabeled home directories
 files_manage_isid_type_dirs(systemd_homework_t)


### PR DESCRIPTION
When using commands like
homectl update foobar --member-of systemd-journal
and also in some part of the error handling of systemd_homeworkd this is necessary.

Solves:
avc:  denied  { rmdir } for
comm="systemd-homewor" name=".identity-blob"
scontext=system_u:system_r:systemd_homework_t:s0
tcontext=system_u:object_r:systemd_homed_record_t:s0 tclass=dir