### PR TITLE
Allow staff user mounton /var/lib dirs

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -9224,6 +9224,24 @@ interface(`files_watch_var_run_path',`
 
 #######################################
 ## <summary>
+##      Mounton a /var/lib directory.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`files_mounton_var_lib_dirs',`
+        gen_require(`
+                type var_lib_t;
+        ')
+
+	allow $1 var_lib_t:dir mounton;
+')
+
+#######################################
+## <summary>
 ##      Mounton a /run directory.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -67,6 +67,7 @@ domain_obj_id_change_exemption(staff_t)
 
 files_read_kernel_modules(staff_t)
 files_mounton_rootfs(staff_t)
+files_mounton_var_lib_dirs(staff_t)
 files_mounton_var_run_dirs(staff_t)
 files_mounton_generic_tmp_dirs(staff_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/11/2026 13:59:48.528:1239) : proctitle=/usr/bin/bwrap --args 26 ldconfig -X -C /run/ld-so-cache-dir/230088fe839bc94f9e60312d47444d36fff18a3bd8770deab1829a4f4253dbc2.fr type=PATH msg=audit(06/11/2026 13:59:48.528:1239) : item=0 name=/newroot/usr/lib/x86_64-linux-gnu/GL inode=394883 dev=fd:02 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:var_lib_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/11/2026 13:59:48.528:1239) : arch=x86_64 syscall=mount success=no exit=EACCES(Permission denied) a0=0x55e6dec40fa4 a1=0x55e70fc788b0 a2=0x55e6dec40fa4 a3=MS_NOSUID|MS_NODEV items=1 ppid=7534 pid=7535 auid=user15131 uid=user15131 gid=user15131 euid=user15131 suid=user15131 fsuid=user15131 egid=user15131 sgid=user15131 fsgid=user15131 tty=pts3 ses=6 comm=bwrap exe=/usr/bin/bwrap subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(06/11/2026 13:59:48.528:1239) : avc:  denied  { mounton } for  pid=7535 comm=bwrap path=/newroot/usr/lib/x86_64-linux-gnu/GL dev="vda2" ino=394883 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:var_lib_t:s0 tclass=dir permissive=0

Resolves: RHEL-163438