### PR TITLE
Allow aide get attributes of allfilesystems

### DIFF
--- a/policy/modules/contrib/aide.te
+++ b/policy/modules/contrib/aide.te
@@ -47,8 +47,7 @@ files_read_all_symlinks(aide_t)
 files_getattr_all_pipes(aide_t)
 files_getattr_all_sockets(aide_t)
 
-fs_getattr_tmpfs(aide_t)
-fs_getattr_xattr_fs(aide_t)
+fs_getattr_all_fs(aide_t)
 
 init_stream_connectto(aide_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(06/08/2026 11:11:03.251:281) : proctitle=/usr/sbin/aide --config=/etc/aide.conf --check type=SYSCALL msg=audit(06/08/2026 11:11:03.251:281) : arch=aarch64 syscall=fstatfs success=no exit=EACCES(Permission denied) a0=0x5 a1=0xffff90e37ed8 a2=0xaaaadd40e3f0 a3=0x8000 items=0 ppid=32115 pid=32116 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=aide exe=/usr/sbin/aide subj=system_u:system_r:aide_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(06/08/2026 11:11:03.251:281) : avc:  denied  { getattr } for  pid=32116 comm=aide name=/ dev="vda1" ino=1 scontext=system_u:system_r:aide_t:s0-s0:c0.c1023 tcontext=system_u:object_r:dosfs_t:s0 tclass=filesystem permissive=0

Resolves: RHEL-182787