### PR TITLE
Fix formatting issue in files.if

### DIFF
--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -2195,7 +2195,8 @@ interface(`files_getattr_non_auth_pipes',`
 ########################################
 ## <summary>
 ##     Get attributes of all non-authentication related sockets
-## </summary>                                                                                                                                     +## <param name="domain">
+## </summary>
+## <param name="domain">
 ##     <summary>
 ##     Domain allowed access.
 ##     </summary>


### PR DESCRIPTION
A regression was brough with commit 5ff4d4bce902 ("Introduce files_getattr_non_auth_sockets"): a corrupted documentation comment — the summary closing tag was merged onto the same line as param.