### PR TITLE
Allow the kernel to execute also special files

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1921,6 +1921,12 @@ interface(`files_mmap_exec_all_files',`
 	')
 
 	mmap_exec_files_pattern($1, { file_type $2 }, { file_type $2 })
+
+	# possible to reach these via access(2)
+	allow $1 { file_type $2 }:lnk_file execute;
+	allow $1 { file_type $2 }:chr_file execute;
+	allow $1 { file_type $2 }:blk_file execute;
+	allow $1 { file_type $2 }:fifo_file execute;
 ')
 
 ########################################


### PR DESCRIPTION
Update the files_mmap_exec_all_files() to allow also execute on special files with any file label, because such access vectors can be reached by calling access(2) on such files vi NFS (they happen on the server side as a side effect of checking the DAC permissions against overriden creds).

Note that execute on some special files can also be triggered via access(2) on a regular filesystem against the current task, so the NFS checks aren't entirely nonsensical.

Resolves: https://redhat.atlassian.net/browse/RHEL-72728