### PR TITLE
Allow wireguard read cgroup files

### DIFF
--- a/policy/modules/contrib/wireguard.te
+++ b/policy/modules/contrib/wireguard.te
@@ -41,6 +41,8 @@ domain_use_interactive_fds(wireguard_t)
 
 files_read_etc_files(wireguard_t)
 
+fs_read_cgroup_files(wireguard_t)
+
 optional_policy(`
 	auth_read_passwd(wireguard_t)
 ')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/20/2026 09:33:25.163:736) : proctitle=sort -nr -k 2 -t / type=PATH msg=audit(07/20/2026 09:33:25.163:736) : item=0 name=/sys/fs/cgroup/system.slice/cpu.max inode=5331 dev=00:1d mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:cgroup_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/20/2026 09:33:25.163:736) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7fffc5c171b0 a2=O_RDONLY a3=0x0 items=1 ppid=12564 pid=12566 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sort exe=/usr/bin/sort subj=system_u:system_r:wireguard_t:s0 key=(null) type=AVC msg=audit(07/20/2026 09:33:25.163:736) : avc:  denied  { read } for  pid=12566 comm=sort name=cpu.max dev="cgroup2" ino=5331 scontext=system_u:system_r:wireguard_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2496055