### PR TITLE
Remove systemd_homed_stream_connect() reference for bootupd_t

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -86,7 +86,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_homed_stream_connect(bootupd_t)
 	systemd_userdbd_stream_connect(bootupd_t)
 ')
 


### PR DESCRIPTION
This interface does not exist in c9s.

Resolves: RHEL-174888