### PR TITLE
Allow unconfined_t mounton its lnk_files

### DIFF
--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -62,7 +62,7 @@ typealias unconfined_t alias unconfined_crontab_t;
 # Local policy
 #
 
-allow unconfined_t self:{dir file} mounton;
+allow unconfined_t self:{ dir file lnk_file } mounton;
 dontaudit unconfined_t self:dir write;
 dontaudit unconfined_t self:file setattr;
 


### PR DESCRIPTION
Requsted by a test which intentionally tries to mount onto a /proc/<pid>/fd/<n> “magic link” path.
While this scenario is expected to fail anyway, it seems to be reasonable to pair this added rule with existing ones for unconfined_t.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(1763620479.950:520): proctitle="mount08" type=SYSCALL msg=audit(1763620479.950:520): arch=c00000b7 syscall=40 success=no exit=-13 a0=422c30 a1=ffffd37e7580 a2=426cc8 a3=1000 items=0 ppid=93416 pid=93417 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="mount08" exe="/mnt/testarea/ltp/testcases/bin/mount08" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(1763620479.950:520): avc:  denied  { mounton } for  pid=93417 comm="mount08" path="/proc/93417/fd/3" dev="proc" ino=484027 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=lnk_file permissive=0

Resolves: RHEL-127120