### PR TITLE
Dontaudit virt_driver_domain execmem

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -1918,6 +1918,8 @@ tunable_policy(`virt_sandbox_use_audit',`
 # virt_driver_domain local policy (common rules)
 #
 
+dontaudit virt_driver_domain self:process execmem;
+
 manage_files_pattern(virt_driver_domain, virt_log_t, virt_log_t)
 
 optional_policy(`
@@ -2455,8 +2457,6 @@ optional_policy(`
 allow virtstoraged_t self:capability { dac_override dac_read_search fsetid ipc_lock sys_rawio};
 
 allow virtstoraged_t self:process { setsched };
-
-dontaudit virtstoraged_t self:process execmem;
 
 files_tmp_filetrans(virtstoraged_t, virtstoraged_tmp_t, { file dir })
 


### PR DESCRIPTION
virtqemud, when the policy was split from virtd_t was granted ‘execmem’ via ‘virtqemud_use_execmem’, which is not necessary as well as it isn’t necessary for any of the virt daemons to have this capability.

The virtqemud_use_execmem tunable was already removed, but the dontaudit rule was not implemented.

Resolves: RHEL-44901