### PR TITLE
Dontaudit read access of procmail to postfix_etc_t (bsc#1261933)

### DIFF
--- a/policy/modules/contrib/postfix.if
+++ b/policy/modules/contrib/postfix.if
@@ -140,6 +140,25 @@ interface(`postfix_read_config',`
 
 ########################################
 ## <summary>
+##	Dontaudit read to postfix configuration files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`postfix_dontaudit_read_config',`
+	gen_require(`
+		type postfix_etc_t;
+	')
+
+	dontaudit $1 postfix_etc_t:file read;
+')
+
+########################################
+## <summary>
 ##	Create files with the specified type in
 ##	the postfix configuration directories.
 ## </summary>

--- a/policy/modules/contrib/procmail.te
+++ b/policy/modules/contrib/procmail.te
@@ -135,6 +135,7 @@ optional_policy(`
 
 optional_policy(`
 	# for a bug in the postfix local program
+	postfix_dontaudit_read_config(procmail_t)
 	postfix_dontaudit_rw_local_tcp_sockets(procmail_t)
 	postfix_dontaudit_use_fds(procmail_t)
 	postfix_read_spool_files(procmail_t)


### PR DESCRIPTION
Procmail does not need the access and it occurs because postfix has a file descriptor leak.

Fixes:

type=AVC msg=audit(1775896746.188:188): avc:  denied  { read } for  pid=11835 comm="procmail" path="/etc/postfix.lmdbtest/relay.lmdb" dev="nvme0n1p2" ino=9306487 scontext=system_u:system_r:procmail_t:s0 tcontext=unconfined_u:object_r:postfix_etc_t:s0 tclass=file permissive=0