### PR TITLE
Allow insights-client read the process state of the init scripts

### DIFF
--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -180,6 +180,7 @@ files_manage_etc_symlinks(insights_client_t)
 #init_status(insights_client_t)
 #init_status_all_script_files(insights_client_t)
 #init_view_key(insights_client_t)
+init_read_script_state(insights_client_t)
 
 libs_exec_ldconfig(insights_client_t)
 

--- a/policy/modules/contrib/insights_client.te
+++ b/policy/modules/contrib/insights_client.te
@@ -203,6 +203,10 @@ libs_exec_ldconfig(insights_client_t)
 #	abrt_dbus_chat(insights_client_t)
 #')
 #
+optional_policy(`
+	anaconda_read_state_install(insights_client_t)
+')
+
 #optional_policy(`
 #	apache_exec_modules(insights_client_t)
 #	apache_read_semaphores(insights_client_t)

--- a/policy/modules/contrib/rhsmcertd.te
+++ b/policy/modules/contrib/rhsmcertd.te
@@ -169,9 +169,9 @@ optional_policy(`
 	ica_rw_map_tmpfs_files(rhsmcertd_t)
 ')
 
-#optional_policy(`
-#	insights_client_read_config(rhsmcertd_t)
-#')
+optional_policy(`
+	insights_client_read_config(rhsmcertd_t)
+')
 
 optional_policy(`
 	install_read_var_run_files(rhsmcertd_t)


### PR DESCRIPTION
The commit addresses the following AVC denials:
type=PROCTITLE msg=audit(03/26/26 17:58:47.554:275) : proctitle=cat /proc/5360/status type=PATH msg=audit(03/26/26 17:58:47.554:275) : item=0 name=/proc/5360/status inode=14300 dev=00:18 mode=file,444 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:initrc_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(03/26/26 17:58:47.554:275) : arch=x86_64 syscall=openat success=yes exit=3 a0=AT_FDCWD a1=0x7ffec61b5aaa a2=O_RDONLY a3=0x0 items=1 ppid=5368 pid=5370 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=cat exe=/usr/bin/cat subj=system_u:system_r:insights_client_t:s0 key=(null) type=AVC msg=audit(03/26/26 17:58:47.554:275) : avc:  denied  { open } for  pid=5370 comm=cat path=/proc/5360/status dev="proc" ino=14300 scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:system_r:initrc_t:s0 tclass=file permissive=1 type=AVC msg=audit(03/26/26 17:58:47.554:275) : avc:  denied  { read } for  pid=5370 comm=cat name=status dev="proc" ino=14300 scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:system_r:initrc_t:s0 tclass=file permissive=1 type=AVC msg=audit(03/26/26 17:58:47.554:275) : avc:  denied  { search } for  pid=5370 comm=cat name=5360 dev="proc" ino=14890 scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:system_r:initrc_t:s0 tclass=dir permissive=1

Resolves: RHEL-179125