### PR TITLE
Allow initrc_t and unconfined_service_t to transition to install_t

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -530,6 +530,7 @@ optional_policy(`
 
 optional_policy(`
 	anaconda_domtrans_install(init_t)
+	anaconda_domtrans_install(initrc_t)
 ')
 
 optional_policy(`

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -48,5 +48,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	anaconda_domtrans_install(unconfined_service_t)
+')
+
+optional_policy(`
     gpg_manage_admin_home_content(unconfined_service_t)
 ')


### PR DESCRIPTION
When systemd runs a wrapper service rather than an `install_exec_t` binary directly, the process ends up in `initrc_t` or `unconfined_service_t`. Add domtrans rules so executing `install_exec_t` binaries (bootc, ostree, rpm-ostree) from these domains transitions to install_t.