### PR TITLE
f44 backports

### DIFF
--- a/policy/modules/contrib/aide.te
+++ b/policy/modules/contrib/aide.te
@@ -84,3 +84,7 @@ optional_policy(`
 optional_policy(`
     udev_getattr_rules_chr_files(aide_t)
 ')
+
+optional_policy(`
+	xserver_stream_connect_xdm(aide_t)
+')

--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -64,6 +64,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	auth_read_passwd_file(bootupd_t)
+')
+
+optional_policy(`
 	bootloader_domtrans(bootupd_t)
 ')
 
@@ -78,6 +82,12 @@ optional_policy(`
 
 optional_policy(`
 	mount_domtrans(bootupd_t)
+	mount_read_pid_files(bootupd_t)
+')
+
+optional_policy(`
+	systemd_homed_stream_connect(bootupd_t)
+	systemd_userdbd_stream_connect(bootupd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -481,6 +481,7 @@ optional_policy(`
 optional_policy(`
 	dbus_session_bus_client(gpg_pinentry_t)
 	dbus_system_bus_client(gpg_pinentry_t)
+	dbus_write_session_tmp_sock_files(gpg_pinentry_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -79,6 +79,7 @@ allow nut_upsmon_t self:unix_stream_socket { create_socket_perms connectto };
 can_exec(nut_upsmon_t, nut_upsmon_exec_t)
 
 read_files_pattern(nut_upsmon_t, nut_conf_t, nut_conf_t)
+allow nut_upsmon_t nut_conf_t:lnk_file read_lnk_file_perms;
 
 kernel_read_kernel_sysctls(nut_upsmon_t)
 kernel_read_system_state(nut_upsmon_t)

--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -73,6 +73,7 @@ allow thumb_t thumb_tmpfs_t:file { execute mounton };
 
 can_exec(thumb_t, thumb_exec_t)
 
+kernel_mount_proc(thumb_t)
 kernel_read_system_state(thumb_t)
 kernel_dgram_send(thumb_t)
 kernel_dontaudit_list_all_sysctls(thumb_t)

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -499,6 +499,7 @@ allow syslogd_t self:capability { sys_ptrace dac_read_search dac_override sys_re
 dontaudit syslogd_t self:capability sys_tty_config;
 dontaudit syslogd_t self:cap_userns { kill sys_ptrace };
 allow syslogd_t self:capability2 { syslog block_suspend };
+allow syslogd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 # setpgid for metalog
 # setrlimit for syslog-ng
 allow syslogd_t self:process { signal_perms getcap setcap setpgid getsched setsched setrlimit };

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -346,6 +346,7 @@ files_pid_file(systemd_varlink_registry_t)
 #  is for /run/user/$USER ($USER ownership is $USER:$USER)
 allow systemd_logind_t self:capability { chown kill dac_read_search dac_override fowner sys_tty_config sys_admin };
 allow systemd_logind_t self:capability2 block_suspend;
+allow systemd_logind_t self:cap_userns sys_ptrace;
 
 allow systemd_logind_t self:process getcap;
 allow systemd_logind_t self:netlink_kobject_uevent_socket create_socket_perms;

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1385,6 +1385,7 @@ fs_mounton_tmpfs(systemd_coredump_t)
 optional_policy(`
 	container_signull(systemd_coredump_t)
 	container_runtime_signull(systemd_coredump_t)
+	container_spc_signull(systemd_coredump_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1959,6 +1959,7 @@ systemd_read_efivarfs(systemd_userdbd_t)
 
 # systemd-sleep wants cap_sys_admin to check btrfs swapfile offset (https://github.com/systemd/systemd/pull/29382)
 allow systemd_sleep_t self:capability { linux_immutable sys_resource sys_admin };
+allow systemd_sleep_t self:capability2 { perfmon };
 # systemd-sleep needs to set timer for suspend-then-hibernate
 allow systemd_sleep_t self:capability2 wake_alarm;
 dontaudit systemd_sleep_t self:capability sys_ptrace;


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=PROCTITLE msg=audit(06/05/2026 17:03:56.378:3389) : proctitle=lsblk -J -b -O /dev/nvme0n1p3 type=PATH msg=audit(06/05/2026 17:03:56.378:3389) : item=0 name=/run/systemd/userdb/ inode=42 dev=00:1d mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(06/05/2026 17:03:56.378:3389) : cwd=/ type=SYSCALL msg=audit(06/05/2026 17:03:56.378:3389) : arch=x86_64 syscall=openat success=yes exit=5 a0=AT_FDCWD a1=0x7fd4e95e18a2 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=1 ppid=132443 pid=132445 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=lsblk exe=/usr/bin/lsblk subj=system_u:system_r:bootupd_t:s0 key=(null) type=AVC msg=audit(06/05/2026 17:03:56.378:3389) : avc:  denied  { open } for  pid=132445 comm=lsblk path=/run/systemd/userdb dev="tmpfs" ino=42 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=1 type=AVC msg=audit(06/05/2026 17:03:56.378:3389) : avc:  denied  { read } for  pid=132445 comm=lsblk name=userdb dev="tmpfs" ino=42 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=dir permissive=1