### PR TITLE
Allow nut/upsmon read nut_conf_t symlinks

### DIFF
--- a/policy/modules/contrib/nut.te
+++ b/policy/modules/contrib/nut.te
@@ -79,6 +79,7 @@ allow nut_upsmon_t self:unix_stream_socket { create_socket_perms connectto };
 can_exec(nut_upsmon_t, nut_upsmon_exec_t)
 
 read_files_pattern(nut_upsmon_t, nut_conf_t, nut_conf_t)
+allow nut_upsmon_t nut_conf_t:lnk_file read_lnk_file_perms;
 
 kernel_read_kernel_sysctls(nut_upsmon_t)
 kernel_read_system_state(nut_upsmon_t)


### PR DESCRIPTION
When NUT (upsmon) is configured with TLS and a CERTPATH directory (as required by SSL_CTX_load_verify_locations in directory mode), OpenSSL expects that directory to contain hashed symlinks created by openssl rehash.

Steps to Reproduce:
1. Install nut-client and configure /etc/ups/upsmon.conf with: CERTPATH /etc/ups/certs
CERTVERIFY 1
FORCESSL 1

2. Place a CA certificate in /etc/ups/certs/ and run openssl rehash /etc/ups/certs/ to create the hashed symlink (e.g. b4d8ce96.0 -> nut-upsd.crt).

The commit addresses the following AVC denial:
avc:  denied  { read } for  pid=34680 comm="upsmon" name="abcdef01.0" scontext=system_u:system_r:nut_upsmon_t:s0
tcontext=unconfined_u:object_r:nut_conf_t:s0
tclass=lnk_file  permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2489334