### PR TITLE
Dontaudit sa-update perfmon and sys_admin capabilities

### DIFF
--- a/policy/modules/contrib/spamassassin.te
+++ b/policy/modules/contrib/spamassassin.te
@@ -614,6 +614,8 @@ allow spamd_update_t self:fifo_file manage_fifo_file_perms;
 allow spamd_update_t self:unix_dgram_socket create_socket_perms;
 allow spamd_update_t self:unix_stream_socket create_stream_socket_perms;
 allow spamd_update_t self:capability { dac_read_search dac_override };
+dontaudit spamd_update_t self:capability sys_admin;
+dontaudit spamd_update_t self:capability2 perfmon;
 allow spamd_update_t self:cap_userns sys_ptrace;
 
 manage_dirs_pattern(spamd_update_t, spamd_tmp_t, spamd_tmp_t)


### PR DESCRIPTION
Triggered from /usr/share/spamassassin/sa-update.cron: for daemon in mimedefang spamd amavisd spampd; do
    /usr/bin/pgrep -f $daemon >& /dev/null
    [ $? -eq 0 ] && SAUPDATE=yes
done

pkill/pgrep since procps-ng v4.0.5 and commit 23491ebf ("pgrep: Add match to environment variable") [1] has the ability to match processes on an environment variable. To read other processes' environ file, the perfmon or sys_admin capability is required. It is not necessary for logrotate though as it uses pkill without switches, so the permissions are dontaudited.

[1] https://gitlab.com/procps-ng/procps/-/commit/2

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2477361