### PR TITLE
Allow systemd-hostnamed read hwdb files

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1066,6 +1066,8 @@ manage_lnk_files_pattern(systemd_hostnamed_t, hostname_etc_t, hostname_etc_t)
 files_etc_filetrans(systemd_hostnamed_t, hostname_etc_t, file)
 init_pid_filetrans(systemd_hostnamed_t, hostname_etc_t, file )
 
+allow systemd_hostnamed_t systemd_hwdb_etc_t:file read;
+
 kernel_dgram_send(systemd_hostnamed_t)
 kernel_read_xen_state(systemd_hostnamed_t)
 kernel_read_sysctl(systemd_hostnamed_t)


### PR DESCRIPTION
This code path is only reached in specific circumstances: vsock is enabled, and the kernel returns an ambiguous vsock number, which happens on guest machines in some hypervisors only (Hyper-V).

The commit addresses the following AVC denial:
audit: type=1400 audit(1781911480.468:404): avc: denied { read } for pid=11205 comm="systemd-hostnam" name="hwdb.bin" dev="dm-0" ino=8708526 scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:systemd_hwdb_etc_t:s0 tclass=file permissive=0 audit: type=1300 audit(1781911480.468:404): arch=c00000b7 syscall=56 success=no exit=-13 a0=ffffffffffffff9c a1=ffff923aaefb a2=80000 a3=0 items=0 ppid=1 pid=11205 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="systemd-hostnam" exe="/usr/lib/systemd/systemd-hostnamed" subj=system_u:system_r:systemd_hostnamed_t:s0 key=(null)