### PR TITLE
Allow nsswitch_domain connect to read xdm pid socket files

### DIFF
--- a/policy/modules/services/xserver.if
+++ b/policy/modules/services/xserver.if
@@ -1116,6 +1116,25 @@ interface(`xserver_read_xdm_pid',`
 
 ########################################
 ## <summary>
+##	Read XDM pid sock files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xserver_read_xdm_pid_sock_files',`
+	gen_require(`
+		type xdm_var_run_t;
+	')
+
+	files_search_pids($1)
+	read_sock_files_pattern($1, xdm_var_run_t, xdm_var_run_t)
+')
+
+########################################
+## <summary>
 ##	Mmap XDM pid files.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -576,6 +576,7 @@ optional_policy(`
 
 optional_policy(`
 	systemd_homed_stream_connect(nsswitch_domain)
+	systemd_read_userdbd_runtime_sock_files(nsswitch_domain)
 ')
 
 optional_policy(`
@@ -588,6 +589,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+	xserver_read_xdm_pid_sock_files(nsswitch_domain)
 	xserver_stream_connect_xdm(nsswitch_domain)
 ')
 

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -3209,6 +3209,25 @@ interface(`systemd_userdbd_stream_connect',`
 
 #######################################
 ## <summary>
+##	Read named sockets in userdbd runtime directory
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`systemd_read_userdbd_runtime_sock_files',`
+	gen_require(`
+		type systemd_userdbd_runtime_t;
+	')
+
+	files_search_pids($1)
+	read_sock_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
+')
+
+#######################################
+## <summary>
 ##	Manage named sockets in userdbd runtime directory
 ## </summary>
 ## <param name="domain">
@@ -3222,6 +3241,7 @@ interface(`systemd_manage_userdbd_runtime_sock_files',`
         	type systemd_userdbd_runtime_t;
 	')
 
+	files_search_pids($1)
 	manage_sock_files_pattern($1, systemd_userdbd_runtime_t, systemd_userdbd_runtime_t)
 ')
 


### PR DESCRIPTION
This is a follow-up to 8abb59e766cb ("Allow nsswitch_domain connect to xdm over a unix domain socket"). Clients now also need to read account providers' pid socket files.

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(09/07/2026 09:30:53.648:2081) : proctitle=/usr/bin/NetworkManager --no-daemon type=PATH msg=audit(09/07/2026 09:30:53.648:2081) : item=0 name=/proc/self/fd/37 inode=4177 dev=00:1d mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:xdm_var_run_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SYSCALL msg=audit(09/07/2026 09:30:53.648:2081) : arch=x86_64 syscall=getxattr success=no exit=ENODATA(No data available) a0=0x7ffd530d5ac0 a1=0x7ff93047ddfe a2=0x5584b0851650 a3=0x67 items=1 ppid=1 pid=8867 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=NetworkManager exe=/usr/bin/NetworkManager subj=system_u:system_r:NetworkManager_t:s0 key=(null) type=AVC msg=audit(09/07/2026 09:30:53.648:2081) : avc:  denied  { read } for  pid=8867 comm=NetworkManager name=org.gnome.DisplayManager dev="tmpfs" ino=4177 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:xdm_var_run_t:s0 tclass=sock_file permissive=1 Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2529296