### PR TITLE
nsresourced mkosi issues (systemd v261.2)

### DIFF
--- a/policy/modules/system/systemd.te
+++ b/policy/modules/system/systemd.te
@@ -2092,19 +2092,23 @@ optional_policy(`
 #
 
 allow systemd_nsresourced_t self:bpf { map_create map_read map_write prog_load prog_run };
-allow systemd_nsresourced_t self:capability sys_resource;
+allow systemd_nsresourced_t self:capability { setgid setuid sys_resource };
 allow systemd_nsresourced_t self:capability2 { bpf perfmon };
+allow systemd_nsresourced_t self:cap_userns sys_admin;
 allow systemd_nsresourced_t self:perf_event manage_perf_event_perms;
 allow systemd_nsresourced_t systemd_nsresourced_exec_t:file execute_no_trans;
 
 #read_files_pattern(systemd_nsresourced_t, systemd_nsresourced_runtime_t, systemd_nsresourced_runtime_t)
+manage_files_pattern(systemd_nsresourced_t, systemd_nsresourced_runtime_t, systemd_nsresourced_runtime_t)
 manage_dirs_pattern(systemd_nsresourced_t, systemd_nsresourced_runtime_t, systemd_nsresourced_runtime_t)
 
 kernel_dgram_send(systemd_nsresourced_t)
+kernel_read_psi(systemd_nsresourced_t)
 
 dev_read_sysfs(systemd_nsresourced_t)
 
 fs_cgroup_write_memory_pressure(systemd_nsresourced_t)
+fs_read_nsfs_files(systemd_nsresourced_t)
 fs_manage_bpf_dirs(systemd_nsresourced_t)
 fs_manage_bpf_files(systemd_nsresourced_t)
 


### PR DESCRIPTION
Reproducer:

add mkosi.conf to a folder:
```
[Distribution]
Distribution=opensuse

[Output]
Format=directory
```

then
```
sudo systemctl stop systemd-nsresourced.service systemd-nsresourced.socket
sudo rm -rf /run/systemd/nsresource
sudo systemctl start systemd-nsresourced.socket

mkosi build
```

see commits for details

bug for opensuse see: https://bugzilla.suse.com/show_bug.cgi?id=1279902