### PR TITLE
Support cronie create crontab backups

### DIFF
--- a/policy/modules/contrib/cron.te
+++ b/policy/modules/contrib/cron.te
@@ -174,6 +174,13 @@ tunable_policy(`fcron_crond',`
 	allow admin_crontab_t self:process setfscreate;
 ')
 
+optional_policy(`
+	# cronie 1.7+ saves crontab backups to ~/.cache/crontab/
+	gnome_create_generic_admin_cache_dir(admin_crontab_t)
+	gnome_manage_cache_home_dir(admin_crontab_t)
+	gnome_manage_generic_cache_files(admin_crontab_t)
+')
+
 ########################################
 #
 # Cron daemon local policy
@@ -876,6 +883,13 @@ tunable_policy(`fcron_crond',`
 	# fcron wants an instant update of a crontab change for the administrator
 	# also crontab does a security check for crontab -u
 	dontaudit crontab_domain crond_t:process signal;
+')
+
+optional_policy(`
+	# cronie 1.7+ saves crontab backups to ~/.cache/crontab/
+	gnome_create_generic_cache_dir(crontab_t)
+	gnome_manage_cache_home_dir(crontab_t)
+	gnome_manage_generic_cache_files(crontab_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/gnome.if
+++ b/policy/modules/contrib/gnome.if
@@ -489,6 +489,25 @@ interface(`gnome_create_generic_cache_dir',`
 
 ########################################
 ## <summary>
+##	Create generic admin cache dir (.cache)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`gnome_create_generic_admin_cache_dir',`
+	gen_require(`
+		type cache_home_t;
+	')
+
+	allow $1 cache_home_t:dir create_dir_perms;
+	userdom_admin_home_dir_filetrans($1, cache_home_t, dir, ".cache")
+')
+
+########################################
+## <summary>
 ##	Set attributes of cache home dir (.cache)
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
cronie since v1.7 saves crontab backups:
On edition or deletion of the crontab, a backup of the last crontab will be saved to $XDG_CACHE_HOME/crontab/crontab.bak or $XDG_CACHE_HOME/crontab/crontab.<user>.bak if -u is used. If the XDG_CACHE_HOME environment variable is not set, $HOME/.cache will be used instead.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/28/2025 06:58:43.674:441) : proctitle=crontab -r type=PATH msg=audit(11/28/2025 06:58:43.674:441) : item=1 name=/home/staff-user/.cache inode=12909705 dev=fc:02 mode=dir,755 ouid=staff-user ogid=staff-user rdev=00:00 obj=staff_u:object_r:user_home_dir_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(11/28/2025 06:58:43.674:441) : item=0 name=/home/staff-user/ inode=50331822 dev=fc:02 mode=dir,700 ouid=staff-user ogid=staff-user rdev=00:00 obj=staff_u:object_r:user_home_dir_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(11/28/2025 06:58:43.674:441) : arch=x86_64 syscall=mkdir success=yes exit=0 a0=0x7ffcaeda4cf0 a1=0755 a2=0x16 a3=0x0 items=2 ppid=5610 pid=5714 auid=staff-user uid=staff-user gid=staff-user euid=staff-user suid=root fsuid=staff-user egid=staff-user sgid=staff-user fsgid=staff-user tty=pts1 ses=6 comm=crontab exe=/usr/bin/crontab subj=staff_u:staff_r:crontab_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(11/28/2025 06:58:43.674:441) : avc:  denied  { create } for  pid=5714 comm=crontab name=.cache scontext=staff_u:staff_r:crontab_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:user_home_dir_t:s0 tclass=dir permissive=1 type=AVC msg=audit(11/28/2025 06:58:43.674:441) : avc:  denied  { add_name } for  pid=5714 comm=crontab name=.cache scontext=staff_u:staff_r:crontab_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:user_home_dir_t:s0 tclass=dir permissive=1 type=AVC msg=audit(11/28/2025 06:58:43.674:441) : avc:  denied  { write } for  pid=5714 comm=crontab name=staff-user dev="vda2" ino=50331822 scontext=staff_u:staff_r:crontab_t:s0-s0:c0.c1023 tcontext=staff_u:object_r:user_home_dir_t:s0 tclass=dir permissive=1

Resolves: RHEL-129528