### PR TITLE
Allow sysadm_t to mounton kmsg_device_t

### DIFF
--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -48,6 +48,7 @@ dev_rw_lvm_control(sysadm_t)
 dev_rw_watchdog(sysadm_t)
 dev_rw_wireless(sysadm_t)
 dev_write_kmsg(sysadm_t)
+dev_mounton_kmsg(sysadm_t)
 dev_setattr_all_chr_files(sysadm_t)
 
 domain_dontaudit_read_all_domains_state(sysadm_t)


### PR DESCRIPTION
Denial: 
type=AVC msg=audit(1784462583.007:1518): avc:  denied  { mounton } for  pid=17353 comm="(smashell)" path="/run/systemd/mount-rootfs/dev/kmsg" dev="devtmpfs" ino=10 scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:kmsg_device_t:s0 tclass=chr_file permissive=0

Plasmashell would not start succesfully on my system when running as sysadm_t because of this denial.
It only happens after logging out or rebooting and then logging in again via SDDM and not when manually restarting plasmashell in an active session.