### PR TITLE
Support new sanlock features - using libdm and SG_IO

### DIFF
--- a/policy/modules/contrib/sanlock.te
+++ b/policy/modules/contrib/sanlock.te
@@ -71,7 +71,7 @@ ifdef(`enable_mls',`
 #
 # sanlock local policy
 #
-allow sanlock_t self:capability { chown dac_read_search  ipc_lock kill setgid setuid sys_nice sys_resource };
+allow sanlock_t self:capability { chown dac_read_search ipc_lock kill setgid setuid sys_nice sys_rawio sys_resource };
 allow sanlock_t self:process { setrlimit setsched signull signal sigkill };
 
 allow sanlock_t self:fifo_file rw_fifo_file_perms;
@@ -103,6 +103,7 @@ storage_raw_rw_fixed_disk(sanlock_t)
 
 dev_read_rand(sanlock_t)
 dev_read_urand(sanlock_t)
+dev_rw_lvm_control(sanlock_t)
 dev_rw_sysfs(sanlock_t)
 
 auth_use_nsswitch(sanlock_t)


### PR DESCRIPTION
New sanlock now uses libdm to read device-mapper tables, and ioctl SG_IO to submit scsi compare and write commands to scsi or multipath devices.

The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(04/30/2026 05:43:17.944:2606) : proctitle=/usr/sbin/sanlock daemon type=PATH msg=audit(04/30/2026 05:43:17.944:2606) : item=0 name=/dev/mapper/control inode=289 dev=00:06 mode=character,600 ouid=root ogid=root rdev=0a:ec obj=system_u:object_r:lvm_control_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(04/30/2026 05:43:17.944:2606) : arch=x86_64 syscall=openat success=yes exit=12 a0=AT_FDCWD a1=0x7fe3a6a97d80 a2=O_RDWR a3=0x0 items=1 ppid=1 pid=77502 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sanlock exe=/usr/sbin/sanlock subj=system_u:system_r:sanlock_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(04/30/2026 05:43:17.944:2606) : avc:  denied  { open } for  pid=77502 comm=sanlock path=/dev/mapper/control dev="devtmpfs" ino=289 scontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023 tcontext=system_u:object_r:lvm_control_t:s0 tclass=chr_file permissive=1 type=AVC msg=audit(04/30/2026 05:43:17.944:2606) : avc:  denied  { read write } for  pid=77502 comm=sanlock name=control dev="devtmpfs" ino=289 scontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023 tcontext=system_u:object_r:lvm_control_t:s0 tclass=chr_file permissive=1

type=AVC msg=audit(1777306527.811:12433): avc:  denied  { sys_rawio } for  pid=16067 comm="sanlock" capability=17 scontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023 tclass=capability permissive=0
type=SYSCALL msg=audit(1777306527.811:12433): arch=x86_64 syscall=ioctl success=no exit=ENOTTY a0=e a1=80280215 a2=7f3d99898460 a3=1 items=0 ppid=1 pid=16067 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=sanlock exe=/usr/sbin/sanlock subj=system_u:system_r:sanlock_t:s0-s0:c0.c1023 key=(null)

Resolves: RHEL-171586