### PR TITLE
Allow kmscon read cocpit's pid files

### DIFF
--- a/policy/modules/contrib/kmscon.te
+++ b/policy/modules/contrib/kmscon.te
@@ -79,6 +79,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	cockpit_read_pid_files(kmscon_t)
+')
+
+optional_policy(`
     # Allow domtrans to agetty using --login
     # see https://github.com/Aetf/kmscon/commit/21cf668c58867a100272adea6f323cd56fc73e78
     getty_domtrans(kmscon_t)


### PR DESCRIPTION
In particular,
/etc/issue.d/cockpit.issue -> /run/cockpit/inactive.issue was requested to read.

The commit addresses the following AVC denial:
type=AVC msg=audit(1788438104.926:531): avc:  denied  { read } for  pid=13399 comm="kmscon" name="inactive.issue" dev="tmpfs" ino=2841 scontext=system_u:system_r:kmscon_t:s0 tcontext=system_u:object_r:cockpit_var_run_t:s0 tclass=file permissive=0

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2527998