### PR TITLE
Allow virtqemud domain transition on udev execution

### DIFF
--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2434,6 +2434,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	udev_domtrans(virtqemud_t)
+')
+
+optional_policy(`
 	userdom_manage_tmp_files(virtqemud_t)
 	userdom_manage_tmp_sockets(virtqemud_t)
 	userdom_read_all_users_state(virtqemud_t)

--- a/policy/modules/contrib/virt.te
+++ b/policy/modules/contrib/virt.te
@@ -2375,6 +2375,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	iscsid_domtrans(virtqemud_t)
+')
+
+optional_policy(`
 	modutils_domtrans_kmod(virtqemud_t)
 ')
 


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(08/11/2026 05:05:57.702:1278) : proctitle=/usr/sbin/virtqemud --timeout 120 type=PATH msg=audit(08/11/2026 05:05:57.702:1278) : item=0 name=/usr/sbin/udevadm inode=9130222 dev=fc:02 mode=file,755 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:udev_exec_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(08/11/2026 05:05:57.702:1278) : arch=x86_64 syscall=access success=yes exit=0 a0=0x7f016c096668 a1=X_OK a2=0x9 a3=0x0 items=1 ppid=1 pid=25647 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=rpc-virtqemud exe=/usr/sbin/virtqemud subj=system_u:system_r:virtqemud_t:s0 key=(null) type=AVC msg=audit(08/11/2026 05:05:57.702:1278) : avc:  denied  { execute } for  pid=25647 comm=rpc-virtqemud name=udevadm dev="vda2" ino=9130222 scontext=system_u:system_r:virtqemud_t:s0 tcontext=system_u:object_r:udev_exec_t:s0 tclass=file permissive=1

Resolves: RHEL-236185