### PR TITLE
Allow dbus-broker to use inherited user ttys

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -252,6 +252,7 @@ optional_policy(`
 
 optional_policy(`
 	userdom_rw_stream(system_dbusd_t)
+	userdom_use_inherited_user_ttys(system_dbusd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
AVC denial:
type=AVC msg=audit(1748837650.162:326): avc:  denied  { read write } for pid=768 comm="dbus-broker" path="/dev/ttyS0"
scontext=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_tty_device_t:s0 tclass=chr_file

Resolves: RHEL-86925