### PR TITLE
Allow thumb_t mount proc filesystem

### DIFF
--- a/policy/modules/contrib/thumb.te
+++ b/policy/modules/contrib/thumb.te
@@ -73,6 +73,7 @@ allow thumb_t thumb_tmpfs_t:file { execute mounton };
 
 can_exec(thumb_t, thumb_exec_t)
 
+kernel_mount_proc(thumb_t)
 kernel_read_system_state(thumb_t)
 kernel_dgram_send(thumb_t)
 kernel_dontaudit_list_all_sysctls(thumb_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1781569322.166:182): avc:  denied  { mount } for  pid=2884 comm="bwrap" name="/" dev="proc" ino=1 scontext=unconfined_u:unconfined_r:thumb_t:s0-s0:c0.c1023 tcontext=system_u:object_r:proc_t:s0 tclass=filesystem permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2489266