### PR TITLE
Confine systemd-tpm2-setup

### DIFF
--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -71,6 +71,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /usr/lib/systemd/systemd-timedated	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
 /usr/lib/systemd/systemd-timesyncd	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
 /usr/lib/systemd/systemd-time-wait-sync	--	gen_context(system_u:object_r:systemd_timedated_exec_t,s0)
+/usr/lib/systemd/systemd-tpm2-setup	--	gen_context(system_u:object_r:systemd_tpm2_setup_exec_t,s0)
 /usr/lib/systemd/systemd-logind		--	gen_context(system_u:object_r:systemd_logind_exec_t,s0)
 /usr/lib/systemd/systemd-user-runtime-dir		--	gen_context(system_u:object_r:systemd_user_runtimedir_exec_t,s0)
 /usr/lib/systemd/systemd-localed	--	gen_context(system_u:object_r:systemd_localed_exec_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -331,6 +331,7 @@ files_pid_file(systemd_oomd_var_run_t)
 
 systemd_domain_template(systemd_pcrextend)
 systemd_domain_template(systemd_pcrlock)
+systemd_domain_template(systemd_tpm2_setup)
 
 # /run/varlink{,/registry}
 type systemd_varlink_t;
@@ -2125,6 +2126,15 @@ optional_policy(`
 ')
 
 permissive systemd_pcrlock_t;
+
+########################################
+#
+# systemd_tpm2_setup local policy
+#
+
+kernel_dgram_send(systemd_tpm2_setup_t)
+
+permissive systemd_tpm2_setup_t;
 
 #######################################
 #


### PR DESCRIPTION
systemd-tpm2-setup.service and systemd-tpm2-setup-early.service are services that generate the Storage Root Key (SRK) if it has not been generated yet, and stores it in the TPM. If NvPCRs (additional PCR registers in TPM NV Indexes) are defined, these are initialized with the anchoring secret.

The services will store the public key of the SRK key pair in a PEM file in /run/systemd/tpm2-srk-public-key.pem and /var/lib/systemd/tpm2-srk-public-key.pem. They will also store it in TPM2B_PUBLIC format in
/run/systemd/tpm2-srk-public-key.tpm2_public
and /var/lib/systemd/tpm2-srk-public-key.tpm2b_public.

systemd-tpm2-setup-early.service runs very early at boot (possibly in the initrd), and writes the SRK public key to /run/systemd/tpm2-srk-public-key.*  (as /var/ is generally not accessible this early yet), while systemd-tpm2-setup.service runs during a later boot phase and saves the public key to /var/lib/systemd/tpm2-srk-public-key.*.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2507393