### PR TITLE
Use NetworkManager_t instead of networkmanager_t

### DIFF
--- a/policy/modules/contrib/networkmanager.if
+++ b/policy/modules/contrib/networkmanager.if
@@ -651,10 +651,10 @@ interface(`networkmanager_sigkill',`
 #
 interface(`networkmanager_run_bpf',`
 	gen_require(`
-		type networkmanager_t;
+		type NetworkManager_t;
 	')
 
-	allow $1 networkmanager_t:bpf prog_run;
+	allow $1 NetworkManager_t:bpf prog_run;
 ')
 
 ########################################
@@ -669,10 +669,10 @@ interface(`networkmanager_run_bpf',`
 #
 interface(`networkmanager_rw_bpf',`
 	gen_require(`
-		type networkmanager_t;
+		type NetworkManager_t;
 	')
 
-	allow $1 networkmanager_t:bpf { map_read map_write };
+	allow $1 NetworkManager_t:bpf { map_read map_write };
 ')
 
 ########################################


### PR DESCRIPTION
In the 2b56d99a62 ("Allow sysadm_t run and read/write networkmanager bpf programs") commit, the networkmanager_t type was used instead of the correct NetworkManager_t.

Resolves: RHEL-145714