### PR TITLE
Virtstoraged execmem rhel 44901

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -541,8 +541,7 @@ optional_policy(`
 #
 
 allow svirt_tcg_t self:capability sys_rawio;
-allow svirt_tcg_t self:process execstack;
-dontaudit svirt_tcg_t self:process execmem;
+allow svirt_tcg_t self:process { execmem execstack };
 allow svirt_tcg_t self:netlink_route_socket r_netlink_socket_perms;
 
 allow svirt_tcg_t svirt_image_t:blk_file map;

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2476,6 +2476,7 @@ fs_getattr_configfs_dirs(virtstoraged_t)
 
 storage_raw_read_fixed_disk(virtstoraged_t)
 storage_raw_write_fixed_disk(virtstoraged_t)
+storage_setattr_fixed_disk_dev(virtstoraged_t)
 
 userdom_read_user_home_content_files(virtstoraged_t)
 

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -541,7 +541,8 @@ optional_policy(`
 #
 
 allow svirt_tcg_t self:capability sys_rawio;
-allow svirt_tcg_t self:process { execmem execstack };
+allow svirt_tcg_t self:process execstack;
+dontaudit svirt_tcg_t self:process execmem;
 allow svirt_tcg_t self:netlink_route_socket r_netlink_socket_perms;
 
 allow svirt_tcg_t svirt_image_t:blk_file map;
@@ -579,7 +580,8 @@ optional_policy(`
 # fsetid - for chmod'ing its runtime files
 allow virtd_t self:capability { chown dac_read_search fowner fsetid ipc_lock kill mknod net_admin net_raw setgid setpcap setuid sys_admin sys_nice sys_ptrace };
 #allow virtd_t self:capability2 compromise_kernel;
-allow virtd_t self:process { execmem getcap getsched setcap setexec setfscreate setsched setsockcreate sigkill signal signull };
+allow virtd_t self:process { getcap getsched setcap setexec setfscreate setsched setsockcreate sigkill signal signull };
+dontaudit virtd_t self:process execmem;
 ifdef(`hide_broken_symptoms',`
 	# caused by some bogus kernel code
 	dontaudit virtd_t self:capability { sys_module };
@@ -2437,6 +2439,8 @@ optional_policy(`
 allow virtstoraged_t self:capability { dac_override dac_read_search fsetid ipc_lock sys_rawio};
 
 allow virtstoraged_t self:process { setsched };
+
+dontaudit virtstoraged_t self:process execmem;
 
 files_tmp_filetrans(virtstoraged_t, virtstoraged_tmp_t, { file dir })
 

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -28,7 +28,7 @@ gen_tunable(virt_use_execmem, false)
 
 ## <desc>
 ## <p>
-## Allow virtqemu driver to use executable memory and executable stack
+## [Obsolete]Allow virtqemu driver to use executable memory and executable stack
 ## </p>
 ## </desc>
 gen_tunable(virtqemud_use_execmem, true)
@@ -2319,10 +2319,6 @@ storage_setattr_scsi_generic_dev(virtqemud_t)
 
 sysnet_exec_ifconfig(virtqemud_t)
 sysnet_manage_config(virtqemud_t)
-
-tunable_policy(`virtqemud_use_execmem',`
-	allow virtqemud_t self:process { execmem execstack };
-')
 
 tunable_policy(`virt_use_nfs',`
 	fs_manage_nfs_dirs(virtqemud_t)


### PR DESCRIPTION
The virtstoraged tries to use ‘execmem’ capability due to use of G_REGEX_OPTIMIZE which invokes the JIT regex optimizer from PCRE library which indeed uses execmem permissions to do the optimization. The virtqemud, when the policy was split from virtd_t was granted ‘execmem’ via ‘virtqemud_use_execmem’, which is not necessary as well as it isn’t necessary for any of the virt daemons to have this capability.

- none of the libvirt daemons (including libvirtd (thus virtd_t)) should require execmem
- ‘virtqemud_use_execmem’ is bogus and should be removed
- all daemons should get a ‘dontaudit’ for execmem

Resolves: RHEL-44901