### PR TITLE
Add bcachefs as a SELinux capable filesystem

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -28,6 +28,7 @@ typealias fs_t alias inotifyfs_t;
 
 # Use xattrs for the following filesystem types.
 # Requires that a security xattr handler exist for the filesystem.
+fs_use_xattr bcachefs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr btrfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr encfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr erofs gen_context(system_u:object_r:fs_t,s0);


### PR DESCRIPTION
bcachefs v1.38.7 adds support for the security xattr handler:
https://github.com/koverstreet/bcachefs-tools/commit/702ad815f6449535dacf5a8976befaeb40a1598f
https://github.com/koverstreet/bcachefs-tools/commit/3446635f39a2640dbf60a53dd8f930f79330809b

I tested this by rebuilding a Fedora Silverblue 44 base image with [bcachefs-dkms v1.38.6](https://copr.fedorainfracloud.org/coprs/ngompa/bcachefs/build/10722312/) with the two commits above backported, and a patched selinux-policy package.
Kernel log: [Linux v6.18.42](https://github.com/user-attachments/files/30951104/kernel.log)
selinux-testsuite log: [commit d03e89292](https://github.com/user-attachments/files/30951050/selinux-testsuite.log) 

The only failed test is test_rawio, which I guess is [expected](https://github.com/SELinuxProject/selinux-testsuite/commit/4ed5d11312d673203d93dafbcdad441c3afc36f9).

Tested-by: Nikita Shvets <nikitashvets@flyium.com>
Signed-off-by: Nikita Shvets <nikitashvets@flyium.com>