### PR TITLE
fix NetworkManager dnsmasq-forwarders.conf labeling (bsc#1260038)

### DIFF
--- a/policy/modules/contrib/dnsmasq.if
+++ b/policy/modules/contrib/dnsmasq.if
@@ -375,6 +375,7 @@ interface(`dnsmasq_filetrans_named_content',`
 
 	files_pid_filetrans($1, dnsmasq_var_run_t, dir, "network")
 	files_pid_filetrans($1, dnsmasq_var_run_t, file, "dnsmasq.pid")
+	files_pid_filetrans($1, dnsmasq_var_run_t, file, "dnsmasq-forwarders.conf")
 	virt_pid_filetrans($1, dnsmasq_var_run_t, file, "network")
 	files_etc_filetrans($1, dnsmasq_etc_t, file, "dnsmasq.conf")
 	files_etc_filetrans($1, dnsmasq_etc_t, dir, "dnsmasq.d")

--- a/policy/modules/contrib/networkmanager.te
+++ b/policy/modules/contrib/networkmanager.te
@@ -344,6 +344,7 @@ optional_policy(`
 	dnsmasq_dbus_chat(NetworkManager_t)
 	dnsmasq_delete_pid_files(NetworkManager_t)
 	dnsmasq_domtrans(NetworkManager_t)
+	dnsmasq_filetrans_named_content(NetworkManager_t)
 	dnsmasq_initrc_domtrans(NetworkManager_t)
 	dnsmasq_kill(NetworkManager_t)
 	dnsmasq_signal(NetworkManager_t)


### PR DESCRIPTION
Fixes:

AVC details:
type=AVC msg=audit(1777967497.070:759): avc:  denied  { open } for  pid=1500 comm="cmp" path="/run/dnsmasq-forwarders.conf" dev="tmpfs" ino=1953 scontext=unconfined_u:unconfined_r:NetworkManager_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=1 type=AVC msg=audit(1777967497.070:760): avc:  denied  { getattr } for  pid=1500 comm="cmp" path="/run/dnsmasq-forwarders.conf" dev="tmpfs" ino=1953 scontext=unconfined_u:unconfined_r:NetworkManager_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_run_t:s0 tclass=file permissive=1