### PR TITLE
Allow dhcpcd hook scripts read generic files in /proc

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -323,6 +323,7 @@ domtrans_pattern(dhcpc_t, dhcpc_hook_exec_t, dhcpc_hook_t)
 allow dhcpc_hook_t self:netlink_route_socket create_netlink_socket_perms;
 allow dhcpc_hook_t self:unix_dgram_socket { create ioctl };
 
+kernel_read_proc_files(dhcpc_hook_t)
 kernel_request_load_module(dhcpc_hook_t)
 
 manage_dirs_pattern(dhcpc_hook_t, dhcpc_var_run_t, dhcpc_var_run_t)


### PR DESCRIPTION
When the dhcpcd run-hooks script executes mkdir -p to create hook state directories under /run/dhcpcd/hook-state/, the mkdir process reads /proc/filesystems to resolve filesystem type information.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/02/2026 03:55:09.238:403) : proctitle=mkdir -p /run/dhcpcd/hook-state/ntp.conf type=SYSCALL msg=audit(07/02/2026 03:55:09.238:403) : arch=x86_64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0x7fb0157c71f0 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=0 ppid=7087 pid=7089 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=4 comm=mkdir exe=/usr/bin/mkdir subj=unconfined_u:system_r:dhcpc_hook_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(07/02/2026 03:55:09.238:403) : avc:  denied  { open } for  pid=7089 comm=mkdir path=/proc/filesystems dev="proc" ino=4026532068 scontext=unconfined_u:system_r:dhcpc_hook_t:s0-s0:c0.c1023 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=1 type=AVC msg=audit(07/02/2026 03:55:09.238:403) : avc:  denied  { read } for  pid=7089 comm=mkdir name=filesystems dev="proc" ino=4026532068 scontext=unconfined_u:system_r:dhcpc_hook_t:s0-s0:c0.c1023 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2495974