### PR TITLE
Allow dhcpc_hook_t connect to init_t over a unix stream socket

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -346,6 +346,7 @@ optional_policy(`
 
 optional_policy(`
 	init_ioctl_stream_sockets(dhcpc_hook_t)
+	init_stream_connect(dhcpc_hook_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/22/2026 07:55:20.396:466) : proctitle=resolvconf -a eth0.dhcp type=SYSCALL msg=audit(07/22/2026 07:55:20.396:466) : arch=x86_64 syscall=fstat success=yes exit=0 a0=0x1 a1=0x7ffcc40a22a0 a2=0x7ffcc40a2330 a3=0x0 items=0 ppid=14998 pid=15001 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=resolvconf exe=/usr/bin/resolvectl subj=system_u:system_r:dhcpc_hook_t:s0 key=(null) type=AVC msg=audit(07/22/2026 07:55:20.396:466) : avc:  denied  { getattr } for  pid=15001 comm=resolvconf path=socket:[24919] dev="sockfs" ino=24919 scontext=system_u:system_r:dhcpc_hook_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=147153