### PR TITLE
Allow systemd-logind the sys_ptrace capability in the user namespace

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -346,6 +346,7 @@ files_pid_file(systemd_varlink_registry_t)
 #  is for /run/user/$USER ($USER ownership is $USER:$USER)
 allow systemd_logind_t self:capability { chown kill dac_read_search dac_override fowner sys_tty_config sys_admin };
 allow systemd_logind_t self:capability2 block_suspend;
+allow systemd_logind_t self:cap_userns sys_ptrace;
 
 allow systemd_logind_t self:process getcap;
 allow systemd_logind_t self:netlink_kobject_uevent_socket create_socket_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1780228274.651:551): avc:  denied  { sys_ptrace } for  pid=1830 comm="systemd-logind" capability=19  scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:systemd_logind_t:s0 tclass=cap_userns permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2483620