### PR TITLE
Confine thermald

### DIFF
--- a/dist/targeted/modules.conf
+++ b/dist/targeted/modules.conf
@@ -3075,3 +3075,10 @@ redfish-finder = module
 # Policy for go_fdo_server: Run an FDO Manufacturing, Rendezvous, or Owner server.
 #
 go_fdo_server = module
+
+# Layer: contrib
+# Module: thermald
+#
+# Policy for thermald: Thermal management daemon
+#
+thermald = module

--- a/policy/modules/contrib/thermald.fc
+++ b/policy/modules/contrib/thermald.fc
@@ -1,0 +1,4 @@
+/run/thermald		-d	gen_context(system_u:object_r:thermald_var_run_t,s0)
+/run/thermald/.*	--	gen_context(system_u:object_r:thermald_var_run_t,s0)
+
+/usr/bin/thermald	--	gen_context(system_u:object_r:thermald_exec_t,s0)

--- a/policy/modules/contrib/thermald.if
+++ b/policy/modules/contrib/thermald.if
@@ -1,0 +1,1 @@
+## <summary>Thermal management daemon</summary>

--- a/policy/modules/contrib/thermald.te
+++ b/policy/modules/contrib/thermald.te
@@ -1,0 +1,32 @@
+policy_module(thermald, 1.0)
+
+########################################
+#
+# Declarations
+#
+
+type thermald_t;
+type thermald_exec_t;
+init_daemon_domain(thermald_t, thermald_exec_t)
+permissive thermald_t;
+
+type thermald_var_run_t;
+files_pid_file(thermald_var_run_t)
+
+########################################
+#
+# Local policy
+#
+
+allow thermald_t self:unix_dgram_socket { connect create };
+
+manage_files_pattern(thermald_t, thermald_var_run_t, thermald_var_run_t)
+files_pid_filetrans(thermald_t, thermald_var_run_t, file)
+
+optional_policy(`
+	dbus_system_bus_client(thermald_t)
+')
+
+optional_policy(`
+	logging_send_syslog_msg(thermald_t)
+')


### PR DESCRIPTION
thermald is a Linux daemon used to prevent the overheating of platforms. This daemon monitors temperature and applies compensation using available cooling methods.

https://github.com/intel/thermal_daemon