### PR TITLE
Allow journald create and use netlink_tcpdiag_socket

### DIFF
--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -499,6 +499,7 @@ allow syslogd_t self:capability { sys_ptrace dac_read_search dac_override sys_re
 dontaudit syslogd_t self:capability sys_tty_config;
 dontaudit syslogd_t self:cap_userns { kill sys_ptrace };
 allow syslogd_t self:capability2 { syslog block_suspend };
+allow syslogd_t self:netlink_tcpdiag_socket create_netlink_socket_perms;
 # setpgid for metalog
 # setrlimit for syslog-ng
 allow syslogd_t self:process { signal_perms getcap setcap setpgid getsched setsched setrlimit };


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1778148202.184:775): avc:  denied  { create } for  pid=1158 comm="systemd-journal" scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:system_r:syslogd_t:s0 tclass=netlink_tcpdiag_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2467668