### PR TITLE
Allow systemd-machined to manage nspawn runtime directory

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -99,6 +99,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /var/run/systemd/ask-password(/.*)?	gen_context(system_u:object_r:systemd_passwd_var_run_t,s0)
 /var/run/systemd/machines(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /var/run/systemd/machines.lock	--	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
+/var/run/systemd/nspawn(/.*)?	gen_context(system_u:object_r:systemd_machined_var_run_t,s0)
 /var/run/systemd/resolve(/.*)?	gen_context(system_u:object_r:systemd_resolved_var_run_t,s0)
 /var/run/systemd/netif(/.*)?	gen_context(system_u:object_r:systemd_networkd_var_run_t,s0)
 /var/run/systemd/import(/.*)?		gen_context(system_u:object_r:systemd_importd_var_run_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -583,6 +583,7 @@ systemd_dbus_chat_hostnamed(systemd_networkd_t)
 systemd_read_efivarfs(systemd_networkd_t)
 
 init_named_pid_filetrans(systemd_logind_t, systemd_networkd_var_run_t, dir, "netif")
+init_pid_filetrans(systemd_machined_t, systemd_machined_var_run_t, dir, "nspawn")
 
 optional_policy(`
     dbus_system_bus_client(systemd_networkd_t)


### PR DESCRIPTION
Add type transition and file context for /run/systemd/nspawn to allow systemd-machined to create and manage the nspawn directory and its contents.

type=AVC msg=audit(06/09/2026 10:13:07.268:321) : avc:  denied  { create } for  pid=6240 comm=systemd-machine name=nspawn scontext=system_u:system_r:systemd_machined_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0

Resolves: RHEL-108849