### PR TITLE
vfs_snapper support with samba_share_t (bsc#1265400) 

### DIFF
--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -458,6 +458,42 @@ interface(`samba_read_secrets',`
 
 ########################################
 ## <summary>
+##	Allow the specified domain to manage samba's share files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`samba_manage_share_dirs',`
+	gen_require(`
+		type samba_share_t;
+	')
+
+	manage_dirs_pattern($1, samba_share_t, samba_share_t)
+')
+
+########################################
+## <summary>
+##	Allow the specified domain to manage samba's share files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`samba_manage_share_files',`
+	gen_require(`
+		type samba_share_t;
+	')
+
+	manage_files_pattern($1, samba_share_t, samba_share_t)
+')
+
+########################################
+## <summary>
 ##	Allow the specified domain to read samba's shares
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -654,6 +654,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	snapper_dbus_chat(smbd_t)
+')
+
+optional_policy(`
 	seutil_sigchld_newrole(smbd_t)
 ')
 

--- a/policy/modules/contrib/snapper.te
+++ b/policy/modules/contrib/snapper.te
@@ -91,6 +91,12 @@ optional_policy(`
     lvm_domtrans(snapperd_t)
 ')
 
+# support for vfs_snapper + samba share labelled as samba_share_t
+optional_policy(`
+    samba_manage_share_dirs(snapperd_t)
+    samba_manage_share_files(snapperd_t)
+')
+
 optional_policy(`
     snapper_relabel_snapshots(snapperd_t)
 ')


### PR DESCRIPTION
Support snapper to create snapshots in samba shares with samba_share_t
label. When a user decides(*) to set up their samba share:
- with samba_share_t label (without the samba booleans)
- AND vfs_snapper
..snapperd_t can not create snapshots under it as it can not create files
with the samba_share_t label.

However, it needs to do it since those files need to be accessible
for samba:
https://www.samba.org/samba/docs/current/man-html/vfs_snapper.8.html

To allow that scenario, allow snapper to manage samba_share_t
directories and files to be able to create snapshots.

(*) In openSUSE update-samba-security-profile will automatically do
that since [bsc#1259050](https://bugzilla.suse.com/show_bug.cgi?id=1259050).

https://bugzilla.suse.com/show_bug.cgi?id=1265400