### PR TITLE
Allow thump_t setattr on thumb_tmp_t lnk_files

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -56,6 +56,7 @@ userdom_dontaudit_access_check_user_content(thumb_t)
 userdom_rw_inherited_user_tmp_files(thumb_t)
 userdom_manage_home_texlive(thumb_t)
 
+allow thumb_t thumb_tmp_t:lnk_file setattr;
 manage_files_pattern(thumb_t, thumb_tmp_t, thumb_tmp_t)
 manage_dirs_pattern(thumb_t, thumb_tmp_t, thumb_tmp_t)
 manage_sock_files_pattern(thumb_t, thumb_tmp_t, thumb_tmp_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1771401152.590:554): avc:  denied  { setattr } for  pid=7378 comm="unsquashfs" name=".DirIcon" dev="tmpfs" ino=727 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:thumb_tmp_t:s0 tclass=lnk_file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2440544