### PR TITLE
Update dhcpc-hook policy

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -321,7 +321,7 @@ permissive dhcpc_hook_t;
 domtrans_pattern(dhcpc_t, dhcpc_hook_exec_t, dhcpc_hook_t)
 
 allow dhcpc_hook_t self:netlink_route_socket create_netlink_socket_perms;
-allow dhcpc_hook_t self:unix_dgram_socket { create ioctl };
+allow dhcpc_hook_t self:unix_dgram_socket { connect create ioctl };
 
 kernel_read_proc_files(dhcpc_hook_t)
 kernel_request_load_module(dhcpc_hook_t)
@@ -354,11 +354,20 @@ optional_policy(`
 ')
 
 optional_policy(`
+	logging_send_syslog_msg(dhcpc_hook_t)
+')
+
+optional_policy(`
 	nscd_socket_use(dhcpc_hook_t)
 ')
 
 optional_policy(`
+	sysnet_domtrans_ifconfig(dhcpc_hook_t)
 	sysnet_manage_config(dhcpc_hook_t)
+')
+
+optional_policy(`
+	term_use_generic_ptys(dhcpc_hook_t)
 ')
 
 ########################################


### PR DESCRIPTION
Add permissions to support:
- PTY access: dhcpcd-run-hooks accessing /dev/pts/0
- logging
- execution of /usr/bin/ip with transition
- reading /run/netns

Resolves: RHEL-236646