### PR TITLE
Bring back execmem permission for svirt_tcg_t

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -544,8 +544,7 @@ optional_policy(`
 #
 
 allow svirt_tcg_t self:capability sys_rawio;
-allow svirt_tcg_t self:process execstack;
-dontaudit svirt_tcg_t self:process execmem;
+allow svirt_tcg_t self:process { execmem execstack };
 allow svirt_tcg_t self:netlink_route_socket r_netlink_socket_perms;
 
 allow svirt_tcg_t svirt_image_t:blk_file map;


### PR DESCRIPTION
Fix of commit 956c4f9b7a1162e6c65988a4f6a6464982903c6c where execmem was wrongly changed to dontaudit rule.
svirt_tcg_t is policy for the QEMU process running under software (cross-platform) emulation (TCG = tiny code generator) which is JIT translating instructions. That one does require execmem.