### PR TITLE
Remove extra parameters from interface headers

### DIFF
--- a/policy/modules/contrib/boltd.if
+++ b/policy/modules/contrib/boltd.if
@@ -126,11 +126,6 @@ interface(`boltd_manage_lib_dirs',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`boltd_admin',`

--- a/policy/modules/contrib/cron.if
+++ b/policy/modules/contrib/cron.if
@@ -1038,22 +1038,12 @@ interface(`cron_generic_log_filetrans_log',`
 
 #######################################
 ## <summary>
-##  Create specified objects in generic
-##  log directories with the cron log file type.
+##  Create redhat-access-insights.log in generic
+##  log directories with the var_log_t file type.
 ## </summary>
 ## <param name="domain">
 ##  <summary>
 ##  Domain allowed access.
-##  </summary>
-## </param>
-## <param name="object_class">
-##  <summary>
-##  Class of the object being created.
-##  </summary>
-## </param>
-## <param name="name" optional="true">
-##  <summary>
-##  The name of the object being created.
 ##  </summary>
 ## </param>
 #

--- a/policy/modules/contrib/gnome_remote_desktop.if
+++ b/policy/modules/contrib/gnome_remote_desktop.if
@@ -126,11 +126,6 @@ interface(`gnome_remote_desktop_manage_lib_dirs',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`gnome_remote_desktop_admin',`
@@ -154,6 +149,7 @@ interface(`gnome_remote_desktop_admin',`
 	')
 ')
 
+########################################
 ## <summary>
 ##	Read and write to TCP socket
 ## </summary>

--- a/policy/modules/contrib/ibacm.if
+++ b/policy/modules/contrib/ibacm.if
@@ -128,11 +128,6 @@ interface(`ibacm_read_pid_files',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`ibacm_admin',`

--- a/policy/modules/contrib/jetty.if
+++ b/policy/modules/contrib/jetty.if
@@ -365,11 +365,6 @@ interface(`jetty_systemctl',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`jetty_admin',`

--- a/policy/modules/contrib/nvme_stas.if
+++ b/policy/modules/contrib/nvme_stas.if
@@ -38,7 +38,7 @@ interface(`nvme_stas_exec',`
 	can_exec($1, nvme_stas_exec_t)
 ')
 
-###################################### 
+########################################
 ## <summary>
 ##	Send and receive messages from
 ##	nvme_stas over dbus.

--- a/policy/modules/contrib/opendnssec.if
+++ b/policy/modules/contrib/opendnssec.if
@@ -156,11 +156,6 @@ interface(`opendnssec_systemctl',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`opendnssec_admin',`

--- a/policy/modules/contrib/pkcs11proxyd.if
+++ b/policy/modules/contrib/pkcs11proxyd.if
@@ -126,11 +126,6 @@ interface(`pkcs11proxyd_manage_lib_dirs',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`pkcs11proxyd_admin',`

--- a/policy/modules/contrib/qgs.if
+++ b/policy/modules/contrib/qgs.if
@@ -48,11 +48,6 @@ interface(`qgs_exec',`
 ##      Domain allowed access.
 ##      </summary>
 ## </param>
-## <param name="role">
-##      <summary>
-##      Role allowed access.
-##      </summary>
-## </param>
 ## <rolecap/>
 #
 interface(`qgs_admin',`
@@ -78,6 +73,7 @@ interface(`qgs_admin',`
         ')
 ')
 
+########################################
 ## <summary>
 ##      Connect to qgs over an unix
 ##      domain stream socket.

--- a/policy/modules/contrib/rrdcached.if
+++ b/policy/modules/contrib/rrdcached.if
@@ -68,11 +68,6 @@ interface(`rrdcached_read_pid_files',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`rrdcached_admin',`

--- a/policy/modules/contrib/rsync.if
+++ b/policy/modules/contrib/rsync.if
@@ -120,6 +120,7 @@ interface(`rsync_exec',`
 	can_exec($1, rsync_exec_t)
 ')
 
+########################################
 ## <summary>
 ##	Allow the specified domain to ioctl an
 ##	rsync with a unix domain stream socket.

--- a/policy/modules/contrib/sbd.if
+++ b/policy/modules/contrib/sbd.if
@@ -92,11 +92,6 @@ interface(`sbd_systemctl',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`sbd_admin',`

--- a/policy/modules/contrib/stalld.if
+++ b/policy/modules/contrib/stalld.if
@@ -68,11 +68,6 @@ interface(`stalld_read_pid_files',`
 ##      Domain allowed access.
 ##      </summary>
 ## </param>
-## <param name="role">
-##      <summary>
-##      Role allowed access.
-##      </summary>
-## </param>
 ## <rolecap/>
 #
 interface(`stalld_admin',`

--- a/policy/modules/contrib/stratisd.if
+++ b/policy/modules/contrib/stratisd.if
@@ -88,11 +88,6 @@ interface(`stratisd_read_pid_files',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`stratisd_admin',`

--- a/policy/modules/contrib/targetd.if
+++ b/policy/modules/contrib/targetd.if
@@ -132,11 +132,6 @@ interface(`targetd_systemctl',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`targetd_admin',`

--- a/policy/modules/contrib/tlp.if
+++ b/policy/modules/contrib/tlp.if
@@ -187,11 +187,6 @@ interface(`tlp_create_pid_dirs',`
 ##	Domain allowed access.
 ##	</summary>
 ## </param>
-## <param name="role">
-##	<summary>
-##	Role allowed access.
-##	</summary>
-## </param>
 ## <rolecap/>
 #
 interface(`tlp_admin',`


### PR DESCRIPTION
Also add missing ### separators so that the test script can properly separate individual interfaces.

There are no policy changes (just comments), so this should be safe to merge.

Resolves: RHEL-129394