### PR TITLE
Support systemtap an a UEFI+SecureBoot system

### DIFF
--- a/policy/modules/contrib/stapserver.te
+++ b/policy/modules/contrib/stapserver.te
@@ -66,9 +66,9 @@ fs_tmpfs_filetrans(stapserver_t, stapserver_tmpfs_t, { file dir })
 
 kernel_read_system_state(stapserver_t)
 kernel_read_kernel_sysctls(stapserver_t)
+kernel_read_network_state(stapserver_t)
 kernel_read_vm_sysctls(stapserver_t)
 kernel_read_fs_sysctls(stapserver_t)
-files_list_kernel_modules(stapserver_t)
 
 corecmd_exec_bin(stapserver_t)
 corecmd_exec_shell(stapserver_t)
@@ -81,7 +81,9 @@ dev_read_rand(stapserver_t)
 dev_read_urand(stapserver_t)
 
 files_list_tmp(stapserver_t)
+files_getattr_kernel_modules(stapserver_t)
 files_search_kernel_modules(stapserver_t)
+files_list_kernel_modules(stapserver_t)
 
 fs_search_cgroup_dirs(stapserver_t)
 fs_getattr_all_fs(stapserver_t)
@@ -114,6 +116,10 @@ optional_policy(`
 
 optional_policy(`
 	hostname_exec(stapserver_t)
+')
+
+optional_policy(`
+	modutils_getattr_module_deps(stapserver_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=SYSCALL msg=audit(05/22/2026 11:21:20.897:494) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55a9d5936fc0 a2=0x7ffe711b3a30 a3=0x0 items=0 ppid=25756 pid=28811 auid=unset uid=stap-server gid=stap-server euid=stap-server suid=stap-server fsuid=stap-server egid=stap-server sgid=stap-server fsgid=stap-server tty=(none) ses=unset comm=stap exe=/usr/bin/stap subj=system_u:system_r:stapserver_t:s0 key=(null) type=AVC msg=audit(05/22/2026 11:21:20.897:494) : avc:  denied  { getattr } for  pid=28811 comm=stap path=/usr/lib/modules/6.12.0-211.16.1.el10_2.x86_64/modules.block dev="dm-0" ino=362494 scontext=system_u:system_r:stapserver_t:s0 tcontext=system_u:object_r:modules_dep_t:s0 tclass=file permissive=0

Resolves: RHEL-178490