### PR TITLE
Update bootupd policy for running lsblk

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -64,6 +64,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	auth_read_passwd_file(bootupd_t)
+')
+
+optional_policy(`
 	bootloader_domtrans(bootupd_t)
 ')
 
@@ -78,6 +82,12 @@ optional_policy(`
 
 optional_policy(`
 	mount_domtrans(bootupd_t)
+	mount_read_pid_files(bootupd_t)
+')
+
+optional_policy(`
+	systemd_homed_stream_connect(bootupd_t)
+	systemd_userdbd_stream_connect(bootupd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(06/05/2026 17:03:56.378:3389) : proctitle=lsblk -J -b -O /dev/nvme0n1p3 type=PATH msg=audit(06/05/2026 17:03:56.378:3389) : item=0 name=/run/systemd/userdb/ inode=42 dev=00:1d mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(06/05/2026 17:03:56.378:3389) : cwd=/ type=SYSCALL msg=audit(06/05/2026 17:03:56.378:3389) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x7fd4e95e18a2 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=132443 pid=132445 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=lsblk exe=/usr/bin/lsblk subj=system_u:system_r:bootupd_t:s0 key=(null) type=AVC msg=audit(06/05/2026 17:03:56.378:3389) : avc:  denied  { open } for  pid=132445 comm=lsblk path=/run/systemd/userdb dev="tmpfs" ino=42 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=1 type=AVC msg=audit(06/05/2026 17:03:56.378:3389) : avc:  denied  { read } for  pid=132445 comm=lsblk name=userdb dev="tmpfs" ino=42 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=1