### PR TITLE
Allow pcscd get attributes of a pty filesystem

### DIFF
--- a/policy/modules/contrib/pcscd.te
+++ b/policy/modules/contrib/pcscd.te
@@ -64,6 +64,7 @@ files_read_etc_runtime_files(pcscd_t)
 fs_getattr_pidfs(pcscd_t)
 fs_search_cgroup_dirs(pcscd_t)
 
+term_getattr_pty_fs(pcscd_t)
 term_use_unallocated_ttys(pcscd_t)
 term_dontaudit_getattr_pty_dirs(pcscd_t)
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1778294421.382:11002): avc:  denied  { getattr } for  pid=3195 comm="pcscd" name="/" dev="devpts" ino=1 scontext=system_u:system_r:pcscd_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=filesystem permissive=1 type=SYSCALL msg=audit(1778294421.382:11002): arch=x86_64 syscall=fstatfs success=yes exit=0 a0=10 a1=7fb5ee134150 a2=4 a3=8804 items=0 ppid=1 pid=3195 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=pcscd exe=/usr/bin/pcscd subj=system_u:system_r:pcscd_t:s0 key=(null)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2468437