### PR TITLE
Allow iptables_t read state of some processes

### DIFF
--- a/policy/modules/contrib/conntrackd.if
+++ b/policy/modules/contrib/conntrackd.if
@@ -24,6 +24,26 @@ interface(`conntrackd_read_config',`
 
 ########################################
 ## <summary>
+##	Read conntrackd process state files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`conntrackd_read_state',`
+	gen_require(`
+		type conntrackd_t;
+	')
+
+	allow $1 conntrackd_t:dir { search_dir_perms read };
+	allow $1 conntrackd_t:file read_file_perms;
+	allow $1 conntrackd_t:lnk_file read_lnk_file_perms;
+')
+
+########################################
+## <summary>
 ##	Connect to conntrackd over an unix stream socket.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -128,6 +128,10 @@ ifdef(`hide_broken_symptoms',`
 ')
 
 optional_policy(`
+	conntrackd_read_state(iptables_t)
+')
+
+optional_policy(`
 	container_read_state(iptables_t)
 ')
 
@@ -213,6 +217,9 @@ optional_policy(`
 ')
 
 optional_policy(`
-	wireguard_read_fifo_files(iptables_t)
+	virt_virtd_read_state(iptables_t)
 ')
 
+optional_policy(`
+	wireguard_read_fifo_files(iptables_t)
+')


### PR DESCRIPTION
When the "nft list ruleset" command is executed with a transition, e.g. using systemd-run or from some confined services, it needs to get information about processes which created particular nft tables. This commit allows the access to domains where it is reasonable and dontaudits the rest.

Resolves: RHEL-152287