### PR TITLE
Update tuned-ppd policy

### DIFF
--- a/policy/modules/contrib/tuned.te
+++ b/policy/modules/contrib/tuned.te
@@ -186,6 +186,8 @@ filetrans_pattern(tuned_ppd_t, tuned_etc_t, tuned_rw_etc_t, file, "ppd_base_prof
 
 manage_files_pattern(tuned_ppd_t, tuned_log_t, tuned_log_t)
 
+kernel_dgram_send(tuned_ppd_t)
+
 corecmd_exec_bin(tuned_ppd_t)
 dev_read_sysfs(tuned_ppd_t)
 dev_watch_sysfs_dirs(tuned_ppd_t)
@@ -216,6 +218,10 @@ optional_policy(`
 
 optional_policy(`
 	libs_exec_ldconfig(tuned_ppd_t)
+')
+
+optional_policy(`
+	logging_write_syslog_pid_socket(tuned_ppd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=AVC msg=audit(1782922423.815:940): avc:  denied  { sendto } for  pid=2940017 comm="tuned-ppd" path="/systemd/journal/socket" scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=1 type=AVC msg=audit(1782922423.815:938): avc:  denied  { search } for  pid=2940017 comm="tuned-ppd" name="journal" dev="tmpfs" ino=46 scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1782922423.815:939): avc:  denied  { write } for  pid=2940017 comm="tuned-ppd" name="socket" dev="tmpfs" ino=48 scontext=system_u:system_r:tuned_ppd_t:s0 tcontext=system_u:object_r:syslogd_var_run_t:s0 tclass=sock_file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2496055