### PR TITLE
Allow sshd-session to manage user temporary files (RHEL-240889 / RHEL-211174)

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -72,6 +72,7 @@ mls_dbus_send_all_levels(sshd_t)
 ### Policy for session and auth
 ###
 ssh_server_template(sshd_session)
+userdom_manage_tmp_role(system_r, sshd_session_t)
 #type sshd_session_t;
 #role system_r types sshd_session_t;
 type sshd_session_exec_t;


### PR DESCRIPTION
When SSH clients connect with `GSSAPIDelegateCredentials yes`, the `sshd-session` process (running in the `sshd_session_t` domain) attempts to store delegated Kerberos credentials in a temporary file under `/tmp/`.

Currently, this triggers SELinux AVC denials on `create`, `write`, `open`, `setattr`, and `unlink` because the domain lacks permission to manage `tmp_t` files and perform a type transition to `user_tmp_t`.

This occurs because `ssh_server_template(sshd_session)` calls the template macro which has a hardcoded `userdom_manage_tmp_role(system_r, sshd_t)` instead of dynamically referencing `$1_t`.

To resolve this safely and immediately on downstream without breaking other components, this PR adds `userdom_manage_tmp_role(system_r, sshd_session_t)` specifically to the `sshd_session` policy block in `ssh.te`.

### Related Issues
- RHEL-240889: SELinux prevents creation of credentials cache file
- RHEL-211174: sshd-session generates AVCs when GSSAPIDelegateCredentials=yes is used

### Verification
Once compiled and loaded:
1. `sshd_session_t` can successfully write and manage temporary ccache files in `/tmp` without generating AVC denials.
2. Credential cache files correctly transition from `tmp_t` to the standard `user_tmp_t` label.