### PR TITLE
Allow mock create and use its private tmpfs files

### DIFF
--- a/policy/modules/contrib/mock.te
+++ b/policy/modules/contrib/mock.te
@@ -30,6 +30,9 @@ files_type(mock_cache_t)
 type mock_tmp_t;
 files_tmp_file(mock_tmp_t)
 
+type mock_tmpfs_t;
+files_tmpfs_file(mock_tmpfs_t)
+
 type mock_var_lib_t;
 files_type(mock_var_lib_t)
 
@@ -68,6 +71,9 @@ manage_dirs_pattern(mock_t, mock_tmp_t, mock_tmp_t)
 manage_files_pattern(mock_t, mock_tmp_t, mock_tmp_t)
 manage_lnk_files_pattern(mock_t, mock_tmp_t, mock_tmp_t)
 files_tmp_filetrans(mock_t, mock_tmp_t, { dir file lnk_file })
+
+allow mock_t mock_tmpfs_t:file { manage_file_perms map };
+fs_tmpfs_filetrans(mock_t, mock_tmpfs_t, file)
 
 manage_dirs_pattern(mock_t, mock_var_lib_t, mock_var_lib_t)
 manage_files_pattern(mock_t, mock_var_lib_t, mock_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(05/15/2026 04:06:47.542:800) : proctitle=/usr/bin/python3 -tt /usr/libexec/mock/mock --list-snapshots type=PATH msg=audit(05/15/2026 04:06:47.542:800) : item=0 name=/dev/shm/ inode=1 dev=00:1a mode=dir,sticky,777 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:tmpfs_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(05/15/2026 04:06:47.542:800) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ffef397b470 a2=O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC a3=0x180 items=1 ppid=7194 pid=7237 auid=staffuser1544 uid=staffuser1544 gid=mock euid=staff user1544 suid=root fsuid=staffuser1544 egid=mock sgid=mock fsgid=mock tty=pts3 ses=6 comm=mock exe=/usr/bin/python3.14 subj=staff_u:staff_r:mock_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(05/15/2026 04:06:47.542:800) : avc:  denied  { create } for  pid=7237 comm=mock name=sem.UTRis5 scontext=staff_u:staff_r:mock_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:tmpfs_t:s0 tclass=file permissive=0