### PR TITLE
Allow systemd-machined to manage nspawn runtime directory

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -158,6 +158,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/machine(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/machines.lock	--	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
+/run/systemd/nspawn(/.*)?   gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /run/systemd/oom(/.*)?		gen_context(system_u:object_r:systemd_oomd_var_run_t,s0)
 /run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)
 /run/systemd/resolve\.hook/io\.systemd\.Machine	-s	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -582,6 +582,7 @@ manage_lnk_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd
 manage_sock_files_pattern(systemd_machined_t, systemd_machined_var_run_t, systemd_machined_var_run_t)
 init_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, dir, "machines")
 init_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, dir, "machine")
+init_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, dir, "nspawn")
 
 manage_dirs_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_machined_var_lib_t)
 manage_files_pattern(systemd_machined_t, systemd_machined_var_lib_t, systemd_machined_var_lib_t)


### PR DESCRIPTION
Add type transition and file context for /run/systemd/nspawn to allow systemd-machined to create and manage the nspawn directory and its contents.

type=AVC msg=audit(06/09/2026 10:13:07.268:321) : avc:  denied  { create } for  pid=6240 comm=systemd-machine name=nspawn scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0

Resolves: RHEL-108849