### PR TITLE
Allow postmap read aliases

### DIFF
--- a/policy/modules/contrib/postfix.te
+++ b/policy/modules/contrib/postfix.te
@@ -459,6 +459,10 @@ optional_policy(`
 	mailman_manage_data_files(postfix_map_t)
 ')
 
+optional_policy(`
+	mta_read_aliases(postfix_map_t)
+')
+
 ########################################
 #
 # Postfix pickup local policy


### PR DESCRIPTION
The denial appears when postmap is executed by a confined administrator.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(11/28/2025 07:30:56.697:403) : proctitle=postmap -q toor hash /etc/aliases type=PATH msg=audit(11/28/2025 07:30:56.697:403) : item=0 name=/etc/aliases.db inode=5164258 dev=fd:01 mode=file,644 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:etc_aliases_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(11/28/2025 07:30:56.697:403) : arch=x86_64 syscall=openat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0x55eacc9adf30 a2=O_RDONLY a3=0x0 items=1 ppid=5248 pid=24684 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts1 ses=6 comm=postmap exe=/usr/sbin/postmap subj=sysadm_u:sysadm_r:postfix_map_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(11/28/2025 07:30:56.697:403) : avc:  denied  { read } for  pid=24684 comm=postmap name=aliases.db dev="vda1" ino=5164258 scontext=sysadm_u:sysadm_r:postfix_map_t:s0-s0:c0.c1023 tcontext=system_u:object_r:etc_aliases_t:s0 tclass=file permissive=0