### PR TITLE
Add missing rule for automotive policy

### DIFF
--- a/policy/modules/system/selinuxutil.fc
+++ b/policy/modules/system/selinuxutil.fc
@@ -11,7 +11,8 @@
 /etc/selinux/([^/]*/)?setrans\.conf --	gen_context(system_u:object_r:selinux_config_t,mls_systemhigh)
 /etc/selinux/([^/]*/)?seusers	--	gen_context(system_u:object_r:selinux_config_t,s0)
 /etc/selinux/([^/]*/)?modules/(active|tmp|previous)(/.*)? gen_context(system_u:object_r:semanage_store_t,s0)
-/etc/selinux/(minimum|mls|targeted)/(active|tmp|previous)(/.*)? gen_context(system_u:object_r:semanage_store_t,s0)
+# automotive policy is defined only for CentOS Stream, so we need to be careful on rebase
+/etc/selinux/(automotive|minimum|mls|targeted)/(active|tmp|previous)(/.*)? gen_context(system_u:object_r:semanage_store_t,s0)
 /etc/selinux/([^/]*/)?modules/semanage\.read\.LOCK -- gen_context(system_u:object_r:semanage_read_lock_t,s0)
 /etc/selinux/([^/]*/)?modules/semanage\.trans\.LOCK -- gen_context(system_u:object_r:semanage_trans_lock_t,s0)
 /etc/selinux/([^/]*/)?users(/.*)? --	gen_context(system_u:object_r:selinux_config_t,s0)
@@ -58,3 +59,6 @@
 
 /etc/share/selinux/targeted(/.*)?	gen_context(system_u:object_r:semanage_store_t,s0)
 /etc/share/selinux/mls(/.*)?		gen_context(system_u:object_r:semanage_store_t,s0)
+# automotive policy is defined only for CentOS Stream, so we need to be careful on rebase
+/etc/share/selinux/automotive(/.*)?	gen_context(system_u:object_r:semanage_store_t,s0)
+


### PR DESCRIPTION
Existing rule is defined only for minimum, mls and targeted policies, so
we need to extend it also for automotive policy.

Resolves: RHEL-216823
Signed-off-by: Martin Perina <mperina@redhat.com>
