### PR TITLE
Allow lsmd-plugin read udev pid files

### DIFF
--- a/policy/modules/contrib/lsm.te
+++ b/policy/modules/contrib/lsm.te
@@ -129,5 +129,5 @@ storage_write_scsi_generic(lsmd_plugin_t)
 storage_dev_filetrans_named_fixed_disk(lsmd_plugin_t)
 
 optional_policy(`
-	udev_read_pid_files(lsmd_t)
+	udev_read_pid_files(lsmd_plugin_t)
 ')


### PR DESCRIPTION
In the previous commit 0fc37a19d5df ("Allow lsmd-plugin use libStorageMgmt to provision storage"), this particular permission was erroneously added to lsmd_t.