### PR TITLE
Allow unconfined_service_t nnp_transition to container_runtime_t

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -50,3 +50,7 @@ optional_policy(`
 optional_policy(`
     gpg_manage_admin_home_content(unconfined_service_t)
 ')
+
+optional_policy(`
+    container_runtime_nnp_domtrans(unconfined_service_t)
+')


### PR DESCRIPTION
Use the container_runtime_nnp_domtrans() interface added in container-selinux PR #473 [1] to allow podman running as a systemd service under unconfined_service_t with NoNewPrivileges=yes to transition to container_runtime_t.

Resolves: rhbz#2417297
[1] https://github.com/containers/container-selinux/pull/473