### PR TITLE
added caddy related paths.

### DIFF
--- a/policy/modules/contrib/apache.fc
+++ b/policy/modules/contrib/apache.fc
@@ -5,6 +5,7 @@ HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?	gen_context(system_u:objec
 
 /etc/apache(2)?(/.*)?			gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/apache-ssl(2)?(/.*)?		gen_context(system_u:object_r:httpd_config_t,s0)
+/etc/caddy(/.*)?         gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/cherokee(/.*)?			gen_context(system_u:object_r:httpd_config_t,s0)
 /etc/drupal.*				gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 /etc/glpi(/.*)?				gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
@@ -32,6 +33,8 @@ HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?	gen_context(system_u:objec
 
 /usr/.*\.cgi			-- 	gen_context(system_u:object_r:httpd_sys_script_exec_t,s0)
 /opt/.*\.cgi			-- 	gen_context(system_u:object_r:httpd_sys_script_exec_t,s0)
+/usr/lib/systemd/system/caddy.*     --  gen_context(system_u:object_r:httpd_unit_file_t,s0)
+/usr/lib/systemd/system/caddy-api.*     --  gen_context(system_u:object_r:httpd_unit_file_t,s0)
 /usr/lib/systemd/system/httpd.*  --     gen_context(system_u:object_r:httpd_unit_file_t,s0)
 /usr/lib/systemd/system/thttpd.*  --     gen_context(system_u:object_r:httpd_unit_file_t,s0)
 
@@ -63,6 +66,7 @@ HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?	gen_context(system_u:objec
 /usr/bin/apache(2)?		--	gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/bin/apachectl		--	gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/bin/apache-ssl(2)?	--	gen_context(system_u:object_r:httpd_exec_t,s0)
+/usr/bin/caddy         --  gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/bin/cherokee		--	gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/bin/httpd\.event		--	gen_context(system_u:object_r:httpd_exec_t,s0)
 /usr/bin/httpd(\.worker)?	--	gen_context(system_u:object_r:httpd_exec_t,s0)
@@ -113,6 +117,7 @@ ifdef(`distro_suse', `
 /var/cache/ssl.*\.sem		--	gen_context(system_u:object_r:httpd_cache_t,s0)
 
 /var/lib/cacti/rra(/.*)?		gen_context(system_u:object_r:httpd_sys_content_t,s0)
+/var/lib/caddy(/.*)?            gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/cherokee(/.*)?			gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/dav(/.*)?			gen_context(system_u:object_r:httpd_var_lib_t,s0)
 /var/lib/ganglia(/.*)?			gen_context(system_u:object_r:httpd_var_lib_t,s0)
@@ -151,6 +156,7 @@ ifdef(`distro_suse', `
 /var/log/glpi(/.*)?			gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/horizon(/.*)?			gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/cacti(/.*)?			gen_context(system_u:object_r:httpd_log_t,s0)
+/var/log/caddy(/.*)?     gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/cgiwrap\.log.*		--	gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/cherokee(/.*)?		gen_context(system_u:object_r:httpd_log_t,s0)
 /var/log/graphite-web(/.*)?		gen_context(system_u:object_r:httpd_log_t,s0)
@@ -170,6 +176,7 @@ ifdef(`distro_debian', `
 ')
 
 /run/apache.*			gen_context(system_u:object_r:httpd_var_run_t,s0)
+/run/caddy.*            gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/cherokee\.pid		--	gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/gcache_port		-s	gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/httpd.*			gen_context(system_u:object_r:httpd_var_run_t,s0)

--- a/policy/modules/contrib/apache.fc
+++ b/policy/modules/contrib/apache.fc
@@ -33,8 +33,7 @@ HOME_DIR/((www)|(web)|(public_html))(/.*)?/logs(/.*)?	gen_context(system_u:objec
 
 /usr/.*\.cgi			-- 	gen_context(system_u:object_r:httpd_sys_script_exec_t,s0)
 /opt/.*\.cgi			-- 	gen_context(system_u:object_r:httpd_sys_script_exec_t,s0)
-/usr/lib/systemd/system/caddy.*     --  gen_context(system_u:object_r:httpd_unit_file_t,s0)
-/usr/lib/systemd/system/caddy-api.*     --  gen_context(system_u:object_r:httpd_unit_file_t,s0)
+/usr/lib/systemd/system/caddy(|-api).*     --  gen_context(system_u:object_r:httpd_unit_file_t,s0)
 /usr/lib/systemd/system/httpd.*  --     gen_context(system_u:object_r:httpd_unit_file_t,s0)
 /usr/lib/systemd/system/thttpd.*  --     gen_context(system_u:object_r:httpd_unit_file_t,s0)
 
@@ -176,7 +175,6 @@ ifdef(`distro_debian', `
 ')
 
 /run/apache.*			gen_context(system_u:object_r:httpd_var_run_t,s0)
-/run/caddy.*            gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/cherokee\.pid		--	gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/gcache_port		-s	gen_context(system_u:object_r:httpd_var_run_t,s0)
 /run/httpd.*			gen_context(system_u:object_r:httpd_var_run_t,s0)


### PR DESCRIPTION
Hello.
I struggled to setup Caddy and Selinux on my instances.
So I decided to add caddy related path to apache.fc file.

I guess in future after applying changes Caddy will work in Selinux enabled instances without additional setup.