### PR TITLE
Allow accountsd create and use its private tmpfs files

### DIFF
--- a/policy/modules/contrib/accountsd.te
+++ b/policy/modules/contrib/accountsd.te
@@ -21,6 +21,9 @@ role system_r types accountsd_t;
 type accountsd_share_t;
 files_type(accountsd_share_t)
 
+type accountsd_tmpfs_t;
+files_tmpfs_file(accountsd_tmpfs_t)
+
 type accountsd_var_lib_t;
 files_type(accountsd_var_lib_t)
 
@@ -41,6 +44,9 @@ read_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 read_lnk_files_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 list_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
 watch_dirs_pattern(accountsd_t, accountsd_share_t, accountsd_share_t)
+
+allow accountsd_t accountsd_tmpfs_t:file { manage_file_perms map };
+fs_tmpfs_filetrans(accountsd_t, accountsd_tmpfs_t, file)
 
 manage_dirs_pattern(accountsd_t, accountsd_var_lib_t, accountsd_var_lib_t)
 manage_files_pattern(accountsd_t, accountsd_var_lib_t, accountsd_var_lib_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
Aug 16 11:35:16 fedora audit[829]: AVC avc:  denied  { write } for  pid=829 comm="accounts-daemon" path=/memfd:accountsservice_icon_file (deleted) dev="tmpfs" ino=13449 scontext=system_u:system_r:accountsd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0 Aug 16 11:35:16 fedora gnome-control-center[5297]: SetIconFile call failed: GDBus.Error:org.freedesktop.Accounts.Error.Failed: copying icon file failed: Permission denied

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2517426