### PR TITLE
Allow kmscon use netlink permissions (#3368)

### DIFF
--- a/policy/modules/contrib/kmscon.te
+++ b/policy/modules/contrib/kmscon.te
@@ -39,6 +39,9 @@ domain_dontaudit_read_all_domains_state(kmscon_t)
 # Create an udev monitor
 allow kmscon_t self:netlink_kobject_uevent_socket { bind create getopt read setopt getattr };
 
+allow kmscon_t self:netlink_route_socket r_netlink_socket_perms;
+allow kmscon_t self:unix_dgram_socket create_socket_perms;
+
 allow kmscon_t kmscon_devpts_t:chr_file { rw_chr_file_perms setattr_chr_file_perms };
 term_create_pty(kmscon_t, kmscon_devpts_t)
 


### PR DESCRIPTION


kmscon will not show the IP address when configured, SELinux blocks it.
Its a new feature in kmscon 10.0.2 to not use agetty but its own code, see: https://github.com/fedora-selinux/selinux-policy/issues/3368

It is not shown by default on fedora i think, but it is shown on openSUSE by default

Reproducer for fedora rawhide:
```
echo '\a' > /etc/issue
runcon system_u:system_r:kmscon_t:s0 kmscon --show-issue --vt tty3

-> check avcs
```


Fixes:

```
type=AVC msg=audit(08/21/2026 14:27:35.867:190) : avc:  denied  { create } for  pid=990 comm=kmscon scontext=system_u:system_r:kmscon_t:s0 tcontext=system_u:system_r:kmscon_t:s0 tclass=netlink_route_socket permissive=1
type=AVC msg=audit(08/21/2026 14:27:35.867:191) : avc:  denied  { nlmsg_read } for  pid=990 comm=kmscon scontext=system_u:system_r:kmscon_t:s0 tcontext=system_u:system_r:kmscon_t:s0 tclass=netlink_route_socket permissive=1
type=AVC msg=audit(08/21/2026 14:27:35.867:192) : avc:  denied  { create } for  pid=990 comm=kmscon scontext=system_u:system_r:kmscon_t:s0 tcontext=system_u:system_r:kmscon_t:s0 tclass=unix_dgram_socket permissive=1
type=AVC msg=audit(08/21/2026 14:27:35.867:193) : avc:  denied  { ioctl } for  pid=990 comm=kmscon path=socket:[10168] dev="sockfs" ino=10168 ioctlcmd=SIOCGIFNAME scontext=system_u:system_r:kmscon_t:s0 tcontext=system_u:system_r:kmscon_t:s0 tclass=unix_dgram_socket permissive=1
```