### PR TITLE
Allow gpsd the setcap process capability

### DIFF
--- a/policy/modules/contrib/gpsd.te
+++ b/policy/modules/contrib/gpsd.te
@@ -33,7 +33,7 @@ files_pid_file(gpsd_var_run_t)
 allow gpsd_t self:capability { fowner fsetid setuid setgid sys_nice sys_time sys_tty_config };
 dontaudit gpsd_t self:capability { sys_ptrace dac_read_search  };
 allow gpsd_t self:cap_userns sys_ptrace;
-allow gpsd_t self:process { setsched signal_perms getsession };
+allow gpsd_t self:process { setcap setsched signal_perms getsession };
 allow gpsd_t self:shm create_shm_perms;
 allow gpsd_t self:unix_dgram_socket sendto;
 allow gpsd_t self:tcp_socket { accept listen };


### PR DESCRIPTION
gpsd calls cap_set_proc(3) which calls capset(2) to drop all capabilities.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit( 1.03.2026 22:59:40.600:1655) : proctitle=/usr/bin/gpsd -n /dev/em05.at type=SYSCALL msg=audit( 1.03.2026 22:59:40.600:1655) : arch=x86_64 syscall=capset success=no exit=EACCES(Permission denied) a0=0x564277d56c9c a1=0x564277d56ca4 a2=0x564277d56ca4 a3=0x564277d08010 items=0 ppid=1 pid=592931 auid=unset uid=nobody gid=dialout euid=nobody suid=nobody fsuid=nobody egid=dialout sgid=dialout fsgid=dialout > tty=(none) ses=unset comm=gpsd exe=/usr/bin/gpsd subj=system_u:system_r:gpsd_t:s0 key=(null) type=AVC msg=audit( 1.03.2026 22:59:40.600:1655) : avc:  denied  { setcap } for  pid=592931 comm=gpsd scontext=system_u:system_r:gpsd_t:s0 tcontext=system_u:system_r:gpsd_t:s0 tclass=process permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2441643