### PR TITLE
Dontaudit unconfined_t map its private directories

### DIFF
--- a/policy/modules/roles/unconfineduser.te
+++ b/policy/modules/roles/unconfineduser.te
@@ -63,7 +63,7 @@ typealias unconfined_t alias unconfined_crontab_t;
 #
 
 allow unconfined_t self:{ dir file lnk_file } mounton;
-dontaudit unconfined_t self:dir write;
+dontaudit unconfined_t self:dir { map write };
 dontaudit unconfined_t self:file setattr;
 
 allow unconfined_t self:system syslog_read;


### PR DESCRIPTION
Calling mmap(2) on a directory should always fail (with ENODEV) and there is no easy way to get it to fail before hitting the SELinux check. Dontauditing this particular permission in selinux-policy helps stress tests (from the stress-ng suite) not to generate an avc.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/03/2026 04:16:04.674:124) : proctitle=stress-ng --random 10 -x numa,hdd,key --timeout 5s type=AVC msg=audit(03/03/2026 04:16:04.674:124) : avc:  denied  { map } for  pid=18860 comm=stress-ng-pidfd path=/proc/18930 dev="proc" ino=15948 scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=dir permissive=0 type=SYSCALL msg=audit(03/03/2026 04:16:04.674:124) : arch=s390x syscall=mmap success=no exit=EACCES(Permission denied) a0=0x3ffe1776848 a1=0x1000 a2=PROT_READ a3=MAP_PRIVATE items=0 ppid=18855 pid=18860 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=stress-ng-pidfd exe=/usr/bin/stress-ng subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null)

Resolves: RHEL-154554