### PR TITLE
Revert "Define file equivalency for /var/opt"

### DIFF
--- a/config/file_contexts.subs_dist
+++ b/config/file_contexts.subs_dist
@@ -36,4 +36,3 @@
 /bin                 /usr/bin
 /usr/etc             /etc
 /usr/sbin            /usr/bin
-/var/opt             /opt

--- a/policy/modules/contrib/antivirus.fc
+++ b/policy/modules/contrib/antivirus.fc
@@ -27,6 +27,7 @@
 /var/lib/clamav(/.*)?				gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/lib/clamav-unofficial-sigs(/.*)?   gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/lib/clamd.*					gen_context(system_u:object_r:antivirus_db_t,s0)
+/var/opt/f-secure(/.*)?				gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/spool/amavisd(/.*)?			gen_context(system_u:object_r:antivirus_db_t,s0)
 /var/virusmails(/.*)?				gen_context(system_u:object_r:antivirus_db_t,s0)
 

--- a/policy/modules/contrib/apache.fc
+++ b/policy/modules/contrib/apache.fc
@@ -129,6 +129,7 @@ ifdef(`distro_suse', `
 /var/lib/moodle(/.*)?		    gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /var/lib/mod_security(/.*)?     gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/nginx(/.*)?            gen_context(system_u:object_r:httpd_var_lib_t,s0)
+/var/opt/rh/rh-nginx18/lib/nginx(/.*)?            gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/php/session(/.*)?		gen_context(system_u:object_r:httpd_var_run_t,s0)
 /var/lib/php/wsdlcache(/.*)?		gen_context(system_u:object_r:httpd_var_run_t,s0)
 
@@ -157,7 +158,7 @@ ifdef(`distro_suse', `
 /var/log/httpd(/.*)?		gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/lighttpd(/.*)?		gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/nginx(/.*)?     gen_context(system_u:object_r:httpd_log_t,s0)
-
+/var/opt/rh/rh-nginx18/log(/.*)?     gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/php-fpm(/.*)?      gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/roundcubemail(/.*)?	gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/suphp\.log.*	--	gen_context(system_u:object_r:httpd_log_t,s0)
@@ -177,6 +178,7 @@ ifdef(`distro_debian', `
 /run/lighttpd(/.*)?			gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/mod_.*				gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/nginx.*            gen_context(system_u:object_r:httpd_var_run_t,s0)
+/var/opt/rh/rh-nginx18/run/nginx(/.*)?            gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/php-fpm(/.*)?      gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/thttpd\.pid    -- gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/wsgi.*			-s	gen_context(system_u:object_r:httpd_var_run_t,s0)

--- a/policy/modules/contrib/redis.fc
+++ b/policy/modules/contrib/redis.fc
@@ -20,3 +20,6 @@
 
 /run/redis(/.*)?		gen_context(system_u:object_r:redis_var_run_t,s0)
 /run/valkey(/.*)?		gen_context(system_u:object_r:redis_var_run_t,s0)
+
+
+/var/opt/rh/rh-redis32/redis(/.*)?		--	gen_context(system_u:object_r:redis_exec_t,s0)

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -47,6 +47,8 @@ ifdef(`distro_suse', `
 
 /var/ace(/.*)?			gen_context(system_u:object_r:var_auth_t,s0)
 
+/var/opt/quest/vas/vasd(/.*)?	gen_context(system_u:object_r:var_auth_t,s0)
+
 /var/cache/coolkey(/.*)?	gen_context(system_u:object_r:auth_cache_t,s0)
 
 /var/db/shadow.*	--	gen_context(system_u:object_r:shadow_t,s0)


### PR DESCRIPTION
This reverts commit c852a6898d55bf49d53461cce74d51c578310642.

The alias /var/opt -> /opt breaks third-party software that uses the /var/opt namespace for writable data. See issue #2960