### PR TITLE
Allow accounts-daemon read accountsd_share_t symlinks

### DIFF
--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -38,6 +38,7 @@ allow accountsd_t self:fifo_file rw_fifo_file_perms;
 allow accountsd_t self:passwd { rootok passwd chfn chsh };
 
 read_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
+read_lnk_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 list_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 watch_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/21/2026 11:52:51.090:3402) : proctitle=/usr/libexec/accounts-daemon type=PATH msg=audit(04/21/2026 11:52:51.090:3402) : item=0 name=/usr/share/accountsservice/interfaces/org.freedesktop.Malcontent.WebFilter.xml inode=63446 dev=00:23 mode=link,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:accountsd_share_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/21/2026 11:52:51.090:3402) : arch=x86_64 syscall=readlink success=no exit=EACCES(Permission denied) a0=0x562fbe0d9850 a1=0x562fbe0d9b10 a2=0x100 a3=0x21 items=1 ppid=1 pid=99817 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=accounts-daemon exe=/usr/libexec/accounts-daemon subj=system_u:system_r:accountsd_t:s0 key=(null) type=AVC msg=audit(04/21/2026 11:52:51.090:3402) : avc:  denied  { read } for  pid=99817 comm=accounts-daemon name=org.freedesktop.Malcontent.WebFilter.xml dev="nvme0n1p3" ino=63446 scontext=system_u:system_r:accountsd_t:s0 tcontext=system_u:object_r:accountsd_share_t:s0 tclass=lnk_file permissive=0