### PR TITLE
Allow init_t nnp domain transition to postgresql_t

### DIFF
--- a/policy/modules/services/postgresql.te
+++ b/policy/modules/services/postgresql.te
@@ -49,6 +49,7 @@ gen_tunable(postgresql_selinux_unconfined_dbadm, true)
 type postgresql_t;
 type postgresql_exec_t;
 init_daemon_domain(postgresql_t, postgresql_exec_t)
+init_nnp_daemon_domain(postgresql_t)
 
 type postgresql_db_t;
 files_type(postgresql_db_t)


### PR DESCRIPTION
One-line fix for #3281, mirroring the redis fix from #2663.

Verified on Fedora Cloud 44: with this change compiled via selinux-policy-devel and loaded over the base module, postgresql.service starts under an explicit NoNewPrivileges=yes and runs confined as postgresql_t, where it previously fell back to init_t and failed reading its own configuration.

Drafted with AI assistance (Claude); all reproduction and verification steps were run and reviewed by the submitter.