### PR TITLE
Allow domain_kernel_load_modules for valkey

### DIFF
--- a/policy/modules/contrib/redis.te
+++ b/policy/modules/contrib/redis.te
@@ -72,6 +72,7 @@ files_tmp_filetrans(redis_t, redis_tmp_t, { dir file })
 
 kernel_read_system_state(redis_t)
 kernel_read_net_sysctls(redis_t)
+kernel_request_load_module(redis_t)
 
 corenet_all_recvfrom_unlabeled(redis_t)
 corenet_all_recvfrom_netlabel(redis_t)


### PR DESCRIPTION
Starting valkey-server with the RDMA module enabled results in the following AVC denial on rhel9:

avc:  denied  { module_request } for  pid=7697 comm="valkey-server" kmod="net-pf-16-proto-20" scontext=system_u:system_r:redis_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=0

Related: INFRASERV-1648