### PR TITLE
Allow nfsd_t to create netlink_generic_socket (bsc#1267826)

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -244,6 +244,8 @@ allow nfsd_t self:process { setcap };
 allow nfsd_t exports_t:file read_file_perms;
 allow nfsd_t exports_t:dir list_dir_perms;
 
+allow nfsd_t self:netlink_generic_socket create_socket_perms;
+
 manage_dirs_pattern(nfsd_t, nfsd_tmp_t, nfsd_tmp_t)
 manage_files_pattern(nfsd_t, nfsd_tmp_t, nfsd_tmp_t)
 files_tmp_filetrans(nfsd_t, nfsd_tmp_t, { file dir })


### PR DESCRIPTION
Fixing the following AVC:
type=AVC msg=audit(..): avc:  denied  { create } for  pid=1626 comm="rpc.mountd" scontext=system_u:system_r:nfsd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=netlink_generic_socket permissive=0