### PR TITLE
Allow all domains to use inherited sshd-session pipes

### DIFF
--- a/policy/modules/kernel/domain.te
+++ b/policy/modules/kernel/domain.te
@@ -699,6 +699,7 @@ optional_policy(`
 
 optional_policy(`
 	ssh_rw_pipes(domain)
+	ssh_session_rw_pipes(domain)
 ')
 
 optional_policy(`


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer:** I am not an SELinux policy expert — apologies in advance if terminology or conventions are off. This investigation was carried out with the help of an AI assistant (Claude — Fable 5), and every reproducer, AVC, and fix in this PR and its companion issue was verified on a real Fedora 44 system (enforcing, re-checked with `semodule -DB`). I've done my best to make this contribution as valuable as possible — corrections are very welcome.

When OpenSSH split out the sshd-session binary and the policy introduced `sshd_session_t`, the long-standing domain-wide grant for inherited sshd pipes — `ssh_rw_pipes(domain)` in domain.te — was not mirrored for the new type: `ssh_session_rw_pipes()` is only called by `passwd_t`.

**Mechanism.** Stdio pipes inherited from a non-interactive SSH session (no TTY — the default transport of ansible, pyinfra and similar tools) can no longer be passed over D-Bus in `StartTransientUnit` messages: neither dbus-broker nor PID 1 may use `sshd_session_t:fifo_file`, so the kernel strips the `SCM_RIGHTS` fds and sets `MSG_CTRUNC`, which the receiving peer treats as fatal for the connection (sd-bus ≤ v259 / dbus-broker; systemd/systemd#34688, adjudicated as kernel/LSM behavior and closed at the merge of the v260 mitigation systemd/systemd#40089, which keeps the connection alive but cannot restore the stripped fds).

**Symptom.** Every `systemd-run --pipe` and `systemctl --user --machine=<user>@.host` over ssh without a TTY fails with "Connection reset by peer". Once dbus-broker alone is allowed, the same denial reappears inside PID 1 and additionally tears down PID 1's API-bus connection ("Got disconnect on API bus", host-wide `systemctl` outage until the manager's eventual bus reconnect or an immediate `systemctl daemon-reexec` — timing measured in the companion issues).

**Scope of the grant.** The grant is made domain-wide, exactly matching the `sshd_t` rule one line above. (Adjacent precedent: [rhbz#2036829](https://bugzilla.redhat.com/show_bug.cgi?id=2036829) / commit 95d703493 similarly allowed init_t to use inherited userdomain pipes for the shell-pipe sibling of this failure family.) This makes the existing `ssh_session_rw_pipes(passwd_t)` (`usermanage.te:425`) and `allow sshd_net_t sshd_session_t:fifo_file write;` (`ssh.te:94`) redundant — happy to drop the passwd_t call here or in a follow-up, maintainer's preference. Beyond the two measured receivers (`system_dbusd_t`, `init_t`), the transient unit's own payload domain can inherit the same pipes as its stdio, so a confined service doing stdio there would hit the same denial one hop further (not observed in our captures, where payloads ran unconfined). `ssh_session_rw_pipes()` expands to `rw_inherited_fifo_file_perms` = `{ getattr read write append ioctl lock }` — the `read`/`write` denials are the ones observed on the box; the remaining permissions are set parity with the `sshd_t` rule (with the ioctl/isatty follow-on documented for the userdomain-pipe case in commit 95d703493). No `open` is included: inherited fds only.

Raw AVCs are in the commit message (Fedora 44, selinux-policy-targeted-44.4-1.fc44, enforcing, captured 2026-07-16; not dontaudited — `semodule -DB` re-check showed no further denials related to this operation).

Verified on a fully-updated fedora/44 box: with the equivalent raw rules as a local module, both reproducers pass with zero AVCs (also under `semodule -DB`); removing the module restores the failure. `make policy && make validate` pass on the patched tree. Reproduced on aarch64; the policy change is arch-independent.

Fixes #3286
Related: #1106 (sibling failure in the same fd-strip family, open since 2022; its denied object predates the split and was never captured, so closing it is left to the maintainer after verifying)



Companion PR for the same fd-stripping mechanism hitting regular-file redirect targets: #3289.
