### PR TITLE
Allow rhsmcertd read gconf home files

### DIFF
--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -155,6 +155,7 @@ optional_policy(`
 
 optional_policy(`
 	gnome_dontaudit_search_config(rhsmcertd_t)
+	gnome_read_generic_data_home_dirs(rhsmcertd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(05/12/2026 07:25:34.163:286) : proctitle=/usr/bin/python3 /usr/libexec/rhsmcertd-worker --autoheal type=AVC msg=audit(05/12/2026 07:25:34.163:286) : avc:  denied  { read } for  pid=5964 comm=python3 name=site-packages dev="vda1" ino=4769289 scontext=system_u:system_r:rhsmcertd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:gconf_home_t:s0 tclass=dir permissive=1 type=SYSCALL msg=audit(05/12/2026 07:25:34.163:286) : arch=x86_64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0x7fe51977f370 a2=O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC a3=0x0 items=0 ppid=5905 pid=5964 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=4 comm=python3 exe=/usr/bin/python3.9 subj=system_u:system_r:rhsmcertd_t:s0-s0:c0.c1023 key=(null)

Resolves: RHEL-106483