### PR TITLE
Update fstools swap interfaces with dir search

### DIFF
--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -170,6 +170,7 @@ interface(`fstools_getattr_swap_files',`
 		type swapfile_t;
 	')
 
+	allow $1 swapfile_t:dir search;
 	allow $1 swapfile_t:file getattr;
 ')
 
@@ -188,6 +189,7 @@ interface(`fstools_read_swap_files',`
 		type swapfile_t;
 	')
 
+	allow $1 swapfile_t:dir search;
 	allow $1 swapfile_t:file read_file_perms;
 ')
 
@@ -206,6 +208,7 @@ interface(`fstools_rw_swap_files',`
 		type swapfile_t;
 	')
 
+	allow $1 swapfile_t:dir search;
 	allow $1 swapfile_t:file rw_file_perms;
 ')
 


### PR DESCRIPTION
Rules to allow search swapfile_t directory were added next to current allow rules for files which is useful in cases when a swapfile is in a dedicated directory with the swapfile_t type.

The commit addresses the following AVC denial:
avc: denied { search } for comm="systemd-logind" name="swap" dev="dm-0" scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:object_r:swapfile_t:s0 tclass=dir permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2468532