### PR TITLE
Fix typo in the comment of build.conf

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -69,7 +69,7 @@ MLS_SENS = 16
 MLS_CATS = 1024
 
 # Number of MCS Categories
-# The categories will be c0 to c(MLS_CATS-1).
+# The categories will be c0 to c(MCS_CATS-1).
 MCS_CATS = 1024
 
 # Set this to y to only display status messages


### PR DESCRIPTION
Based on the documentation in `build.md` and the content of `Makefile` I am judging this is a typo and the comment refers to `MCS_CATS` and not to `MLS_CATS`.