### PR TITLE
rasdaemon: optionally permit access to ipmitool

### DIFF
--- a/policy/modules/contrib/rasdaemon.te
+++ b/policy/modules/contrib/rasdaemon.te
@@ -19,6 +19,15 @@ systemd_unit_file(rasdaemon_unit_file_t)
 #
 # rasdaemon local policy
 #
+
+gen_tunable(rasdaemon_use_ipmitool, false)
+
+## <desc>
+##     <p>
+##     Determine whether rasdaemon can use ipmitool to access IPMI devices.
+##     </p>
+## </desc>
+
 allow rasdaemon_t self:capability sys_admin;
 allow rasdaemon_t self:fifo_file rw_fifo_file_perms;
 allow rasdaemon_t self:unix_stream_socket create_stream_socket_perms;
@@ -51,5 +60,9 @@ logging_send_syslog_msg(rasdaemon_t)
 
 optional_policy(`
     dmidecode_exec(rasdaemon_t)
+')
+
+tunable_policy(`rasdaemon_use_ipmitool',`
+	ipmitool_domtrans(rasdaemon_t)
 ')
 


### PR DESCRIPTION
rasdaemon can run `ipmitool` to collect extra information. A boolean is added to optionally grant this extra access.

This is an attempt to port over https://github.com/SELinuxProject/refpolicy/pull/1184