### PR TITLE
Allow sys_resource on execution of generic executables conditionally

### DIFF
--- a/policy/global_tunables
+++ b/policy/global_tunables
@@ -153,3 +153,10 @@ gen_tunable(use_virtualbox, false)
 ## </p>
 ## </desc>
 gen_tunable(deny_bluetooth,false)
+
+## <desc>
+## <p>
+## Allow the sys_resource capability to all domains allowed to execute bin_t
+## </p>
+## </desc>
+gen_tunable(corecmd_bin_sys_resource, false)

--- a/policy/modules/contrib/mcelog.te
+++ b/policy/modules/contrib/mcelog.te
@@ -77,9 +77,6 @@ files_pid_filetrans(mcelog_t, mcelog_var_run_t, { dir file sock_file })
 
 kernel_read_system_state(mcelog_t)
 
-corecmd_exec_shell(mcelog_t)
-corecmd_exec_bin(mcelog_t)
-
 dev_read_raw_memory(mcelog_t)
 dev_read_kmsg(mcelog_t)
 dev_rw_sysfs(mcelog_t)
@@ -99,8 +96,12 @@ tunable_policy(`mcelog_client',`
 
 tunable_policy(`mcelog_exec_scripts',`
 	allow mcelog_t self:fifo_file rw_fifo_file_perms;
-	corecmd_exec_bin(mcelog_t)
+	corecmd_exec_bin_noattr(mcelog_t)
 	corecmd_exec_shell(mcelog_t)
+')
+
+tunable_policy(`mcelog_exec_scripts && corecmd_bin_sys_resource',`
+	allow mcelog_t self:capability sys_resource;
 ')
 
 tunable_policy(`mcelog_foreground',`

--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -100,11 +100,15 @@ tunable_policy(`redis_enable_notify',`
 	corenet_tcp_connect_pop_port(redis_t)
     corenet_sendrecv_pop_client_packets(redis_t)
 
-    corecmd_exec_bin(redis_t)
+    corecmd_exec_bin_noattr(redis_t)
     corecmd_exec_shell(redis_t)
 
 	fs_getattr_tmpfs(redis_t)
 	fs_getattr_xattr_fs(redis_t)
+')
+
+tunable_policy(`redis_enable_notify && corecmd_bin_sys_resource',`
+	allow redis_t self:capability sys_resource;
 ')
 
 optional_policy(`

--- a/policy/modules/kernel/corecommands.if
+++ b/policy/modules/kernel/corecommands.if
@@ -398,6 +398,46 @@ interface(`corecmd_read_bin_sockets',`
 #
 interface(`corecmd_exec_bin',`
 	gen_require(`
+		attribute sys_resource_type;
+		type bin_t;
+	')
+
+	read_lnk_files_pattern($1, bin_t, bin_t)
+	list_dirs_pattern($1, bin_t, bin_t)
+	can_exec($1, bin_t)
+
+	ifdef(`enable_mls',`',`
+		files_exec_all_base_ro_files($1)
+	')
+
+	typeattribute $1 sys_resource_type;
+')
+
+########################################
+## <summary>
+##	Execute generic programs in bin directories in the caller domain.
+## </summary>
+## <desc>
+##	<p>
+##	Allow the specified domain to execute generic programs
+##	in system bin directories without a domain transition.
+##	Unlike in corecmd_exec_bin(), do not assign the sys_resource_type attribute.
+##	</p>
+##	<p>
+##	Related interface:
+##	</p>
+##	<ul>
+##		<li>corecmd_exec_bin()</li>
+##	</ul>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corecmd_exec_bin_noattr',`
+	gen_require(`
 		type bin_t;
 	')
 

--- a/policy/modules/kernel/corecommands.te
+++ b/policy/modules/kernel/corecommands.te
@@ -6,6 +6,11 @@ policy_module(corecommands, 1.18.1)
 #
 
 #
+# Types with the sys_resource_type attribute are allowed the sys_resource capability.
+#
+attribute sys_resource_type;
+
+#
 # Types with the exec_type attribute are executable files.
 #
 attribute exec_type;
@@ -27,3 +32,8 @@ corecmd_executable_file(shell_exec_t)
 
 type chroot_exec_t;
 corecmd_executable_file(chroot_exec_t)
+
+dontaudit sys_resource_type self:capability sys_resource;
+tunable_policy(`corecmd_bin_sys_resource',`
+	allow sys_resource_type self:capability sys_resource;
+')


### PR DESCRIPTION
Allow the sys_resource capability to each domain which is allowed to execute generic programs in system bin directories without domain transition when the coreutils_bin_sys_resource tunable is on. If the tunable is off, which is the default state, the capability is dontaudited instead. The allow or dontaudit rule applies to the sys_resource_type attribute. Unability to set the name of the calling thread or kernel memory map descriptor fields is not critical.

coreutils-single is a collection of GNU core utilities, but packaged as a single multicall binary. Each program now executes prctl() with PR_SET_MM which requires the CAP_SYS_RESOURCE capability.

prctl(PR_SET_NAME, "mkdir")             = 0
prctl(PR_SET_MM, PR_SET_MM_ARG_START, 0x7fff20a92dc7, 0, 0) = 0

capabilities(7)
      CAP_SYS_RESOURCE
             •  employ the prctl(2) PR_SET_MM operation;

PR_SET_MM(2const)
DESCRIPTION
       Modify certain kernel memory map descriptor fields of the calling
process. Usually these fields are set by the kernel and dynamic loader (see ld.so(8) for more information) and a regular application should not use this feature. However, there are cases, such as self-modifying programs, where a program might find it useful to change its own memory map. The calling process must have the CAP_SYS_RESOURCE capability.

Resolves: RHEL-141858