### PR TITLE
Allow rhsmcertd read the file_contexts files.

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -199,6 +199,7 @@ optional_policy(`
 optional_policy(`
 	seutil_read_config(rhsmcertd_t)
 	seutil_read_default_contexts(rhsmcertd_t)
+	seutil_read_file_contexts(rhsmcertd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/11/26 06:50:35.124:5302) : proctitle=/usr/bin/python3 /usr/libexec/rhsm-package-profile-uploader --force-upload type=SYSCALL msg=audit(08/11/26 06:50:35.124:5302) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x558dc66df7e0 a2=O_RDONLY|O_CLOEXEC a3=0x0 items=0 ppid=59678 pid=59950 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rhsm-package-pr exe=/usr/bin/python3.9 subj=system_u:system_r:rhsmcertd_t:s0 key=(null) type=AVC msg=audit(08/11/26 06:50:35.124:5302) : avc:  denied  { search } for  pid=59950 comm=rhsm-package-pr name=files dev="vda1" ino=393987 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:file_context_t:s0 tclass=dir permissive=0

Resolves: RHEL-236545