### PR TITLE
Update qatlib policy

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -22,7 +22,7 @@ files_pid_file(qatlib_var_run_t)
 #
 # qatlib local policy
 #
-allow qatlib_t self:capability { sys_admin sys_module };
+allow qatlib_t self:capability { fsetid sys_admin sys_module };
 allow qatlib_t self:fifo_file rw_fifo_file_perms;
 allow qatlib_t self:system module_load;
 allow qatlib_t self:unix_stream_socket create_stream_socket_perms;
@@ -86,4 +86,12 @@ optional_policy(`
 	systemd_search_unit_dirs(qatlib_t)
 	systemd_machined_stream_connect(qatlib_t)
 	systemd_userdbd_stream_connect(qatlib_t)
+')
+
+optional_policy(`
+	systemd_homed_stream_connect(qatlib_t)
+')
+
+optional_policy(`
+	xserver_stream_connect_xdm(qatlib_t)
 ')


### PR DESCRIPTION
The qat.service needs to set correct ownership and permissions on a subset of /dev/vfio/ device nodes. The qat_init.sh script runs chown :qat and chmod +060 on each VFIO group device.
The chown command resolves the "qat" group name via NSS.

Resolves: https://github.com/fedora-selinux/selinux-policy/issues/3182