### PR TITLE
systemd pcrlock policy

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -579,6 +579,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	systemd_pcrlock_filetrans_named_content(named_filetrans_domain)
+')
+
+optional_policy(`
 	sssd_filetrans_named_content(named_filetrans_domain)
 ')
 
@@ -601,10 +605,6 @@ optional_policy(`
 
 optional_policy(`
 	virt_filetrans_named_content(named_filetrans_domain)
-')
-
-optional_policy(`
-	systemd_pcrlock_filetrans_named_content(named_filetrans_domain)
 ')
 
 selinux_getattr_fs(domain)

--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -603,6 +603,10 @@ optional_policy(`
 	virt_filetrans_named_content(named_filetrans_domain)
 ')
 
+optional_policy(`
+	systemd_pcrlock_filetrans_named_content(named_filetrans_domain)
+')
+
 selinux_getattr_fs(domain)
 selinux_search_fs(domain)
 selinux_dontaudit_read_fs(domain)

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -296,6 +296,11 @@ optional_policy(`
 		oddjob_dbus_chat(unconfined_t)
 	')
 
+
+	optional_policy(`
+		systemd_pcrlock_exec(unconfined_t)
+	')
+ 
 	optional_policy(`
 		systemd_systemctl_entrypoint(unconfined_t)
 	')

--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -296,7 +296,6 @@ optional_policy(`
 		oddjob_dbus_chat(unconfined_t)
 	')
 
-
 	optional_policy(`
 		systemd_pcrlock_exec(unconfined_t)
 	')

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -127,6 +127,8 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/lib/systemd/linger(/.*)?		gen_context(system_u:object_r:systemd_logind_var_lib_t,mls_systemhigh)
 /var/lib/systemd/sleep(/.*)?		gen_context(system_u:object_r:systemd_sleep_var_lib_t,s0)
 /var/lib/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_lib_t,s0)
+/var/lib/systemd/pcrlock.*   --   gen_context(system_u:object_r:systemd_pcrlock_var_lib_t,s0)
+/var/lib/pcrlock\.d(/.*)?              gen_context(system_u:object_r:systemd_pcrlock_var_lib_t,s0)
 /var/lib/private/systemd/journal-upload(/.*)?		gen_context(system_u:object_r:systemd_journal_upload_var_lib_t,s0)
 /var/lib/private/systemd/timesync(/.*)?		gen_context(system_u:object_r:systemd_timedated_var_lib_t,s0)
 /usr/lib/systemd/resolv.*   --   gen_context(system_u:object_r:lib_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -161,7 +161,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/machines(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines.lock	--	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/oom(/.*)?		gen_context(system_u:object_r:systemd_oomd_var_run_t,s0)
-/run/systemd/pcrlock.json	--	gen_context(system_u:object_r:systemd_pcrlock_var_lib_t,s0)
+/run/systemd/pcrlock.json	--	gen_context(system_u:object_r:systemd_pcrlock_var_run_t,s0)
 /run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)
 /run/systemd/resolve\.hook/io\.systemd\.Machine	-s	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/resolve\.hook/io\.systemd\.Network	-s	gen_context(system_u:object_r:systemd_networkd_var_run_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -161,6 +161,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/machines(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines.lock	--	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/oom(/.*)?		gen_context(system_u:object_r:systemd_oomd_var_run_t,s0)
+/run/systemd/pcrlock.json	--	gen_context(system_u:object_r:systemd_pcrlock_var_lib_t,s0)
 /run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)
 /run/systemd/resolve\.hook/io\.systemd\.Machine	-s	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/resolve\.hook/io\.systemd\.Network	-s	gen_context(system_u:object_r:systemd_networkd_var_run_t,s0)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -175,7 +175,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/varlink/registry/.+	-l	gen_context(system_u:object_r:systemd_varlink_registry_t,s0)
 
 /run/log/bootchart.*	--	gen_context(system_u:object_r:systemd_bootchart_var_run_t,s0)
-/run/log/systemd/tpm2-measure.log	--	gen_context(system_u:object_r:systemd_pcrlock_var_lib_t,s0)
+/run/log/systemd/tpm2-measure.log	--	gen_context(system_u:object_r:systemd_pcrlock_var_run_t,s0)
 
 /run/systemd/units(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -175,6 +175,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/varlink/registry/.+	-l	gen_context(system_u:object_r:systemd_varlink_registry_t,s0)
 
 /run/log/bootchart.*	--	gen_context(system_u:object_r:systemd_bootchart_var_run_t,s0)
+/run/log/systemd/tpm2-measure.log	--	gen_context(system_u:object_r:systemd_pcrlock_var_lib_t,s0)
 
 /run/systemd/units(/.*)?		gen_context(system_u:object_r:systemd_unit_file_t,s0)
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1008,7 +1008,7 @@ interface(`systemd_passwd_agent_exec',`
 #
 interface(`systemd_pcrlock_exec',`
     gen_require(`
-        type systemd_pcrlock_exec_t, systemd_pcrlock_var_lib_t;
+        type systemd_pcrlock_exec_t;
     ')
 
     can_exec($1,systemd_pcrlock_exec_t)

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1012,7 +1012,7 @@ interface(`systemd_pcrlock_exec',`
     ')
 
     can_exec($1,systemd_pcrlock_exec_t)
-    files_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, { dir file }, "pcrlock.d")
+    systemd_pcrlock_filetrans_named_content($1)
     init_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, file)
     # this should be a named file transition like
     # init_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, file, "pcrlock.json")
@@ -2047,6 +2047,25 @@ interface(`systemd_filetrans_named_content',`
 	files_etc_filetrans($1, hostname_etc_t, file, "machine-info" )
 	init_var_lib_filetrans($1, systemd_rfkill_var_lib_t, dir, "rfkill" )
 ')
+
+########################################
+## <summary>
+##	Transition to systemd pcrlock named content
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_pcrlock_filetrans_named_content',`
+	gen_require(`
+		type systemd_pcrlock_var_lib_t;
+	')
+	# Needed when /var/lib/pcrlock.d gets unlinked and recreated
+	files_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, { dir file }, "pcrlock.d")
+')
+
 
 ########################################
 ## <summary>

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -178,6 +178,24 @@ interface(`systemd_systemctl_entrypoint',`
 
 #######################################
 ## <summary>
+##     Execute pcrlock in its own domain
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`systemd_domtrans_pcrlock',`
+    gen_require(`
+        type systemd_pcrlock_t, systemd_pcrlock_exec_t;
+    ')
+
+    domtrans_pattern($1, systemd_pcrlock_exec_t, systemd_pcrlock_t)
+')
+
+#######################################
+## <summary>
 ##	Execute systemctl in the specified domain
 ## </summary>
 ## <param name="domain">
@@ -976,6 +994,30 @@ interface(`systemd_passwd_agent_exec',`
 
 	can_exec($1, systemd_passwd_agent_exec_t)
 	systemd_manage_passwd_run($1)
+')
+
+#######################################
+## <summary>
+##  Allow a domain to execute pcrlock in the caller domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##  Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`systemd_pcrlock_exec',`
+    gen_require(`
+        type systemd_pcrlock_exec_t, systemd_pcrlock_var_lib_t;
+    ')
+
+    can_exec($1,systemd_pcrlock_exec_t)
+    files_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, { dir file }, "pcrlock.d")
+    init_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, file)
+    # this should be a named file transition like
+    # init_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, file, "pcrlock.json")
+    # but ATM system creates a temporary file like .#pcrlock.jsonabb6f6e6c7abd54f
+    # the pound sign can be used, so we have to use this rule until this is changed
 ')
 
 ########################################

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1444,25 +1444,6 @@ interface(`systemd_manage_passwd_run',`
 	allow systemd_passwd_agent_t $1:unix_dgram_socket sendto;
 ')
 
-########################################
-## <summary>
-##     Manage pcrlock files
-## </summary>
-## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
-## </param>
-#
-interface(`systemd_manage_pcrlock_files',`
-    gen_require(`
-       type systemd_pcrlock_var_lib_t;
-    ')
-
-    manage_files_pattern($1, systemd_pcrlock_var_lib_t, systemd_pcrlock_var_lib_t)
-    manage_dirs_pattern($1, systemd_pcrlock_var_lib_t, systemd_pcrlock_var_lib_t)
-')
-
 ######################################
 ## <summary>
 ##  Template for temporary sockets and files in /dev/.systemd/ask-password
@@ -1493,6 +1474,42 @@ interface(`systemd_passwd_agent_dev_template',`
         allow systemd_passwd_agent_t $1_t:unix_dgram_socket sendto;
 	allow systemd_passwd_agent_t systemd_$1_device_t:sock_file write;
         allow systemd_passwd_agent_t systemd_$1_device_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##     Manage pcrlock /var/lib files
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`systemd_pcrlock_manage_var_lib_files',`
+    gen_require(`
+       type systemd_pcrlock_var_lib_t;
+    ')
+
+    manage_files_pattern($1, systemd_pcrlock_var_lib_t, systemd_pcrlock_var_lib_t)
+')
+
+########################################
+## <summary>
+##     Manage pcrlock /var/lib dirs
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`systemd_pcrlock_manage_var_lib_dirs',`
+    gen_require(`
+       type systemd_pcrlock_var_lib_t;
+    ')
+
+    manage_dirs_pattern($1, systemd_pcrlock_var_lib_t, systemd_pcrlock_var_lib_t)
 ')
 
 ########################################
@@ -2059,7 +2076,6 @@ interface(`systemd_pcrlock_filetrans_named_content',`
 	# Needed when /var/lib/pcrlock.d gets unlinked and recreated
 	files_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, { dir file }, "pcrlock.d")
 ')
-
 
 ########################################
 ## <summary>

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1408,6 +1408,25 @@ interface(`systemd_manage_passwd_run',`
 	allow systemd_passwd_agent_t $1:unix_dgram_socket sendto;
 ')
 
+########################################
+## <summary>
+##     Manage pcrlock files
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`systemd_manage_pcrlock_files',`
+    gen_require(`
+       type systemd_pcrlock_var_lib_t;
+    ')
+
+    manage_files_pattern($1, systemd_pcrlock_var_lib_t, systemd_pcrlock_var_lib_t)
+    manage_dirs_pattern($1, systemd_pcrlock_var_lib_t, systemd_pcrlock_var_lib_t)
+')
+
 ######################################
 ## <summary>
 ##  Template for temporary sockets and files in /dev/.systemd/ask-password

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1012,12 +1012,6 @@ interface(`systemd_pcrlock_exec',`
     ')
 
     can_exec($1,systemd_pcrlock_exec_t)
-    systemd_pcrlock_filetrans_named_content($1)
-    init_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, file)
-    # this should be a named file transition like
-    # init_var_lib_filetrans($1, systemd_pcrlock_var_lib_t, file, "pcrlock.json")
-    # but ATM system creates a temporary file like .#pcrlock.jsonabb6f6e6c7abd54f
-    # the pound sign can be used, so we have to use this rule until this is changed
 ')
 
 ########################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2125,6 +2125,26 @@ optional_policy(`
 	logging_write_journal_files(systemd_pcrextend_t)
 ')
 
+systemd_manage_pcrlock_files(systemd_pcrlock_t)
+
+init_read_pid_files(systemd_pcrlock_t)
+init_search_var_lib_dirs(systemd_pcrlock_t)
+init_var_lib_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
+# These files are also created in /run and then moved to their proper location
+init_pid_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
+
+dev_list_sysfs(systemd_pcrlock_t)
+dev_read_sysfs(systemd_pcrlock_t)
+dev_rw_tpm(systemd_pcrlock_t)
+
+# for operations on the EFI partition
+fs_manage_dos_files(systemd_pcrlock_t)
+fs_read_efivarfs_files(systemd_pcrlock_t)
+storage_raw_read_fixed_disk_blk_device(systemd_pcrlock_t)
+
+udev_read_db(systemd_pcrlock_t)
+
+# still keep it permissive for now. Failure to run can prevent booting
 permissive systemd_pcrlock_t;
 
 #######################################

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -335,6 +335,9 @@ systemd_domain_template(systemd_pcrlock)
 type systemd_pcrlock_var_lib_t;
 files_type(systemd_pcrlock_var_lib_t);
 
+type systemd_pcrlock_var_run_t;
+files_pid_file(systemd_pcrlock_var_run_t)
+
 # /run/varlink{,/registry}
 type systemd_varlink_t;
 files_pid_file(systemd_varlink_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2128,7 +2128,6 @@ optional_policy(`
 	logging_write_journal_files(systemd_pcrextend_t)
 ')
 
-systemd_manage_pcrlock_files(systemd_pcrlock_t)
 ########################################
 #
 # systemd_pcrlock local policy
@@ -2136,6 +2135,9 @@ systemd_manage_pcrlock_files(systemd_pcrlock_t)
 
 # still keep it permissive for now. Failure to run can prevent booting
 permissive systemd_pcrlock_t;
+
+systemd_pcrlock_manage_var_lib_files(systemd_pcrlock_t)
+systemd_pcrlock_manage_var_lib_dirs(systemd_pcrlock_t)
 
 init_search_var_lib_dirs(systemd_pcrlock_t)
 init_var_lib_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2109,7 +2109,7 @@ init_named_pid_filetrans(systemd_nsresourced_t, systemd_nsresourced_runtime_t, f
 
 ########################################
 #
-# systemd_pcrextend and systemd_pcrlock local policy
+# systemd_pcrextend local policy
 #
 
 permissive systemd_pcrextend_t;
@@ -2129,6 +2129,13 @@ optional_policy(`
 ')
 
 systemd_manage_pcrlock_files(systemd_pcrlock_t)
+########################################
+#
+# systemd_pcrlock local policy
+#
+
+# still keep it permissive for now. Failure to run can prevent booting
+permissive systemd_pcrlock_t;
 
 init_search_var_lib_dirs(systemd_pcrlock_t)
 init_var_lib_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
@@ -2149,9 +2156,6 @@ fs_read_efivarfs_files(systemd_pcrlock_t)
 storage_raw_read_fixed_disk_blk_device(systemd_pcrlock_t)
 
 udev_read_db(systemd_pcrlock_t)
-
-# still keep it permissive for now. Failure to run can prevent booting
-permissive systemd_pcrlock_t;
 
 #######################################
 #

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2132,6 +2132,7 @@ init_search_var_lib_dirs(systemd_pcrlock_t)
 init_var_lib_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
 # These files are also created in /run and then moved to their proper location
 init_pid_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
+systemd_pcrlock_filetrans_named_content(systemd_pcrlock_t)
 
 dev_list_sysfs(systemd_pcrlock_t)
 dev_read_sysfs(systemd_pcrlock_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -332,6 +332,9 @@ files_pid_file(systemd_oomd_var_run_t)
 systemd_domain_template(systemd_pcrextend)
 systemd_domain_template(systemd_pcrlock)
 
+type systemd_pcrlock_var_lib_t;
+files_type(systemd_pcrlock_var_lib_t);
+
 # /run/varlink{,/registry}
 type systemd_varlink_t;
 files_pid_file(systemd_varlink_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2134,6 +2134,7 @@ init_search_var_lib_dirs(systemd_pcrlock_t)
 init_var_lib_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
 systemd_pcrlock_filetrans_named_content(systemd_pcrlock_t)
 
+init_delete_pid_dir_entry(systemd_pcrlock_t)
 init_read_pid_files(systemd_pcrlock_t)
 manage_files_pattern(systemd_pcrlock_t, systemd_pcrlock_var_run_t, systemd_pcrlock_var_run_t)
 

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2139,6 +2139,7 @@ dev_read_sysfs(systemd_pcrlock_t)
 dev_rw_tpm(systemd_pcrlock_t)
 
 # for operations on the EFI partition
+fs_manage_dos_dirs(systemd_pcrlock_t)
 fs_manage_dos_files(systemd_pcrlock_t)
 fs_read_efivarfs_files(systemd_pcrlock_t)
 storage_raw_read_fixed_disk_blk_device(systemd_pcrlock_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2130,12 +2130,12 @@ optional_policy(`
 
 systemd_manage_pcrlock_files(systemd_pcrlock_t)
 
-init_read_pid_files(systemd_pcrlock_t)
 init_search_var_lib_dirs(systemd_pcrlock_t)
 init_var_lib_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
-# These files are also created in /run and then moved to their proper location
-init_pid_filetrans(systemd_pcrlock_t, systemd_pcrlock_var_lib_t, { dir file })
 systemd_pcrlock_filetrans_named_content(systemd_pcrlock_t)
+
+init_read_pid_files(systemd_pcrlock_t)
+manage_files_pattern(systemd_pcrlock_t, systemd_pcrlock_var_run_t, systemd_pcrlock_var_run_t)
 
 dev_list_sysfs(systemd_pcrlock_t)
 dev_read_sysfs(systemd_pcrlock_t)


### PR DESCRIPTION
Basically we use systemd pcrlock mostly for [sdbootutil](https://github.com/openSUSE/sdbootutil) for a while now, we just did not find the time to upstream the general parts. 

I cherry-picked the commits that relate to general pcrlock for this PR. If you would like the sdbootutil(+snapper) policy as well, let me know. I don't think fedora is using it ATM though and it is still in movement, so I did not include it.

I can also squash the commits if you like, just thought that you might want to check the history/development for review. 

https://www.freedesktop.org/software/systemd/man/latest/systemd-pcrlock.html