### PR TITLE
Dontaudit ksmtuned dac_read_search and dac_override capabilities

### DIFF
--- a/policy/modules/contrib/ksmtuned.te
+++ b/policy/modules/contrib/ksmtuned.te
@@ -48,6 +48,7 @@ files_pid_file(ksmtuned_var_run_t)
 #
 
 allow ksmtuned_t self:capability { sys_ptrace sys_tty_config };
+dontaudit ksmtuned_t self:capability { dac_override dac_read_search };
 allow ksmtuned_t self:cap_userns { sys_ptrace };
 allow ksmtuned_t self:fifo_file rw_fifo_file_perms;
 


### PR DESCRIPTION
These capability requests are triggerd because of

committed_memory () {
    # calculate how much memory is committed to running qemu processes
    local pidlist
    pidlist=$(pgrep -d ' ' -- '^qemu(-(kvm|system-.+)|:.{1,11})$')
    if [ -n "$pidlist" ]; then
        ps -p "$pidlist" -o rsz=
    fi | awk '{ sum += $1 }; END { print 0+sum }'
}

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/04/2026 03:54:00.515:655) : proctitle=pgrep -d   -- ^qemu(-(kvm|system-.+)|:.{1,11})$
type=PATH msg=audit(05/04/2026 03:54:00.515:655) : item=0 name=environ inode=26908 dev=00:17 mode=file,400 ouid=systemd-resolve ogid=systemd-resolve rdev=00:00 obj=system_u:system_r:systemd_resolved_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/04/2026 03:54:00.515:655) : cwd=/
type=SYSCALL msg=audit(05/04/2026 03:54:00.515:655) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=0x5 a1=0x7f6496737148 a2=O_RDONLY a3=0x0 items=1 ppid=10717 pid=10718 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pgrep exe=/usr/bin/pgrep subj=system_u:system_r:ksmtuned_t:s0 key=(null)
type=AVC msg=audit(05/04/2026 03:54:00.515:655) : avc:  denied  { dac_override } for  pid=10718 comm=pgrep capability=dac_override  scontext=system_u:system_r:ksmtuned_t:s0 tcontext=system_u:system_r:ksmtuned_t:s0 tclass=capability permissive=0
type=AVC msg=audit(05/04/2026 03:54:00.515:655) : avc:  denied  { dac_read_search } for  pid=10718 comm=pgrep capability=dac_read_search  scontext=system_u:system_r:ksmtuned_t:s0 tcontext=system_u:system_r:ksmtuned_t:s0 tclass=capability permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2464873