### PR TITLE
Networkmanager: Allow NM to manage files under /run

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -711,6 +711,7 @@ optional_policy(`
 	systemd_status_systemd_services(NetworkManager_dispatcher_sendmail_t)
 	systemd_start_systemd_services(NetworkManager_dispatcher_nvme_t)
 	systemd_status_systemd_services(NetworkManager_dispatcher_nvme_t)
+	systemd_ssh_issue_manage_pid_files(NetworkManager_dispatcher_console_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -616,8 +616,6 @@ dev_rw_wireless(NetworkManager_dispatcher_tlp_t)
 
 domain_read_all_domains_state(NetworkManager_dispatcher_dnssec_t)
 
-files_manage_etc_files(NetworkManager_dispatcher_console_t)
-
 fs_getattr_pidfs(NetworkManager_dispatcher_iscsid_t)
 fs_getattr_pidfs(NetworkManager_dispatcher_sendmail_t)
 fs_getattr_pidfs(NetworkManager_dispatcher_winbind_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -505,6 +505,26 @@ interface(`systemd_ssh_issue_read_pid_files',`
 
 ######################################
 ## <summary>
+##	Manage systemd_ssh_issue PID files and dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_ssh_issue_manage_pid_files',`
+	gen_require(`
+		type systemd_ssh_issue_var_run_t;
+	')
+
+	files_search_pids($1)
+	manage_dirs_pattern($1, systemd_ssh_issue_var_run_t, systemd_ssh_issue_var_run_t)
+	manage_files_pattern($1, systemd_ssh_issue_var_run_t, systemd_ssh_issue_var_run_t)
+')
+
+######################################
+## <summary>
 ##	Read systemd_login PID files.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
In console-login-helper-messages we moved the generated issues from `/etc` to `/run` in v0.22.0.

Allow `systemd_ssh_issue_manage_pid_files(NetworkManager_dispatcher_console_t)` through a new interface `systemd_ssh_issue_manage_pid_files`.

Fixes https://github.com/fedora-selinux/selinux-policy/issues/3123