### PR TITLE
Label malware-detection-config.yml with insights_client_etc_rw_t

### DIFF
--- a/policy/modules/contrib/insights_client.fc
+++ b/policy/modules/contrib/insights_client.fc
@@ -10,6 +10,7 @@
 /etc/insights-client/\.unregistered			--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 /etc/insights-client/insights-client-egg-release	--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 /etc/insights-client/machine-id				--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
+/etc/insights-client/malware-detection-config.yml	--	gen_context(system_u:object_r:insights_client_etc_rw_t,s0)
 
 /usr/bin/insights-client				--	gen_context(system_u:object_r:insights_client_exec_t,s0)
 /usr/bin/redhat-access-insights				--	gen_context(system_u:object_r:insights_client_exec_t,s0)

--- a/policy/modules/contrib/insights_client.if
+++ b/policy/modules/contrib/insights_client.if
@@ -103,6 +103,7 @@ interface(`insights_client_filetrans_named_content',`
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, ".unregistered")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "insights-client-egg-release")
 	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "machine-id")
+	filetrans_pattern($1, insights_client_etc_t, insights_client_etc_rw_t, file, "malware-detection-config.yml")
 
 	files_pid_filetrans($1, insights_client_run_t, file, "insights-client.pid")
 	files_pid_filetrans($1, insights_client_run_t, file, "insights-client.ppid")


### PR DESCRIPTION
Label /etc/insights-client/malware-detection-config.yml with insights_client_etc_rw_t and back it with an automated file transition. This is used by "insights-client --collector malware-detection".

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/23/2026 11:01:48.953:698) : proctitle=/usr/bin/python3 /usr/lib/python3.12/site-packages/insights_client/run.py --collector malware-detection type=PATH msg=audit(07/23/2026 11:01:48.953:698) : item=1 name=/etc/insights-client/malware-detection-config.yml inode=50637117 dev=fd:00 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:insights_client_etc_t:s0 nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=PATH msg=audit(07/23/2026 11:01:48.953:698) : item=0 name=/etc/insights-client/ inode=50626150 dev=fd:00 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:insights_client_etc_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=CWD msg=audit(07/23/2026 11:01:48.953:698) : cwd=/ type=SYSCALL msg=audit(07/23/2026 11:01:48.953:698) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f4b17f00830 a2=O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC a3=0x1b6 items=2 ppid=30709 pid=30716 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=python3 exe=/usr/bin/python3.12 subj=system_u:system_r:insights_core_t:s0 key=(null) type=AVC msg=audit(07/23/2026 11:01:48.953:698) : avc:  denied  { write } for  pid=30716 comm=python3 path=/etc/insights-client/malware-detection-config.yml dev="dm-0" ino=50637117 scontext=system_u:system_r:insights_core_t:s0 tcontext=system_u:object_r:insights_client_etc_t:s0 tclass=file permissive=0

Resolves: RHEL-213627