### PR TITLE
Dontaudit tlp_t requesting dac_read_search (bsc#1265386)

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -33,6 +33,7 @@ allow tlp_t self:netlink_generic_socket create_socket_perms;
 # greps for only tuned-ppd, power-profiles-daemon and
 # tlp-pd. ps does not need those two necessarily to work:
 dontaudit tlp_t self:cap_userns sys_ptrace;
+dontaudit tlp_t self:capability dac_read_search;
 dontaudit tlp_t self:capability2 perfmon;
 
 allow tlp_t tlp_unit_file_t:file read_file_perms;


### PR DESCRIPTION
same reason as https://github.com/fedora-selinux/selinux-policy/pull/3104


Fixes:

type=AVC msg=audit(1778932108.807:70): avc:  denied  { dac_read_search } for  pid=2673 comm="ps" capability=2  scontext=system_u:syste m_r:tlp_t:s0 tcontext=system_u:system_r:tlp_t:s0 tclass=capability permissive=1 type=AVC msg=audit(1778932714.328:132): avc:  denied  { dac_read_search } for  pid=6364 comm="ps" capability=2  scontext=system_u:syst em_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tclass=capability permissive=1 type=AVC msg=audit(1778932714.858:133): avc:  denied  { dac_read_search } for  pid=6687 comm="ps" capability=2  scontext=system_u:syst em_r:tlp_t:s0-s0:c0.c1023 tcontext=system_u:system_r:tlp_t:s0-s0:c0.c1023 tclass=capability permissive=1