### PR TITLE
Allow qatlib map kernel modules

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -56,6 +56,7 @@ dev_setattr_generic_dirs(qatlib_t)
 
 domain_use_interactive_fds(qatlib_t)
 
+files_map_kernel_modules(qatlib_t)
 files_read_kernel_modules(qatlib_t)
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/22/2026 16:11:20.117:98) : proctitle=modprobe vfio-pci type=AVC msg=audit(01/22/2026 16:11:20.117:98) : avc:  denied  { map } for  pid=39218 comm=modprobe path=/usr/lib/modules/6.12.0-185.1818_2272231082.el10.x86_64/modules.dep.bin dev="dm-0" ino=184674694 scontext=system_u:system_r:qatlib_t:s0 tcontext=unconfined_u:object_r:modules_object_t:s0 tclass=file permissive=0 type=SYSCALL msg=audit(01/22/2026 16:11:20.117:98) : arch=x86_64 syscall=mmap success=no exit=EACCES(Permission denied) a0=0x0 a1=0x6b9dc a2=PROT_READ a3=MAP_PRIVATE items=0 ppid=39216 pid=39218 auid=unset uid=root gid=systemd-coredump euid=root suid=root fsuid=root egid=systemd-coredump sgid=systemd-coredump fsgid=systemd-coredump tty=(none) ses=unset comm=modprobe exe=/usr/bin/kmod subj=system_u:system_r:qatlib_t:s0 key=(null)

Resolves: RHEL-133799