### PR TITLE
Allow nfsidmapd read virt lib files

### DIFF
--- a/policy/modules/contrib/rpc.te
+++ b/policy/modules/contrib/rpc.te
@@ -481,7 +481,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	virt_search_lib(nfsidmap_t)
+	virt_read_lib_files(nfsidmap_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/29/2025 17:58:19.560:1301) : proctitle=nfsidmap 1234567 uid:SYS type=AVC msg=audit(11/29/2025 17:58:19.560:1301) : avc:  denied  { read } for  pid=48398 comm=nfsidmap name=dnsmasq dev="dm-0" ino=1336377 scontext=system_u:system_r:nfsidmap_t:s0 tcontext=system_u:object_r:virt_var_lib_t:s0 tclass=dir permissive=0 type=SYSCALL msg=audit(11/29/2025 17:58:19.560:1301) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f966ba7a1aa a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=0 ppid=40655 pid=48398 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=nfsidmap exe=/usr/sbin/nfsidmap subj=system_u:system_r:nfsidmap_t:s0 key=(null)

Resolves: RHEL-132866