### PR TITLE
Allow systemd-coredump signull spc container

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1388,6 +1388,7 @@ fs_mounton_tmpfs(systemd_coredump_t)
 optional_policy(`
 	container_signull(systemd_coredump_t)
 	container_runtime_signull(systemd_coredump_t)
+	container_spc_signull(systemd_coredump_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
When coredump forwarding (CoredumpReceive) is enabled, systemd-coredump checks if the container leader is alive and listens on the coredump socket.

The commit addresses the following AVC denial:
type=AVC msg=audit(1778479042.810:839): avc:  denied  { signull } for  pid=219591 comm="systemd-coredum" scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=unconfined_u:unconfined_r:spc_t:s0 tclass=process permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2468997