### PR TITLE
Allow ctdbd manage access to Samba PID directories

### DIFF
--- a/policy/modules/contrib/ctdb.te
+++ b/policy/modules/contrib/ctdb.te
@@ -156,6 +156,7 @@ optional_policy(`
 	samba_domtrans_net(ctdbd_t)
 	samba_manage_var_dirs(ctdbd_t)
 	samba_manage_var_files(ctdbd_t)
+	samba_manage_pid(ctdbd_t)
 	samba_systemctl(ctdbd_t)
 ')
 

--- a/policy/modules/contrib/samba.if
+++ b/policy/modules/contrib/samba.if
@@ -61,6 +61,27 @@ interface(`samba_search_pid',`
 
 ########################################
 ## <summary>
+##	Manage samba PID dirs, files, and sock files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`samba_manage_pid',`
+	gen_require(`
+		type smbd_var_run_t;
+	')
+
+	files_search_pids($1)
+	manage_dirs_pattern($1, smbd_var_run_t, smbd_var_run_t)
+	manage_files_pattern($1, smbd_var_run_t, smbd_var_run_t)
+	manage_sock_files_pattern($1, smbd_var_run_t, smbd_var_run_t)
+')
+
+########################################
+## <summary>
 ##	Connect to nmbd.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
CTDB now [respects](https://gitlab.com/samba-team/samba/-/merge_requests/4631) Samba's _--with-piddir_, _--with-sockets-dir_, and _-with-lockdir_ configure options. As a result, _ctdbd_ needs access to Samba's PID directories (`smbd_var_run_t`) to manage dirs, files, and socket files at those configured locations.

A new _samba_manage_pid()_ interface is introduced to grant manage access to `smbd_var_run_t` resources.

The commit addresses the following known AVC denials:

> type=AVC msg=audit(1784029509.330:2952): avc:  denied  { write } for pid=35818 comm="ctdbd" name="ctdb" dev="tmpfs" ino=1370 scontext=system_u:system_r:ctdbd_t:s0
> 
> tcontext=unconfined_u:object_r:smbd_var_run_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1784029509.330:2952): avc:  denied  { remove_name } for  pid=35818 comm="ctdbd" name="ctdbd.socket" dev="tmpfs" ino=1466 scontext=system_u:system_r:ctdbd_t:s0 tcontext=unconfined_u:object_r:smbd_var_run_t:s0 tclass=dir permissive=1
> 
> type=AVC msg=audit(1784029509.330:2952): avc:  denied  { unlink } for pid=35818 comm="ctdbd" name="ctdbd.socket" dev="tmpfs" ino=1466 scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:smbd_var_run_t:s0 tclass=sock_file permissive=1
> 
> type=AVC msg=audit(1784029509.331:2953): avc:  denied  { add_name } for pid=35818 comm="ctdbd" name="ctdbd.socket" scontext=system_u:system_r:ctdbd_t:s0 tcontext=unconfined_u:object_r:smbd_var_run_t:s0 tclass=dir permissive=1
> 
> type=AVC msg=audit(1784029509.331:2953): avc:  denied  { create } for pid=35818 comm="ctdbd" name="ctdbd.socket" scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:smbd_var_run_t:s0 tclass=sock_file permissive=1
> 
> type=AVC msg=audit(1784029509.331:2954): avc:  denied  { setattr } for pid=35818 comm="ctdbd" name="ctdbd.socket" dev="tmpfs" ino=1565 scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:smbd_var_run_t:s0 tclass=sock_file permissive=1
> 
> type=AVC msg=audit(1784029509.339:2956): avc:  denied  { write } for pid=35818 comm="ctdbd" name="eventd.socket" dev="tmpfs" ino=1567 scontext=system_u:system_r:ctdbd_t:s0 tcontext=system_u:object_r:smbd_var_run_t:s0 tclass=sock_file permissive=1