### PR TITLE
Allow pcscd_t to search cgroup

### DIFF
--- a/policy/modules/contrib/pcscd.te
+++ b/policy/modules/contrib/pcscd.te
@@ -62,6 +62,7 @@ dev_read_sysfs(pcscd_t)
 files_read_etc_runtime_files(pcscd_t)
 
 fs_getattr_pidfs(pcscd_t)
+fs_search_cgroup_dirs(pcscd_t)
 
 term_use_unallocated_ttys(pcscd_t)
 term_dontaudit_getattr_pty_dirs(pcscd_t)


### PR DESCRIPTION
Fixes the se denials with pcscd service traversing cgroug 