### PR TITLE
Allow loadkeys create and use its private tmpfs files

### DIFF
--- a/policy/modules/contrib/loadkeys.te
+++ b/policy/modules/contrib/loadkeys.te
@@ -12,6 +12,9 @@ type loadkeys_exec_t;
 init_system_domain(loadkeys_t, loadkeys_exec_t)
 role loadkeys_roles types loadkeys_t;
 
+type loadkeys_tmpfs_t;
+files_tmpfs_file(loadkeys_tmpfs_t)
+
 ########################################
 #
 # Local policy
@@ -19,6 +22,9 @@ role loadkeys_roles types loadkeys_t;
 
 allow loadkeys_t self:capability {  dac_read_search setuid sys_tty_config };
 allow loadkeys_t self:fifo_file rw_fifo_file_perms;
+
+allow loadkeys_t loadkeys_tmpfs_t:file rw_inherited_file_perms;
+fs_tmpfs_filetrans(loadkeys_t, loadkeys_tmpfs_t, file)
 
 kernel_read_system_state(loadkeys_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/26/2026 08:45:15.090:74) : proctitle=/usr/bin/loadkeys -q -C /dev/tty1 -u us type=SYSCALL msg=audit(06/26/2026 08:45:15.090:74) : arch=x86_64 syscall=read success=no exit=EACCES(Permission denied) a0=0x4 a1=0x562e26f01ea0 a2=0x2000 a3=0x0 items=0 ppid=662 pid=675 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=loadkeys exe=/usr/bin/loadkeys subj=system_u:system_r:loadkeys_t:s0 key=(null) type=AVC msg=audit(06/26/2026 08:45:15.090:74) : avc:  denied  { read } for  pid=675 comm=loadkeys path=/memfd:/usr/lib/kbd/keymaps/xkb/us.map.gz (deleted) dev="tmpfs" ino=109 scontext=system_u:system_r:loadkeys_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0