### PR TITLE
Split using dirsrv_ and dirsrvadmin_ interfaces into separate blocks

### DIFF
--- a/policy/modules/contrib/apache.te
+++ b/policy/modules/contrib/apache.te
@@ -986,11 +986,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	#needed by FreeIPA 
-	dirsrv_stream_connect(httpd_t)
-')
-
-optional_policy(`
 	dirsrv_getattr_unit_files(httpd_t)
 	dirsrv_manage_config(httpd_t)
 	dirsrv_manage_log(httpd_t)
@@ -998,6 +993,12 @@ optional_policy(`
 	dirsrv_read_share(httpd_t)
 	dirsrv_signal(httpd_t)
 	dirsrv_signull(httpd_t)
+
+	#needed by FreeIPA 
+	dirsrv_stream_connect(httpd_t)
+')
+
+optional_policy(`
 	dirsrvadmin_manage_config(httpd_t)
 	dirsrvadmin_manage_tmp(httpd_t)
 	dirsrvadmin_domtrans_unconfined_script_t(httpd_t)

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -1321,8 +1321,11 @@ ifdef(`distro_redhat',`
 	')
 
 	optional_policy(`
-		dirsrvadmin_read_config(initrc_t)
 		dirsrv_manage_var_run(initrc_t)
+	')
+
+	optional_policy(`
+		dirsrvadmin_read_config(initrc_t)
 	')
 
 	optional_policy(`


### PR DESCRIPTION
In init.te and apache.te, dirsrv_ and dirsrvadmin_ interfaces were in the same optional block, although they are from different modules. Moreover, dirsrvadmin is not shipped any longer, which effects in dirsrv rules not applying either.

Resolves: RHEL-62706