### PR TITLE
Fix NFS mount with xprtsec=tls / xprtsec=mtls (bsc#1275783)

### DIFF
--- a/policy/modules/contrib/ktls.te
+++ b/policy/modules/contrib/ktls.te
@@ -19,6 +19,7 @@ allow ktlshd_t self:unix_dgram_socket create_socket_perms;
 kernel_read_net_sysctls(ktlshd_t)
 kernel_read_network_state_symlinks(ktlshd_t)
 kernel_read_proc_files(ktlshd_t)
+kernel_request_load_module(ktlshd_t)
 kernel_rw_key(ktlshd_t)
 
 domain_read_view_all_domains_keyrings(ktlshd_t)
@@ -36,6 +37,10 @@ optional_policy(`
 	miscfiles_map_generic_certs(ktlshd_t)
 	miscfiles_write_generic_certs(ktlshd_t)
 	miscfiles_dontaudit_write_generic_cert_dirs(ktlshd_t)
+')
+
+optional_policy(`
+	rpc_tcp_rw_nfs_sockets(ktlshd_t)
 ')
 
 optional_policy(`

--- a/policy/modules/contrib/rpc.if
+++ b/policy/modules/contrib/rpc.if
@@ -336,6 +336,24 @@ interface(`rpc_systemctl_rpcd',`
 
 ########################################
 ## <summary>
+##	Allow domain to read and write to an NFS TCP socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rpc_tcp_rw_nfs_sockets',`
+	gen_require(`
+		type nfsd_t;
+	')
+
+	allow $1 nfsd_t:tcp_socket rw_socket_perms;
+')
+
+########################################
+## <summary>
 ##	Allow domain to read and write to an NFS UDP socket.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
ktlshd_t was made enforcing here: https://github.com/fedora-selinux/selinux-policy/pull/2885

NFS mounts using xprtsec=tls or xprtsec=mtls fail with that (found by openQA test).
e.g.:

mount -t nfs -o rw,vers=4.2,sec=sys,xprtsec=mtls 127.0.0.1:/opt/export/test /opt/nfs/test

Full reproducer see: https://bugzilla.suse.com/show_bug.cgi?id=1275783

Fixes:

----
type=PROCTITLE msg=audit(08/24/2026 16:40:44.003:112) : proctitle=/usr/sbin/tlshd type=SOCKADDR msg=audit(08/24/2026 16:40:44.003:112) : saddr={ saddr_fam=inet laddr=127.0.0.1 lport=752 } type=SYSCALL msg=audit(08/24/2026 16:40:44.003:112) : arch=x86_64 syscall=getpeername success=yes exit=0 a0=0x5 a1=0x7ffca669a300 a2=0x7ffca669a2a8 a3=0x4000 items=0 ppid=637 pid=1235 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tlshd exe=/usr/sbin/tlshd subj=system_u:system_r:ktlshd_t:s0 key=(null) type=AVC msg=audit(08/24/2026 16:40:44.003:112) : avc:  denied  { getattr } for  pid=1235 comm=tlshd laddr=127.0.0.1 lport=2049 faddr=127.0.0.1 fport=752 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=tcp_socket permissive=1 ----
type=PROCTITLE msg=audit(08/24/2026 16:40:44.004:113) : proctitle=/usr/sbin/tlshd type=SYSCALL msg=audit(08/24/2026 16:40:44.004:113) : arch=x86_64 syscall=getsockopt success=yes exit=0 a0=0x5 a1=SOL_SOCKET a2=SO_PROTOCOL a3=0x7ffca669a2ac items=0 ppid=637 pid=1235 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tlshd exe=/usr/sbin/tlshd subj=system_u:system_r:ktlshd_t:s0 key=(null) type=AVC msg=audit(08/24/2026 16:40:44.004:113) : avc:  denied  { getopt } for  pid=1235 comm=tlshd laddr=127.0.0.1 lport=2049 faddr=127.0.0.1 fport=752 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=tcp_socket permissive=1 ----
type=PROCTITLE msg=audit(08/24/2026 16:40:44.004:114) : proctitle=/usr/sbin/tlshd type=SYSCALL msg=audit(08/24/2026 16:40:44.004:114) : arch=x86_64 syscall=setsockopt success=yes exit=0 a0=0x5 a1=tcp a2=TCP_NODELAY a3=0x7ffca669a834 items=0 ppid=637 pid=1235 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tlshd exe=/usr/sbin/tlshd subj=system_u:system_r:ktlshd_t:s0 key=(null) type=AVC msg=audit(08/24/2026 16:40:44.004:114) : avc:  denied  { setopt } for  pid=1235 comm=tlshd laddr=127.0.0.1 lport=2049 faddr=127.0.0.1 fport=752 scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:system_r:nfsd_t:s0 tclass=tcp_socket permissive=1 ----
type=PROCTITLE msg=audit(08/24/2026 16:40:44.035:115) : proctitle=/usr/sbin/tlshd type=SYSCALL msg=audit(08/24/2026 16:40:44.035:115) : arch=x86_64 syscall=setsockopt success=yes exit=0 a0=0x5 a1=tcp a2=TCP_ULP a3=0x562f9fce22d0 items=0 ppid=637 pid=1236 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=tlshd exe=/usr/sbin/tlshd subj=system_u:system_r:ktlshd_t:s0 key=(null) type=AVC msg=audit(08/24/2026 16:40:44.035:115) : avc:  denied  { module_request } for  pid=1236 comm=tlshd kmod="tcp-ulp-tls" scontext=system_u:system_r:ktlshd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=system permissive=1