### PR TITLE
Allow sshd_session_t dyntransition to sftpd_t

### DIFF
--- a/policy/modules/contrib/ftp.if
+++ b/policy/modules/contrib/ftp.if
@@ -213,6 +213,8 @@ interface(`ftp_dyntrans_sftpd',`
 	')
 
 	dyntrans_pattern($1, sftpd_t)
+
+	allow sftpd_t $1:fifo_file { read write };
 ')
 
 ########################################

--- a/policy/modules/contrib/ftp.te
+++ b/policy/modules/contrib/ftp.te
@@ -419,6 +419,7 @@ miscfiles_read_public_files(anon_sftpd_t)
 # Sftpd local policy
 #
 
+fs_getattr_xattr_fs(sftpd_t)
 
 userdom_read_user_home_content_files(sftpd_t)
 userdom_read_user_home_content_symlinks(sftpd_t)

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -130,6 +130,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	ftp_dyntrans_sftpd(sshd_session_t)
+	ftp_dyntrans_anon_sftpd(sshd_session_t)
+')
+
+optional_policy(`
 	ica_rw_map_tmpfs_files(sshd_session_t)
 ')
 
@@ -525,11 +530,6 @@ optional_policy(`
 
 optional_policy(`
 	daemontools_service_domain(sshd_t, sshd_exec_t)
-')
-
-optional_policy(`
-	ftp_dyntrans_sftpd(sshd_t)
-	ftp_dyntrans_anon_sftpd(sshd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This permission was previously allowed for sshd_t. After the split of the sshd server into session and auth processes (efa131d050dd6, "Define types for new openssh executables"), it is now needed for sshd_session_t instead.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/16/2026 15:30:35.811:481) : proctitle=sshd-session: root@internal-sftp type=SYSCALL msg=audit(06/16/2026 15:30:35.811:481) : arch=x86_64 syscall=write success=yes exit=41 a0=0x7 a1=0x5596e3731660 a2=0x29 a3=0x0 items=0 ppid=52913 pid=52914 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=5 comm=sshd-session exe=/usr/libexec/openssh/sshd-session subj=system_u:system_r:sftpd_t:s0-s0:c0.c1023 key=(null)
 type=AVC msg=audit(06/16/2026 15:30:35.811:481) : avc:  denied  { dyntransition } for  pid=52914 comm=sshd-session scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sftpd_t:s0-s0:c0.c1023 tclass=process permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2483737