### PR TITLE
Label /usr/bin/sudo-rs and /usr/bin/su-rs

### DIFF
--- a/policy/modules/admin/su.fc
+++ b/policy/modules/admin/su.fc
@@ -1,3 +1,4 @@
 /usr/(local/)?bin/ksu	--	gen_context(system_u:object_r:su_exec_t,s0)
 /usr/bin/kdesu		--	gen_context(system_u:object_r:su_exec_t,s0)
 /usr/bin/su		--	gen_context(system_u:object_r:su_exec_t,s0)
+/usr/bin/su-rs		--	gen_context(system_u:object_r:su_exec_t,s0)

--- a/policy/modules/admin/sudo.fc
+++ b/policy/modules/admin/sudo.fc
@@ -1,5 +1,6 @@
 
 /usr/bin/sudo(edit)?	--	gen_context(system_u:object_r:sudo_exec_t,s0)
+/usr/bin/sudo-rs	--	gen_context(system_u:object_r:sudo_exec_t,s0)
 
 /var/db/sudo(/.*)?		gen_context(system_u:object_r:sudo_db_t,s0)
 


### PR DESCRIPTION
The sudo-rs package brings memory safe implementation of sudo and su. With this commit, /usr/bin/sudo-rs is now labeled with sudo_exec_t and /usr/bin/su-rs with su_exec_t, similar to the original counterparts implemented in C.

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/3159