### PR TITLE
Allow lsmd-plugin use libStorageMgmt to provision storage

### DIFF
--- a/policy/modules/contrib/lsm.te
+++ b/policy/modules/contrib/lsm.te
@@ -30,6 +30,9 @@ role system_r types lsmd_plugin_t;
 type lsmd_plugin_tmp_t;
 files_tmp_file(lsmd_plugin_tmp_t)
 
+type lsmd_plugin_tmpfs_t;
+files_tmpfs_file(lsmd_plugin_tmpfs_t)
+
 ########################################
 #
 # Local policy
@@ -79,6 +82,9 @@ manage_files_pattern(lsmd_plugin_t, lsmd_plugin_tmp_t, lsmd_plugin_tmp_t)
 manage_dirs_pattern(lsmd_plugin_t, lsmd_plugin_tmp_t, lsmd_plugin_tmp_t)
 files_tmp_filetrans(lsmd_plugin_t, lsmd_plugin_tmp_t, { file dir })
 
+manage_files_pattern(lsmd_plugin_t, lsmd_plugin_tmpfs_t, lsmd_plugin_tmpfs_t)
+fs_tmpfs_filetrans(lsmd_plugin_t, lsmd_plugin_tmpfs_t, file)
+
 tunable_policy(`lsmd_plugin_connect_any',`
 	corenet_tcp_connect_all_ports(lsmd_plugin_t)
 	corenet_sendrecv_all_packets(lsmd_plugin_t)
@@ -89,6 +95,7 @@ kernel_read_system_state(lsmd_plugin_t)
 
 auth_read_passwd(lsmd_plugin_t)
 
+dev_read_raw_memory(lsmd_plugin_t)
 dev_read_urand(lsmd_plugin_t)
 dev_read_sysfs(lsmd_plugin_t)
 
@@ -120,3 +127,7 @@ storage_create_fixed_disk_dev(lsmd_plugin_t)
 storage_read_scsi_generic(lsmd_plugin_t)
 storage_write_scsi_generic(lsmd_plugin_t)
 storage_dev_filetrans_named_fixed_disk(lsmd_plugin_t)
+
+optional_policy(`
+	udev_read_pid_files(lsmd_t)
+')


### PR DESCRIPTION
Using the libStorageMgmt hpsa plugin results in SELinux denials. As an effect, storage using HP Smart Array adapter cannot be provisioned.

Steps to reproduce:
Issue any command that changes RAID adapter state
All denials have source context system_u:system_r:lsmd_plugin_t:s0
- the lsmd plugin domain that both hpsa_lsmplugin (Python) and ssacli (the HP binary it spawns) run under.

What was requested:
- ssacli reads /dev/mem (physical memory access) to talk to the controller firmware
- hpsa_lsmplugin reads udev runtime data files under /run/udev/data/ for block devices (b8:0 = sda, b259:* = NVMe partitions). Used for vpd83/serial disk-path resolution.
- ssacli creates a named POSIX semaphore in /dev/shm/ (sem_open). Only seen once; likely an internal locking mechanism.

Resolves: RHEL-179467