### PR TITLE
Allow unconfined_service_t to execute install_exec_t in install_t

### DIFF
--- a/policy/modules/system/unconfined.te
+++ b/policy/modules/system/unconfined.te
@@ -24,6 +24,10 @@ init_use_notify(unconfined_service_t)
 usermanage_run_passwd(unconfined_service_t, system_r)
 
 optional_policy(`
+	anaconda_run_install(unconfined_service_t, system_r)
+')
+
+optional_policy(`
 	rpm_transition_script(unconfined_service_t, system_r)
 ')
 


### PR DESCRIPTION
Fixes https://github.com/fedora-selinux/selinux-policy/issues/3349