### PR TITLE
Do not audit iptables attempts to read other process state

### DIFF
--- a/policy/modules/contrib/powerprofiles.te
+++ b/policy/modules/contrib/powerprofiles.te
@@ -13,8 +13,6 @@ init_nnp_daemon_domain(powerprofiles_t)
 type powerprofiles_var_lib_t;
 files_type(powerprofiles_var_lib_t);
 
-permissive powerprofiles_t;
-
 allow powerprofiles_t self:capability2 bpf;
 allow powerprofiles_t self:netlink_kobject_uevent_socket create_socket_perms;
 

--- a/policy/modules/contrib/qgs.te
+++ b/policy/modules/contrib/qgs.te
@@ -9,8 +9,6 @@ type qgs_t;
 type qgs_exec_t;
 init_daemon_domain(qgs_t, qgs_exec_t)
 
-permissive qgs_t;
-
 type qgs_var_lib_t;
 files_type(qgs_var_lib_t);
 

--- a/policy/modules/contrib/redfish-finder.te
+++ b/policy/modules/contrib/redfish-finder.te
@@ -14,8 +14,6 @@ init_daemon_domain(redfish_finder_t, redfish_finder_exec_t)
 # redfish-finder local policy
 #
 
-permissive redfish_finder_t;
-
 corecmd_exec_bin(redfish_finder_t)
 dev_read_sysfs(redfish_finder_t)
 

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -76,7 +76,6 @@ ssh_server_template(sshd_session)
 #role system_r types sshd_session_t;
 type sshd_session_exec_t;
 corecmd_executable_file(sshd_session_exec_t)
-permissive sshd_session_t;
 domain_type(sshd_session_t);
 domain_entry_file(sshd_session_t, sshd_session_exec_t)
 domain_dyntrans_type(sshd_session_t)
@@ -161,7 +160,6 @@ term_relabelto_all_ptys(sshd_session_t)
 type sshd_auth_t;
 role system_r types sshd_auth_t;
 type sshd_auth_exec_t;
-permissive sshd_auth_t;
 domain_type(sshd_auth_t);
 corecmd_executable_file(sshd_auth_exec_t)
 domain_entry_file(sshd_auth_t, sshd_auth_exec_t)

--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -91,6 +91,8 @@ dev_read_sysfs(iptables_t)
 dev_read_urand(iptables_t)
 dev_read_rand(iptables_t)
 
+domain_dontaudit_read_all_domains_state(iptables_t)
+
 fs_getattr_xattr_fs(iptables_t)
 fs_search_auto_mountpoints(iptables_t)
 fs_read_nsfs_files(iptables_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1935,8 +1935,6 @@ optional_policy(`
 allow systemd_mountfsd_t self:capability { sys_ptrace sys_resource };
 allow systemd_mountfsd_t systemd_mountfsd_exec_t:file execute_no_trans;
 
-permissive systemd_mountfsd_t;
-
 kernel_dgram_send(systemd_mountfsd_t)
 
 ########################################
@@ -1969,8 +1967,6 @@ optional_policy(`
     dbus_watch_pid_dir_path(systemd_oomd_t)
     dbus_watch_pid_sock_files(systemd_oomd_t)
 ')
-
-permissive systemd_oomd_t;
 
 ########################################
 #


### PR DESCRIPTION
This generic dontaudit rule applies to reading state of all domains for which there is no particular allow rule.

Resolves: RHEL-164304