### PR TITLE
Allow virtproxyd connect to systemd-homed over a unix stream socket

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2156,6 +2156,10 @@ optional_policy(`
 	dnsmasq_filetrans_named_content_fromdir(virtproxyd_t, virtproxyd_var_run_t)
 ')
 
+optional_policy(`
+	systemd_homed_stream_connect(virtproxyd_t)
+')
+
 #######################################
 #
 # virtqemud local policy


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1786399205.391:2636): avc:  denied  { connectto } for  pid=180629 comm="rpc-virtproxyd" path="/run/systemd/userdb/io.systemd.Home" scontext=system_u:system_r:virtproxyd_t:s0 tcontext=system_u:system_r:systemd_homed_t:s0 tclass=unix_stream_socket permissive=0

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/3330