### PR TITLE
[f43] Allow systemd-logind the sys_ptrace capability in the user namespace

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -28,6 +28,7 @@ typealias fs_t alias inotifyfs_t;
 
 # Use xattrs for the following filesystem types.
 # Requires that a security xattr handler exist for the filesystem.
+fs_use_xattr bcachefs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr btrfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr encfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_xattr erofs gen_context(system_u:object_r:fs_t,s0);

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -346,6 +346,7 @@ files_pid_file(systemd_varlink_registry_t)
 #  is for /run/user/$USER ($USER ownership is $USER:$USER)
 allow systemd_logind_t self:capability { chown kill dac_read_search dac_override fowner sys_tty_config sys_admin };
 allow systemd_logind_t self:capability2 block_suspend;
+allow systemd_logind_t self:cap_userns sys_ptrace;
 
 allow systemd_logind_t self:process getcap;
 allow systemd_logind_t self:netlink_kobject_uevent_socket create_socket_perms;

--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -50,3 +50,7 @@ optional_policy(`
 optional_policy(`
     gpg_manage_admin_home_content(unconfined_service_t)
 ')
+
+optional_policy(`
+    container_runtime_nnp_domtrans(unconfined_service_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1780228274.651:551): avc:  denied  { sys_ptrace } for  pid=1830 comm="systemd-logind" capability=19  scontext=system_u:system_r:systemd_logind_t:s0 tcontext=system_u:system_r:systemd_logind_t:s0 tclass=cap_userns permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2514494