### PR TITLE
Allow kernel write to unconfined and sysadm users' keys

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -538,6 +538,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	sysadm_write_keys(kernel_t)
+')
+
+optional_policy(`
 	systemd_coredump_domtrans(kernel_t)
 
 	# Systemd symlinks /usr/bin/{poweroff,reboot} (which are invoked by
@@ -550,6 +554,10 @@ optional_policy(`
 
 	dbus_system_bus_client(kernel_systemctl_t)
 	init_read_utmp(kernel_systemctl_t)
+')
+
+optional_policy(`
+	unconfined_write_keys(kernel_t)
 ')
 
 optional_policy(`

--- a/policy/modules/roles/sysadm.if
+++ b/policy/modules/roles/sysadm.if
@@ -271,3 +271,21 @@ interface(`sysadm_dgram_send',`
 
 	allow $1 sysadm_t:unix_dgram_socket sendto;
 ')
+
+########################################
+## <summary>
+##	Write keys for the sysadm user.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sysadm_write_keys',`
+	gen_require(`
+		type sysadm_t;
+	')
+
+	allow $1 sysadm_t:key write;
+')


### PR DESCRIPTION
The kernel worker thread is being denied write access to kernel keyring keys that are owned by user domains (specifically unconfined_t and sysadm_t). This prevents the NVMe subsystem from properly managing cryptographic keys needed for DH-HMAC-CHAP authentication with secure concatenation.

The commit addresses the following AVC denial:
type=AVC msg=audit(1773831423.769:1376): avc:  denied  { write } for  pid=280132 comm="kworker/u64:0" scontext=system_u:system_r:kernel_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=key permissive=0

Resolves: RHEL-156860