### PR TITLE
Allow namespace_init_t execute generic programs in bin directories

### DIFF
--- a/policy/modules/contrib/namespace.te
+++ b/policy/modules/contrib/namespace.te
@@ -22,6 +22,7 @@ allow namespace_init_t self:unix_stream_socket create_stream_socket_perms;
 
 kernel_read_system_state(namespace_init_t)
 
+corecmd_exec_bin(namespace_init_t)
 corecmd_exec_shell(namespace_init_t)
 
 domain_use_interactive_fds(namespace_init_t)


### PR DESCRIPTION
When the /tmp polyinstantiation is enabled and configured for sshd, an SSH login, which now triggers /etc/security/namespace.init, produces AVC denials when attempted to execute /usr/bin/getent and /usr/bin/cut.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/14/2026 07:00:49.335:1213) : proctitle=/usr/bin/sh /etc/security/namespace.init /tmp /tmp-inst/system_u:object_r:tmp_t:s0-s0:c0.c1023_user27276 1 user27276 1 1 type=PATH msg=audit(08/14/2026 07:00:49.335:1213) : item=0 name=/usr/bin/getent inode=342473 dev=fd:01 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:bin_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/14/2026 07:00:49.335:1213) : arch=x86_64 syscall=access success=yes exit=0 a0=0x55af01a1ba20 a1=X_OK a2=0x7ffec33fd490 a3=0x0 items=1 ppid=29114 pid=29116 auid=user27276 uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=19 comm=namespace.init exe=/usr/bin/bash subj=system_u:system_r:namespace_init_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(08/14/2026 07:00:49.335:1213) : avc:  denied  { execute } for  pid=29116 comm=namespace.init name=getent dev="vda1" ino=342473 scontext=system_u:system_r:namespace_init_t:s0-s0:c0.c1023 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=1

Resolves: RHEL-223973