### PR TITLE
Do not audit iptables attempts to read other process state

### DIFF
--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -91,6 +91,8 @@ dev_read_sysfs(iptables_t)
 dev_read_urand(iptables_t)
 dev_read_rand(iptables_t)
 
+domain_dontaudit_read_all_domains_state(iptables_t)
+
 fs_getattr_xattr_fs(iptables_t)
 fs_search_auto_mountpoints(iptables_t)
 fs_read_nsfs_files(iptables_t)


### PR DESCRIPTION
This generic dontaudit rule applies to reading state of all domains for which there is no particular allow rule.

Resolves: RHEL-164304