### PR TITLE
Samba: Allow all domains to connect in DC configuration

### DIFF
--- a/policy/modules/contrib/samba.te
+++ b/policy/modules/contrib/samba.te
@@ -538,6 +538,7 @@ tunable_policy(`samba_portmapper',`
 tunable_policy(`samba_domain_controller',`
 	gen_require(`
 		class passwd passwd;
+		attribute domain;
 	')
 
 	usermanage_domtrans_passwd(smbd_t)
@@ -549,6 +550,8 @@ tunable_policy(`samba_domain_controller',`
 	usermanage_domtrans_passwd(samba_dcerpcd_t)
 	usermanage_kill_passwd(samba_dcerpcd_t)
 	allow samba_dcerpcd_t self:passwd passwd;
+
+	unconfined_server_stream_connectto(domain)
 ')
 
 tunable_policy(`samba_enable_home_dirs',`


### PR DESCRIPTION
When running as DC samba components run as unconfined_service_t. If e.g. winbind is set in /etc/nsswitch.conf many other components of the system try to connect to it. This allows all domains to stream connect to unconfined_service_t.

Solves e.g.:
type=AVC: avc:  denied  { connectto } for comm="(vdrctl)" path="/run/samba/winbindd/pipe" scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=unix_stream_socket permissive=0 type=AVC: avc:  denied  { connectto } for comm="sshd-session" path="/run/samba/winbindd/pipe" scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=unix_stream_socket permissive=1

This isn't optimal. The real solution would be to properly confine samba in a DC config and then allow only access to the domains that are used for this, but that's not a small feat. So for now this is needed