### PR TITLE
Allow staff_t and user_t execute udev without a domain transition

### DIFF
--- a/policy/modules/roles/staff.te
+++ b/policy/modules/roles/staff.te
@@ -378,6 +378,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	udev_exec(staff_t)
+')
+
+optional_policy(`
 	userhelper_console_role_template(staff, staff_r, staff_t)
 ')
 

--- a/policy/modules/roles/unprivuser.te
+++ b/policy/modules/roles/unprivuser.te
@@ -180,6 +180,10 @@ optional_policy(`
 #')
 
 optional_policy(`
+	udev_exec(user_t)
+')
+
+optional_policy(`
 	usbmuxd_stream_connect(user_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial and subsequent ones (dontaudited by default):
type=PATH msg=audit(08/04/2026 11:16:44.321:514) : item=0 name=/usr/bin/udevadm inode=21984 dev=00:22 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:udev_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/04/2026 11:16:44.321:514) : arch=x86_64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55bfc8c33100 a2=0x7ffce7752d90 a3=0x0 items=1 ppid=13117 pid=13118 auid=staff uid=staff gid=staff euid=staff suid=staff fsuid=staff egid=staff sgid=staff fsgid=staff tty=pts2 ses=6 comm=bash exe=/usr/bin/bash subj=staff_u:staff_r:staff_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(08/04/2026 11:16:44.321:514) : avc:  denied  { getattr } for  pid=13118 comm=bash path=/usr/bin/udevadm dev="vda3" ino=21984 scontext=staff_u:staff_r:staff_t:s0-s0:c0.c1023 tcontext=system_u:object_r:udev_exec_t:s0 tclass=file permissive=0

Resolves: RHEL-130797