### PR TITLE
Allow virtqemud execute kmod in the kmod domain

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2362,6 +2362,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	modutils_domtrans_kmod(virtqemud_t)
+')
+
+optional_policy(`
 	nbdkit_domtrans(virtqemud_t)
 	nbdkit_signal(virtqemud_t)
 	nbdkit_signull(virtqemud_t)


### PR DESCRIPTION
Triggered by dettaching a PCI node device:
virsh nodedev-dettach pci_0000_18_00_1

The commit addresses the following AVC denial:
type=AVC msg=audit(1750821038.379:192): avc:  denied  { execute } for  pid=7896 comm="rpc-virtqemud" name="kmod" dev="dm-0" ino=134351583 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:kmod_exec_t:s0 tclass=file permissive=1

Resolves: RHEL-99904