### PR TITLE
Allow systemd-sleep the perfmon capability

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1962,6 +1962,7 @@ systemd_read_efivarfs(systemd_userdbd_t)
 
 # systemd-sleep wants cap_sys_admin to check btrfs swapfile offset (https://github.com/systemd/systemd/pull/29382)
 allow systemd_sleep_t self:capability { linux_immutable sys_resource sys_admin };
+allow systemd_sleep_t self:capability2 { perfmon };
 # systemd-sleep needs to set timer for suspend-then-hibernate
 allow systemd_sleep_t self:capability2 wake_alarm;
 dontaudit systemd_sleep_t self:capability sys_ptrace;


### PR DESCRIPTION
To read other processes' environ file, the perfmon or sys_admin capability is required; sys_admin has already been allowed for systemd-sleep in selinux-policy, but the kernel capability check for perfmon is earlier, so this denial is triggered.

The commit addresses the following AVC denial:
type=AVC msg=audit(1779929095.817:622): avc:  denied  { perfmon } for  pid=32885 comm="systemd-sleep" capability=38  scontext=system_u:system_r:systemd_sleep_t:s0 tcontext=system_u:system_r:systemd_sleep_t:s0 tclass=capability2 permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2482456