### PR TITLE
Allow qatlib manage hugetlbfs directories

### DIFF
--- a/policy/modules/contrib/qatlib.te
+++ b/policy/modules/contrib/qatlib.te
@@ -59,6 +59,8 @@ domain_use_interactive_fds(qatlib_t)
 files_map_kernel_modules(qatlib_t)
 files_read_kernel_modules(qatlib_t)
 
+fs_manage_hugetlbfs_dirs(qatlib_t)
+
 optional_policy(`
         auth_read_passwd_file(qatlib_t)
 ')


### PR DESCRIPTION
The qat_init.sh script needs to “mkdir/chown/chmod” and also “rm -rf” this directory:
QAT_HUGEPAGES_DIR="/dev/hugepages/qat”

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/17/2026 06:00:47.278:425) : proctitle=/usr/bin/sh /usr/sbin/qat_init.sh type=PATH msg=audit(07/17/2026 06:00:47.278:425) : item=0 name=/dev/hugepages inode=4829 dev=00:21 mode=dir,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:hugetlbfs_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/17/2026 06:00:47.278:425) : arch=x86_64 syscall=newfstatat success=yes exit=0 a0=AT_FDCWD a1=0x564e51717870 a2=0x7fffafa52350 a3=0x0 items=1 ppid=1 pid=7200 auid=unset uid=root gid=qat euid=root suid=root fsuid=root egid=qat sgid=qat fsgid=qat tty=(none) ses=unset comm=qat_init.sh exe=/usr/bin/bash subj=system_u:system_r:qatlib_t:s0 key=(null) type=AVC msg=audit(07/17/2026 06:00:47.278:425) : avc:  denied  { getattr } for  pid=7200 comm=qat_init.sh path=/dev/hugepages dev="hugetlbfs" ino=4829 scontext=system_u:system_r:qatlib_t:s0 tcontext=system_u:object_r:hugetlbfs_t:s0 tclass=dir permissive=1

Resolves: RHEL-211089