### PR TITLE
Adjustments for systemd 262

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -6426,6 +6426,28 @@ interface(`files_etc_filetrans_system_conf',`
     filetrans_pattern($1, etc_t, system_conf_t, file)
 ')
 
+###################################
+## <summary>
+##  Create the sysctl.d directory in /run with the type used
+##  for the manageable system config files and manage config
+##  files in it.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  The type of the process performing this action.
+##  </summary>
+## </param>
+#
+interface(`files_manage_pid_system_conf',`
+    gen_require(`
+        type var_run_t, system_conf_t;
+    ')
+
+    filetrans_pattern($1, var_run_t, system_conf_t, dir, "sysctl.d")
+    manage_dirs_pattern($1, var_run_t, system_conf_t)
+    manage_files_pattern($1, system_conf_t, system_conf_t)
+')
+
 ######################################
 ## <summary>
 ##  Manage manageable system db files in /var/lib.

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -418,6 +418,7 @@ miscfiles_manage_localization(init_t)
 miscfiles_filetrans_named_content(init_t)
 
 udev_manage_rules_files(init_t)
+manage_lnk_files_pattern(init_t, udev_var_run_t, udev_var_run_t)
 
 userdom_use_user_ttys(init_t)
 userdom_read_user_tmp_files(init_t)

--- a/policy/modules/system/systemd.fc
+++ b/policy/modules/system/systemd.fc
@@ -138,6 +138,7 @@ HOME_DIR/\.config/systemd/user(/.*)?		gen_context(system_u:object_r:systemd_unit
 /run/systemd/.+\.conf\.d/.+\.conf	--	gen_context(system_u:object_r:systemd_conf_t,s0)
 /run/systemd/.+\.conf\.d/.+\.conf	-l	gen_context(system_u:object_r:systemd_conf_t,s0)
 /run/.*nologin.*		gen_context(system_u:object_r:systemd_logind_var_run_t,s0)
+/run/systemd/coredumpd(/.*)?	gen_context(system_u:object_r:systemd_coredump_var_run_t,s0)
 /run/systemd/default-hostname	--	gen_context(system_u:object_r:hostname_etc_t,s0)
 
 /run/systemd/generator(/.*)?	gen_context(system_u:object_r:systemd_generator_unit_file_t,s0)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -1329,6 +1329,8 @@ kernel_read_security_state(systemd_sysctl_t)
 kernel_write_security_state(systemd_sysctl_t)
 
 files_read_system_conf_files(systemd_sysctl_t)
+# create /run/sysctl.d and config files in it
+files_manage_pid_system_conf(systemd_sysctl_t)
 
 # fs.binfmt_misc.status
 fs_register_binary_executable_type(systemd_sysctl_t)

--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -69,6 +69,9 @@ files_tmpfs_file(systemd_coredump_tmpfs_t)
 type systemd_coredump_var_lib_t;
 files_type(systemd_coredump_var_lib_t)
 
+type systemd_coredump_var_run_t;
+files_pid_file(systemd_coredump_var_run_t)
+
 systemd_domain_template(systemd_hibernate_resume)
 
 systemd_domain_template(systemd_hwdb)
@@ -1366,6 +1369,9 @@ manage_dirs_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_core
 manage_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_coredump_var_lib_t)
 mmap_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_coredump_var_lib_t)
 init_var_lib_filetrans(systemd_coredump_t, systemd_coredump_var_lib_t, dir, "coredump")
+
+# /run/systemd/coredumpd/kernel socket
+allow systemd_coredump_t systemd_coredump_var_run_t:sock_file manage_sock_file_perms;
 
 kernel_rw_usermodehelper_state(systemd_coredump_t)
 


### PR DESCRIPTION
Three patches so silence new AVCs reported when booting Fedora rawhide with systemd-262~rc1.