### PR TITLE
fix vpnc_t setpgid permission for openconnect (bsc#1272934)

### DIFF
--- a/policy/modules/contrib/vpn.te
+++ b/policy/modules/contrib/vpn.te
@@ -26,7 +26,7 @@ files_pid_file(vpnc_var_run_t)
 #
 
 allow vpnc_t self:capability { dac_read_search dac_override net_admin ipc_lock net_raw setuid };
-allow vpnc_t self:process { getsched signal };
+allow vpnc_t self:process { getsched setpgid signal };
 dontaudit vpnc_t self:process setsched;
 allow vpnc_t self:fifo_file rw_fifo_file_perms;
 allow vpnc_t self:netlink_route_socket rw_netlink_socket_perms;


### PR DESCRIPTION
Fixes:
AVC details:
time->Wed Aug  5 21:00:23 2026
type=AVC msg=audit(1785956423.634:803): avc:  denied  { setpgid } for  pid=64980 comm="openconnect" scontext=system_u:system_r:vpnc_t:s0 tcontext=system_u:system_r:vpnc_t:s0 tclass=process permissive=0 time->Wed Aug  5 21:00:23 2026
type=AVC msg=audit(1785956423.644:804): avc:  denied  { setpgid } for  pid=64981 comm="openconnect" scontext=system_u:system_r:vpnc_t:s0 tcontext=system_u:system_r:vpnc_t:s0 tclass=process permissive=0