### PR TITLE
Allow blueman get the attributes of a tmpfs filesystem

### DIFF
--- a/policy/modules/contrib/blueman.te
+++ b/policy/modules/contrib/blueman.te
@@ -68,6 +68,7 @@ domain_dontaudit_read_all_domains_state(blueman_t)
 files_list_tmp(blueman_t)
 files_dontaudit_write_all_mountpoints(blueman_t)
 
+fs_getattr_tmpfs(blueman_t)
 fs_getattr_xattr_fs(blueman_t)
 
 auth_use_nsswitch(blueman_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(06/10/2026 19:50:20.579:200) : avc:  denied  { getattr } for  pid=5538 comm=[pango] fontcon name=/ dev="tmpfs" ino=1 scontext=system_u:system_r:blueman_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2487673