### PR TITLE
Allow bootupcl nnp transition to mount_t

### DIFF
--- a/policy/modules/contrib/anaconda.te
+++ b/policy/modules/contrib/anaconda.te
@@ -102,6 +102,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	mount_nnp_domtrans(install_t)
     mount_run(install_t, install_roles)
 ')
 

--- a/policy/modules/system/mount.if
+++ b/policy/modules/system/mount.if
@@ -27,6 +27,24 @@ interface(`mount_domtrans',`
 
 ########################################
 ## <summary>
+##      Allow caller to transition to mount_t with NoNewPrivileges.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`mount_nnp_domtrans',`
+	gen_require(`
+		type mount_t;
+	')
+
+	allow $1 mount_t:process2 nnp_transition;
+')
+
+########################################
+## <summary>
 ##	Execute mount in the mount domain, and
 ##	allow the specified role the mount domain,
 ##	and use the caller's terminal.


### PR DESCRIPTION
bootupctl is running in the install_t domain.

The commit addresses the following AVC denial:
type=AVC msg=audit(02/27/26 15:09:37.739:2040) : avc:  denied  { nnp_transition nosuid_transition } for  pid=13078 comm=bootupctl scontext=system_u:system_r:install_t:s0:c75,c789 tcontext=system_u:system_r:mount_t:s0:c75,c789 tclass=process2 permissive=0 type=SELINUX_ERR msg=audit(02/27/26 15:09:37.739:2041) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:install_t:s0:c75,c789 newcontext=system_u:system_r:mount_t:s0:c75,c789

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2443825