### PR TITLE
Allow aide connect to the GDM userdb provider socket

### DIFF
--- a/policy/modules/contrib/aide.te
+++ b/policy/modules/contrib/aide.te
@@ -84,3 +84,7 @@ optional_policy(`
 optional_policy(`
     udev_getattr_rules_chr_files(aide_t)
 ')
+
+optional_policy(`
+	xserver_stream_connect_xdm(aide_t)
+')


### PR DESCRIPTION
aide resolves file ownership through NSS; on systems with systemd userdb, glibc probes every provider socket below `/run/systemd/userdb/`. `aide.te` already wires the systemd-userdbd, systemd-homed and systemd-machined provider legs, but the GDM provider socket (`org.gnome.DisplayManager`, labeled `xdm_var_run_t` via the named file transition in `xserver.te`) is missing, so every aide run floods the audit log with hundreds of `sock_file write` denials against `xdm_var_run_t`.

The patch adds `xserver_stream_connect_xdm(aide_t)` in an `optional_policy` block, consistent with the per-provider-leg style the file already uses (and with `xserver_stream_connect_xdm(nsswitch_domain)` introduced for the same socket class).

AVC class on an unpatched Fedora 44 host (~448 records per full-filesystem `aide --init`):

```text
avc: denied { write } for comm="aide" name="org.gnome.DisplayManager"
  scontext=system_u:system_r:aide_t tcontext=system_u:object_r:xdm_var_run_t
  tclass=sock_file permissive=0
```

Verified on Fedora 44: with the xdm leg granted as a local module, the same run is AVC-clean.

Resolves: rhbz#2463619