### PR TITLE
Allow haveged (entropyd_t)  create and use its private tmpfs files

### DIFF
--- a/policy/modules/contrib/entropyd.te
+++ b/policy/modules/contrib/entropyd.te
@@ -21,6 +21,9 @@ init_daemon_domain(entropyd_t, entropyd_exec_t)
 type entropyd_initrc_exec_t;
 init_script_file(entropyd_initrc_exec_t)
 
+type entropyd_tmpfs_t;
+files_tmpfs_file(entropyd_tmpfs_t)
+
 type entropyd_var_run_t;
 files_pid_file(entropyd_var_run_t)
 
@@ -32,6 +35,9 @@ files_pid_file(entropyd_var_run_t)
 allow entropyd_t self:capability { dac_read_search  ipc_lock sys_admin };
 dontaudit entropyd_t self:capability sys_tty_config;
 allow entropyd_t self:process signal_perms;
+
+allow entropyd_t entropyd_tmpfs_t:file { manage_file_perms map };
+fs_tmpfs_filetrans(entropyd_t, entropyd_tmpfs_t, file)
 
 manage_files_pattern(entropyd_t, entropyd_var_run_t, entropyd_var_run_t)
 files_pid_filetrans(entropyd_t, entropyd_var_run_t, file)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC avc:  denied  { create } for  comm="haveged" name="sem.XXXXXX" scontext=system_u:system_r:entropyd_t:s0
tcontext=system_u:object_r:tmpfs_t:s0
tclass=file permissive=0

Corresponding daemon log:
haveged: command socket is listening at fd 3
haveged: Warning: Couldn't create named semaphore haveged_sem error: Permission denied
         haveged: disabling command mode for this instance

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/3206