### PR TITLE
Update udev_manage_pid_files() to include read symlinks

### DIFF
--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -345,6 +345,7 @@ interface(`udev_manage_pid_files',`
 
 	files_search_pids($1)
 	manage_files_pattern($1, udev_var_run_t, udev_var_run_t)
+	read_lnk_files_pattern($1, udev_var_run_t, udev_var_run_t)
 ')
 
 #######################################


### PR DESCRIPTION
Update the udev_manage_pid_files() interface so that it includes reading udev_var_run_t symlinks which is needed since systemd v256:

The legacy socket for controlling systemd-udevd has been removed, and udevadm now unconditionally uses Varlink IPC. The legacy UNIX socket /run/udev/control, which is sometimes used to check whether udevd is running, has been replaced with a symlink to the Varlink socket.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2529179