### PR TITLE
Support gnome-remote-desktop's smartcard redirection support

### DIFF
--- a/policy/modules/contrib/dbus.te
+++ b/policy/modules/contrib/dbus.te
@@ -272,6 +272,8 @@ optional_policy(`
 optional_policy(`
 	# /var/lib/gdm/.local/share/icc/edid-0a027915105823af34f99b1704e80336.icc
 	xserver_read_inherited_xdm_lib_files(system_dbusd_t)
+	# dbus-broker forwards the socketpair FD passed via SCM_RIGHTS from xdm_t
+	xserver_rw_xdm_stream_sockets(system_dbusd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/gnome_remote_desktop.fc
+++ b/policy/modules/contrib/gnome_remote_desktop.fc
@@ -1,3 +1,4 @@
 /usr/libexec/gnome-remote-desktop-daemon		--	gen_context(system_u:object_r:gnome_remote_desktop_exec_t,s0)
+/usr/libexec/grd-pcscd		--	gen_context(system_u:object_r:gnome_remote_desktop_exec_t,s0)
 
 /var/lib/gnome-remote-desktop(/.*)?		gen_context(system_u:object_r:gnome_remote_desktop_var_lib_t,s0)

--- a/policy/modules/contrib/gnome_remote_desktop.te
+++ b/policy/modules/contrib/gnome_remote_desktop.te
@@ -10,6 +10,8 @@ type gnome_remote_desktop_exec_t;
 domain_type(gnome_remote_desktop_t)
 domain_entry_file(gnome_remote_desktop_t, gnome_remote_desktop_exec_t)
 role system_r types gnome_remote_desktop_t;
+# gnome-remote-desktop-pcscd.service uses NoNewPrivileges=yes hardening
+init_nnp_daemon_domain(gnome_remote_desktop_t)
 
 type gnome_remote_desktop_var_lib_t;
 files_type(gnome_remote_desktop_var_lib_t)
@@ -68,7 +70,9 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# sssd children send D-Bus messages to grd-pcscd for smartcard operations
 	sssd_read_public_files(gnome_remote_desktop_t)
+	sssd_dbus_chat(gnome_remote_desktop_t)
 ')
 
 optional_policy(`
@@ -86,6 +90,13 @@ optional_policy(`
 ')
 
 optional_policy(`
+	# grd-pcscd reads/writes the received socketpair FD created by normal users
+	unconfined_rw_stream(gnome_remote_desktop_t)
+')
+
+optional_policy(`
 	xserver_dbus_chat_xdm(gnome_remote_desktop_t)
 	xserver_read_xdm_state(gnome_remote_desktop_t)
+	# grd-pcscd reads/writes the received socketpair FD created by xdm_t
+	xserver_rw_xdm_stream_sockets(gnome_remote_desktop_t)
 ')


### PR DESCRIPTION
GNOME Remote Desktop is gaining smartcard redirection support over RDP, landing upstream for GNOME 51. This is tracked across three upstream MRs:
- gnome-remote-desktop: https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/merge_requests/406
- gdm: https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/374
- sssd: https://github.com/SSSD/sssd/pull/8837

Resolves: RHEL-227725