### PR TITLE
Allow sanlock the sys_admin capability

### DIFF
--- a/policy/modules/contrib/sanlock.te
+++ b/policy/modules/contrib/sanlock.te
@@ -71,7 +71,7 @@ ifdef(`enable_mls',`
 #
 # sanlock local policy
 #
-allow sanlock_t self:capability { chown dac_read_search ipc_lock kill setgid setuid sys_nice sys_rawio sys_resource };
+allow sanlock_t self:capability { chown dac_read_search ipc_lock kill setgid setuid sys_admin sys_nice sys_rawio sys_resource };
 allow sanlock_t self:process { setrlimit setsched signull signal sigkill };
 
 allow sanlock_t self:fifo_file rw_fifo_file_perms;


### PR DESCRIPTION
sanlock legitimately needs DM ioctls to translate LV addresses to PV addresses for the CAW path.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/24/2026 07:15:42.461:410) : proctitle=/usr/sbin/sanlock daemon type=SYSCALL msg=audit(07/24/2026 07:15:42.461:410) : arch=x86_64 syscall=ioctl success=no exit=EACCES(Permission denied) a0=0xc a1=0xc138fd00 a2=0x7f7728001590 a3=0x7f7738d03533 items=0 ppid=1 pid=6589 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=sanlock exe=/usr/sbin/sanlock subj=system_u:system_r:sanlock_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(07/24/2026 07:15:42.461:410) : avc:  denied  { sys_admin } for  pid=6589 comm=sanlock capability=sys_admin  scontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023 tcontext=system_u:system_r:sanlock_t:s0-s0:c0.c1023 tclass=capability permissive=0

Resolves: RHEL-180192