### PR TITLE
Allow bootupd read all passwd sources

### DIFF
--- a/policy/modules/contrib/bootupd.te
+++ b/policy/modules/contrib/bootupd.te
@@ -64,7 +64,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	auth_read_passwd_file(bootupd_t)
+	auth_read_passwd(bootupd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
audit: type=1400 audit(1785239276.085:4): avc:  denied  { search } for  pid=786 comm="lsblk" name="sss" dev="vda4" ino=534753 scontext=system_u:system_r:bootupd_t:s0 tcontext=system_u:object_r:sssd_var_lib_t:s0 tclass=dir permissive=1

Resolves: RHEL-219156