### PR TITLE
Allow sysadm_t run and read/write networkmanager bpf programs

### DIFF
--- a/policy/modules/contrib/networkmanager.if
+++ b/policy/modules/contrib/networkmanager.if
@@ -641,6 +641,42 @@ interface(`networkmanager_sigkill',`
 
 ########################################
 ## <summary>
+##	Run networkmanager BPF programs.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`networkmanager_run_bpf',`
+	gen_require(`
+		type networkmanager_t;
+	')
+
+	allow $1 networkmanager_t:bpf prog_run;
+')
+
+########################################
+## <summary>
+##	Read and write networkmanager BPF programs.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access.
+## </summary>
+## </param>
+#
+interface(`networkmanager_rw_bpf',`
+	gen_require(`
+		type networkmanager_t;
+	')
+
+	allow $1 networkmanager_t:bpf { map_read map_write };
+')
+
+########################################
+## <summary>
 ##	Transition to networkmanager named content
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -459,6 +459,8 @@ optional_policy(`
 
 optional_policy(`
 	networkmanager_filetrans_named_content(sysadm_t)
+	networkmanager_run_bpf(sysadm_t)
+	networkmanager_rw_bpf(sysadm_t)
 	networkmanager_stream_connect(sysadm_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(02/02/2026 09:48:37.569:882) : proctitle=bpftool prog type=SYSCALL msg=audit(02/02/2026 09:48:37.569:882) : arch=x86_64 syscall=bpf success=yes exit=3 a0=BPF_PROG_GET_FD_BY_ID a1=0x7ffdf2a78710 a2=0xc a3=0x55c1826f63a0 items=0 ppid=40702 pid=40703 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=11 comm=bpftool exe=/usr/sbin/bpftool subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(02/02/2026 09:48:37.569:882) : avc:  denied  { prog_run } for  pid=40703 comm=bpftool scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=bpf permissive=1

type=PROCTITLE msg=audit(02/02/2026 09:48:37.570:883) : proctitle=bpftool prog
type=SYSCALL msg=audit(02/02/2026 09:48:37.570:883) : arch=x86_64 syscall=bpf success=yes exit=4 a0=BPF_MAP_GET_FD_BY_ID a1=0x7ffdf2a781b0 a2=0xc a3=0x55c1826f7790 items=0 ppid=40702 pid=40703 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts2 ses=11 comm=bpftool exe=/usr/sbin/bpftool subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(02/02/2026 09:48:37.570:883) : avc:  denied  { map_read map_write } for  pid=40703 comm=bpftool scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:NetworkManager_t:s0 tclass=bpf permissive=1

Resolves: RHEL-145714