### PR TITLE
packit: Stop notifying martinpitt for Cockpit test failures

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -22,7 +22,7 @@ jobs:
     trigger: pull_request
     notifications:
       failure_comment:
-        message: "Cockpit tests failed for commit {commit_sha}. @martinpitt, @jelly, @mvollmer please check."
+        message: "Cockpit tests failed for commit {commit_sha}. @jelly, @mvollmer please check."
     targets:
     - fedora-development
     tf_extra_params:

--- a/plans/cockpit.fmf
+++ b/plans/cockpit.fmf
@@ -1,6 +1,6 @@
 # reverse dependency test for https://github.com/cockpit-project/cockpit
 # packit should automatically notify the cockpit maintainers on failures.
-# For questions, please contact @martinpitt, @jelly, @mvollmer
+# For questions, please contact @jelly or @mvollmer
 
 enabled: false
 adjust+:


### PR DESCRIPTION
Martin left Red Hat and no is no longer involved in Cockpit development.