### PR TITLE
portage_compile_domain: Require xdm_xserver_tmp_t type

### DIFF
--- a/policy/modules/contrib/portage.if
+++ b/policy/modules/contrib/portage.if
@@ -197,6 +197,10 @@ interface(`portage_compile_domain',`
 	ifdef(`TODO',`
 	# some gui ebuilds want to interact with X server, like xawtv
 	optional_policy(`
+		gen_require(`
+			type xdm_xserver_tmp_t;
+		')
+
 		allow $1 xdm_xserver_tmp_t:dir { add_entry_dir_perms del_entry_dir_perms };
 		allow $1 xdm_xserver_tmp_t:sock_file { create_file_perms delete_file_perms write_file_perms };
 	')


### PR DESCRIPTION
Add a new gen_require section for the optional_policy block. This should be handled by an interface, but the type is not defined in the policy any more (should we just remove this altogether). The interface is only used in the portage policy module, which is disabled.