### PR TITLE
Allow rsync to read var_t (bsc#1279565)

### DIFF
--- a/policy/modules/contrib/rsync.te
+++ b/policy/modules/contrib/rsync.te
@@ -122,6 +122,7 @@ dev_read_urand(rsync_t)
 fs_getattr_xattr_fs(rsync_t)
 fs_search_auto_mountpoints(rsync_t)
 
+files_list_var(rsync_t)
 files_search_home(rsync_t)
 
 auth_use_nsswitch(rsync_t)


### PR DESCRIPTION
Currently rsyncd fails to start unless rsync_export_all_ro is set

Solves:
avc:  denied  { read } for  comm="rsync" name="var" dev="vda2" scontext=system_u:system_r:rsync_t:s0
tcontext=system_u:object_r:var_t:s0
tclass=dir