### PR TITLE
Add missing interface requirements

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -59,7 +59,7 @@ template(`sudo_role_template',`
 	allow $1_sudo_t $3:file read_file_perms;;
 	allow $1_sudo_t $3:key search;
 
-	allow $1_sudo_t $1_t:unix_stream_socket { getattr connectto ioctl read write };
+	allow $1_sudo_t $3:unix_stream_socket { getattr connectto ioctl read write };
 
 	# Enter this derived domain from the user domain
 	domtrans_pattern($3, sudo_exec_t, $1_sudo_t)

--- a/policy/modules/contrib/apache.if
+++ b/policy/modules/contrib/apache.if
@@ -15,7 +15,7 @@ template(`apache_user_content_template',`
 	gen_require(`
 		attribute httpd_exec_scripts, httpd_script_exec_type;
 		type httpd_t, httpd_suexec_t;
-		attribute httpd_script_type, httpd_user_content_type;
+		attribute httpd_content_type, httpd_script_type, httpd_user_content_type;
 	')
 
 	#This type is for webpages

--- a/policy/modules/contrib/condor.if
+++ b/policy/modules/contrib/condor.if
@@ -84,7 +84,7 @@ interface(`condor_domtrans_master',`
 #
 interface(`condor_startd_ranged_domtrans_to',`
     gen_require(`
-        type sshd_t;
+        type condor_startd_t;
     ')
     condor_startd_domtrans_to($1, $2)
 

--- a/policy/modules/contrib/conntrackd.if
+++ b/policy/modules/contrib/conntrackd.if
@@ -106,6 +106,7 @@ interface(`conntrackd_admin',`
 	gen_require(`
 		type conntrackd_t, conntrackd_tmp_t, conntrackd_log_t;
 		type conntrackd_conf_t, conntrackd_var_run_t, conntrackd_initrc_exec_t;
+		type conntrackd_unit_file_t;
 	')
 
 	allow $1 conntrackd_t:process signal_perms;

--- a/policy/modules/contrib/firewalld.if
+++ b/policy/modules/contrib/firewalld.if
@@ -180,6 +180,7 @@ interface(`firewalld_admin',`
 		type firewalld_t, firewalld_initrc_exec_t;
 		type firewalld_etc_rw_t, firewalld_var_run_t;
 		type firewalld_var_log_t;
+		type firewalld_unit_file_t;
 	')
 
 	allow $1 firewalld_t:process signal_perms;

--- a/policy/modules/contrib/ftp.if
+++ b/policy/modules/contrib/ftp.if
@@ -239,6 +239,7 @@ interface(`ftp_admin',`
 		type ftpd_var_run_t, xferlog_t, anon_sftpd_t;
 		type ftpd_initrc_exec_t, ftpdctl_tmp_t;
 		type ftpd_keytab_t;
+		type ftpd_unit_file_t;
 	')
 
 	allow $1 ftpd_t:process signal_perms;

--- a/policy/modules/contrib/kerberos.if
+++ b/policy/modules/contrib/kerberos.if
@@ -612,7 +612,7 @@ interface(`kerberos_filetrans_home_content',`
 interface(`kerberos_filetrans_named_content',`
 	gen_require(`
 		type krb5_conf_t, krb5_keytab_t, krb5kdc_conf_t;
-		type krb5kdc_principal_t;
+		type krb5kdc_principal_t, krb5_home_t;
 	')
 
 	files_etc_filetrans($1, krb5_conf_t, file, "krb5.conf")

--- a/policy/modules/contrib/kismet.if
+++ b/policy/modules/contrib/kismet.if
@@ -18,12 +18,12 @@
 template(`kismet_role',`
 	gen_require(`
 		type kismet_exec_t, kismet_home_t, kismet_tmp_t;
-		type kistmet_tmpfs_t, kismet_t;
+		type kismet_tmpfs_t, kismet_t;
 	')
 
 	kismet_run($1, $2)
 
-	allow $2 kistmet_t:process { ptrace signal_perms };
+	allow $2 kismet_t:process { ptrace signal_perms };
 	ps_process_pattern($2, kismet_t)
 
 	allow $2 kismet_home_t:dir { manage_dir_perms relabel_dir_perms };

--- a/policy/modules/contrib/piranha.if
+++ b/policy/modules/contrib/piranha.if
@@ -13,7 +13,7 @@
 #
 template(`piranha_domain_template',`
 	gen_require(`
-		attribute piranha_domain;
+		attribute piranha_domain, piranha_tmpfs;
 	')
 
 	##############################

--- a/policy/modules/contrib/postfix.if
+++ b/policy/modules/contrib/postfix.if
@@ -58,6 +58,10 @@ template(`postfix_domain_template',`
 ## </param>
 #
 template(`postfix_server_domain_template',`
+	gen_require(`
+		type postfix_master_t;
+	')
+
 	postfix_domain_template($1)
 
 	type postfix_$1_tmp_t;

--- a/policy/modules/contrib/qmail.if
+++ b/policy/modules/contrib/qmail.if
@@ -16,6 +16,10 @@
 ## </param>
 #
 template(`qmail_child_domain_template',`
+	gen_require(`
+		type qmail_etc_t, qmail_start_t;
+	')
+
 	type $1_t;
 	domain_type($1_t)
 	type $1_exec_t;

--- a/policy/modules/contrib/screen.if
+++ b/policy/modules/contrib/screen.if
@@ -121,6 +121,10 @@ template(`screen_role_template',`
 ## </param>
 #
 template(`screen_admin_role_template',`
+	gen_require(`
+		type screen_home_t;
+	')
+
 	screen_role_template($1, $2, $3)
 
 	userdom_admin_home_dir_filetrans($1_screen_t, screen_home_t, file, ".screenrc")

--- a/policy/modules/contrib/sssd.if
+++ b/policy/modules/contrib/sssd.if
@@ -486,7 +486,7 @@ interface(`sssd_run_stream_connect',`
 #
 interface(`sssd_dontaudit_run_stream_connect',`
 	gen_require(`
-		type sssd_t, sssd_var_lib_t;
+		type sssd_t, sssd_var_run_t;
 	')
 
 	dontaudit $1 sssd_t:unix_stream_socket connectto;

--- a/policy/modules/contrib/zebra.if
+++ b/policy/modules/contrib/zebra.if
@@ -86,6 +86,7 @@ interface(`zebra_admin',`
 	gen_require(`
 		type zebra_t, zebra_tmp_t, zebra_log_t;
 		type zebra_conf_t, zebra_var_run_t, zebra_initrc_exec_t;
+		type zebra_unit_file_t;
 	')
 
 	allow $1 zebra_t:process signal_perms;

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -1311,6 +1311,7 @@ interface(`dev_dontaudit_getattr_all_chr_files',`
 #
 interface(`dev_setattr_all_blk_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1330,6 +1331,7 @@ interface(`dev_setattr_all_blk_files',`
 #
 interface(`dev_setattr_all_chr_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1420,6 +1422,7 @@ interface(`dev_dontaudit_write_all_chr_files',`
 #
 interface(`dev_create_all_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1438,6 +1441,7 @@ interface(`dev_create_all_files',`
 #
 interface(`dev_create_all_blk_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1456,6 +1460,7 @@ interface(`dev_create_all_blk_files',`
 #
 interface(`dev_create_all_chr_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1510,6 +1515,7 @@ interface(`dev_rw_all_inherited_blk_files',`
 #
 interface(`dev_delete_all_blk_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1528,6 +1534,7 @@ interface(`dev_delete_all_blk_files',`
 #
 interface(`dev_delete_all_chr_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1546,6 +1553,7 @@ interface(`dev_delete_all_chr_files',`
 #
 interface(`dev_rename_all_blk_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1564,6 +1572,7 @@ interface(`dev_rename_all_blk_files',`
 #
 interface(`dev_rename_all_chr_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1582,6 +1591,7 @@ interface(`dev_rename_all_chr_files',`
 #
 interface(`dev_manage_all_blk_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node;
 	')
 
@@ -1606,6 +1616,7 @@ interface(`dev_manage_all_blk_files',`
 #
 interface(`dev_manage_all_chr_files',`
 	gen_require(`
+		type device_t;
 		attribute device_node, memory_raw_read, memory_raw_write;
 	')
 
@@ -1864,7 +1875,7 @@ interface(`dev_relabel_autofs_dev',`
 #
 interface(`dev_rw_cardmgr',`
 	gen_require(`
-		type cardmgr_dev_t;
+		type device_t, cardmgr_dev_t;
 	')
 
 	rw_chr_files_pattern($1, device_t, cardmgr_dev_t)
@@ -2134,7 +2145,7 @@ interface(`dev_rw_ecryptfs',`
 #
 interface(`dev_setattr_dlm_control',`
 	gen_require(`
-	type device_t, kvm_device_t;
+		type device_t, dlm_control_device_t;
 	')
 
 	setattr_chr_files_pattern($1, device_t, dlm_control_device_t)
@@ -2680,7 +2691,7 @@ interface(`dev_dontaudit_setattr_framebuffer_dev',`
 #
 interface(`dev_read_framebuffer',`
 	gen_require(`
-		type framebuf_device_t;
+		type device_t, framebuf_device_t;
 	')
 
 	read_chr_files_pattern($1, device_t, framebuf_device_t)
@@ -4145,7 +4156,7 @@ interface(`dev_dontaudit_getattr_nvram_dev',`
 #
 interface(`dev_read_nvram',`
 	gen_require(`
-		type nvram_device_t;
+		type device_t, nvram_device_t;
 	')
 
 	read_chr_files_pattern($1, device_t, nvram_device_t)
@@ -4163,7 +4174,7 @@ interface(`dev_read_nvram',`
 #
 interface(`dev_rw_nvram',`
 	gen_require(`
-		type nvram_device_t;
+		type device_t, nvram_device_t;
 	')
 
 	rw_chr_files_pattern($1, device_t, nvram_device_t)
@@ -5527,7 +5538,7 @@ interface(`dev_delete_urand',`
 #
 interface(`dev_setattr_urand',`
         gen_require(`
-                type urandom_device_t;
+                type device_t, urandom_device_t;
         ')
 
 	setattr_chr_files_pattern($1, device_t, urandom_device_t)
@@ -5563,7 +5574,7 @@ interface(`dev_getattr_generic_usb_dev',`
 #
 interface(`dev_setattr_generic_usb_dev',`
 	gen_require(`
-		type usb_device_t;
+		type device_t, usb_device_t;
 	')
 
 	setattr_chr_files_pattern($1, device_t, usb_device_t)
@@ -5581,7 +5592,7 @@ interface(`dev_setattr_generic_usb_dev',`
 #
 interface(`dev_read_generic_usb_dev',`
 	gen_require(`
-		type usb_device_t;
+		type device_t, usb_device_t;
 	')
 
 	read_chr_files_pattern($1, device_t, usb_device_t)
@@ -5617,7 +5628,7 @@ interface(`dev_rw_generic_usb_dev',`
 #
 interface(`dev_relabel_generic_usb_dev',`
 	gen_require(`
-		type usb_device_t;
+		type device_t, usb_device_t;
 	')
 
 	relabel_chr_files_pattern($1, device_t, usb_device_t)
@@ -7003,7 +7014,7 @@ interface(`dev_read_hfi1',`
 interface(`dev_filetrans_printer_named_dev',`
 
 	gen_require(`
-		type printer_device_t;
+		type device_t, printer_device_t;
 
 	')
 	filetrans_pattern($1, device_t, printer_device_t, chr_file, "irlpt0")
@@ -7891,7 +7902,7 @@ gen_require(`
 interface(`dev_filetrans_xserver_named_dev',`
 
 	gen_require(`
-		type xserver_misc_device_t;
+		type device_t, xserver_misc_device_t;
 	')
 
 	filetrans_pattern($1, device_t, xserver_misc_device_t, chr_file, "3dfx")

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6328,7 +6328,7 @@ interface(`files_filetrans_system_conf_named_files',`
 #
 interface(`files_relabelto_system_conf_files',`
     gen_require(`
-        type usr_t;
+        type system_conf_t;
     ')
 
     relabelto_files_pattern($1, system_conf_t, system_conf_t)
@@ -6346,7 +6346,7 @@ interface(`files_relabelto_system_conf_files',`
 #
 interface(`files_relabelfrom_system_conf_files',`
     gen_require(`
-        type usr_t;
+        type system_conf_t;
     ')
 
     relabelfrom_files_pattern($1, system_conf_t, system_conf_t)
@@ -6553,7 +6553,7 @@ interface(`files_getattr_tmp_dirs',`
 #
 interface(`files_dontaudit_access_check_tmp',`
 	gen_require(`
-		type etc_t;
+		type tmp_t;
 	')
 
 	dontaudit $1 tmp_t:dir_file_class_set audit_access;
@@ -7996,7 +7996,7 @@ interface(`files_write_var_dirs',`
 #
 interface(`files_setattr_var_dirs',`
 	gen_require(`
-		type usr_t;
+		type var_t;
 	')
 
 	allow $1 var_t:dir setattr;
@@ -9473,6 +9473,7 @@ interface(`files_dontaudit_getattr_all_pids',`
 #
 interface(`files_dontaudit_write_all_pids',`
 	gen_require(`
+		type var_run_t;
 		attribute pidfile;
 	')
 
@@ -10369,7 +10370,7 @@ interface(`files_rw_tmpfs_files',`
 #
 interface(`files_watch_tmpfs_dirs',`
 	gen_require(`
-		type root_t;
+		type tmpfs_t;
 	')
 
 	allow $1 tmpfs_t:dir watch_dir_perms;
@@ -10669,6 +10670,7 @@ interface(`files_filetrans_named_content',`
         type var_lock_t;
 		type tmp_t;
         type system_conf_t;
+		type etc_runtime_t;
 	')
 
 	files_pid_filetrans($1, mnt_t, dir, "media")

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -1158,7 +1158,7 @@ interface(`fs_cgroup_filetrans_memory_pressure',`
 #
 interface(`fs_cgroup_getattr_memory_pressure',`
 	gen_require(`
-		type cgroup_memory_pressure_t;
+		type cgroup_t, cgroup_memory_pressure_t;
 	')
 
 	getattr_files_pattern($1, cgroup_t, cgroup_memory_pressure_t)
@@ -1176,7 +1176,7 @@ interface(`fs_cgroup_getattr_memory_pressure',`
 #
 interface(`fs_cgroup_write_memory_pressure',`
 	gen_require(`
-		type cgroup_memory_pressure_t;
+		type cgroup_t, cgroup_memory_pressure_t;
 	')
 
 	write_files_pattern($1, cgroup_t, cgroup_memory_pressure_t)

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -1599,7 +1599,7 @@ interface(`kernel_dontaudit_search_network_state',`
 #
 interface(`kernel_search_network_state',`
 	gen_require(`
-		type proc_net_t;
+		type proc_t, proc_net_t;
 	')
 
 	search_dirs_pattern($1, proc_t, proc_net_t)
@@ -3863,7 +3863,7 @@ interface(`kernel_rw_stream_socket_perms',`
 #
 interface(`kernel_ioctl_stream_sockets',`
     gen_require(`
-        type init_t;
+        type kernel_t;
     ')
 
     allow $1 kernel_t:unix_stream_socket { getopt ioctl };
@@ -4139,7 +4139,7 @@ interface(`kernel_dontaudit_search_security_state',`
 #
 interface(`kernel_search_security_state',`
 	gen_require(`
-		type proc_security_t;
+		type proc_t, proc_security_t;
 	')
 
 	search_dirs_pattern($1, proc_t, proc_security_t)
@@ -4235,7 +4235,7 @@ interface(`kernel_read_security_state_symlinks',`
 #
 interface(`kernel_rw_nmi_watchdog_state',`
 	gen_require(`
-		type sysctl_t, sysctl_kernel_t, sysctl_nmi_watchdog_t;
+		type proc_t, sysctl_t, sysctl_kernel_t, sysctl_nmi_watchdog_t;
 	')
 
 	rw_files_pattern($1, { proc_t sysctl_t sysctl_kernel_t }, sysctl_nmi_watchdog_t)
@@ -4254,7 +4254,7 @@ interface(`kernel_rw_nmi_watchdog_state',`
 #
 interface(`kernel_write_nmi_watchdog_state',`
 	gen_require(`
-		type sysctl_t, sysctl_kernel_t, sysctl_nmi_watchdog_t;
+		type proc_t, sysctl_t, sysctl_kernel_t, sysctl_nmi_watchdog_t;
 	')
 
 	write_files_pattern($1, { proc_t sysctl_t sysctl_kernel_t }, sysctl_nmi_watchdog_t)
@@ -4355,7 +4355,7 @@ interface(`kernel_dontaudit_search_usermodehelper_state',`
 #
 interface(`kernel_search_usermodehelper_state',`
 	gen_require(`
-		type usermodehelper_t;
+		type proc_t, usermodehelper_t;
 	')
 
 	search_dirs_pattern($1, proc_t, usermodehelper_t)
@@ -4614,7 +4614,7 @@ interface(`kernel_manage_perf_event',`
 #
 interface(`kernel_prog_run_bpf',`
 	gen_require(`
-		type init_t;
+		type kernel_t;
 	')
 
     allow $1 kernel_t:bpf { map_read map_write prog_run };

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -197,7 +197,8 @@ template(`ssh_dyntransition_domain_template',`
 #
 template(`ssh_server_template',`
     gen_require(`
-        type sshd_t;
+        type sshd_t, sshd_key_t, sshd_exec_t;
+        attribute ssh_server;
     ')
 
 	type $1_t, ssh_server;

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -1653,8 +1653,9 @@ interface(`logging_admin_syslog',`
 		type syslogd_t, klogd_t, syslog_conf_t;
 		type syslogd_tmp_t, syslogd_var_lib_t;
 		type syslogd_var_run_t, klogd_var_run_t;
-		type klogd_tmp_t, var_log_t;
+		type klogd_tmp_t;
 		type syslogd_initrc_exec_t;
+		attribute logfile;
 	')
 
 	allow $1 self:capability2 syslog;

--- a/policy/modules/system/selinuxutil.if
+++ b/policy/modules/system/selinuxutil.if
@@ -1478,7 +1478,7 @@ interface(`seutil_run_semanage',`
 #
 interface(`seutil_run_setsebool',`
 	gen_require(`
-		type semanage_t;
+		type setsebool_t;
 	')
 
 	seutil_domtrans_setsebool($1)

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -2439,7 +2439,7 @@ interface(`userdom_relabel_user_home_files',`
 #
 interface(`userdom_relabel_user_home_dirs',`
 	gen_require(`
-		type user_home_dir_t;
+		type user_home_t;
 	')
 
 	allow $1 user_home_t:dir relabel_file_perms;


### PR DESCRIPTION
Found and fixed mostly by claude code (but thoroughly reviewed by me).

Note that aside from adding missing attributes and types in the gen_require there some different changes found by checking the interface requires:

policy/modules/admin/sudo.if - the type associated with the role is passed as the 3rd argument and should not be "created" as  $1_t (even though this does not cause any policy changes since the macro is consistently used with $3 = $1_t)

policy/modules/contrib/kismet.if - kistmet_tmpfs_t and kistmet_t are just typos (not found so far because the interface was never used)

policy/modules/contrib/portage.if - I added a new gen_require section for the optional_policy block. This should be handled by an interface, but the type is not defined in the policy any more (should we just remove this alltogether?)