### PR TITLE
config: make /etc/systemd/user same as /usr/lib/systemd/user

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -19,6 +19,7 @@
 /usr/local/lib64 /usr/lib
 /usr/local/lib32 /usr/lib
 /etc/systemd/system /usr/lib/systemd/system
+/etc/systemd/user /usr/lib/systemd/user
 /var/lib/xguest/home /home
 /var/named/chroot/usr/lib64 /usr/lib
 /var/named/chroot/lib64 /usr/lib


### PR DESCRIPTION
/etc/systemd/user is mislabeled as etc_t, while the user unit under /usr/lib/systemd/user and HOME_DIR/.config/systemd/user are correctly identified as systemd_unit_file_t.