### PR TITLE
Allow insights-client read gconf home files

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -274,10 +274,7 @@ optional_policy(`
 #')
 
 optional_policy(`
-#	gnome_search_gconf(insights_client_t)
-#	gnome_manage_generic_cache_files(insights_client_t)
-#	gnome_manage_home_config(insights_client_t)
-#	gnome_manage_home_config_dirs(insights_client_t)
+	gnome_read_gconf_home_files(insights_client_t)
 	gnome_read_generic_data_home_dirs(insights_client_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/13/2026 10:27:42.626:698) : proctitle=/usr/bin/python3 /usr/bin/insights-client type=SYSCALL msg=audit(05/13/2026 10:27:42.626:698) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x7f8ab40a2370 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=0 ppid=1 pid=10466 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=insights-client exe=/usr/bin/python3.9 subj=system_u:system_r:insights_client_t:s0 key=(null) type=AVC msg=audit(05/13/2026 10:27:42.626:698) : avc:  denied  { read } for  pid=10466 comm=insights-client name=site-packages dev="vda1" ino=16777867 scontext=system_u:system_r:insights_client_t:s0 tcontext=unconfined_u:object_r:gconf_home_t:s0 tclass=dir permissive=0CLONE - [RHEL9]insights-client triggers SELinux denials when reading root'

Resolves: RHEL-176023