### PR TITLE
Allow virtqemud relabelfrom its private fifo files

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2212,6 +2212,7 @@ delete_lnk_files_pattern(virtqemud_t, virt_etc_rw_t, virt_etc_rw_t)
 manage_files_pattern(virtqemud_t, virtqemud_lock_t, virtqemud_lock_t)
 files_lock_filetrans(virtqemud_t, virtqemud_lock_t, file)
 
+allow virtqemud_t self:fifo_file relabelfrom;
 allow virtqemud_t virtqemud_var_run_t:dir relabelfrom;
 allow virtqemud_t virtqemud_var_run_t:sock_file relabelfrom;
 allow virtqemud_t virt_log_t:file relabel_file_perms;


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(07/31/2026 07:31:36.499:827) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(07/31/2026 07:31:36.499:827) : item=0 name=(null) inode=36675 dev=00:0f mode=fifo,600 ouid=root ogid=root rdev=00:00 obj=system_u:system_r:virtqemud_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(07/31/2026 07:31:36.499:827) : arch=x86_64 syscall=fsetxattr success=yes exit=0 a0=0x16 a1=0x7f58af1f41ac a2=0x7f58840023f0 a3=0x2c items=1 ppid=1 pid=16580 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(07/31/2026 07:31:36.499:827) : avc:  denied  { relabelfrom } for  pid=16580 comm=rpc-virtqemud name= dev="pipefs" ino=36675 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:system_r:virtqemud_t:s0 tclass=fifo_file permissive=1

Resolves: RHEL-222520