### PR TITLE
go-fdo-server policy creation

### DIFF
--- a/dist/targeted/modules.conf
+++ b/dist/targeted/modules.conf
@@ -3068,3 +3068,10 @@ switcheroo = module
 #
 #
 redfish-finder = module
+
+# Layer: contrib
+# Module: go_fdo_server
+#
+# Policy for go_fdo_server: Run an FDO Manufacturing, Rendezvous, or Owner server.
+#
+go_fdo_server = module

--- a/policy/modules/contrib/go_fdo_server.fc
+++ b/policy/modules/contrib/go_fdo_server.fc
@@ -1,0 +1,18 @@
+/usr/bin/go-fdo-server		--	gen_context(system_u:object_r:go_fdo_server_exec_t,s0)
+
+# Helper scripts
+/usr/libexec/go-fdo-server(/.*)?		gen_context(system_u:object_r:go_fdo_server_exec_t,s0)
+
+# Configuration directories
+/etc/go-fdo-server(/.*)?		gen_context(system_u:object_r:go_fdo_server_etc_t,s0)
+
+# PKI/Certificates
+/etc/pki/go-fdo-server(/.*)?		gen_context(system_u:object_r:go_fdo_server_cert_t,s0)
+
+# Database and state files (created at runtime)
+/var/lib/go-fdo-server-manufacturer(/.*)?	gen_context(system_u:object_r:go_fdo_server_var_lib_t,s0)
+/var/lib/go-fdo-server-rendezvous(/.*)?		gen_context(system_u:object_r:go_fdo_server_var_lib_t,s0)
+/var/lib/go-fdo-server-owner(/.*)?		gen_context(system_u:object_r:go_fdo_server_var_lib_t,s0)
+
+# Systemd unit files
+/usr/lib/systemd/system/go-fdo-server-.*\.service	gen_context(system_u:object_r:go_fdo_server_unit_t,s0)

--- a/policy/modules/contrib/go_fdo_server.if
+++ b/policy/modules/contrib/go_fdo_server.if
@@ -1,0 +1,39 @@
+## <summary>policy for go_fdo_server</summary>
+
+########################################
+## <summary>
+##	Execute go_fdo_server_exec_t in the go_fdo_server domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`go_fdo_server_domtrans',`
+	gen_require(`
+		type go_fdo_server_t, go_fdo_server_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, go_fdo_server_exec_t, go_fdo_server_t)
+')
+
+######################################
+## <summary>
+##	Execute go_fdo_server in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`go_fdo_server_exec',`
+	gen_require(`
+		type go_fdo_server_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, go_fdo_server_exec_t)
+')

--- a/policy/modules/contrib/go_fdo_server.te
+++ b/policy/modules/contrib/go_fdo_server.te
@@ -1,0 +1,58 @@
+policy_module(go_fdo_server, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type go_fdo_server_t;
+type go_fdo_server_exec_t;
+init_daemon_domain(go_fdo_server_t, go_fdo_server_exec_t)
+
+type go_fdo_server_cert_t;
+miscfiles_cert_type(go_fdo_server_cert_t)
+
+type go_fdo_server_etc_t;
+files_config_file(go_fdo_server_etc_t)
+
+type go_fdo_server_var_lib_t;
+files_type(go_fdo_server_var_lib_t)
+
+type go_fdo_server_unit_t;
+systemd_unit_file(go_fdo_server_unit_t)
+
+permissive go_fdo_server_t;
+
+########################################
+#
+# go_fdo_server local policy
+#
+allow go_fdo_server_t self:capability { setgid setuid };
+allow go_fdo_server_t self:fifo_file rw_fifo_file_perms;
+allow go_fdo_server_t self:tcp_socket create_stream_socket_perms;
+allow go_fdo_server_t self:udp_socket create_socket_perms;
+allow go_fdo_server_t self:unix_stream_socket create_stream_socket_perms;
+
+# Patterns
+manage_dirs_pattern(go_fdo_server_t, go_fdo_server_var_lib_t, go_fdo_server_var_lib_t)
+manage_files_pattern(go_fdo_server_t, go_fdo_server_var_lib_t, go_fdo_server_var_lib_t)
+read_files_pattern(go_fdo_server_t, go_fdo_server_cert_t, go_fdo_server_cert_t)
+read_files_pattern(go_fdo_server_t, go_fdo_server_etc_t, go_fdo_server_etc_t)
+
+# Base system interfaces
+corenet_tcp_bind_generic_port(go_fdo_server_t)
+domain_use_interactive_fds(go_fdo_server_t)
+files_read_etc_files(go_fdo_server_t)
+
+# Module interfaces
+optional_policy(`
+    auth_use_nsswitch(go_fdo_server_t)
+')
+
+optional_policy(`
+    miscfiles_read_localization(go_fdo_server_t)
+')
+
+optional_policy(`
+    sysnet_dns_name_resolve(go_fdo_server_t)
+')


### PR DESCRIPTION
Newly created policy for the new go-fdo-server package. 

The policy was generated with the help of Claude code. 
**File Types:**
- `go_fdo_server_t` - Process domain
- `go_fdo_server_exec_t` - Executable files
- `go_fdo_server_etc_t` - Configuration files
- `go_fdo_server_cert_t` - Certificate files
- `go_fdo_server_var_lib_t` - Database and state files
- `go_fdo_server_unit_t` - Systemd unit files

**Key Permissions:**
- Network: TCP/UDP socket creation, port binding
- Files: Read config/certs, manage databases
- System: setuid/setgid capabilities, nsswitch, DNS resolution
- Systemd: Proper daemon domain transitions

Resolves: RHEL-145754