### PR TITLE
Allow rhsmcertd read selinux config and default file contexts

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -197,7 +197,8 @@ optional_policy(`
 ')
 
 optional_policy(`
-	seutil_dontaudit_read_file_contexts(rhsmcertd_t)
+	seutil_read_config(rhsmcertd_t)
+	seutil_read_default_contexts(rhsmcertd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(06/01/2026 14:13:05.192:4420) : proctitle=/usr/libexec/platform-python /usr/libexec/rhsmcertd-worker type=PATH msg=audit(06/01/2026 14:13:05.192:4420) : item=0 name=/etc/selinux/config inode=34238920 dev=fd:00 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:selinux_config_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(06/01/2026 14:13:05.192:4420) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7ff14b63a0bb a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=16990 pid=16994 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=99 comm=rhsmcertd-worke exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:rhsmcertd_t:s0 key=(null) type=AVC msg=audit(06/01/2026 14:13:05.192:4420) : avc:  denied  { read } for  pid=16994 comm=rhsmcertd-worke name=config dev="dm-0" ino=34238920 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:selinux_config_t:s0 tclass=file permissive=0

type=PROCTITLE msg=audit(06/01/2026 14:13:05.194:4421) : proctitle=/usr/libexec/platform-python /usr/libexec/rhsmcertd-worker
type=PATH msg=audit(06/01/2026 14:13:05.194:4421) : item=0 name=/etc/selinux/targeted/contexts/files/file_contexts.subs_dist nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=SYSCALL msg=audit(06/01/2026 14:13:05.194:4421) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55f3b12ea120 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=1 ppid=16990 pid=16994 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=99 comm=rhsmcertd-worke exe=/usr/libexec/platform-python3.6 subj=system_u:system_r:rhsmcertd_t:s0 key=(null)
type=AVC msg=audit(06/01/2026 14:13:05.194:4421) : avc:  denied  { search } for  pid=16994 comm=rhsmcertd-worke name=contexts dev="dm-0" ino=51083708 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:default_context_t:s0 tclass=dir permissive=0

Resolves: RHEL-180764