### PR TITLE
Allow init nnp domain transition do dirsrv_t and dirsrv_snmp_t

### DIFF
--- a/policy/modules/contrib/dirsrv.te
+++ b/policy/modules/contrib/dirsrv.te
@@ -14,11 +14,13 @@ systemd_unit_file(dirsrv_unit_file_t)
 
 domain_type(dirsrv_t)
 init_daemon_domain(dirsrv_t, dirsrv_exec_t)
+init_nnp_daemon_domain(dirsrv_t)
 
 type dirsrv_snmp_t;
 type dirsrv_snmp_exec_t;
 domain_type(dirsrv_snmp_t)
 init_daemon_domain(dirsrv_snmp_t, dirsrv_snmp_exec_t)
+init_nnp_daemon_domain(dirsrv_snmp_t)
 
 type dirsrv_var_lib_t;
 files_type(dirsrv_var_lib_t)


### PR DESCRIPTION
New 389-ds-base package comes up with hardening dirsrv service units, including NoNewPrivileges=yes.

The commit addresses the following AVC denial:
type=AVC msg=audit(1775741107.400:9691): avc:  denied  { nnp_transition } for  pid=980206 comm="(ns-slapd)" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:dirsrv_t:s0 tclass=process2 permissive=0 type=AVC msg=audit(1775833368.436:10776): avc:  denied  { nnp_transition } for  pid=1113882 comm="(ap-agent)" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:dirsrv_snmp_t:s0 tclass=process2 permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2457951