### PR TITLE
Allow sysadm user run fail2ban-client

### DIFF
--- a/policy/modules/admin/sudo.if
+++ b/policy/modules/admin/sudo.if
@@ -101,6 +101,10 @@ template(`sudo_role_template',`
 	')
 
 	optional_policy(`
+		fail2ban_domtrans_client($1_sudo_t)
+	')
+
+	optional_policy(`
 		iotop_domtrans($1_sudo_t)
 	')
 

--- a/policy/modules/roles/sysadm.te
+++ b/policy/modules/roles/sysadm.te
@@ -301,6 +301,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	fail2ban_stream_connect(sysadm_t)
+')
+
+optional_policy(`
 	firstboot_run(sysadm_t, sysadm_r)
 ')
 


### PR DESCRIPTION
The fail2ban-client command is used to communicate with fail2ban-server. This commit supports running fail2ban-client as a confined administrator, or in a sudo command.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/27/2026 08:39:39.481:384) : proctitle=/usr/bin/python3 -s /usr/bin/fail2ban-client status type=PATH msg=audit(07/27/2026 08:39:39.481:384) : item=0 name=/var/run/fail2ban/fail2ban.sock inode=1136 dev=00:1a mode=socket,700 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:fail2ban_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(07/27/2026 08:39:39.481:384) : saddr={ saddr_fam=local path=/var/run/fail2ban/fail2ban.sock } type=SYSCALL msg=audit(07/27/2026 08:39:39.481:384) : arch=x86_64 syscall=connect success=yes exit=0 a0=0x3 a1=0x7ffc355e03d0 a2=0x22 a3=0x7f7c98e199f1 items=1 ppid=6758 pid=6826 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts1 ses=7 comm=fail2ban-client exe=/usr/bin/python3.9 subj=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(07/27/2026 08:39:39.481:384) : avc:  denied  { connectto } for  pid=6826 comm=fail2ban-client path=/run/fail2ban/fail2ban.sock scontext=sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=system_u:system_r:fail2ban_t:s0 tclass=unix_stream_socket permissive=0

Resolves: RHEL-194366