### PR TITLE
Allow net_admin to the nfsd_t domain

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -237,7 +237,7 @@ optional_policy(`
 # NFSD local policy
 #
 
-allow nfsd_t self:capability { dac_read_search dac_override setgid setuid sys_admin sys_chroot sys_rawio sys_resource };
+allow nfsd_t self:capability { dac_read_search dac_override net_admin setgid setuid sys_admin sys_chroot sys_rawio sys_resource };
 
 allow nfsd_t self:process { setcap };
 


### PR DESCRIPTION
nfs-utils 2.9.1 added a netlink interface to mountd/exportd to handle sunrpc cache upcalls from the kernel.  The netlink interface requires CAP_NET_ADMIN.

The commit addresses the following AVC denial:
type=AVC msg=audit(1783461620.873:503): avc:  denied  { net_admin } for  pid=57981 comm="rpc.mountd" capability=12  scontext=system_u:system_r:nfsd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=capability permissive=0