### PR TITLE
Allow system_mail_t read procmail home content

### DIFF
--- a/policy/modules/contrib/mta.te
+++ b/policy/modules/contrib/mta.te
@@ -348,6 +348,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	procmail_read_home_files(system_mail_t)
+')
+
+optional_policy(`
 	qmail_domtrans_inject(system_mail_t)
 	qmail_manage_spool_dirs(system_mail_t)
 	qmail_manage_spool_files(system_mail_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1780795473.754:1497): avc:  denied  { open } for  pid=76207 comm="procmail" path="/root/.procmailrc" dev="sdd4" ino=59822955 scontext=system_u:system_r:system_mail_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:procmail_home_t:s0 tclass=file permissive=1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2486098