### PR TITLE
Allow gpg_pinentry_t to write session dbus socket files

### DIFF
--- a/policy/modules/contrib/gpg.te
+++ b/policy/modules/contrib/gpg.te
@@ -481,6 +481,7 @@ optional_policy(`
 optional_policy(`
 	dbus_session_bus_client(gpg_pinentry_t)
 	dbus_system_bus_client(gpg_pinentry_t)
+	dbus_write_session_tmp_sock_files(gpg_pinentry_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
pinentry-gnome3 1.3.x renders its prompt through gcr-prompter, reached over the D-Bus session bus. Connecting to the session bus socket file requires `sock_file write` on `session_dbusd_tmp_t`, which the existing `dbus_session_bus_client()` call does not grant (it covers `unix_stream_socket connectto` and `dbus send_msg` only). Without it, pinentry silently falls back to the curses interface for users mapped to `staff_u`; GUI passphrase prompts never appear.

The patch adds the existing `dbus_write_session_tmp_sock_files()` interface for `gpg_pinentry_t`, the same idiom already used by `pulseaudio_t`, `thumb_t`, `gkeyringd_domain` and others.

AVC on an unpatched Fedora 44 host (staff_u-mapped login):

```text
avc: denied { write } for comm="pinentry-gnome3"
  scontext=staff_u:staff_r:gpg_pinentry_t tcontext=staff_u:object_r:session_dbusd_tmp_t
  tclass=sock_file permissive=0
```

Verified on Fedora 44: with this rule loaded as a local module, the GNOME passphrase dialog appears and gpg signing works; no functional regressions observed over six weeks of desktop use.

Resolves: rhbz#2463953