### PR TITLE
Allow dhcpc hook query the chronyd service

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -339,6 +339,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	chronyd_systemctl(dhcpc_hook_t)
+')
+
+optional_policy(`
 	dbus_send_system_bus(dhcpc_hook_t)
 	dbus_stream_connect_system_dbusd(dhcpc_hook_t)
 	dbus_write_pid_sock_files(dhcpc_hook_t)


### PR DESCRIPTION
The commit addresses the following AVC denial example: type=USER_AVC msg=audit(08/06/2026 14:36:46.775:5903) : pid=1 uid=root auid=unset ses=unset subj=system_u:system_r:init_t:s0 msg='avc:  denied  { start } for auid=unset uid=root gid=root path=/usr/lib/systemd/system/chronyd.service cmdline="" function="bus_unit_method_start_generic" scontext=system_u:system_r:dhcpc_hook_t:s0 tcontext=system_u:object_r:chronyd_unit_file_t:s0 tclass=service permissive=1 exe=/usr/lib/systemd/systemd sauid=root hostname=? addr=? terminal=?'

Resolves: RHEL-240725