### PR TITLE
Allow geoclue read cgroup files

### DIFF
--- a/policy/modules/contrib/geoclue.te
+++ b/policy/modules/contrib/geoclue.te
@@ -54,6 +54,7 @@ files_watch_etc_dirs(geoclue_t)
 fs_getattr_cgroup(geoclue_t)
 fs_getattr_tmpfs(geoclue_t)
 fs_getattr_xattr_fs(geoclue_t)
+fs_read_cgroup_files(geoclue_t)
 
 init_dbus_chat(geoclue_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1783614992.168:161): avc: denied { read } for pid=2216 comm="geoclue" name="memory.pressure" dev="cgroup2" ino=8922 scontext=system_u:system_r:geoclue_t:s0 tcontext=system_u:object_r:cgroup_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2499770