### PR TITLE
Make insights_client_t accessible from the system cronjob

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -234,11 +234,12 @@ optional_policy(`
 #	container_runtime_domtrans(insights_client_t)
 #')
 #
-#optional_policy(`
+
+optional_policy(`
 #	cron_signull_system_job(insights_client_t)
-#	cron_system_entry(insights_client_t, insights_client_exec_t)
-#')
-#
+	cron_system_entry(insights_client_t, insights_client_exec_t)
+')
+
 #optional_policy(`
 #	dbus_system_bus_client(insights_client_t)
 #')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(01/06/26 06:58:02.103:8350) : proctitle=/usr/bin/python3 /usr/bin/insights-client --validate --offline --verbose type=PATH msg=audit(01/06/26 06:58:02.103:8350) : item=0 name=/usr/bin/python3 inode=17356567 dev=fd:00 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:bin_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(01/06/26 06:58:02.103:8350) : arch=x86_64 syscall=execve success=no exit=EACCES(Permission denied) a0=0x7fc750eff4f0 a1=0x7fc750f0a300 a2=0x7fc750f4eb10 a3=0x0 items=1 ppid=176745 pid=176748 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=insights-client exe=/usr/bin/python3.9 subj=system_u:system_r:system_cronjob_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(01/06/26 06:58:02.103:8350) : avc:  denied  { transition } for  pid=176748 comm=insights-client path=/usr/bin/python3.9 dev="dm-0" ino=17356567 scontext=system_u:system_r:system_cronjob_t:s0-s0:c0.c1023 tcontext=system_u:system_r:insights_core_t:s0-s0:c0.c1023 tclass=process permissive=0

Resolves: RHEL-180832