### PR TITLE
Allow cupsd_t to communicate with fprintd via dbus (bsc#1268366)

### DIFF
--- a/policy/modules/contrib/fprintd.te
+++ b/policy/modules/contrib/fprintd.te
@@ -54,6 +54,10 @@ userdom_use_user_ptys(fprintd_t)
 userdom_read_all_users_state(fprintd_t)
 
 optional_policy(`
+	cups_dbus_chat(fprintd_t)
+')
+
+optional_policy(`
 	dbus_system_domain(fprintd_t, fprintd_exec_t)
 
 	optional_policy(`


### PR DESCRIPTION
When a user has a fingerprint reader configured and wants to authenticate with cups, this is needed.

Fixes:
----
time->Tue Jun 16 23:01:26 2026
type=USER_AVC msg=audit(1781643686.065:266): pid=1455 uid=494 auid=4294967295 ses=4294967295 subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:cupsd_t:s0-s0:c0.c1023 tcontext=system_u:system_r:fprintd_t:s0 tclass=dbus permissive=0 exe="/usr/bin/dbus-broker" sauid=494 hostname=? addr=? terminal=?'