### PR TITLE
Allow rsync to getattr pipes and sockes if rsync_export_all_ro is set

### DIFF
--- a/policy/modules/contrib/rsync.te
+++ b/policy/modules/contrib/rsync.te
@@ -170,6 +170,8 @@ tunable_policy(`rsync_export_all_ro',`
 	fs_read_nfs_files(rsync_t)
 	fs_read_fusefs_files(rsync_t)
 	fs_read_cifs_files(rsync_t)
+	files_getattr_non_auth_pipes(rsync_t)
+	files_getattr_non_auth_sockets(rsync_t)
 	files_list_non_auth_dirs(rsync_t)
 	files_read_non_auth_files(rsync_t)
 	files_read_non_auth_symlinks(rsync_t)

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2176,6 +2176,24 @@ interface(`files_getattr_non_auth_dirs',`
 
 ########################################
 ## <summary>
+##     Get attributes of all non-authentication related pipes
+## </summary>
+## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`files_getattr_non_auth_pipes',`
+       gen_require(`
+               attribute non_auth_file_type;
+       ')
+
+       allow $1 non_auth_file_type:fifo_file getattr_fifo_file_perms;
+')
+
+########################################
+## <summary>
 ##	Read all non-authentication related
 ##	directories.
 ## </summary>

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2194,6 +2194,23 @@ interface(`files_getattr_non_auth_pipes',`
 
 ########################################
 ## <summary>
+##     Get attributes of all non-authentication related sockets
+## </summary>                                                                                                                                     +## <param name="domain">
+##     <summary>
+##     Domain allowed access.
+##     </summary>
+## </param>
+#
+interface(`files_getattr_non_auth_sockets',`
+       gen_require(`
+               attribute non_auth_file_type;
+       ')
+
+       allow $1 non_auth_file_type:sock_file getattr_sock_file_perms;
+')
+
+########################################
+## <summary>
 ##	Read all non-authentication related
 ##	directories.
 ## </summary>


### PR DESCRIPTION
Introduces two new interfaces
- files_getattr_non_auth_sockets
- files_getattr_non_auth_pipes interface
and uses it in the rsync_export_all_ro boolean to allow access