### PR TITLE
Move bootupd systemd interface to 2 optional blocks

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -86,8 +86,11 @@ optional_policy(`
 ')
 
 optional_policy(`
-	systemd_homed_stream_connect(bootupd_t)
 	systemd_userdbd_stream_connect(bootupd_t)
+')
+
+optional_policy(`
+	systemd_homed_stream_connect(bootupd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The systemd_homed_stream_connect() and systemd_userdbd_stream_connect() interfaces are actually from different modules.