### PR TITLE
Allow samba-bgqd send to nmbd over a unix datagram socket

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -1387,6 +1387,7 @@ optional_policy(`
 allow smbd_t samba_dcerpcd_t:process noatsecure;
 allow smbd_t samba_dcerpcd_t:unix_stream_socket connectto;
 allow winbind_t samba_dcerpcd_t:unix_stream_socket connectto;
+allow samba_bgqd_t nmbd_t: unix_dgram_socket sendto;
 allow samba_bgqd_t smbd_t: unix_dgram_socket sendto;
 allow samba_dcerpcd_t samba_bgqd_t:unix_dgram_socket sendto;
 allow samba_dcerpcd_t nmbd_t:unix_dgram_socket sendto;


### PR DESCRIPTION
samba-bgqd needs to access the /var/lib/samba/private/msg.sock/PID socket file.

The commit addresses the following AVC denial:
type=AVC msg=audit(1779039885.619:1254): avc:  denied  { sendto } for  pid=1786 comm="samba-bgqd" path="/var/lib/samba/private/msg.sock/1777" scontext=system_u:system_r:samba_bgqd_t:s0 tcontext=system_u:system_r:nmbd_t:s0 tclass=unix_dgram_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2478311