### PR TITLE
Add missing fc rule for org.gnome.DisplayManager (bsc#1264182)

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -205,6 +205,7 @@ ifndef(`distro_debian',`
 /run/video.rom	--	gen_context(system_u:object_r:xserver_var_run_t,s0)
 /run/xorg(/.*)?		gen_context(system_u:object_r:xserver_var_run_t,s0)
 /run/systemd/multi-session-x(/.*)?	gen_context(system_u:object_r:xdm_var_run_t,s0)
+/run/systemd/userdb/org\.gnome\.DisplayManager	-s	gen_context(system_u:object_r:xdm_var_run_t,s0)
 
 ifdef(`distro_suse',`
 /var/lib/pam_devperm/:0	--	gen_context(system_u:object_r:xdm_var_lib_t,s0)


### PR DESCRIPTION
Commit 9466835ee36bdc5bd357df38b1fc98f37ea4ad36
"Allow gdm bind a socket in the /run/systemd/userdbd directory" added a named filetrans rule for org.gnome.DisplayManager.

However, there is no general file context rule for /run/systemd/userdb/org.gnome.DisplayManager.
This is a problem on systemd soft-reboot, as systemd will write the labels in the directory from the policy and does not itself have a named filetrans.

So adding the missing file context rule.

Fixes:
----
time->Fri May  8 16:11:00 2026
type=PROCTITLE msg=audit(1778249460.946:293): proctitle="/usr/sbin/gdm" type=PATH msg=audit(1778249460.946:293): item=1 name="/run/systemd/userdb/org.gnome.DisplayManager" inode=2056 dev=00:1d mode=0140666 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(1778249460.946:293): item=0 name="/run/systemd/userdb/" inode=44 dev=00:1d mode=040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(1778249460.946:293): cwd="/"
type=SYSCALL msg=audit(1778249460.946:293): arch=c000003e syscall=87 success=no exit=-13 a0=7f5e37ffeb32 a1=20 a2=1e a3=0 items=2 ppid=1 pid=2322 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=47444D2075736572646220776F726B exe="/usr/sbin/gdm" subj=system_u:system_r:xdm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(1778249460.946:293): avc:  denied  { unlink } for  pid=2322 comm=47444D2075736572646220776F726B name="org.gnome.DisplayManager" dev="tmpfs" ino=2056 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=sock_file permissive=0