### PR TITLE
ssh-session accesses gitolite ssh config files (bsc#1277259)

### DIFF
--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -536,7 +536,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	gitosis_manage_lib_files(sshd_t)
+	gitosis_manage_lib_files(sshd_session_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Due to the split of sshd_t and sshd_session_t it is not possible to push to a gitolite repository anymore.

sshd-session can not read the /srv/gitolite/.ssh/authorized_keys which is needed for authentication.

For context, the following AVC was from openSUSE Microos, which has the folder in /srv, but the problem is likely the similar on fedora (but there it is in /var):
- opensuse path: https://github.com/openSUSE/selinux-policy/blob/492b478c74c8a9f9105f41c5f13317405b968902/policy/modules/contrib/gitosis.fc#L7
- fedora path: https://github.com/fedora-selinux/selinux-policy/blob/20502349848410c85d23159a7997ce9c6ec71687/policy/modules/contrib/gitosis.fc#L7

Addresses:
```
----
type=PROCTITLE msg=audit(08/28/2026 14:22:57.060:129) : proctitle=sshd-session: git [priv]
type=PATH msg=audit(08/28/2026 14:22:57.060:129) : item=0 name=/srv/gitolite/.ssh/authorized_keys nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(08/28/2026 14:22:57.060:129) : cwd=/
type=SYSCALL msg=audit(08/28/2026 14:22:57.060:129) : arch=aarch64 syscall=newfstatat success=no exit=EACCES(Permission denied) a0=AT_FDCWD a1=0xffffd7c149e8 a2=0xffffd7c15a58 a3=0x100 items=1 ppid=1019 pid=3083 auid=unset uid=root gid=root euid=git suid=root fsuid=git egid=git sgid=root fsgid=git tty=(none) ses=unset comm=sshd-session exe=/usr/libexec/ssh/sshd-session subj=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(08/28/2026 14:22:57.060:129) : avc:  denied  { search } for  pid=3083 comm=sshd-session name=gitolite dev="mmcblk0p2" ino=260 scontext=system_u:system_r:sshd_session_t:s0-s0:c0.c1023 tcontext=system_u:object_r:gitosis_var_lib_t:s0 tclass=dir permissive=0
```