### PR TITLE
Allow pcm-sensor-server the sys_admin capability

### DIFF
--- a/policy/modules/contrib/pcm.te
+++ b/policy/modules/contrib/pcm.te
@@ -11,7 +11,7 @@ init_daemon_domain(pcmsensor_t, pcmsensor_exec_t)
 
 permissive pcmsensor_t;
 
-allow pcmsensor_t self:capability { sys_rawio sys_resource };
+allow pcmsensor_t self:capability { sys_admin sys_rawio sys_resource };
 allow pcmsensor_t self:capability2 perfmon;
 allow pcmsensor_t self:perf_event { cpu kernel open read };
 allow pcmsensor_t self:process { ptrace setrlimit setsched };


### PR DESCRIPTION
Triggered by the pread64() syscall which goes down to proc_bus_pci_read() kernel function, checking the capability.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(04/27/2026 10:43:57.509:22035) : proctitle=/usr/sbin/pcm-sensor-server type=SYSCALL msg=audit(04/27/2026 10:43:57.509:22035) : arch=x86_64 syscall=pread success=yes exit=0 a0=0x43 a1=0x7fcb3dff28b0 a2=0x8 a3=0xa8 items=0 ppid=1 pid=160676 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=pcm-sensor-serv exe=/usr/sbin/pcm-sensor-server subj=system_u:system_r:pcmsensor_t:s0 key=(null) type=AVC msg=audit(04/27/2026 10:43:57.509:22035) : avc:  denied  { sys_admin } for  pid=160676 comm=pcm-sensor-serv capability=sys_admin  scontext=system_u:system_r:pcmsensor_t:s0 tcontext=system_u:system_r:pcmsensor_t:s0 tclass=capability permissive=0

Resolves: RHEL-171325