### PR TITLE
Allow virtnwfilterd_t r/w on packet_socket (bsc#1264273)

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2077,7 +2077,7 @@ allow virtnwfilterd_t self:capability net_raw;
 allow virtnwfilterd_t self:netlink_generic_socket create_socket_perms;
 allow virtnwfilterd_t self:netlink_netfilter_socket create_socket_perms;
 allow virtnwfilterd_t self:netlink_rdma_socket create_socket_perms;
-allow virtnwfilterd_t self:packet_socket { bind create getopt ioctl map setopt };
+allow virtnwfilterd_t self:packet_socket create_socket_perms;
 allow virtnwfilterd_t self:rawip_socket create_socket_perms;
 
 manage_dirs_pattern(virtnwfilterd_t, virt_var_run_t, virt_var_run_t)


### PR DESCRIPTION
Already has permissions for other types and it's needed for e.g. dhcp network filter.
Solves:
avc:  denied  { read write } for comm="dhcp-snoop" path="socket:[21972]" dev="sockfs" scontext=system_u:system_r:virtnwfilterd_t:s0
tcontext=system_u:system_r:virtnwfilterd_t:s0
tclass=packet_socket permissive=0