### PR TITLE
[f44] Allow sshd-auth/sshd-session get attributes of their sshd parent

### DIFF
--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -38,6 +38,7 @@ allow accountsd_t self:fifo_file rw_fifo_file_perms;
 allow accountsd_t self:passwd { rootok passwd chfn chsh };
 
 read_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
+list_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 watch_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 
 manage_dirs_pattern(accountsd_t, accountsd_var_lib_t, accountsd_var_lib_t)

--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -38,6 +38,7 @@ allow accountsd_t self:fifo_file rw_fifo_file_perms;
 allow accountsd_t self:passwd { rootok passwd chfn chsh };
 
 read_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
+read_lnk_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 list_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 watch_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 

--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -14,11 +14,13 @@ systemd_unit_file(dirsrv_unit_file_t)
 
 domain_type(dirsrv_t)
 init_daemon_domain(dirsrv_t, dirsrv_exec_t)
+init_nnp_daemon_domain(dirsrv_t)
 
 type dirsrv_snmp_t;
 type dirsrv_snmp_exec_t;
 domain_type(dirsrv_snmp_t)
 init_daemon_domain(dirsrv_snmp_t, dirsrv_snmp_exec_t)
+init_nnp_daemon_domain(dirsrv_snmp_t)
 
 type dirsrv_var_lib_t;
 files_type(dirsrv_var_lib_t)

--- a/policy/modules/contrib/gpsd.te
+++ b/policy/modules/contrib/gpsd.te
@@ -33,7 +33,7 @@ files_pid_file(gpsd_var_run_t)
 allow gpsd_t self:capability { fowner fsetid setuid setgid sys_nice sys_time sys_tty_config };
 dontaudit gpsd_t self:capability { sys_ptrace dac_read_search  };
 allow gpsd_t self:cap_userns sys_ptrace;
-allow gpsd_t self:process { setsched signal_perms getsession };
+allow gpsd_t self:process { setcap setsched signal_perms getsession };
 allow gpsd_t self:shm create_shm_perms;
 allow gpsd_t self:unix_dgram_socket sendto;
 allow gpsd_t self:tcp_socket { accept listen };

--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -56,6 +56,7 @@ userdom_dontaudit_access_check_user_content(thumb_t)
 userdom_rw_inherited_user_tmp_files(thumb_t)
 userdom_manage_home_texlive(thumb_t)
 
+allow thumb_t thumb_tmp_t:lnk_file setattr;
 manage_files_pattern(thumb_t, thumb_tmp_t, thumb_tmp_t)
 manage_dirs_pattern(thumb_t, thumb_tmp_t, thumb_tmp_t)
 manage_sock_files_pattern(thumb_t, thumb_tmp_t, thumb_tmp_t)

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -95,7 +95,7 @@ allow sshd_net_t sshd_t:vsock_socket { read write };
 allow sshd_net_t sshd_session_t:fifo_file write;
 allow sshd_net_t sshd_session_t:unix_stream_socket { ioctl read write };
 allow sshd_session_t sshd_t:tcp_socket { getattr getopt read setopt write };
-allow sshd_session_t sshd_t:unix_stream_socket { read write };
+allow sshd_session_t sshd_t:unix_stream_socket { getattr read write };
 allow sshd_session_t sshd_t:vsock_socket { getattr };
 
 allow sshd_session_t sshd_auth_t:process signal;
@@ -177,6 +177,7 @@ allow sshd_auth_t self:process { setcurrent setrlimit };
 allow sshd_auth_t self:unix_dgram_socket { create ioctl };
 
 allow sshd_auth_t sshd_t:tcp_socket { getattr read write getopt setopt };
+allow sshd_auth_t sshd_t:unix_stream_socket getattr;
 allow sshd_auth_t sshd_t:vsock_socket getattr;
 
 allow sshd_auth_t sshd_session_t:unix_stream_socket { read write };


### PR DESCRIPTION
Required when a connection to localhost is being made using a unix stream socket instead of networking, e.g. with this ssh configuration:

ProxyCommand /usr/lib/systemd/systemd-ssh-proxy unix/run/ssh-unix-local/socket %p

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(13.4.2026 16:26:31.013:837) : proctitle=sshd-session: [accepted] type=SOCKADDR msg=audit(13.4.2026 16:26:31.013:837) : saddr={ saddr_fam=local unnamed socket } type=SYSCALL msg=audit(13.4.2026 16:26:31.013:837) : arch=x86_64 syscall=getpeername success=yes exit=0 a0=0x6 a1=0x7ffd345aa0e0 a2=0x7ffd345aa05c a3=0xffffffff items=0 ppid=1 pid=303885 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(13.4.2026 16:26:31.013:837) : avc:  denied  { getattr } for  pid=303885 comm=sshd-session path=/run/ssh-unix-local/socket scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

type=PROCTITLE msg=audit(13.4.2026 16:26:31.026:838) : proctitle=/usr/libexec/openssh/sshd-auth -i -o AuthorizedKeysFile /run/credentials/sshd@0-1-303884_303885-1000.service/ssh.ephemeral-autho
type=SOCKADDR msg=audit(13.4.2026 16:26:31.026:838) : saddr={ saddr_fam=local unnamed socket }
type=SYSCALL msg=audit(13.4.2026 16:26:31.026:838) : arch=x86_64 syscall=getpeername success=yes exit=0 a0=0x5 a1=0x7fff356edc50 a2=0x7fff356edbcc a3=0x4 items=0 ppid=303885 pid=303889 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sshd-auth exe=/usr/libexec/openssh/sshd-auth subj=system_u:system_r:sshd_auth_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(13.4.2026 16:26:31.026:838) : avc:  denied  { getattr } for  pid=303889 comm=sshd-auth path=/run/ssh-unix-local/socket scontext=system_u:system_r:sshd_auth_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sshd_t:s0-s0:c0.c1023 tclass=unix_stream_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2444160