### PR TITLE
Allow sshd-session X11 forwarding

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -107,6 +107,9 @@ manage_files_pattern(sshd_session_t, ssh_home_t, ssh_home_t)
 kernel_stream_connect(sshd_session_t)
 kernel_read_net_sysctls(sshd_session_t)
 
+# -X/ForwardX11 yes
+corenet_tcp_bind_xserver_port(sshd_session_t)
+
 fs_getattr_all_fs(sshd_session_t)
 
 tunable_policy(`ssh_sysadm_login',`

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -867,6 +867,9 @@ manage_dirs_pattern(ssh_agent_type, ssh_agent_tmp_t, ssh_agent_tmp_t)
 manage_sock_files_pattern(ssh_agent_type, ssh_agent_tmp_t, ssh_agent_tmp_t)
 files_tmp_filetrans(ssh_agent_type, ssh_agent_tmp_t, { dir sock_file })
 
+manage_files_pattern(ssh_agent_type, ssh_home_t, ssh_home_t)
+manage_sock_files_pattern(ssh_agent_type, ssh_home_t, ssh_home_t)
+
 kernel_read_kernel_sysctls(ssh_agent_type)
 
 dev_read_urand(ssh_agent_type)

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -103,6 +103,7 @@ allow sshd_session_t ssh_home_t:dir relabelto;
 allow sshd_session_t ssh_home_t:file relabelto;
 manage_dirs_pattern(sshd_session_t, ssh_home_t, ssh_home_t)
 manage_files_pattern(sshd_session_t, ssh_home_t, ssh_home_t)
+manage_sock_files_pattern(sshd_session_t, ssh_home_t, ssh_home_t)
 
 kernel_stream_connect(sshd_session_t)
 kernel_read_net_sysctls(sshd_session_t)


### PR DESCRIPTION
The commit addresses the following AVC denial:
type=AVC msg=audit(1787754986.272:561): avc:  denied  { name_bind } for  pid=3763 comm="sshd-session" src=6010 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xserver_port_t:s0 tclass=tcp_socket permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2524485