### PR TITLE
Allow haproxy execmem permission

### DIFF
--- a/policy/modules/contrib/rhcs.te
+++ b/policy/modules/contrib/rhcs.te
@@ -679,6 +679,10 @@ fs_getattr_xattr_fs(haproxy_t)
 
 sysnet_dns_name_resolve(haproxy_t)
 
+tunable_policy(`deny_execmem',`',`
+	allow haproxy_t self:process execmem;
+')
+
 tunable_policy(`haproxy_connect_any',`
 	corenet_tcp_connect_all_ports(haproxy_t)
 	corenet_tcp_bind_all_ports(haproxy_t)


### PR DESCRIPTION
New version of the haproxy package will have PCRE2 with Jit enabled (also to match the enabled features of other Linux distributions). This feature requires the execmem permission for the haproxy_t type.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2479957