### PR TITLE
rhsmcertd: allow bootc/ostree transient package persistence detection

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -61,7 +61,8 @@ files_lock_filetrans(rhsmcertd_t, rhsmcertd_lock_t, file)
 
 manage_dirs_pattern(rhsmcertd_t, rhsmcertd_tmp_t, rhsmcertd_tmp_t)
 manage_files_pattern(rhsmcertd_t, rhsmcertd_tmp_t, rhsmcertd_tmp_t)
-files_tmp_filetrans(rhsmcertd_t, rhsmcertd_tmp_t, { dir file })
+manage_lnk_files_pattern(rhsmcertd_t, rhsmcertd_tmp_t, rhsmcertd_tmp_t)
+files_tmp_filetrans(rhsmcertd_t, rhsmcertd_tmp_t, { dir file lnk_file })
 
 manage_files_pattern(rhsmcertd_t, rhsmcertd_tmpfs_t, rhsmcertd_tmpfs_t)
 fs_tmpfs_filetrans(rhsmcertd_t, rhsmcertd_tmpfs_t, file)
@@ -111,10 +112,12 @@ files_manage_generic_locks(rhsmcertd_t)
 files_manage_system_conf_files(rhsmcertd_t)
 files_create_boot_flag(rhsmcertd_t)
 files_dontaudit_write_all_mountpoints(rhsmcertd_t)
+files_read_generic_pids(rhsmcertd_t)
 
 fs_dontaudit_write_configfs_dirs(rhsmcertd_t)
 fs_getattr_cgroup(rhsmcertd_t)
 fs_getattr_tmpfs(rhsmcertd_t)
+fs_getattr_xattr_fs(rhsmcertd_t)
 fs_read_xenfs_files(rhsmcertd_t)
 
 auth_map_passwd(rhsmcertd_t)
@@ -172,6 +175,14 @@ optional_policy(`
 
 optional_policy(`
 	install_read_var_run_files(rhsmcertd_t)
+')
+
+# On bootc/ostree image-mode systems, rhsm-package-profile-uploader
+# executes rpm-ostree (install_exec_t) to determine which packages are
+# persistent vs transient.  Transition to install_t so the child process
+# has the permissions it needs (systemctl, reading deployment state, etc).
+optional_policy(`
+	anaconda_domtrans_install(rhsmcertd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/rpm.fc
+++ b/policy/modules/contrib/rpm.fc
@@ -38,8 +38,13 @@
 /usr/share/yumex/yumex-yum-backend --	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/share/yumex/yum_childtask\.py --	gen_context(system_u:object_r:rpm_exec_t,s0)
 
-# These may be hardlinked, and they're not /var, so just use usr_t
-/usr/share/rpm(/.*)?			gen_context(system_u:object_r:usr_t,s0)
+# On image-mode (bootc/ostree) systems, /usr/lib/sysimage/rpm is a symlink to
+# ../../share/rpm, so the rpmdb actually lives here.  Label it rpm_var_lib_t
+# (consistent with /usr/lib/sysimage/rpm and /var/lib/rpm above) so that
+# processes like rhsmcertd_t can access the rpmdb on transient /usr overlays.
+# On traditional package-mode systems this path does not exist, so the rule
+# is harmless.
+/usr/share/rpm(/.*)?			gen_context(system_u:object_r:rpm_var_lib_t,s0)
 
 ifdef(`distro_redhat', `
 /usr/bin/bcfg2				--	gen_context(system_u:object_r:rpm_exec_t,s0)


### PR DESCRIPTION
rhsmcertd: allow bootc/ostree transient package persistence detection
On image-mode (bootc/ostree) systems, subscription-manager's
rhsm-package-profile-uploader needs to determine which packages are
persistent vs transient.  This requires:

rpm.fc: Label /usr/share/rpm as rpm_var_lib_t instead of usr_t.
  On image-mode systems, /usr/lib/sysimage/rpm is a symlink to
  ../../share/rpm, so the rpmdb actually lives at /usr/share/rpm.
  Without the correct label, overlay WAL/SHM files inherit usr_t
  and rhsmcertd_t is denied write access.  On traditional
  package-mode systems this path does not exist, so the rule is
  harmless.

rhsmcertd.te:
  - anaconda_domtrans_install: transition to install_t when
    executing rpm-ostree (install_exec_t), so the child process
    has the permissions it needs (systemctl, reading deployment
    state, etc).
  - fs_getattr_xattr_fs: allow statfs() on root filesystem,
    needed by libostree when opening the sysroot.
  - manage_lnk_files_pattern + lnk_file: allow rhsmcertd to
    manage symlinks in tmp (rpm-ostree creates temporary rpmdb
    symlinks).

Resolves: RHEL-152111

Assisted-by: AI