### PR TITLE
Dontaudit tlp_t dac_override (bsc#1272935)

### DIFF
--- a/policy/modules/contrib/tlp.te
+++ b/policy/modules/contrib/tlp.te
@@ -33,7 +33,7 @@ allow tlp_t self:netlink_generic_socket create_socket_perms;
 # greps for only tuned-ppd, power-profiles-daemon and
 # tlp-pd. ps does not need those two necessarily to work:
 dontaudit tlp_t self:cap_userns sys_ptrace;
-dontaudit tlp_t self:capability dac_read_search;
+dontaudit tlp_t self:capability { dac_read_search dac_override };
 dontaudit tlp_t self:capability2 perfmon;
 
 allow tlp_t tlp_unit_file_t:file read_file_perms;


### PR DESCRIPTION
Fixes:
avc:  denied  { dac_override } for  pid=6910 comm="ps" capability=1  scontext=system_u:system_r:tlp_t:s0 tcontext=system_u:system_r:tlp_t:s0 tclass=capability permissive=0