### PR TITLE
Support console version of initial-setup

### DIFF
--- a/policy/modules/contrib/anaconda.fc
+++ b/policy/modules/contrib/anaconda.fc
@@ -7,7 +7,9 @@
 /usr/bin/bootc          --  gen_context(system_u:object_r:install_exec_t,s0)
 /usr/bin/ostree         --  gen_context(system_u:object_r:install_exec_t,s0)
 /usr/bin/rpm-ostree     --  gen_context(system_u:object_r:install_exec_t,s0)
+
 /usr/libexec/rpm-ostreed --  gen_context(system_u:object_r:install_exec_t,s0)
+/usr/libexec/initial-setup(/.*)?	-- system_u:object_r:install_exec_t:s0
 
 /usr/bin/preupg.*   --  gen_context(system_u:object_r:preupgrade_exec_t,s0)
 /var/lib/preupgrade(/.*)?   gen_context(system_u:object_r:preupgrade_data_t,s0)

--- a/policy/modules/contrib/kmscon.if
+++ b/policy/modules/contrib/kmscon.if
@@ -23,3 +23,21 @@ interface(`kmscon_systemctl',`
 
        ps_process_pattern($1, kmscon_t)
 ')
+
+########################################
+## <summary>
+##	Read/write kmscon devpts chr files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`kmscon_rw_inherited_devpts_chr_files',`
+	gen_require(`
+		type kmscon_devpts_t;
+	')
+
+	allow $1 kmscon_devpts_t:chr_file rw_inherited_chr_file_perms;
+')

--- a/policy/modules/contrib/kmscon.te
+++ b/policy/modules/contrib/kmscon.te
@@ -72,6 +72,10 @@ miscfiles_manage_fonts_cache(kmscon_t)
 term_use_unallocated_ttys(kmscon_t)
 
 optional_policy(`
+	anaconda_domtrans_install(kmscon_t)
+')
+
+optional_policy(`
     # Allow domtrans to agetty using --login
     # see https://github.com/Aetf/kmscon/commit/21cf668c58867a100272adea6f323cd56fc73e78
     getty_domtrans(kmscon_t)

--- a/policy/modules/system/userdomain.te
+++ b/policy/modules/system/userdomain.te
@@ -464,6 +464,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	kmscon_rw_inherited_devpts_chr_files(login_userdomain)
+')
+
+optional_policy(`
 	logging_mmap_journal(login_userdomain)
 	logging_read_syslog_pid(login_userdomain)
 	logging_watch_generic_log_dirs(login_userdomain)


### PR DESCRIPTION
kmscon spawns scripts in /usr/libexec/initial-setup, so: Label /usr/libexec/initial-setup with install_exec_t. Allow kmscon run install_t executables with a domain transition.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2484542