### PR TITLE
Allow NetworkManager_dispatcher_nvme_t check status of systemd services

### DIFF
--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -710,6 +710,7 @@ optional_policy(`
 	systemd_start_systemd_services(NetworkManager_dispatcher_sendmail_t)
 	systemd_status_systemd_services(NetworkManager_dispatcher_sendmail_t)
 	systemd_start_systemd_services(NetworkManager_dispatcher_nvme_t)
+	systemd_status_systemd_services(NetworkManager_dispatcher_nvme_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This commit allows the NetworkManager_dispatcher_nvme_t domain permission to check the status of systemd services, which is needed before starting the nvmf-connect-nbft.service, e.g. when provisioning a system which boots from SAN over NVMe-TCP.

The commit addresses the following USER_AVC denial: type=USER_AVC msg=audit(1775500021.101:49): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='avc:  denied  { status } for auid=n/a uid=0 gid=0 path="/usr/lib/systemd/system/nvmf-connect-nbft.service" cmdline="" function="reply_unit_path" scontext=system_u:system_r:NetworkManager_dispatcher_nvme_t:s0 tcontext=system_u:object_r:systemd_unit_file_t:s0 tclass=service permissive=0 exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'

Resolves: RHEL-164864