### PR TITLE
Allow go-fdo-server to read system information

### DIFF
--- a/policy/modules/contrib/go_fdo_server.te
+++ b/policy/modules/contrib/go_fdo_server.te
@@ -39,8 +39,12 @@ manage_files_pattern(go_fdo_server_t, go_fdo_server_var_lib_t, go_fdo_server_var
 read_files_pattern(go_fdo_server_t, go_fdo_server_cert_t, go_fdo_server_cert_t)
 read_files_pattern(go_fdo_server_t, go_fdo_server_etc_t, go_fdo_server_etc_t)
 
+#Kernel 
+kernel_read_net_sysctls(go_fdo_server_t)
+
 # Base system interfaces
 corenet_tcp_bind_generic_port(go_fdo_server_t)
+dev_read_sysfs(go_fdo_server_t)
 domain_use_interactive_fds(go_fdo_server_t)
 files_read_etc_files(go_fdo_server_t)
 


### PR DESCRIPTION
The go-fdo-server daemon needs to read system information during startup:
- Transparent hugepage settings in /sys for Go runtime memory optimization
- Network sysctl values in /proc/sys/net for proper TCP server configuration

Added interfaces:
- dev_read_sysfs(go_fdo_server_t) for sysfs access
- kernel_read_net_sysctls(go_fdo_server_t) for network sysctl access

Resolves: RHEL-145754